### PR TITLE
blackbox: parameter posterior for learned Bayesian networks

### DIFF
--- a/mixle/inference/blackbox.py
+++ b/mixle/inference/blackbox.py
@@ -11,9 +11,11 @@ Gaussian posterior in that space from a finite-difference Hessian of the model's
     post.sample(...)        # parameter draws (a fitted model per draw)
     post.cov                # unconstrained-space posterior covariance
 
-Coverage is the parameter round-trip in ``_FLATTENERS`` -- the scalar exponential-family leaves plus
-``Composite`` and ``Mixture`` (recursively), so heterogeneous records and mixtures-of-anything are
-covered out of the box. It is extensible exactly like ``register_family``: add a leaf's
+Coverage is the parameter round-trip in :func:`_flatten` -- the scalar exponential-family leaves, the
+``Categorical`` simplex, plus ``Composite``, ``Mixture`` and ``HeterogeneousBayesianNetwork``
+(recursively), so heterogeneous records, mixtures-of-anything, and learned Bayesian networks (categorical
+CPTs + conditional-linear-Gaussian coefficients) are covered out of the box. It is extensible exactly
+like ``register_family``: add a leaf's
 (extract, rebuild) and every composite over it works. A model whose structure is not yet flattenable
 raises a clear error rather than returning a wrong answer.
 """
@@ -109,6 +111,17 @@ def _flatten(model) -> tuple[np.ndarray, Callable[[np.ndarray], Any]]:
         to_u, from_u = leaves[name]
         return np.asarray(to_u(model), dtype=float), (lambda u, _f=from_u: _f(u))
 
+    if isinstance(model, S.CategoricalDistribution):
+        # the category-probability simplex over the (fixed) support -> K-1 softmax logits
+        keys = sorted(model.pmap.keys(), key=repr)
+        u0 = np.asarray(_simplex_to_u([model.pmap[k] for k in keys]), dtype=float)
+
+        def rebuild(u, _keys=keys, _k=len(keys), _dv=model.default_value, _nm=model.name):
+            p, rest = _simplex_from_u(u, _k)
+            return S.CategoricalDistribution(dict(zip(_keys, p)), default_value=_dv, name=_nm), rest
+
+        return u0, rebuild
+
     if isinstance(model, S.CompositeDistribution):
         parts = [_flatten(d) for d in model.dists]
         u0 = np.concatenate([p[0] for p in parts]) if parts else np.zeros(0)
@@ -138,9 +151,81 @@ def _flatten(model) -> tuple[np.ndarray, Callable[[np.ndarray], Any]]:
 
         return u0, rebuild
 
+    from mixle.inference.bayesian_network import HeterogeneousBayesianNetwork
+
+    if isinstance(model, HeterogeneousBayesianNetwork):
+        parts = [_flatten_factor(f) for f in model.factors]
+        u0 = np.concatenate([p[0] for p in parts]) if parts else np.zeros(0)
+
+        def rebuild(u, _parts=parts):
+            facs, rest = [], u
+            for _, rb in _parts:
+                f, rest = rb(rest)
+                facs.append(f)
+            return HeterogeneousBayesianNetwork(facs), rest
+
+        return u0, rebuild
+
     raise NotImplementedError(
         f"laplace_posterior cannot flatten a {name}; add it to _leaf_flatteners (the same per-family "
         "extend point as register_family), or use the model's bespoke inference."
+    )
+
+
+def _flatten_factor(f) -> tuple[np.ndarray, Callable[[np.ndarray], Any]]:
+    """Flatten one Bayesian-network factor's numeric parameters to unconstrained coords (keeping its fixed
+    structure -- child, parent set, discrete levels, GLM kind -- outside the vector) and return
+    ``(u0, rebuild)`` where ``rebuild`` reconstructs the factor from such a vector plus the remaining tail."""
+    from mixle.inference.bayesian_network import (
+        _DiscreteConditionalFactor,
+        _GLMFactor,
+        _LinearGaussianFactor,
+        _MarginalFactor,
+    )
+
+    if isinstance(f, _MarginalFactor):  # a root field: flatten its fitted marginal (categorical / Gaussian / count)
+        u0, rb = _flatten(f.dist)
+        return u0, (lambda u, _rb=rb, _c=f.child: (lambda d, r: (_MarginalFactor(_c, d), r))(*_rb(u)))
+
+    if isinstance(f, _LinearGaussianFactor):  # CLG node: regression coefficients (real) + a log scale
+        u0 = np.concatenate([np.asarray(f.coef, dtype=float), np.asarray(_pos_to_u(f.sigma), dtype=float)])
+        nc = int(np.asarray(f.coef).shape[0])
+
+        def rb(u, _c=f.child, _p=f.parents, _d=f.discrete, _nc=nc):
+            coef = np.asarray(u[:_nc], dtype=float)
+            sigma, rest = _pos_from_u(u[_nc:])
+            return _LinearGaussianFactor(_c, _p, _d, coef, sigma), rest
+
+        return u0, rb
+
+    if isinstance(f, _GLMFactor):  # GLM node: the logistic / Poisson / softmax weights are already unconstrained
+        w = np.asarray(f.weights, dtype=float)
+        u0 = w.ravel()
+
+        def rb(u, _c=f.child, _p=f.parents, _d=f.discrete, _k=f.kind, _lv=f.levels, _sh=w.shape):
+            n = int(np.prod(_sh)) if _sh else 0
+            weights = np.asarray(u[:n], dtype=float).reshape(_sh)
+            return _GLMFactor(_c, _p, _d, _k, _lv, weights), u[n:]
+
+        return u0, rb
+
+    if isinstance(f, _DiscreteConditionalFactor):  # per-config CPTs: flatten the backoff + each config's child dist
+        cfgs = sorted(f.table.keys(), key=repr)
+        subs = [_flatten(f.backoff)] + [_flatten(f.table[c]) for c in cfgs]
+        u0 = np.concatenate([s[0] for s in subs]) if subs else np.zeros(0)
+
+        def rb(u, _c=f.child, _p=f.parents, _cfgs=cfgs, _subs=subs):
+            dists, rest = [], u
+            for _, rbf in _subs:
+                d, rest = rbf(rest)
+                dists.append(d)
+            table = {cfg: dists[i + 1] for i, cfg in enumerate(_cfgs)}
+            return _DiscreteConditionalFactor(_c, _p, table, dists[0]), rest
+
+        return u0, rb
+
+    raise NotImplementedError(
+        f"laplace_posterior cannot flatten a {type(f).__name__} Bayesian-network factor; add it to _flatten_factor."
     )
 
 

--- a/mixle/tests/blackbox_laplace_test.py
+++ b/mixle/tests/blackbox_laplace_test.py
@@ -48,6 +48,37 @@ class BlackboxLaplaceTest(unittest.TestCase):
         m = laplace_posterior(fit, data).sample(1, rng=np.random.RandomState(5))
         self.assertEqual(len(m.components), 2)  # a valid posterior draw rebuilt into a fitted mixture
 
+    def test_bayesian_network_gets_a_parameter_posterior(self):
+        # a learned heterogeneous DAG (categorical marginal + conditional-linear-Gaussian edges) is now
+        # flattenable, so uq(model, data) / create(..., quantify_uq=True) attach a real posterior, not None.
+        from mixle.inference.bayesian_network import learn_bayesian_network
+
+        rng = np.random.RandomState(0)
+        plan_spend_records = []
+        for _ in range(400):
+            plan = rng.choice(["free", "pro", "enterprise"], p=[0.5, 0.3, 0.2])
+            base = {"free": 10.0, "pro": 50.0, "enterprise": 200.0}[plan]
+            spend = base + rng.normal(0, 5)
+            seats = 0.5 * spend + rng.normal(0, 3)
+            plan_spend_records.append((plan, float(spend), float(seats)))
+
+        bn = learn_bayesian_network(plan_spend_records, max_parents=2)
+
+        # flatten round-trips exactly: same joint log-likelihood after params -> vector -> params
+        u0, rebuild = _flatten(bn)
+        self.assertGreater(len(u0), 0)
+        back, _ = rebuild(u0)
+        enc0 = bn.dist_to_encoder().seq_encode(plan_spend_records)
+        enc1 = back.dist_to_encoder().seq_encode(plan_spend_records)
+        self.assertAlmostEqual(
+            float(np.sum(bn.seq_log_density(enc0))), float(np.sum(back.seq_log_density(enc1))), places=6
+        )
+
+        post = laplace_posterior(bn, plan_spend_records)
+        self.assertIsNotNone(post)  # the uq handle a BN used to get None for
+        draw = post.sample(1, rng=np.random.RandomState(1))
+        self.assertEqual(len(draw.factors), len(bn.factors))  # a valid draw rebuilt into a network
+
     def test_unsupported_structure_raises_clearly(self):
         hmm = S.HiddenMarkovModelDistribution(
             [S.GaussianDistribution(-1, 1), S.GaussianDistribution(1, 1)], [0.5, 0.5], [[0.7, 0.3], [0.3, 0.7]]


### PR DESCRIPTION
## What

`laplace_posterior` raised `NotImplementedError` on any `HeterogeneousBayesianNetwork`, so you couldn't get a parameter posterior over a learned Bayesian network. This teaches `_flatten` (in `mixle/inference/blackbox.py`) to flatten a BN's factor parameters to an unconstrained vector and back.

## Changes

- **`CategoricalDistribution`** — the `pmap` simplex over its fixed support flattens to K−1 softmax logits and back (same log-ratio unconstraining the mixture weights already use); keys, `default_value`, and `name` are held in the closure as structure, not free params.
- **`HeterogeneousBayesianNetwork`** — a recursive branch (mirroring `Composite`/`Mixture`) that flattens each factor via a new `_flatten_factor` dispatcher:
  - `_MarginalFactor` → recurse into its fitted marginal (Gaussian, categorical, Poisson, …).
  - `_LinearGaussianFactor` (CLG) → regression coefficients as raw reals + `log(sigma)`.
  - `_GLMFactor` → logistic/Poisson/softmax weights pass through unconstrained (ravel/reshape).
  - `_DiscreteConditionalFactor` (categorical CPT) → flatten backoff + each config's child dist, configs in a deterministic `repr`-sorted order.

  Rebuild reconstructs each factor with new numeric params while preserving fixed structure (child, parent set, discrete levels, GLM kind).

## Result

A learned BN now yields a `LaplacePosterior` whose draws rebuild into fitted networks — the parameter posterior any higher-level `uq`/`create(quantify_uq=True)` wrapper needs.

## Tests

Added `test_bayesian_network_gets_a_parameter_posterior`: learns a BN over synthetic plan/spend records (categorical `plan` → CLG `spend` → CLG `seats`), asserts the flatten round-trip preserves the joint log-likelihood exactly, and that `laplace_posterior` returns a non-`None` posterior whose draws rebuild into networks. Verified round-trip on both the marginal-categorical + CLG graph and a `_DiscreteConditionalFactor` (categorical-on-categorical) graph. All 6 tests in the file pass; ruff clean.