### PR TITLE
tests: skip embedder-path Budget cases when torch is absent

### DIFF
--- a/mixle/tests/context_test.py
+++ b/mixle/tests/context_test.py
@@ -41,6 +41,7 @@ class BudgetTest(unittest.TestCase):
         pkt = assemble_context(s, "long document", budget=ContextBudget(max_chars=5))
         self.assertEqual(len(pkt), 1)  # always at least the single best item
 
+    @unittest.skipUnless(_HAS_TORCH, "10 items crosses into semantic retrieval, which needs the represent embedder")
     def test_item_cap_is_honored(self):
         s = Substrate()
         for i in range(10):

--- a/mixle/tests/multihop_test.py
+++ b/mixle/tests/multihop_test.py
@@ -5,6 +5,13 @@ import unittest
 from mixle.substrate import ContextBudget, Substrate, SubstrateItem, multihop
 from mixle.telemetry import Telemetry
 
+try:
+    import torch  # noqa: F401
+
+    _HAS_TORCH = True
+except ImportError:
+    _HAS_TORCH = False
+
 
 def _lineage_shard():
     """A bug report -> (link) the model artifact -> (link) its training trace. The trace shares NO
@@ -60,6 +67,7 @@ class ChainTest(unittest.TestCase):
 
 
 class BudgetTest(unittest.TestCase):
+    @unittest.skipUnless(_HAS_TORCH, "30 items crosses into semantic retrieval, which needs the represent embedder")
     def test_max_items_caps_the_chain(self):
         s = Substrate()
         for i in range(30):


### PR DESCRIPTION
## What

Two substrate `BudgetTest` cases error under the `fast` CI job with `ModuleNotFoundError: No module named 'torch'`:

- `context_test.py::BudgetTest::test_item_cap_is_honored` (adds 10 items)
- `multihop_test.py::BudgetTest::test_max_items_caps_the_chain` (adds 30 items)

Both cross the item-count threshold where retrieval switches from lexical to **semantic**, which needs the `represent` embedder (torch). The `fast` job installs only `.[test]`, which doesn't include torch, so these two error at run time. They were simply never exercised in CI before (this surfaced on the first PR to run `fast` against `v0.6.2` content).

## Fix

Guard just those two methods with `@unittest.skipUnless(_HAS_TORCH, ...)`, matching the existing guard already on `SemanticAssemblyTest` in `context_test.py`. The lexical Budget cases (`<4` items) keep running; only the embedder-dependent ones skip. Also adds the small `_HAS_TORCH` probe to `multihop_test.py` (it had none).

## Verified

- **With torch** (local `.venv`): both files pass fully — 20 passed.
- **Without torch** (simulated torchless env, as fast CI): 17 passed, 3 skipped, **zero errors** — the two cases skip cleanly instead of crashing.
- ruff check clean.

## Note

These are pre-existing failures on `v0.6.2`, unrelated to any feature change — split out from the BN Laplace PR (#1) to keep that one scoped.