### PR TITLE
task/distill: fit the student through NeuralCategorical + optimize(), not a hand-rolled torch loop

### DIFF
--- a/mixle/task/distill.py
+++ b/mixle/task/distill.py
@@ -294,9 +294,18 @@ def _encode_labels(teacher_labels: Sequence[Any], labels: Sequence[str] | None) 
 
 
 def _fit_mlp(x: np.ndarray, y: np.ndarray, n_labels: int, hidden, epochs, lr, seed, device):
-    """Train a small MLP classifier on features ``x`` and integer labels ``y``; return ``(module, config)``."""
+    """Train a small MLP classifier on features ``x`` and integer labels ``y``; return ``(module, config)``.
+
+    Wraps the module in a :class:`~mixle.models.NeuralCategorical` leaf and fits it through the ordinary
+    :func:`~mixle.inference.optimize` entry point -- the same declare-a-leaf/call-optimize path every other
+    mixle model goes through, rather than a bespoke torch loop. ``epochs`` is the leaf's ``m_steps`` (full-batch
+    gradient steps per call); a single ``optimize`` iteration (``max_its=1``) runs exactly one such M-step, so
+    training is unchanged in substance -- only the fitting path is now the shared one.
+    """
     import torch
 
+    from mixle.inference import optimize
+    from mixle.models import NeuralCategorical
     from mixle.models.neural import make_mlp
 
     cfg = {
@@ -307,17 +316,9 @@ def _fit_mlp(x: np.ndarray, y: np.ndarray, n_labels: int, hidden, epochs, lr, se
     }
     torch.manual_seed(seed)
     module = make_mlp(**cfg).to(device)
-    xt = torch.from_numpy(x).to(device)
-    yt = torch.from_numpy(y).to(device)
-    opt = torch.optim.Adam(module.parameters(), lr=lr)
-    loss_fn = torch.nn.CrossEntropyLoss()
-    module.train()
-    for _ in range(int(epochs)):
-        opt.zero_grad()
-        loss = loss_fn(module(xt), yt)
-        loss.backward()
-        opt.step()
-    return module, cfg
+    leaf = NeuralCategorical(module, m_steps=int(epochs), lr=float(lr), device=device)
+    fit = optimize(list(zip(x, y)), leaf.estimator(), prev_estimate=leaf, max_its=1, out=None)
+    return fit.module, cfg
 
 
 def _student(module, cfg, adapter, task, n_examples, label_list, recipe) -> TaskModel:


### PR DESCRIPTION
## Summary

- `mixle/task/distill.py`'s `_fit_mlp` (the training core behind `distill`, `distill_from_labels`,
  `distill_records`, `distill_records_from_labels`) hand-rolled its own torch training loop —
  raw `Adam`/`CrossEntropyLoss` with a manual `for epoch: backward(); step()` — instead of going
  through mixle's own declare-a-leaf/`optimize()` pattern that every other model in the library uses.
- `mixle.models.NeuralCategorical` (the softmax-classifier leaf) already implements this exact
  training loop as its EM estimator (`m_steps` of full-batch gradient descent, warm-startable,
  serializable, composable in a `Mixture`/`Composite`). `_fit_mlp` was duplicating it with a second,
  divergent implementation rather than building on it.
- This PR wraps the module in a `NeuralCategorical` leaf and fits it via
  `optimize(data, leaf.estimator(), prev_estimate=leaf, max_its=1)`. `epochs` maps to the leaf's
  `m_steps`; a single `optimize()` iteration runs exactly one M-step, so training is unchanged in
  substance — only the fitting path is now the shared one.
- Public signatures of `distill`/`distill_from_labels`/`distill_records`/`distill_records_from_labels`
  are untouched; this is an internal-only change.

## Test plan

- [x] Targeted: `task_distill_test.py`, `distill_methods_test.py`, `edge_distill_test.py`,
      `task_distill_structured_test.py` — 51/51 passed, including the accuracy-threshold tests,
      the save/load round-trip test, and the footprint test that checks module architecture
      (`fp.bytes`/`fp.ops` computed from `Linear` layer shapes — unaffected since `make_mlp`/`cfg`
      are unchanged).
- [x] Full suite: `pytest -m "not optional and not benchmark"` — 4618 passed, 2 skipped
      (unrelated, missing Java runtime for a Spark path), no regressions.
- [x] `ruff check` / `ruff format --check` clean.