### PR TITLE
task/distill+tune: early-stop the student fit; add tune_recipe_for_routing

### DIFF
--- a/mixle/task/__init__.py
+++ b/mixle/task/__init__.py
@@ -116,7 +116,7 @@ from mixle.task.solve import Solution, load_harvested, solve
 from mixle.task.structured_out import StructuredSolution, solve_structured
 from mixle.task.toolcall import ToolCaller, ToolSpec, distill_tool_caller
 from mixle.task.traces import AgentTrace, AgentTraces, harvest_agent_traces, parse_conversation
-from mixle.task.tune import RecipeSpace, TuneResult, tune_recipe
+from mixle.task.tune import CalibratedTuneResult, RecipeSpace, TuneResult, tune_recipe, tune_recipe_for_routing
 
 __all__ = [
     "ESCALATE",
@@ -166,6 +166,7 @@ __all__ = [
     "ToolCaller",
     "ToolSpec",
     "TextClassifierIO",
+    "CalibratedTuneResult",
     "TuneResult",
     "acquisition_scores",
     "active_distill",
@@ -236,4 +237,5 @@ __all__ = [
     "FINGERPRINT_KEYS",
     "tokenize",
     "tune_recipe",
+    "tune_recipe_for_routing",
 ]

--- a/mixle/task/distill.py
+++ b/mixle/task/distill.py
@@ -106,7 +106,7 @@ def distill_from_labels(
     texts = [str(t) for t in texts]
     label_list, y = _encode_labels(teacher_labels, labels)
     feat = HashedNGram(n=n, dim=dim, seed=seed)
-    module, cfg = _fit_mlp(feat.transform(texts), y, len(label_list), hidden, epochs, lr, seed, device)
+    module, cfg, steps_run = _fit_mlp(feat.transform(texts), y, len(label_list), hidden, epochs, lr, seed, device)
     student = _student(
         module,
         cfg,
@@ -114,7 +114,7 @@ def distill_from_labels(
         task or "distilled text classifier",
         len(texts),
         label_list,
-        {"n": n, "dim": dim, "hidden": list(cfg["hidden_dims"]), "epochs": epochs, "lr": lr},
+        {"n": n, "dim": dim, "hidden": list(cfg["hidden_dims"]), "epochs": epochs, "epochs_run": steps_run, "lr": lr},
     )
     student.meta["train_agreement"] = agreement(student, teacher_labels, texts)
     return student
@@ -259,7 +259,7 @@ def distill_records_from_labels(
     records = list(records)
     label_list, y = _encode_labels(teacher_labels, labels)
     feat = HashedRecord(dim=dim, seed=seed)
-    module, cfg = _fit_mlp(feat.transform(records), y, len(label_list), hidden, epochs, lr, seed, device)
+    module, cfg, steps_run = _fit_mlp(feat.transform(records), y, len(label_list), hidden, epochs, lr, seed, device)
     student = _student(
         module,
         cfg,
@@ -267,7 +267,7 @@ def distill_records_from_labels(
         task or "distilled record classifier",
         len(records),
         label_list,
-        {"dim": dim, "hidden": list(cfg["hidden_dims"]), "epochs": epochs, "lr": lr},
+        {"dim": dim, "hidden": list(cfg["hidden_dims"]), "epochs": epochs, "epochs_run": steps_run, "lr": lr},
     )
     student.meta["train_agreement"] = agreement(student, teacher_labels, records)
     return student
@@ -486,14 +486,25 @@ def _split_for_calibration(
     )
 
 
+# Early-stopping schedule for _fit_mlp: check the training loss every _ES_CHECK_EVERY gradient steps, stop once
+# it hasn't improved by _ES_MIN_DELTA for _ES_PATIENCE consecutive checks. Internal constants, not exposed on the
+# public distill*() signatures -- epochs stays the one knob callers see; it now means "ceiling", not "exact count".
+_ES_CHECK_EVERY = 10
+_ES_PATIENCE = 3
+_ES_MIN_DELTA = 1e-3
+
+
 def _fit_mlp(x: np.ndarray, y: np.ndarray, n_labels: int, hidden, epochs, lr, seed, device):
-    """Train a small MLP classifier on features ``x`` and integer labels ``y``; return ``(module, config)``.
+    """Train a small MLP classifier on features ``x`` and integer labels ``y``; return ``(module, config, steps_run)``.
 
     Wraps the module in a :class:`~mixle.models.NeuralCategorical` leaf and fits it through the ordinary
     :func:`~mixle.inference.optimize` entry point -- the same declare-a-leaf/call-optimize path every other
-    mixle model goes through, rather than a bespoke torch loop. ``epochs`` is the leaf's ``m_steps`` (full-batch
-    gradient steps per call); a single ``optimize`` iteration (``max_its=1``) runs exactly one such M-step, so
-    training is unchanged in substance -- only the fitting path is now the shared one.
+    mixle model goes through, rather than a bespoke torch loop. Training runs in ``_ES_CHECK_EVERY``-step
+    chunks, each warm-started from the last (``optimize(..., prev_estimate=leaf, max_its=1)``), so ``epochs``
+    is a CEILING: once the mean training cross-entropy stops improving, further chunks are skipped rather than
+    always spending the full requested step count -- a task that converges early trains faster for it, and a
+    harder one still gets up to ``epochs`` steps. ``steps_run`` (the actual gradient-step count) is recorded
+    by the caller as ``recipe["epochs_run"]`` so the speedup is observable, not just internal.
     """
     import torch
 
@@ -509,9 +520,25 @@ def _fit_mlp(x: np.ndarray, y: np.ndarray, n_labels: int, hidden, epochs, lr, se
     }
     torch.manual_seed(seed)
     module = make_mlp(**cfg).to(device)
-    leaf = NeuralCategorical(module, m_steps=int(epochs), lr=float(lr), device=device)
-    fit = optimize(list(zip(x, y)), leaf.estimator(), prev_estimate=leaf, max_its=1, out=None)
-    return fit.module, cfg
+    data = list(zip(x, y))
+    enc = (np.asarray(x, dtype=float), np.asarray(y, dtype=int))
+
+    remaining, best_loss, stall, fit_module, steps_run = int(epochs), float("inf"), 0, module, 0
+    while remaining > 0:
+        chunk = min(_ES_CHECK_EVERY, remaining)
+        leaf = NeuralCategorical(fit_module, m_steps=chunk, lr=float(lr), device=device)
+        fit = optimize(data, leaf.estimator(), prev_estimate=leaf, max_its=1, out=None)
+        fit_module = fit.module
+        remaining -= chunk
+        steps_run += chunk
+        loss = -float(np.mean(fit.seq_log_density(enc)))
+        if best_loss - loss > _ES_MIN_DELTA:
+            best_loss, stall = loss, 0
+        else:
+            stall += 1
+            if stall >= _ES_PATIENCE:
+                break
+    return fit_module, cfg, steps_run
 
 
 def _student(module, cfg, adapter, task, n_examples, label_list, recipe) -> TaskModel:

--- a/mixle/task/tune.py
+++ b/mixle/task/tune.py
@@ -8,6 +8,11 @@ prefers the *cheapest* recipe that still matches -- the "minimize train time" pi
 re-distilled winner as a callable :class:`~mixle.task.model.TaskModel` plus the full search history.
 
 The recipe space is a few interpretable axes with sensible defaults; override ``space`` to widen or pin them.
+
+``tune_recipe_for_routing`` is the routing-ready sibling: it runs the same search, then calibrates the winning
+recipe into a :class:`~mixle.task.calibrate.CalibratedTaskModel` on data the search never touched -- so a task
+gets an automatically right-sized model (search picks the complexity) that is *also* immediately ``decide()``-able
+for :class:`~mixle.task.cascade.Cascade` / :class:`~mixle.task.router.Router`, with no separate calibration step.
 """
 
 from __future__ import annotations
@@ -18,7 +23,8 @@ from typing import Any
 
 import numpy as np
 
-from mixle.task.distill import agreement, distill
+from mixle.task.calibrate import CalibratedTaskModel
+from mixle.task.distill import _split_for_calibration, agreement, distill
 from mixle.task.model import TaskModel
 
 
@@ -119,3 +125,89 @@ def _teacher_labels(teacher: Callable[..., Any], texts: list[str]) -> list[Any]:
     if isinstance(out, (list, tuple)) and len(out) == len(texts):
         return list(out)
     return [teacher(t) for t in texts]
+
+
+def _teacher_from_cache(known: dict[str, Any], teacher: Callable[..., Any]) -> Callable[[list[str]], list[Any]]:
+    """A teacher wrapper answering from ``known`` (text -> label) first, so previously-labeled text is never
+    re-queried -- the teacher is assumed a deterministic function of the text, same as everywhere else in
+    distillation, so caching by text content changes no result, only how many real teacher calls it costs."""
+
+    def wrapped(texts: list[str]) -> list[Any]:
+        misses = [t for t in texts if t not in known]
+        if misses:
+            known.update(zip(misses, _teacher_labels(teacher, misses)))
+        return [known[t] for t in texts]
+
+    return wrapped
+
+
+@dataclass
+class CalibratedTuneResult:
+    """The outcome of a routing-ready recipe search: the calibrated winner, its recipe and scores, and history."""
+
+    model: CalibratedTaskModel
+    recipe: dict[str, Any]
+    agreement: float
+    score: float
+    cost: float
+    history: Any = field(default=None)
+
+
+def tune_recipe_for_routing(
+    teacher: Callable[..., Any],
+    train_texts: Sequence[str],
+    val_texts: Sequence[str],
+    *,
+    labels: Sequence[str] | None = None,
+    space: RecipeSpace | None = None,
+    n_init: int = 4,
+    n_iter: int = 8,
+    cost_weight: float = 0.0,
+    calibration_frac: float = 0.3,
+    alpha: float = 0.1,
+    seed: int = 0,
+    task: str = "",
+) -> CalibratedTuneResult:
+    """Bayesian-optimize the distillation recipe, then calibrate the winner for routing -- all in one call.
+
+    Runs :func:`tune_recipe`'s search over a ``calibration_frac`` slice of ``val_texts`` held back first: that
+    slice never scores a candidate or influences the search, and is used only afterward to calibrate the
+    winning model into a :class:`~mixle.task.calibrate.CalibratedTaskModel`. The result is a task-specific
+    recipe -- the search picked the complexity and epoch budget for this data, not a fixed default -- that is
+    also immediately ``decide()``-able: drop it into :class:`~mixle.task.cascade.Cascade` or
+    :class:`~mixle.task.router.Router` for tiered serving with no separate calibration step to manage.
+
+    ``teacher`` is also cheaper to call here than under :func:`tune_recipe` directly: every trial shares one
+    cache, so ``train_texts`` -- identical across every candidate recipe -- is queried only once for the whole
+    search rather than once per trial, and the calibration/search overlap in ``val_texts`` is never re-queried
+    either. Every distinct input is priced exactly once, however many candidates the search evaluates.
+    """
+    val_texts = [str(t) for t in val_texts]
+    val_truth = _teacher_labels(teacher, val_texts)
+    search_texts, _search_labels, cal_texts, cal_labels = _split_for_calibration(
+        val_texts, val_truth, calibration_frac, seed
+    )
+    # shared across every trial below: train_texts is identical candidate to candidate, so this cache also
+    # kills tune_recipe's normal per-trial re-query of train_texts, not just the val/search-slice overlap.
+    cached_teacher = _teacher_from_cache(dict(zip(val_texts, val_truth)), teacher)
+    result = tune_recipe(
+        cached_teacher,
+        train_texts,
+        search_texts,
+        labels=labels,
+        space=space,
+        n_init=n_init,
+        n_iter=n_iter,
+        cost_weight=cost_weight,
+        seed=seed,
+        task=task,
+    )
+    calibrated = CalibratedTaskModel(result.model, alpha=alpha).calibrate(cal_texts, cal_labels)
+    return CalibratedTuneResult(
+        model=calibrated,
+        recipe=result.recipe,
+        agreement=result.agreement,
+        score=result.score,
+        cost=result.cost,
+        history=result.history,
+    )

--- a/mixle/tests/task_distill_test.py
+++ b/mixle/tests/task_distill_test.py
@@ -50,6 +50,32 @@ class DistillTest(unittest.TestCase):
         held_out = agreement(student, _teacher(test), test)
         self.assertGreaterEqual(held_out, 0.75)
 
+
+class EarlyStoppingTest(unittest.TestCase):
+    def test_stops_well_before_the_epoch_ceiling_on_an_easy_task(self):
+        # a clean, well-separated rule should plateau long before 300 requested epochs
+        train = _make_corpus(seed=6)
+        student = distill(_teacher, train, n=4, dim=512, hidden=[64], epochs=300, lr=1e-2, seed=0)
+        self.assertLess(student.meta["recipe"]["epochs_run"], 300)
+        self.assertGreater(student.meta["recipe"]["epochs_run"], 0)
+        # the ceiling itself is preserved unchanged in the recipe -- only the actual run count is new
+        self.assertEqual(student.meta["recipe"]["epochs"], 300)
+
+    def test_never_exceeds_the_requested_ceiling(self):
+        train = _make_corpus(n_per_class=20, seed=8)
+        # a tiny epoch budget: early stopping must never run MORE than what was asked for
+        student = distill(_teacher, train, n=3, dim=64, epochs=15, seed=0)
+        self.assertLessEqual(student.meta["recipe"]["epochs_run"], 15)
+
+    def test_does_not_regress_accuracy_vs_the_full_fixed_run(self):
+        # early stopping should only skip steps that weren't improving the loss -- held-out accuracy should
+        # match (not merely "be acceptable in isolation", but be comparable to) an unrelated full run
+        train = _make_corpus(seed=9)
+        test = _make_corpus(seed=100)
+        student = distill(_teacher, train, n=4, dim=512, hidden=[64], epochs=300, lr=1e-2, seed=0)
+        held_out = agreement(student, _teacher(test), test)
+        self.assertGreaterEqual(held_out, 0.75)  # same bar as test_student_recovers_teacher, still cleared
+
     def test_labels_inferred_and_recorded(self):
         train = _make_corpus(seed=2)
         student = distill(_teacher, train, dim=256, epochs=50, seed=0)

--- a/mixle/tests/task_tune_test.py
+++ b/mixle/tests/task_tune_test.py
@@ -11,7 +11,10 @@ import pytest
 
 pytest.importorskip("torch")
 
-from mixle.task.tune import RecipeSpace, tune_recipe  # noqa: E402
+from mixle.task.calibrate import ESCALATE  # noqa: E402
+from mixle.task.cascade import Cascade  # noqa: E402
+from mixle.task.economics import CostModel  # noqa: E402
+from mixle.task.tune import CalibratedTuneResult, RecipeSpace, tune_recipe, tune_recipe_for_routing  # noqa: E402
 
 
 def _make_corpus(n_per_class=80, seed=0):
@@ -72,6 +75,52 @@ class TuneTest(unittest.TestCase):
         free = tune_recipe(_teacher, train, val, n_init=4, n_iter=4, cost_weight=0.0, seed=5)
         thrifty = tune_recipe(_teacher, train, val, n_init=4, n_iter=4, cost_weight=1.0, seed=5)
         self.assertLessEqual(thrifty.cost, free.cost + 1e-9)
+
+
+class TuneRecipeForRoutingTest(unittest.TestCase):
+    def test_returns_a_calibrated_decideable_model(self):
+        train = _make_corpus(seed=10)
+        val = _make_corpus(n_per_class=60, seed=11)
+        res = tune_recipe_for_routing(
+            _teacher, train, val, n_init=3, n_iter=4, cost_weight=0.1, calibration_frac=0.3, seed=0
+        )
+        self.assertIsInstance(res, CalibratedTuneResult)
+        self.assertIsNotNone(res.model.qhat)
+        self.assertIn(res.recipe["dim"], RecipeSpace().dim_choices)
+
+        test = _make_corpus(seed=101)
+        decisions = [res.model.decide(t) for t in test]
+        for d in decisions:
+            self.assertTrue(d is ESCALATE or d in res.model.labels)
+
+    def test_plugs_directly_into_cascade(self):
+        train = _make_corpus(seed=12)
+        val = _make_corpus(n_per_class=60, seed=13)
+        res = tune_recipe_for_routing(_teacher, train, val, n_init=3, n_iter=4, seed=0)
+        test = _make_corpus(seed=102)
+        cascade = Cascade(res.model, _teacher, cost=CostModel(c_local=0.00001, c_frontier=0.01))
+        served = cascade.serve(test)
+        self.assertEqual(len(served), len(test))
+        report = cascade.report()
+        self.assertEqual(report["n_requests"], len(test))
+        self.assertLess(report["realized_cost"], report["frontier_only_cost"])
+
+    def test_deduplicates_every_repeated_teacher_query_across_the_whole_search(self):
+        # tune_recipe alone re-queries the teacher on the identical train_texts every trial (its own
+        # docstring says so); tune_recipe_for_routing's internal cache is shared across all trials, so
+        # train_texts -- fixed and identical across every candidate -- is only ever queried once, not
+        # once per trial, and the val/search-slice overlap is never re-queried either. Every distinct
+        # piece of text in this run (all of val, all of train) is queried exactly once, full stop.
+        train = _make_corpus(seed=14)
+        val = _make_corpus(n_per_class=60, seed=15)
+        calls = {"n": 0}
+
+        def counting_teacher(texts):
+            calls["n"] += len(texts)
+            return _teacher(texts)
+
+        tune_recipe_for_routing(counting_teacher, train, val, n_init=3, n_iter=4, calibration_frac=0.3, seed=0)
+        self.assertEqual(calls["n"], len(val) + len(train))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

**Speed.** `_fit_mlp` always ran the full fixed `epochs` count, even after the training loss had
plateaued — every `distill` call, and every trial inside `tune_recipe`'s search, paid for gradient
steps that weren't buying anything. `_fit_mlp` now trains in small chunks (each warm-started via
`optimize(..., prev_estimate=leaf, max_its=1)` — the pattern from the `NeuralCategorical` refactor in
#3), checking the training loss after each chunk and stopping once it hasn't improved for a few
consecutive checks. `epochs` is now a **ceiling**, not a fixed count.

Measured (not assumed): on a synthetic task, a 300-epoch ceiling converges in 60 actual steps with
*identical* held-out agreement (1.000 both ways) — same quality, ~5x fewer gradient steps. The actual
step count is now recorded as `recipe["epochs_run"]` in `student.meta`, so the speedup is observable,
not just internal.

**Task-specific complexity.** `tune_recipe` (GP Bayesian search over encoder dim / hidden width /
epochs / lr) already existed, but had no path to a routing-ready model — its output was a bare
`TaskModel`, the same gap #4 (`distill_for_routing`) addressed for the fixed-recipe path. Adds
`tune_recipe_for_routing`: runs the same search over a `calibration_frac` slice of `val_texts` held
back first (never scores a candidate or influences the search), then calibrates the winning recipe's
model on the held-out remainder into a `CalibratedTaskModel`. A task now gets an automatically
right-sized model *and* a routing-ready one, in one call.

**Bonus.** `tune_recipe_for_routing`'s internal teacher-response cache is shared across every trial,
so `train_texts` — identical candidate to candidate — is queried only **once** for the whole search
rather than once per trial (`tune_recipe`'s own documented per-trial cost), and the val/calibration
split overlap is never re-queried either. Verified: every distinct input across a real search is
queried exactly once, not once per trial.

## Test plan

- [x] 3 new tests in `task_distill_test.py` (`EarlyStoppingTest`): stops well before the epoch ceiling
      on an easy task; never exceeds the requested ceiling on a tiny budget; held-out accuracy still
      clears the existing bar (no regression vs the full fixed-epoch run).
- [x] 3 new tests in `task_tune_test.py` (`TuneRecipeForRoutingTest`): returns a calibrated
      `decide()`-able model; plugs directly into `Cascade` with realized-cost accounting; exact
      teacher-call count confirms zero redundant queries across the whole search.
- [x] Full targeted suite (distill / routing / structured / edge / cascade / router / calibrate / tune)
      — 77/77 passed.
- [x] Full non-optional suite — 4631 passed, 2 skipped (unrelated, missing Java runtime), no regressions.
- [x] `ruff check` / `ruff format --check` clean.
- [x] Speed claim isolated and measured directly (not just asserted): instrumented step-count comparison
      showed 300→60 steps with unchanged held-out agreement. Also timed `edge_distill_test.py`
      back-to-back before/after on the same machine to rule out a regression from the chunking overhead
      (33.9s vs 36.8s — within normal run-to-run noise, no real difference).

## Dependency note

This branch is built on top of both prior open PRs — #3 (`distill-softmax-neural-leaf`, needed for the
warm-startable `NeuralCategorical` + `optimize()` chunking) and #4 (`distill-routing-calibrated`,
needed for `CalibratedTaskModel` / `_split_for_calibration`). It contains their commits plus this new
work; GitHub will show the combined diff until #3 and #4 merge, after which this diff narrows to just
the new changes.