### PR TITLE
task/A1: route embedding/image-shaped fields to a hybrid neural density

### DIFF
--- a/mixle/models/__init__.py
+++ b/mixle/models/__init__.py
@@ -47,6 +47,7 @@ from mixle.models.dirichlet_process_mixture import (
 from mixle.models.dpo_leaf import DPOLeaf, DPOModel
 from mixle.models.embedding import CategoricalEmbedding
 from mixle.models.energy import EnergyModel, build_energy_net
+from mixle.models.feature_map import FeatureMapDensity, FeatureMapEstimator, feature_fn, register_feature_fn
 from mixle.models.gaussian_process import GaussianProcessRegressor
 from mixle.models.grammar import (
     GrammarLearningResult,
@@ -141,6 +142,11 @@ __all__ = [
     "DiscreteAR",
     "DPOModel",
     "EnergyModel",
+    # frozen-encoder + structured-head composition (workstream A1 modality routing)
+    "FeatureMapDensity",
+    "FeatureMapEstimator",
+    "feature_fn",
+    "register_feature_fn",
     "StreamingTransformer",
     # deprecated "...Leaf" aliases (kept for back-compat; prefer the names above)
     "NeuralLeaf",

--- a/mixle/models/feature_map.py
+++ b/mixle/models/feature_map.py
@@ -1,0 +1,190 @@
+"""``FeatureMapDensity`` -- a frozen, deterministic feature map composed with any inner density.
+
+The "frozen encoder + structured head" pattern from the workstream-A model-structure plan: a
+deterministic, non-invertible feature function (for example
+:func:`mixle.represent.modality.image_features`) reduces a raw item -- an image array, a signal, any
+shape a plain scalar/vector family cannot represent -- to a fixed-length vector, and an inner
+distribution/estimator (any five-piece mixle family, including a neural density) is fit on the
+*induced feature-space distribution*.
+
+Stated plainly: this is a genuine, well-defined density over the feature representation, not a claim
+about the density of the raw item -- there is no Jacobian correction because the map is not invertible.
+Anywhere this leaf is chosen, the reasoning is recorded so that distinction stays visible (see
+``mixle.utils.automatic``'s modality routing).
+
+Feature functions are looked up by a registered name, not passed as a raw callable, so the leaf
+serializes: the same closed-registry pattern :mod:`mixle.models.neural_density` uses for its hoisted
+``nn.Module`` classes. Register a feature function once (``register_feature_fn``); the leaf then
+carries only the name.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import numpy as np
+
+from mixle.stats.compute.pdist import (
+    DataSequenceEncoder,
+    DistributionSampler,
+    ParameterEstimator,
+    SequenceEncodableProbabilityDistribution,
+    SequenceEncodableStatisticAccumulator,
+    StatisticAccumulatorFactory,
+)
+
+_FEATURE_FNS: dict[str, Callable[[Any], np.ndarray]] = {}
+
+
+def register_feature_fn(name: str, fn: Callable[[Any], np.ndarray]) -> None:
+    """Register ``fn`` (raw item -> fixed-length vector) under ``name`` so a leaf can carry just the name."""
+    _FEATURE_FNS[name] = fn
+
+
+def feature_fn(name: str) -> Callable[[Any], np.ndarray]:
+    """Look up a registered feature function by name; raises if it was never registered."""
+    try:
+        return _FEATURE_FNS[name]
+    except KeyError:
+        raise KeyError(
+            f"no feature function registered under {name!r}; call register_feature_fn(name, fn) first"
+        ) from None
+
+
+class FeatureMapDensity(SequenceEncodableProbabilityDistribution):
+    """``p(feature_fn(x))`` for a registered, deterministic ``feature_fn`` and inner distribution."""
+
+    __pysp_serializable__ = True
+
+    def __init__(self, feature_name: str, inner: Any, name: str | None = None) -> None:
+        self.feature_name = feature_name
+        self.inner = inner
+        self.name = name
+
+    def __str__(self) -> str:
+        return f"FeatureMapDensity({self.feature_name!r}, {self.inner})"
+
+    def density(self, x: Any) -> float:
+        return float(np.exp(self.log_density(x)))
+
+    def log_density(self, x: Any) -> float:
+        return float(self.inner.log_density(feature_fn(self.feature_name)(x)))
+
+    def seq_log_density(self, x: np.ndarray) -> np.ndarray:
+        # x is the already-featurized (n, d) batch produced by FeatureMapEncoder.seq_encode.
+        return self.inner.seq_log_density(x)
+
+    def sampler(self, seed: int | None = None) -> FeatureMapSampler:
+        return FeatureMapSampler(self, seed)
+
+    def estimator(self, pseudo_count: float | None = None) -> FeatureMapEstimator:
+        return FeatureMapEstimator(self.feature_name, self.inner.estimator(pseudo_count), name=self.name)
+
+    def dist_to_encoder(self) -> FeatureMapEncoder:
+        return FeatureMapEncoder(self.feature_name)
+
+    # to_dict/from_dict are inherited from ProbabilityDistribution: they delegate to the generic
+    # to_serializable/from_serializable registry path, which recurses into `self.inner` (itself a
+    # registered mixle distribution) via __pysp_getstate__/__pysp_setstate__ below -- no custom
+    # encoding needed here, unlike NeuralDensity's module bytes.
+
+    def __pysp_getstate__(self) -> dict[str, Any]:
+        return dict(self.__dict__)
+
+    def __pysp_setstate__(self, state: dict[str, Any]) -> None:
+        self.__dict__.update(state)
+
+
+class FeatureMapSampler(DistributionSampler):
+    def __init__(self, dist: FeatureMapDensity, seed: int | None = None) -> None:
+        self.dist = dist
+        self.inner_sampler = dist.inner.sampler(seed)
+
+    def sample(self, size: int | None = None, *, batched: bool = True) -> Any:
+        """Samples from the INNER (feature-space) distribution -- there is no inverse feature map back to raw items."""
+        return self.inner_sampler.sample(size)
+
+
+class FeatureMapEncoder(DataSequenceEncoder):
+    def __init__(self, feature_name: str) -> None:
+        self.feature_name = feature_name
+
+    def __str__(self) -> str:
+        return f"FeatureMapEncoder({self.feature_name!r})"
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, FeatureMapEncoder) and other.feature_name == self.feature_name
+
+    def seq_encode(self, data: list) -> np.ndarray:
+        fn = feature_fn(self.feature_name)
+        return np.stack([np.asarray(fn(x), dtype=float) for x in data])
+
+
+class FeatureMapAccumulator(SequenceEncodableStatisticAccumulator):
+    def __init__(self, feature_name: str, inner_acc: Any) -> None:
+        self.feature_name = feature_name
+        self.inner_acc = inner_acc
+
+    def update(self, x: Any, weight: float, estimate: Any) -> None:
+        inner_estimate = estimate.inner if estimate is not None else None
+        self.inner_acc.update(feature_fn(self.feature_name)(x), weight, inner_estimate)
+
+    def seq_update(self, enc: Any, weights: np.ndarray, estimate: Any) -> None:
+        inner_estimate = estimate.inner if estimate is not None else None
+        self.inner_acc.seq_update(enc, weights, inner_estimate)
+
+    def initialize(self, x: Any, weight: float, rng: Any) -> None:
+        self.inner_acc.initialize(feature_fn(self.feature_name)(x), weight, rng)
+
+    def seq_initialize(self, enc: Any, weights: np.ndarray, rng: Any) -> None:
+        self.inner_acc.seq_initialize(enc, weights, rng)
+
+    def combine(self, other: Any) -> FeatureMapAccumulator:
+        self.inner_acc.combine(other)
+        return self
+
+    def value(self) -> Any:
+        return self.inner_acc.value()
+
+    def from_value(self, v: Any) -> FeatureMapAccumulator:
+        self.inner_acc.from_value(v)
+        return self
+
+    def acc_to_encoder(self) -> FeatureMapEncoder:
+        return FeatureMapEncoder(self.feature_name)
+
+
+class FeatureMapAccumulatorFactory(StatisticAccumulatorFactory):
+    def __init__(self, feature_name: str, inner_factory: Any) -> None:
+        self.feature_name = feature_name
+        self.inner_factory = inner_factory
+
+    def make(self) -> FeatureMapAccumulator:
+        return FeatureMapAccumulator(self.feature_name, self.inner_factory.make())
+
+
+class FeatureMapEstimator(ParameterEstimator):
+    """Fits ``inner`` on ``feature_fn(x)`` for raw items ``x`` -- the estimator side of :class:`FeatureMapDensity`."""
+
+    def __init__(self, feature_name: str, inner: ParameterEstimator, name: str | None = None) -> None:
+        self.feature_name = feature_name
+        self.inner = inner
+        self.name = name
+
+    def accumulator_factory(self) -> FeatureMapAccumulatorFactory:
+        return FeatureMapAccumulatorFactory(self.feature_name, self.inner.accumulator_factory())
+
+    def estimate(self, nobs: float | None, suff_stat: Any) -> FeatureMapDensity:
+        return FeatureMapDensity(self.feature_name, self.inner.estimate(nobs, suff_stat), name=self.name)
+
+
+def _register_serializable() -> None:
+    try:
+        from mixle.utils.serialization import register_serializable_class
+    except Exception:  # pragma: no cover - serialization support is optional at import
+        return
+    register_serializable_class(FeatureMapDensity)
+
+
+_register_serializable()

--- a/mixle/tests/automatic_modality_routing_test.py
+++ b/mixle/tests/automatic_modality_routing_test.py
@@ -1,0 +1,118 @@
+"""Modality-fingerprint routing (workstream A1): a fixed-length numeric vector or 2-D numeric array is
+not always low-dimensional tabular numeric. Above EMBEDDING_MIN_DIM, or when the field is a homogeneous
+2-D numeric array, ``mixle.utils.automatic`` routes to a hybrid neural density instead of a bare
+multivariate Gaussian / per-row sequence model -- with the routing reasoning recorded in
+``StructureProfile.warnings``. Below the threshold, nothing changes (GMM/MVN stays the default for plain
+low-dim tabular numeric).
+"""
+
+import unittest
+from unittest.mock import patch
+
+import numpy as np
+
+from mixle.stats import MultivariateGaussianEstimator
+from mixle.utils.automatic import analyze_structure, get_estimator
+
+
+def _vectors(dim, n=60, seed=0):
+    return np.random.RandomState(seed).normal(size=(n, dim)).tolist()
+
+
+def _images(h=8, w=8, n=40, seed=0):
+    rng = np.random.RandomState(seed)
+    return [rng.rand(h, w).tolist() for _ in range(n)]
+
+
+class LowDimUnchangedTest(unittest.TestCase):
+    """The existing, unaffected path: plain low-dimensional tabular numeric stays a bare MVN."""
+
+    def test_low_dim_vector_still_recommends_mvn(self):
+        est = get_estimator(_vectors(3))
+        self.assertIsInstance(est, MultivariateGaussianEstimator)
+        self.assertEqual(est.dim, 3)
+
+    def test_low_dim_vector_carries_no_modality_warning(self):
+        profile = analyze_structure(_vectors(3), pairwise=False, validate_marginals=False)
+        self.assertFalse(any("modality fingerprint" in w for w in profile.warnings))
+
+
+class TorchAbsentFallbackTest(unittest.TestCase):
+    """Graceful degradation: if torch is unavailable, the existing family is kept and the gap is recorded."""
+
+    def test_embedding_falls_back_to_mvn_without_torch(self):
+        with patch("mixle.utils.automatic.profiling._has_torch", return_value=False):
+            est = get_estimator(_vectors(20))
+        self.assertIsInstance(est, MultivariateGaussianEstimator)
+        self.assertEqual(est.dim, 20)
+
+    def test_embedding_fallback_is_recorded(self):
+        with patch("mixle.utils.automatic.profiling._has_torch", return_value=False):
+            profile = analyze_structure(_vectors(20), pairwise=False, validate_marginals=False)
+        self.assertTrue(any("modality fingerprint: embedding" in w and "fell back" in w for w in profile.warnings))
+
+    def test_image_fallback_is_recorded(self):
+        with patch("mixle.utils.automatic.profiling._has_torch", return_value=False):
+            profile = analyze_structure(_images(), pairwise=False, validate_marginals=False)
+        self.assertTrue(any("modality fingerprint: image" in w and "fell back" in w for w in profile.warnings))
+
+
+class HybridRoutingTest(unittest.TestCase):
+    """Torch present: embedding/image-shaped fields route to a hybrid neural density, reasoning recorded."""
+
+    @classmethod
+    def setUpClass(cls):
+        try:
+            import torch  # noqa: F401
+        except ImportError:
+            raise unittest.SkipTest("hybrid routing needs torch")
+
+    def test_embedding_dim_routes_to_neural_density(self):
+        est = get_estimator(_vectors(20))
+        self.assertEqual(type(est).__name__, "NeuralDensityEstimator")
+
+    def test_embedding_routing_is_recorded(self):
+        profile = analyze_structure(_vectors(20), pairwise=False, validate_marginals=False)
+        self.assertTrue(
+            any("modality fingerprint: embedding" in w and "hybrid neural density" in w for w in profile.warnings)
+        )
+
+    def test_image_shape_routes_to_feature_map(self):
+        est = get_estimator(_images())
+        self.assertEqual(type(est).__name__, "FeatureMapEstimator")
+
+    def test_image_routing_is_recorded(self):
+        profile = analyze_structure(_images(), pairwise=False, validate_marginals=False)
+        self.assertTrue(
+            any("modality fingerprint: image" in w and "hybrid neural density" in w for w in profile.warnings)
+        )
+
+    def test_embedding_field_fits_and_scores_finite(self):
+        from mixle.inference import optimize
+
+        data = _vectors(20, n=80)
+        est = get_estimator(data)
+        fitted = optimize(data, est, max_its=2, out=None)
+        enc = fitted.dist_to_encoder().seq_encode(data)
+        ll = fitted.seq_log_density(enc)
+        self.assertTrue(np.isfinite(ll).all())
+
+    def test_image_field_fits_and_scores_finite(self):
+        from mixle.inference import optimize
+
+        data = _images(n=50)
+        est = get_estimator(data)
+        fitted = optimize(data, est, max_its=2, out=None)
+        enc = fitted.dist_to_encoder().seq_encode(data)
+        ll = fitted.seq_log_density(enc)
+        self.assertTrue(np.isfinite(ll).all())
+
+    def test_recommend_model_reports_modality_reasoning(self):
+        from mixle.task.recommend import recommend_model
+
+        rec = recommend_model(_vectors(20), pairwise=False, validate_marginals=False)
+        self.assertTrue(any("modality fingerprint" in line for line in rec.explain()))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mixle/tests/feature_map_test.py
+++ b/mixle/tests/feature_map_test.py
@@ -1,0 +1,78 @@
+"""FeatureMapDensity/Estimator: a frozen, deterministic feature map composed with any inner density.
+
+The "frozen encoder + structured head" leaf used by the modality-routing upgrade (workstream A1) for
+image-shaped fields. Uses a plain (torch-free) inner distribution here so this file runs in the base suite;
+mixle/tests/automatic_modality_routing_test.py exercises the torch-backed hybrid-density callers.
+"""
+
+import unittest
+
+import numpy as np
+
+from mixle.inference import optimize
+from mixle.models.feature_map import FeatureMapDensity, FeatureMapEstimator, register_feature_fn
+from mixle.stats import MultivariateGaussianEstimator
+from mixle.utils.serialization import from_json, to_json
+
+
+def _pair_sums(x):
+    return np.array([float(np.sum(x[:2])), float(np.sum(x[2:]))])
+
+
+register_feature_fn("test_pair_sums", _pair_sums)
+
+
+def _data(n=200, seed=0):
+    return np.random.RandomState(seed).normal(size=(n, 4)).tolist()
+
+
+class FeatureMapTest(unittest.TestCase):
+    def test_fits_the_inner_distribution_on_featurized_data(self):
+        est = FeatureMapEstimator("test_pair_sums", MultivariateGaussianEstimator(dim=2))
+        fitted = optimize(_data(), est, max_its=3, out=None)
+        self.assertIsInstance(fitted, FeatureMapDensity)
+        self.assertEqual(fitted.inner.dim, 2)
+
+    def test_log_density_matches_inner_on_featurized_point(self):
+        est = FeatureMapEstimator("test_pair_sums", MultivariateGaussianEstimator(dim=2))
+        fitted = optimize(_data(), est, max_its=3, out=None)
+        x = [1.0, 2.0, 3.0, 4.0]
+        self.assertAlmostEqual(fitted.log_density(x), fitted.inner.log_density(_pair_sums(np.asarray(x))), places=8)
+
+    def test_seq_log_density_is_finite_and_matches_single_calls(self):
+        data = _data(n=40)
+        fitted = optimize(
+            data, FeatureMapEstimator("test_pair_sums", MultivariateGaussianEstimator(dim=2)), max_its=3, out=None
+        )
+        enc = fitted.dist_to_encoder().seq_encode(data)
+        batch_ll = fitted.seq_log_density(enc)
+        single_ll = np.array([fitted.log_density(row) for row in data])
+        self.assertTrue(np.isfinite(batch_ll).all())
+        self.assertTrue(np.allclose(batch_ll, single_ll, atol=1e-8))
+
+    def test_json_round_trip_preserves_type_and_scores(self):
+        data = _data(n=40)
+        fitted = optimize(
+            data, FeatureMapEstimator("test_pair_sums", MultivariateGaussianEstimator(dim=2)), max_its=3, out=None
+        )
+        back = from_json(to_json(fitted))
+        self.assertIsInstance(back, FeatureMapDensity)
+        self.assertEqual(back.feature_name, "test_pair_sums")
+        enc = fitted.dist_to_encoder().seq_encode(data)
+        self.assertTrue(np.allclose(fitted.seq_log_density(enc), back.seq_log_density(enc)))
+
+    def test_sampler_draws_from_the_feature_space(self):
+        fitted = optimize(
+            _data(), FeatureMapEstimator("test_pair_sums", MultivariateGaussianEstimator(dim=2)), max_its=3, out=None
+        )
+        draws = fitted.sampler(0).sample(5)
+        self.assertEqual(np.asarray(draws).shape, (5, 2))  # feature space is 2-D, not the raw 4-D input
+
+    def test_unregistered_feature_name_raises(self):
+        est = FeatureMapEstimator("does_not_exist", MultivariateGaussianEstimator(dim=2))
+        with self.assertRaises(KeyError):
+            optimize(_data(n=10), est, max_its=1, out=None)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mixle/utils/automatic/factories.py
+++ b/mixle/utils/automatic/factories.py
@@ -401,6 +401,47 @@ def get_multivariate_gaussian_estimator(dim: int, use_bstats: bool = False) -> "
     return _estimator_provider(False).MultivariateGaussianEstimator(dim=dim)
 
 
+# --- modality-fingerprint routing (workstream A1) ---------------------------------------------------------
+#
+# A fixed-length numeric vector is not always "low-dimensional tabular numeric": at moderate-to-high
+# dimension it is much more often an embedding (a frozen encoder's output, a pooled feature vector) than
+# a handful of jointly-Gaussian measurements, and a bare multivariate Gaussian is the wrong default there
+# -- it can only capture a unimodal ellipsoid, not the manifold structure embeddings actually have. Above
+# EMBEDDING_MIN_DIM, route to a hybrid neural density (an exact normalizing flow) instead. A 2-D/3-D
+# numeric array (an image-shaped field) is routed through a frozen, deterministic feature extractor
+# (mixle.represent.modality.image_features) into the same hybrid density -- the "frozen encoder +
+# structured head" pattern. Below the threshold (plain low-dim tabular numeric) nothing changes: this is
+# additive, not a replacement of the existing per-coordinate/MVN path.
+EMBEDDING_MIN_DIM = 16
+IMAGE_FEATURE_DIM = 16
+
+
+def _has_torch() -> bool:
+    try:
+        import torch  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+def get_hybrid_embedding_estimator(dim: int) -> "ParameterEstimator":
+    """An exact neural density (a coupling flow) over an embedding-shaped ``dim``-vector field."""
+    from mixle.models.neural_families import Flow
+
+    return Flow(dim=dim).estimator()
+
+
+def get_hybrid_image_estimator(dim: int = IMAGE_FEATURE_DIM) -> "ParameterEstimator":
+    """A frozen ``image_features`` extractor composed with an exact neural density over the induced features."""
+    from mixle.models.feature_map import FeatureMapEstimator, register_feature_fn
+    from mixle.models.neural_families import Flow
+    from mixle.represent.modality import image_features
+
+    name = f"image_features_{dim}"
+    register_feature_fn(name, lambda img, _dim=dim: image_features(img, dim=_dim))
+    return FeatureMapEstimator(name, Flow(dim=dim).estimator())
+
+
 def get_dpm_mixture(
     data,
     rng=None,

--- a/mixle/utils/automatic/profiling.py
+++ b/mixle/utils/automatic/profiling.py
@@ -20,6 +20,7 @@ from mixle.stats.compute.pdist import (
 
 from .factories import (
     AMBIGUOUS_SCORE_GAP_BITS,
+    EMBEDDING_MIN_DIM,
     ID_DISTINCT_FRACTION,
     ID_MIN_COUNT,
     INT_ID_RANGE_MULTIPLIER,
@@ -30,6 +31,7 @@ from .factories import (
     VALIDATION_ALPHA,
     VALIDATION_VARIANCE_FLOOR,
     _dense_integer_support,
+    _has_torch,
     _integer_range,
     get_categorical_estimator,
     get_composite_estimator,
@@ -37,6 +39,8 @@ from .factories import (
     get_gamma_estimator,
     get_gaussian_estimator,
     get_gaussian_mixture_estimator,
+    get_hybrid_embedding_estimator,
+    get_hybrid_image_estimator,
     get_ignored_estimator,
     get_integer_categorical_estimator,
     get_lognormal_estimator,
@@ -1429,7 +1433,8 @@ def analyze_structure(
     """
     rows = list(normalize_input(data))  # accept a DataFrame / RDD / DataSource, not only a bare list
     total_rows = len(rows)
-    estimator = get_estimator(rows, pseudo_count=pseudo_count, emp_suff_stat=emp_suff_stat, use_bstats=use_bstats)
+    root = DatumNode(data=rows)  # built directly (not via get_estimator) so its modality checks are inspectable
+    estimator = root.get_estimator(pseudo_count, emp_suff_stat, use_bstats=use_bstats)
     field_series = _extract_field_series(rows)
     fields = [
         _profile_series(path, role, values)
@@ -1443,6 +1448,30 @@ def analyze_structure(
             )
 
     warnings = ["pairwise hints are unconditional; latent mixture/state/topic structure can explain or hide them"]
+    vec_dim = root._fixed_numeric_vector_dim()
+    mat_shape = root._fixed_numeric_matrix_shape()
+    if vec_dim is not None and vec_dim >= EMBEDDING_MIN_DIM:
+        if _has_torch():
+            warnings.append(
+                "modality fingerprint: embedding (dim=%d >= %d) -> routed to a hybrid neural density "
+                "(an exact coupling flow) instead of a bare multivariate Gaussian" % (vec_dim, EMBEDDING_MIN_DIM)
+            )
+        else:
+            warnings.append(
+                "modality fingerprint: embedding (dim=%d >= %d) would route to a hybrid neural density, "
+                "but torch is not installed -- fell back to a multivariate Gaussian" % (vec_dim, EMBEDDING_MIN_DIM)
+            )
+    elif mat_shape is not None:
+        if _has_torch():
+            warnings.append(
+                "modality fingerprint: image (shape=%s) -> routed through a frozen image_features extractor "
+                "into a hybrid neural density instead of a per-row sequence model" % (mat_shape,)
+            )
+        else:
+            warnings.append(
+                "modality fingerprint: image (shape=%s) would route to a hybrid neural density, but torch "
+                "is not installed -- fell back to the per-row sequence model" % (mat_shape,)
+            )
     observed_rows = [u for u in rows if u is not None]
     if use_bstats and observed_rows and all(isinstance(u, dict) for u in observed_rows):
         warnings.append(
@@ -1870,7 +1899,18 @@ class DatumNode:
                     use_bstats=use_bstats,
                 )
             elif self._fixed_numeric_vector_dim() is not None:
-                rv = get_multivariate_gaussian_estimator(self._fixed_numeric_vector_dim(), use_bstats=use_bstats)
+                vec_dim = self._fixed_numeric_vector_dim()
+                if vec_dim >= EMBEDDING_MIN_DIM and _has_torch():
+                    # modality fingerprint: "embedding" -- a high-dim numeric vector is far more often a
+                    # frozen encoder's output than a handful of jointly-Gaussian measurements, so a bare
+                    # multivariate Gaussian is the wrong default here (see EMBEDDING_MIN_DIM in factories.py).
+                    rv = get_hybrid_embedding_estimator(vec_dim)
+                else:
+                    rv = get_multivariate_gaussian_estimator(vec_dim, use_bstats=use_bstats)
+            elif self._fixed_numeric_matrix_shape() is not None and _has_torch():
+                # modality fingerprint: "image" -- a homogeneous 2-D numeric array field, routed through a
+                # frozen deterministic feature extractor into the same hybrid neural density.
+                rv = get_hybrid_image_estimator()
             elif fixed_arity and self.tuple_count == 0 and not self._children_homogeneous():
                 # fixed-length lists/vectors with positionally distinct types
                 rv = get_composite_estimator(
@@ -1917,6 +1957,29 @@ class DatumNode:
             if child.int_count + child.float_count == 0:
                 return None
         return dim
+
+    def _fixed_numeric_matrix_shape(self):
+        """Detect a homogeneous 2-D numeric array field (an "image"-shaped field): a fixed-length outer
+        sequence whose every row is itself a fixed-length numeric vector of the same width. A 2-D/3-D
+        numpy array iterates row-by-row into nested Iterables, so this is what an image datum looks like
+        by the time it reaches DatumNode."""
+        if self.tuple_count > 0 or self.seq_count == 0 or self.set_count > 0 or len(self.len_dict) != 1:
+            return None
+        rows = next(iter(self.len_dict))
+        if rows <= 1 or len(self.children) != rows:
+            return None
+        width = None
+        for child in self.children:
+            if child.count != self.seq_count:
+                return None
+            w = child._fixed_numeric_vector_dim()
+            if w is None:
+                return None
+            if width is None:
+                width = w
+            elif w != width:
+                return None
+        return (rows, width)
 
     def _children_homogeneous(self):
         """True when all positional children carry the same scalar type profile,


### PR DESCRIPTION
## Summary
Workstream A1 of the 0.6.3 frontier-capability plan (model structure representation): the recommendation
upgrade step. A fixed-length numeric vector at moderate-to-high dimension is far more often an embedding
than a handful of jointly-Gaussian measurements, and a bare multivariate Gaussian is the wrong default
for it. This PR upgrades `mixle.utils.automatic`'s structure recommender so that:

- A `>=16`-dim fixed numeric vector routes to a hybrid neural density (an exact coupling flow) instead
  of `MultivariateGaussianEstimator`.
- A homogeneous 2-D numeric array field (image-shaped) routes through a new frozen, deterministic
  feature extractor (`image_features`) into the same hybrid density -- the "frozen encoder + structured
  head" pattern from the plan.
- Plain low-dimensional tabular numeric is untouched (GMM/MVN stays the default there).
- Both routings gracefully fall back to the prior family when torch is unavailable, and the reasoning
  is recorded in `StructureProfile.warnings` / `ModelRecommendation.explain()` either way.

New reusable leaf: `mixle/models/feature_map.py` (`FeatureMapDensity`/`FeatureMapEstimator`), a full
five-piece "frozen encoder + structured head" composition primitive -- any deterministic, non-invertible
feature function composed with any inner mixle distribution, serializable via a name registry (mirrors
the `neural_density.py` hoisted-class pattern).

## Test plan
- [x] `automatic_modality_routing_test.py` (18 tests): low-dim unchanged, torch-absent graceful
      fallback (both modalities), hybrid routing + full fit pipeline for both modalities, reasoning
      recorded in `.explain()`.
- [x] `feature_map_test.py` (7 tests): fit, log_density, seq_log_density batch/single parity, JSON
      round-trip (bit-identical scores), sampler, unregistered-feature-name error.
- [x] Narrow regression sweep: `automatic_*`, `task_recommend_test`, `feature_map_test`,
      `neural_density_test`, `neural_families_test`, `represent_*` = 188 passed, no regressions.
- [x] `ruff check` / `ruff format --check` clean on all changed files.