### PR TITLE
task/H1: exact decision-margin ledger + fix mixture correction term in explain()

### DIFF
--- a/mixle/inference/__init__.py
+++ b/mixle/inference/__init__.py
@@ -94,7 +94,7 @@ from mixle.inference.event_study import (
     poisson_lograte_effect,
     tipping_drift,
 )
-from mixle.inference.explain import Explanation, explain
+from mixle.inference.explain import Explanation, explain, explain_margin, explain_margin_mixture
 from mixle.inference.fisher import FisherView, FixedFisherView, to_fisher
 from mixle.inference.forecast import Forecast, forecast
 
@@ -311,6 +311,8 @@ from mixle.stats.compute.sequence import estimate, initialize, seq_estimate, seq
 __all__ = [
     "Explanation",
     "explain",
+    "explain_margin",
+    "explain_margin_mixture",
     "InterventionalNetwork",
     "average_causal_effect",
     "counterfactual",

--- a/mixle/inference/explain.py
+++ b/mixle/inference/explain.py
@@ -1,11 +1,18 @@
-"""``explain`` -- exact per-part attribution of a model's score for one observation.
+"""``explain`` -- exact per-part attribution of a model's score for one observation, and
+``explain_margin``/``explain_margin_mixture`` -- exact per-part attribution of a DECISION MARGIN between
+two named hypotheses (workstream H1 of the 0.6.3 frontier-capability plan: the answer-with-receipts
+evidence ledger).
 
 Because mixle models are *generative and structured*, a prediction's score decomposes exactly — no
 surrogate models, no sampling approximations:
 
   * a Composite / Record factorizes over fields:      ``log p(x) = sum_i log p_i(x_i)``
   * a learned Bayesian network factorizes over nodes: ``log p(x) = sum_i log P(x_i | parents)``
-  * a Mixture adds the latent view: per-component responsibilities, then the winner's field breakdown.
+  * a Mixture adds the latent view: per-component responsibilities, then the winner's field breakdown
+    -- PLUS an explicit ``correction`` term for the logsumexp normalizer, since a mixture's total
+    log-density is not a sum of any single component's parts (the one place these structures are not
+    purely additive). The ledger always satisfies ``sum(v for _, v in parts) + correction == total``
+    to machine precision -- that identity is the point, not an approximation of it.
 
 ``explain(model, x)`` returns those parts with their exact log-likelihood contributions, sorted so the
 most *suspicious* part (lowest contribution) is first — "WHICH field makes this record unlikely" is read
@@ -14,7 +21,20 @@ straight off the model rather than estimated::
     ex = explain(model, record)
     ex.parts             # [(name, log-contribution), ...] ascending (most anomalous first)
     ex.total             # == model.log_density(record), exactly
+    ex.correction         # 0 for Composite/BN (purely additive); the logsumexp residual for Mixture
     ex.responsibilities  # mixtures: posterior over components
+
+``explain_margin(model, answer, runner_up)`` decomposes ``log p(answer) - log p(runner_up)`` -- the
+decision margin between two named hypotheses -- into the same kind of per-factor ledger:
+
+  * Composite / BN: ``answer``/``runner_up`` are two full candidate records; a field/factor that does not
+    differ between them contributes exactly 0, so a single corrupted field is visible as the one part
+    that does not collapse to 0.
+  * Mixture used as a generative classifier (``explain_margin_mixture``): ``answer``/``runner_up`` are
+    component indices (e.g. class labels) at the SAME observed ``x``; the margin is
+    ``(log_w[a] + log p_a(x)) - (log_w[b] + log p_b(x))`` -- the mixture's logsumexp normalizer cancels
+    EXACTLY in this subtraction, so the margin ledger needs no correction term (it is computed and
+    asserted at 0.0, not assumed).
 """
 
 from __future__ import annotations
@@ -27,15 +47,29 @@ import numpy as np
 
 @dataclass
 class Explanation:
-    """Exact additive attribution of ``log p(x)`` (plus the latent posterior for mixtures)."""
+    """Exact additive attribution of a log-density (or a decision margin between two hypotheses).
+
+    ``correction`` is the explicitly named non-additive residual -- 0.0 for purely additive structures
+    (Composite, Bayesian network, and any margin comparison, since the normalizer cancels there); the
+    logsumexp term for a Mixture's absolute ``log p(x)``. ``sum(v for _, v in parts) + correction`` equals
+    ``total`` exactly, for every supported structure -- this is asserted to machine precision in tests.
+    """
 
     total: float
     parts: list[tuple[str, float]] = field(default_factory=list)
+    correction: float = 0.0
     responsibilities: np.ndarray | None = None
     component: int | None = None  # the most responsible component (mixtures)
 
     def most_anomalous(self, k: int = 3) -> list[tuple[str, float]]:
         return self.parts[: int(k)]
+
+    def ledger_sum(self) -> float:
+        """``sum(parts) + correction`` -- should equal ``total`` to machine precision; see class docstring."""
+        return float(sum(v for _, v in self.parts)) + self.correction
+
+    def is_exact(self, atol: float = 1e-9) -> bool:
+        return abs(self.ledger_sum() - self.total) <= atol
 
     def summary(self) -> str:
         lines = [f"log p(x) = {self.total:.3f}"]
@@ -43,11 +77,20 @@ class Explanation:
             probs = ", ".join(f"{p:.3f}" for p in self.responsibilities)
             lines.append(f"  component posterior: [{probs}] (component {self.component})")
         lines += [f"  {name}: {v:+.3f}" for name, v in self.parts]
+        if self.correction:
+            lines.append(f"  correction (logsumexp normalizer): {self.correction:+.3f}")
         return "\n".join(lines)
 
 
 def _composite_parts(dist: Any, x: Any, prefix: str = "field") -> list[tuple[str, float]]:
     return [(f"{prefix}[{i}]", float(d.log_density(xi))) for i, (d, xi) in enumerate(zip(dist.dists, x))]
+
+
+def _composite_margin_parts(dist: Any, answer: Any, runner_up: Any, prefix: str = "field") -> list[tuple[str, float]]:
+    return [
+        (f"{prefix}[{i}]", float(d.log_density(a_i)) - float(d.log_density(r_i)))
+        for i, (d, a_i, r_i) in enumerate(zip(dist.dists, answer, runner_up))
+    ]
 
 
 def explain(model: Any, x: Any) -> Explanation:
@@ -58,17 +101,26 @@ def explain(model: Any, x: Any) -> Explanation:
         total = float(sum(v for _, v in parts))
         return Explanation(total, sorted(parts, key=lambda p: p[1]))
 
-    # mixture: latent posterior, then the winning component's own breakdown when it is a composite
+    # mixture: latent posterior, then the winning component's own breakdown when it is a composite.
+    # The winner's raw (prior + field) score is NOT the mixture's true total (that is a logsumexp over
+    # every component) -- the gap is the explicit, named correction term, not an omission.
     if hasattr(model, "components") and hasattr(model, "posterior"):
         resp = np.asarray(model.posterior(x), dtype=np.float64).reshape(-1)
         winner = int(np.argmax(resp))
         comp = model.components[winner]
         if hasattr(comp, "dists"):
-            parts = _composite_parts(comp, x, prefix=f"component[{winner}].field")
+            field_parts = _composite_parts(comp, x, prefix=f"component[{winner}].field")
         else:
-            parts = [(f"component[{winner}]", float(comp.log_density(x)))]
+            field_parts = [(f"component[{winner}]", float(comp.log_density(x)))]
+        parts = [(f"component[{winner}].prior", float(model.log_w[winner])), *field_parts]
+        total = float(model.log_density(x))
+        correction = total - float(sum(v for _, v in parts))
         return Explanation(
-            float(model.log_density(x)), sorted(parts, key=lambda p: p[1]), responsibilities=resp, component=winner
+            total,
+            sorted(parts, key=lambda p: p[1]),
+            correction=correction,
+            responsibilities=resp,
+            component=winner,
         )
 
     # composite / record: one part per field, summing exactly to the total
@@ -77,3 +129,61 @@ def explain(model: Any, x: Any) -> Explanation:
         return Explanation(float(sum(v for _, v in parts)), sorted(parts, key=lambda p: p[1]))
 
     return Explanation(float(model.log_density(x)), [("model", float(model.log_density(x)))])
+
+
+def explain_margin(model: Any, answer: Any, runner_up: Any) -> Explanation:
+    """Exact per-part attribution of the decision margin ``log p(answer) - log p(runner_up)``.
+
+    ``answer``/``runner_up`` are two full candidate records for Composite/Bayesian-network models, so a
+    field that is identical between them contributes exactly 0 -- the diagnostic for a single corrupted
+    field. For a Mixture used as a generative classifier, use :func:`explain_margin_mixture` instead
+    (the margin there needs the observed point plus two component indices, not two full records).
+    """
+    if hasattr(model, "components") and hasattr(model, "log_w"):
+        raise TypeError(
+            "explain_margin needs two full candidate records; a Mixture's hypotheses are component "
+            "indices at one observed point -- call explain_margin_mixture(model, x, answer, runner_up)."
+        )
+
+    if hasattr(model, "factors") and hasattr(model, "order"):
+        parts = [
+            (
+                f"field[{f.child}]|parents{tuple(f.parents)}",
+                float(f.log_density(answer)) - float(f.log_density(runner_up)),
+            )
+            for f in model.factors
+        ]
+        total = float(model.log_density(answer)) - float(model.log_density(runner_up))
+        return Explanation(total, sorted(parts, key=lambda p: p[1]), correction=total - float(sum(v for _, v in parts)))
+
+    if hasattr(model, "dists"):
+        parts = _composite_margin_parts(model, answer, runner_up)
+        total = float(model.log_density(answer)) - float(model.log_density(runner_up))
+        return Explanation(total, sorted(parts, key=lambda p: p[1]), correction=total - float(sum(v for _, v in parts)))
+
+    total = float(model.log_density(answer)) - float(model.log_density(runner_up))
+    return Explanation(total, [("model", total)], correction=0.0)
+
+
+def explain_margin_mixture(model: Any, x: Any, answer: int, runner_up: int) -> Explanation:
+    """Exact per-part attribution of the decision margin between two Mixture components at one point ``x``.
+
+    ``answer``/``runner_up`` are component indices (e.g. class labels) of a Mixture used as a generative
+    classifier: the margin is ``(log_w[answer] + log p_answer(x)) - (log_w[runner_up] + log p_runner_up(x))``.
+    The mixture's logsumexp normalizer -- the same term :func:`explain` must name as a correction for the
+    absolute ``log p(x)`` -- cancels EXACTLY in this subtraction, so the margin ledger needs no correction
+    (computed and asserted at 0.0, not assumed away).
+    """
+    a_idx, r_idx = int(answer), int(runner_up)
+    ca, cr = model.components[a_idx], model.components[r_idx]
+    wa, wr = float(model.log_w[a_idx]), float(model.log_w[r_idx])
+    if hasattr(ca, "dists") and hasattr(cr, "dists"):
+        parts = [("prior", wa - wr)] + [
+            (f"field[{i}]", float(da.log_density(xi)) - float(dr.log_density(xi)))
+            for i, (da, dr, xi) in enumerate(zip(ca.dists, cr.dists, x))
+        ]
+    else:
+        parts = [("prior", wa - wr), ("component_density", float(ca.log_density(x)) - float(cr.log_density(x)))]
+    total = (wa + float(ca.log_density(x))) - (wr + float(cr.log_density(x)))
+    correction = total - float(sum(v for _, v in parts))
+    return Explanation(total, sorted(parts, key=lambda p: p[1]), correction=correction)

--- a/mixle/tests/explain_margin_test.py
+++ b/mixle/tests/explain_margin_test.py
@@ -1,0 +1,117 @@
+"""explain_margin() / explain_margin_mixture(): exact per-part attribution of a DECISION MARGIN --
+log p(answer) - log p(runner_up) -- between two named hypotheses (workstream H1 of the 0.6.3
+frontier-capability plan: the answer-with-receipts evidence ledger).
+
+The ledger must sum to the margin at machine precision on every supported structure, and a deliberately
+corrupted evidence field must be caught: its contribution is the one part that does not collapse to 0
+when every other field is identical between the two candidate records.
+"""
+
+import numpy as np
+import pytest
+
+from mixle.inference import explain_margin, explain_margin_mixture
+from mixle.inference.bayesian_network import HeterogeneousBayesianNetwork, _LinearGaussianFactor, _MarginalFactor
+from mixle.stats import (
+    CategoricalDistribution,
+    CompositeDistribution,
+    GaussianDistribution,
+    MixtureDistribution,
+)
+
+
+def _composite():
+    return CompositeDistribution(
+        (
+            CategoricalDistribution({"a": 0.9, "b": 0.1}),
+            GaussianDistribution(0.0, 1.0),
+            GaussianDistribution(5.0, 2.0),
+        )
+    )
+
+
+class CompositeMarginTest:
+    def test_margin_ledger_sums_exactly(self):
+        comp = _composite()
+        answer, runner_up = ("a", 0.2, 5.1), ("b", -0.3, 4.8)
+        ex = explain_margin(comp, answer, runner_up)
+        expected = comp.log_density(answer) - comp.log_density(runner_up)
+        np.testing.assert_allclose(ex.total, expected, atol=1e-12)
+        np.testing.assert_allclose(ex.ledger_sum(), ex.total, atol=1e-12)
+        assert ex.is_exact()
+        assert abs(ex.correction) < 1e-9  # Composite is purely additive -- no logsumexp anywhere
+
+    def test_corrupted_single_field_is_the_only_nonzero_contribution(self):
+        comp = _composite()
+        answer = ("a", 0.1, 5.2)
+        corrupted = ("a", 0.1, -50.0)  # only field[2] differs from `answer`
+        ex = explain_margin(comp, answer, corrupted)
+        by_name = dict(ex.parts)
+        assert by_name["field[0]"] == 0.0  # identical category -> exactly 0, not merely small
+        assert by_name["field[1]"] == 0.0  # identical Gaussian field -> exactly 0
+        assert abs(by_name["field[2]"]) > 100.0  # the corrupted field is the visible anomaly
+        assert ex.is_exact()
+
+
+class BayesianNetworkMarginTest:
+    def _net(self):
+        return HeterogeneousBayesianNetwork(
+            [
+                _MarginalFactor(0, GaussianDistribution(0.0, 1.0)),
+                _LinearGaussianFactor(1, [0], {}, np.array([2.0, 0.0]), 0.5),
+            ]
+        )
+
+    def test_margin_ledger_sums_exactly(self):
+        net = self._net()
+        answer, runner_up = (0.5, 1.1), (0.4, 0.9)
+        ex = explain_margin(net, answer, runner_up)
+        expected = net.log_density(answer) - net.log_density(runner_up)
+        np.testing.assert_allclose(ex.total, expected, atol=1e-12)
+        assert ex.is_exact()
+        assert abs(ex.correction) < 1e-9  # a BN factorization is purely additive -- no logsumexp
+
+    def test_corrupted_parent_flips_the_dependent_edge_contribution(self):
+        net = self._net()
+        answer = (0.5, 1.0)  # child ~= 2*parent, on-model
+        corrupted = (0.5, 20.0)  # only the child (an edge target) corrupted -> only the edge factor moves
+        ex = explain_margin(net, answer, corrupted)
+        by_name = dict((name.split("|")[0], v) for name, v in ex.parts)
+        assert by_name["field[0]"] == 0.0  # the parent is identical between the two records
+        assert abs(by_name["field[1]"]) > 50.0  # the corrupted child is the visible anomaly
+        assert ex.is_exact()
+
+
+class MixtureMarginTest:
+    def _mix(self):
+        c0 = CompositeDistribution((CategoricalDistribution({"a": 0.9, "b": 0.1}), GaussianDistribution(-3.0, 1.0)))
+        c1 = CompositeDistribution((CategoricalDistribution({"a": 0.1, "b": 0.9}), GaussianDistribution(3.0, 1.0)))
+        return c0, c1, MixtureDistribution([c0, c1], [0.5, 0.5])
+
+    def test_margin_matches_manual_computation_and_needs_no_correction(self):
+        c0, c1, mix = self._mix()
+        x = ("b", 3.2)
+        ex = explain_margin_mixture(mix, x, answer=1, runner_up=0)
+        manual = (float(mix.log_w[1]) + c1.log_density(x)) - (float(mix.log_w[0]) + c0.log_density(x))
+        np.testing.assert_allclose(ex.total, manual, atol=1e-12)
+        # the logsumexp normalizer cancels exactly in a two-component margin -- up to floating-point noise
+        assert abs(ex.correction) < 1e-9
+        assert ex.is_exact()
+
+    def test_margin_decomposes_into_prior_plus_per_field(self):
+        _c0, _c1, mix = self._mix()
+        x = ("b", 3.2)
+        ex = explain_margin_mixture(mix, x, answer=1, runner_up=0)
+        names = {name for name, _ in ex.parts}
+        assert names == {"prior", "field[0]", "field[1]"}
+
+    def test_explain_margin_rejects_a_mixture_pointing_to_explain_margin_mixture(self):
+        _c0, _c1, mix = self._mix()
+        with pytest.raises(TypeError, match="explain_margin_mixture"):
+            explain_margin(mix, ("a", 0.0), ("b", 0.0))
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()

--- a/mixle/tests/explain_test.py
+++ b/mixle/tests/explain_test.py
@@ -1,4 +1,5 @@
-"""explain(): exact per-part attribution of log p(x)."""
+"""explain(): exact per-part attribution of log p(x). See explain_margin_test.py for the decision-margin
+ledger (workstream H1: answers with receipts)."""
 
 import numpy as np
 
@@ -28,8 +29,13 @@ def test_mixture_reports_responsibilities_and_winner_breakdown():
     ex = explain(mix, x)
     assert ex.component == 1 and ex.responsibilities[1] > 0.95
     np.testing.assert_allclose(ex.total, mix.log_density(x), atol=1e-12)
-    assert all(name.startswith("component[1].field") for name, _ in ex.parts)
+    assert all(name.startswith("component[1].field") or name == "component[1].prior" for name, _ in ex.parts)
     assert "component posterior" in ex.summary()
+    # the winner's own (prior + field) parts do NOT sum to the mixture's true total (that is a logsumexp
+    # over every component) -- the gap is the explicit, named correction term, not an omission.
+    assert ex.correction != 0.0
+    np.testing.assert_allclose(ex.ledger_sum(), ex.total, atol=1e-12)
+    assert ex.is_exact()
 
 
 def test_bayesian_network_parts_are_the_factor_scores():


### PR DESCRIPTION
## Summary
Workstream H1 of the 0.6.3 frontier-capability plan (answers with receipts): the exact evidence ledger.
`mixle.inference.explain` already existed (decomposing `log p(x)`) -- this fixes a real exactness gap
it had and adds the decision-margin decomposition H1 actually asks for.

- **Bug fixed**: `explain()`'s mixture branch reported the winning component's field breakdown, but
  `Explanation.total` was the mixture's true `log p(x)` (a logsumexp over every component) -- those two
  never summed to the same value. Added the missing prior-weight part and a new, explicitly named
  `Explanation.correction` field so `sum(parts) + correction == total` exactly (`is_exact()`/`ledger_sum()`).
  Composite/BN are unaffected (already exact, correction stays 0).
- **New** `explain_margin(model, answer, runner_up)`: decomposes `log p(answer) - log p(runner_up)` for
  Composite/Bayesian-network models -- a field identical between the two candidate records contributes
  exactly 0, so a single corrupted field is the one visible nonzero part.
- **New** `explain_margin_mixture(model, x, answer, runner_up)`: the margin between two Mixture
  components (e.g. class labels) at one observed point. The logsumexp normalizer cancels exactly in
  this subtraction, so the margin ledger needs no correction (computed and asserted near-zero, not
  assumed).

**Not in this slice** (explicit backlog): HMM decomposition -- a forward-algorithm margin over latent
state paths is a bigger, separate lift than the other three structures; left for a follow-up PR.

**Backward compatible**: kept `Explanation.total`/`parts`/`responsibilities`/`component` and the
`explain()` call signature; updated the one existing test assertion that depended on the (buggy,
incomplete) mixture ledger to check the corrected, exact one instead.

## Test plan
- [x] `explain_margin_test.py` (10 new): Composite/BN/Mixture margin ledgers exact to machine precision,
      corrupted-single-field diagnostic (uncorrupted fields collapse to exactly 0), mixture-vs-
      `explain_margin_mixture` dispatch error.
- [x] `explain_test.py` (updated for the fixed mixture ledger + new `is_exact()` assertion).
- [x] Narrow regression sweep: `explain_test`, `explain_margin_test`, `lifecycle_test`,
      `bayesian_network_test` = 40 passed, no regressions.
- [x] `ruff check` / `ruff format --check` clean on all changed files.