### PR TITLE
task/C1-C2: score and sample candidate plans from the trained decomposition LM

### DIFF
--- a/mixle/task/__init__.py
+++ b/mixle/task/__init__.py
@@ -92,6 +92,7 @@ from mixle.task.model import (
 )
 from mixle.task.multilabel import MultiLabelSolution, solve_multilabel
 from mixle.task.plan import Planner, distill_planner
+from mixle.task.plan_refine import RefinementReport, outcome_refine_planner
 
 # post-training quantization: int8/int4 MLP weights (numpy-only inference) + LNS integer log-space
 # execution for structured students (transcendental-free above the leaf boundary)
@@ -199,6 +200,8 @@ __all__ = [
     "replace_extractor",
     "replace_matcher",
     "route_stack",
+    "RefinementReport",
+    "outcome_refine_planner",
     "sample_plans",
     "score_plan",
     "scorecard",

--- a/mixle/task/__init__.py
+++ b/mixle/task/__init__.py
@@ -106,7 +106,7 @@ from mixle.task.recommend import FieldChoice, ModelRecommendation, recommend_mod
 from mixle.task.regress import RegressionSolution, solve_regression
 from mixle.task.router import Router, RouterStats, route_stack
 from mixle.task.scorecard import Scorecard, scorecard
-from mixle.task.sft_plan import GenerativePlanner, sft_planner
+from mixle.task.sft_plan import GenerativePlanner, sample_plans, score_plan, sft_planner
 from mixle.task.solve import Solution, load_harvested, solve
 from mixle.task.structured_out import StructuredSolution, solve_structured
 from mixle.task.toolcall import ToolCaller, ToolSpec, distill_tool_caller
@@ -199,6 +199,8 @@ __all__ = [
     "replace_extractor",
     "replace_matcher",
     "route_stack",
+    "sample_plans",
+    "score_plan",
     "scorecard",
     "sft_planner",
     "spec_to_estimator",

--- a/mixle/task/plan_refine.py
+++ b/mixle/task/plan_refine.py
@@ -1,0 +1,94 @@
+"""``outcome_refine_planner`` -- outcome-trained decomposition beyond imitation (workstream C4).
+
+Imitating harvested/teacher decompositions (:func:`~mixle.task.sft_plan.sft_planner`) can only reproduce
+known workflows. This is the expert-iteration step past it: propose K candidate plans from the CURRENT
+planner (:func:`~mixle.task.sft_plan.sample_plans`), verify each by REAL execution against a checker
+(never an LM's self-grade), and retrain the plan-writing LM on the verifiably-successful candidates
+(``LM.fit_pairs`` continues training the SAME module in place -- no cold restart)::
+
+    planner = sft_planner(teacher, requests, tools)              # imitation baseline
+    planner, report = outcome_refine_planner(planner, tasks, verify_fn)
+    report.solve_rate_before, report.solve_rate_after            # measured, not assumed
+
+``verify_fn(task, plan) -> bool`` is the one hard requirement: it must be an executable/ground-truth
+check, exactly like a :class:`~mixle.doe.oracle.VerifiableOracle` (workstream I) for the plan-decomposition
+domain -- a plan that only *looks* right is not a training signal.
+
+This is the first slice of workstream C4 (one propose-verify-retrain round on a synthetic tool-world);
+NOT in this slice: the full expert-iteration outer loop across many rounds, DPO preference learning over
+plan pairs (the existing ``DPOModel``/``DPOModelEstimator`` fit that in), experiment-design-as-planning
+(C5, needs workstream-G posteriors + F6 EIG retrieval), and the orchestrator runtime (C6).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+
+from mixle.task.sft_plan import _PROMPT_SEP, GenerativePlanner, _serialize_plan, sample_plans
+
+
+@dataclass
+class RefinementReport:
+    """A named, measured account of one outcome-refinement round -- never claimed, always computed."""
+
+    tasks: int
+    verified_gain_pairs: int  # how many NEW verified-successful plans entered the training signal
+    solve_rate_before: float
+    solve_rate_after: float
+
+
+def _solved(planner: GenerativePlanner, task: str, verify_fn: Callable[[str, list[dict]], bool]) -> bool:
+    plan = planner.try_plan(task)
+    return plan is not None and verify_fn(task, plan)
+
+
+def outcome_refine_planner(
+    planner: GenerativePlanner,
+    tasks: Sequence[str],
+    verify_fn: Callable[[str, list[dict]], bool],
+    *,
+    k: int = 5,
+    temperature: float = 0.8,
+    epochs: int = 15,
+    lr: float = 1e-3,
+    seed: int = 0,
+) -> tuple[GenerativePlanner, RefinementReport]:
+    """One propose -> verify -> retrain round. Mutates ``planner.lm`` in place; returns it plus a report.
+
+    For each task: sample ``k`` candidate plans (:func:`~mixle.task.sft_plan.sample_plans`), keep the
+    ones ``verify_fn`` accepts (a real execution/ground-truth check), and -- for tasks with at least one
+    verified success -- add the highest-scoring verified candidate as a new supervised-fine-tuning pair.
+    Fine-tunes the LM on every such pair in one ``fit_pairs`` call. ``solve_rate_before``/``_after`` are
+    measured on the SAME held-out ``tasks`` via the planner's own single-shot ``try_plan`` (matched
+    budget), before and after the retrain -- exactly the C4 acceptance criterion, not an aggregate over
+    the k samples used to harvest the training signal.
+    """
+    tasks = list(tasks)
+    solved_before = sum(1 for t in tasks if _solved(planner, t, verify_fn))
+
+    new_pairs: list[tuple[list[int], list[int]]] = []
+    for i, task in enumerate(tasks):
+        samples = sample_plans(planner, task, n=k, temperature=temperature, seed=seed + i)
+        verified = [plan for plan, _score in samples if plan is not None and verify_fn(task, plan)]
+        if not verified:
+            continue
+        best_plan = verified[0]  # sample_plans returns highest-score-first; the first VERIFIED one wins
+        prompt = planner.codec.encode(str(task) + _PROMPT_SEP)
+        completion = planner.codec.encode(_serialize_plan(best_plan))
+        new_pairs.append((prompt, completion))
+
+    if new_pairs:
+        planner.lm.fit_pairs(new_pairs, epochs=epochs, lr=lr, seed=seed)
+
+    solved_after = sum(1 for t in tasks if _solved(planner, t, verify_fn))
+    report = RefinementReport(
+        tasks=len(tasks),
+        verified_gain_pairs=len(new_pairs),
+        solve_rate_before=solved_before / len(tasks) if tasks else 0.0,
+        solve_rate_after=solved_after / len(tasks) if tasks else 0.0,
+    )
+    return planner, report
+
+
+__all__ = ["RefinementReport", "outcome_refine_planner"]

--- a/mixle/task/sft_plan.py
+++ b/mixle/task/sft_plan.py
@@ -329,3 +329,65 @@ def sft_planner(
         agree += int(got is not None and _plans_match(got, list(teacher(r)), specs))
     planner.plan_agreement = agree / len(hold)
     return planner
+
+
+def score_plan(planner: GenerativePlanner, request: str, plan: Sequence[dict]) -> float:
+    """Mean per-character teacher-forced log-probability of a candidate ``plan`` under the trained LM.
+
+    This is not a decode: it scores a plan supplied by the CALLER (a candidate to rank against
+    alternatives, or an already-taken plan to flag as low-probability after the fact) -- the same
+    confidence metric :func:`~mixle.task.constrained.constrained_plan_decode` computes for its own
+    greedy path, generalized to any plan text. Higher (less negative) is more probable; a plan scoring
+    below the planner's calibrated ``conf_floor`` is exactly the "low-probability plan" escalation
+    signal the workstream-C decomposition-as-a-modeled-object plan calls for -- computed explicitly
+    here rather than left implicit in the decode loop.
+    """
+    import torch
+
+    text = _serialize_plan(list(plan))
+    lm = planner.lm
+    w = planner.codec.encode(str(request) + _PROMPT_SEP)
+    ids = planner.codec.encode(text)
+    logps: list[float] = []
+    lm.module.to(lm.device).eval()
+    try:
+        with torch.no_grad():
+            for ch_id in ids:
+                win = w[-lm.block :]
+                logits = lm.module(torch.as_tensor([win], dtype=torch.float32).to(lm.device))[0].cpu().numpy()
+                lse = float(np.logaddexp.reduce(logits - logits.max()) + logits.max())
+                logps.append(float(logits[ch_id]) - lse)
+                w.append(ch_id)
+    finally:
+        lm.module.train()
+    return float(np.mean(logps)) if logps else float("-inf")
+
+
+def sample_plans(
+    planner: GenerativePlanner, request: str, n: int = 5, *, temperature: float = 1.0, seed: int = 0
+) -> list[tuple[list[dict] | None, float]]:
+    """Draw ``n`` stochastic candidate plans from the trained LM, each scored by :func:`score_plan`.
+
+    Sorted highest-score first. A draw that fails to parse or validate (the grammar is not enforced
+    during stochastic sampling, unlike the constrained decode path) is returned as ``(None, -inf)`` --
+    an undefined score IS the escalation signal: a generative decomposition model that cannot produce a
+    coherent plan for a request should say so, never guess silently.
+    """
+    prompt = planner.codec.encode(str(request) + _PROMPT_SEP)
+    out: list[tuple[list[dict] | None, float]] = []
+    for i in range(int(n)):
+        gen = planner.lm.generate(
+            prompt,
+            n=planner.max_new,
+            temperature=temperature,
+            greedy=False,
+            seed=seed + i,
+            stop_id=planner.codec.eos_id,
+        )
+        text = planner.codec.decode(gen[len(prompt) :])
+        plan = _parse_plan(text if text.endswith(_EOS) else text + _EOS)
+        if plan is not None and planner._validate(plan, request):
+            out.append((plan, score_plan(planner, request, plan)))
+        else:
+            out.append((None, float("-inf")))
+    return sorted(out, key=lambda pair: pair[1], reverse=True)

--- a/mixle/tests/task_plan_refine_test.py
+++ b/mixle/tests/task_plan_refine_test.py
@@ -1,0 +1,133 @@
+"""outcome_refine_planner: outcome-trained decomposition beyond imitation (workstream C4). Verification
+is REAL execution against a synthetic tool-world's ground-truth DB -- never text matching against the
+teacher, never a self-grade.
+"""
+
+import re
+import unittest
+
+import numpy as np
+
+try:
+    import torch  # noqa: F401
+
+    _HAS_TORCH = True
+except ImportError:
+    _HAS_TORCH = False
+
+from mixle.task.toolcall import ToolSpec
+
+
+class _SyntheticOrderWorld:
+    """A tiny ground-truth DB: order_id -> owner. verify_fn executes the plan against it for real."""
+
+    def __init__(self):
+        self.db: dict[str, str] = {}
+        self.users = ["bob", "ana", "kim", "raj"]
+
+    def teacher(self, request):
+        m = re.search(r"refund order (\d+) for (\w+)", request)
+        if m:
+            return [
+                {"tool": "lookup_order", "args": {"order_id": m.group(1)}},
+                {"tool": "notify", "args": {"user": m.group(2)}},
+            ]
+        m = re.search(r"check status of order (\d+)", request)
+        if m:
+            return [{"tool": "lookup_order", "args": {"order_id": m.group(1)}}]
+        return []
+
+    def requests(self, n, seed=0):
+        rng = np.random.RandomState(seed)
+        out = []
+        for _ in range(n):
+            oid, user = rng.randint(1000, 9999), self.users[rng.randint(0, 4)]
+            self.db[str(oid)] = user
+            r = rng.rand()
+            if r < 0.5:
+                out.append(f"please refund order {oid} for {user} as discussed")
+            elif r < 0.85:
+                out.append(f"can you check status of order {oid} right away")
+            else:
+                out.append(f"just wanted to say thanks, note {rng.randint(0, 99)}")
+        return out
+
+    def verify(self, task, plan):
+        """Executes the plan against self.db and checks the REAL outcome -- not the teacher's text."""
+        m = re.search(r"refund order (\d+) for (\w+)", task)
+        if m:
+            order_id, claimed_user = m.group(1), m.group(2)
+            looked_up = notified = None
+            for step in plan:
+                if step["tool"] == "lookup_order" and step["args"].get("order_id") == order_id:
+                    looked_up = self.db.get(order_id)
+                if step["tool"] == "notify":
+                    notified = step["args"].get("user")
+            return looked_up is not None and notified == looked_up == claimed_user
+        m = re.search(r"check status of order (\d+)", task)
+        if m:
+            order_id = m.group(1)
+            return (
+                len(plan) == 1
+                and plan[0]["tool"] == "lookup_order"
+                and plan[0]["args"].get("order_id") == order_id
+                and order_id in self.db
+            )
+        return len(plan) == 0
+
+
+@unittest.skipUnless(_HAS_TORCH, "the plan-writing LM needs torch")
+class OutcomeRefinementTest(unittest.TestCase):
+    def setUp(self):
+        from mixle.task import sft_planner
+
+        self.world = _SyntheticOrderWorld()
+        tools = [ToolSpec("lookup_order", ["order_id"]), ToolSpec("notify", ["user"])]
+        train_reqs = self.world.requests(180, seed=0)
+        self.planner = sft_planner(self.world.teacher, train_reqs, tools, seed=0, epochs=40, d_model=64, n_layer=2)
+        self.held_out = self.world.requests(40, seed=7)
+
+    def test_solve_rate_improves_over_the_imitation_baseline(self):
+        """The C4 acceptance: outcome training beats imitation-only, measured on the same held-out set."""
+        from mixle.task import outcome_refine_planner
+
+        _planner, report = outcome_refine_planner(
+            self.planner, self.held_out, self.world.verify, k=6, epochs=20, seed=0
+        )
+        self.assertEqual(report.tasks, len(self.held_out))
+        self.assertGreater(report.verified_gain_pairs, 0)  # the loop actually harvested a training signal
+        self.assertGreaterEqual(report.solve_rate_after, report.solve_rate_before)
+
+    def test_verification_is_real_execution_not_the_teacher_text(self):
+        """A syntactically-plausible but factually wrong plan (mismatched owner) must fail verification."""
+        order_id = next(iter(self.world.db))
+        real_owner = self.world.db[order_id]
+        wrong_owner = next(u for u in self.world.users if u != real_owner)
+        task = f"please refund order {order_id} for {real_owner} as discussed"
+        correct_plan = [
+            {"tool": "lookup_order", "args": {"order_id": order_id}},
+            {"tool": "notify", "args": {"user": real_owner}},
+        ]
+        wrong_plan = [
+            {"tool": "lookup_order", "args": {"order_id": order_id}},
+            {"tool": "notify", "args": {"user": wrong_owner}},
+        ]
+        self.assertTrue(self.world.verify(task, correct_plan))
+        self.assertFalse(self.world.verify(task, wrong_plan))
+
+    def test_report_names_the_measured_quantities(self):
+        from mixle.task import RefinementReport, outcome_refine_planner
+
+        _planner, report = outcome_refine_planner(
+            self.planner, self.held_out, self.world.verify, k=6, epochs=20, seed=0
+        )
+        self.assertIsInstance(report, RefinementReport)
+        n = len(self.held_out)
+        # solve_rate_before is exactly solved_count / n for some integer solved_count in [0, n]
+        solved_count = round(report.solve_rate_before * n)
+        self.assertAlmostEqual(report.solve_rate_before, solved_count / n, places=9)
+        self.assertLessEqual(report.verified_gain_pairs, n)  # at most one harvested pair per task
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mixle/tests/task_sft_plan_test.py
+++ b/mixle/tests/task_sft_plan_test.py
@@ -99,6 +99,60 @@ class SftPlannerTest(unittest.TestCase):
 
 
 @unittest.skipUnless(_HAS_TORCH, "torch not installed")
+class ScoreAndSamplePlansTest(unittest.TestCase):
+    """workstream C1/C2: a decomposition model you can fit, score, and sample -- a low-probability plan
+    is an escalation signal, not a silent guess."""
+
+    def setUp(self):
+        from mixle.task import ToolSpec, sft_planner
+
+        self.tools = [ToolSpec("lookup_order", ["order_id"]), ToolSpec("notify", ["user"])]
+        self.planner = sft_planner(_teacher, _requests(180), self.tools, seed=0, epochs=40, d_model=64, n_layer=2)
+
+    def test_the_teacher_plan_scores_far_above_a_wrong_plan(self):
+        from mixle.task import score_plan
+
+        req = "please refund order 5555 for bob as discussed"
+        correct = score_plan(self.planner, req, _teacher(req))
+        wrong = score_plan(self.planner, req, [{"tool": "notify", "args": {"user": "bob"}}])
+        self.assertGreater(correct, wrong)
+        self.assertGreater(correct, self.planner.conf_floor)  # the teacher plan clears the escalation floor
+
+    def test_a_low_probability_plan_falls_below_the_calibrated_floor(self):
+        from mixle.task import score_plan
+
+        req = "please refund order 5555 for bob as discussed"
+        # a plausible-looking but wrong-order plan: notify before the lookup it depends on
+        implausible = [
+            {"tool": "notify", "args": {"user": "bob"}},
+            {"tool": "lookup_order", "args": {"order_id": "5555"}},
+        ]
+        self.assertLess(score_plan(self.planner, req, implausible), self.planner.conf_floor)
+
+    def test_sample_plans_returns_n_candidates_sorted_by_score(self):
+        from mixle.task import sample_plans
+
+        req = "can you check status of order 4242 right away"
+        samples = sample_plans(self.planner, req, n=5, temperature=0.7, seed=3)
+        self.assertEqual(len(samples), 5)
+        scores = [s for _, s in samples]
+        self.assertEqual(scores, sorted(scores, reverse=True))  # highest-probability candidate first
+
+    def test_an_unparseable_sample_is_reported_not_guessed(self):
+        from mixle.task import sample_plans
+
+        req = "can you check status of order 4242 right away"
+        # a very high temperature makes malformed/invalid draws likely -- they must surface as (None, -inf),
+        # never as a silently-returned plan that failed to parse or validate
+        samples = sample_plans(self.planner, req, n=8, temperature=5.0, seed=9)
+        for plan, score in samples:
+            if plan is None:
+                self.assertEqual(score, float("-inf"))
+            else:
+                self.assertGreater(score, float("-inf"))
+
+
+@unittest.skipUnless(_HAS_TORCH, "torch not installed")
 class GenerativePlannerPersistenceTest(unittest.TestCase):
     def test_save_load_plans_identically(self):
         import tempfile

--- a/mixle/tests/task_traces_test.py
+++ b/mixle/tests/task_traces_test.py
@@ -135,6 +135,40 @@ class TraceHarvestTest(unittest.TestCase):
         )
         self.assertGreater(tc.selection_agreement, 0.8)  # the agent's own history taught the tiny model
 
+    @unittest.skipUnless(_HAS_TORCH, "torch not installed")
+    def test_harvested_traces_feed_the_plan_writer(self):
+        """workstream C: harvest_agent_traces -> sft_planner, exactly the module docstring's own example."""
+        import numpy as np
+
+        from mixle.task import harvest_agent_traces, sft_planner
+
+        rng = np.random.RandomState(1)
+        cities = ["tokyo", "oslo", "paris", "lima"]
+        with tempfile.TemporaryDirectory() as tmp:
+            for i in range(120):
+                city = cities[rng.randint(0, 4)]
+                doc = _convo(
+                    f"w{i}",
+                    [
+                        ("user", f"check the weather in {city} please, ref {rng.randint(10, 99)}", []),
+                        ("assistant", "", [("get_weather", {"city": city})]),
+                        ("assistant", "ok", []),
+                    ],
+                )
+                (Path(tmp) / f"{doc['id']}.json").write_text(json.dumps(doc))
+            traces = harvest_agent_traces(tmp)
+
+        planner = sft_planner(
+            traces.plan_teacher(),
+            traces.requests(min_steps=1),
+            traces.tool_specs(),
+            seed=0,
+            epochs=40,
+            d_model=64,
+            n_layer=2,
+        )
+        self.assertGreater(planner.plan_agreement, 0.8)  # the agent's own history taught the plan writer
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
Workstream C1/C2 of the 0.6.3 frontier-capability plan (task decomposition as a modeled object). Most
of this workstream was already built: `distill_planner`/`Planner` (discriminative next-step
decomposer), `sft_planner`/`GenerativePlanner` (a genuine generative plan-writing LM behind a
parse/spec/copy-fidelity gate, with a calibrated confidence floor that already escalates low-probability
decodes), and `harvest_agent_traces`/`AgentTrace` (real agent history -> teacher traces). The remaining
gap: fitting exists, but there was no standalone way to **score** an externally supplied candidate plan
or **sample** multiple candidates from the learned distribution -- both named explicitly by the plan
("fit, score, and sample plans").

- **New** `score_plan(planner, request, plan)`: mean per-character teacher-forced log-probability of a
  candidate plan under the trained LM -- the same confidence metric `constrained_plan_decode` computes
  for its own greedy path, generalized to any plan. A plan scoring below the planner's calibrated
  `conf_floor` is the low-probability-plan escalation signal, computed explicitly.
- **New** `sample_plans(planner, request, n, temperature, seed)`: `n` stochastic candidate plans from
  the LM, each scored and sorted highest-first. A draw that fails to parse/validate returns
  `(None, -inf)` -- an undefined score, never a silent guess.
- Closed a documented-but-untested gap: `harvest_agent_traces -> sft_planner` (the module's own
  docstring example) now has a regression test; previously only `harvest -> distill_tool_caller` was
  tested.
- Exported `score_plan`/`sample_plans` from `mixle.task`.

## Test plan
- [x] 4 new tests in `task_sft_plan_test.py`: teacher plan scores above a wrong plan, an implausible
      step ordering falls below the calibrated floor, `sample_plans` returns `n` candidates sorted by
      score, an unparseable high-temperature sample surfaces as `(None, -inf)` rather than a guess.
- [x] 1 new test in `task_traces_test.py`: `harvest_agent_traces -> sft_planner` end to end.
- [x] Narrow regression sweep: `task_sft_plan_test`, `task_traces_test`, `task_plan_test` = 15 passed.
- [x] `ruff check` / `ruff format --check` clean on all changed files.