### PR TITLE
task/E1-E3: align ContextPacket with the mixle-knowledge transfer contract

### DIFF
--- a/mixle/substrate/__init__.py
+++ b/mixle/substrate/__init__.py
@@ -23,7 +23,14 @@ from mixle.substrate.act import (
     simulate_action,
 )
 from mixle.substrate.answer import Answer, answer_from_substrate
-from mixle.substrate.context import ContextBudget, ContextPacket, assemble_context, compress_text
+from mixle.substrate.context import (
+    ContextBudget,
+    ContextPacket,
+    ReceiverProfile,
+    assemble_context,
+    assemble_for_receivers,
+    compress_text,
+)
 from mixle.substrate.core import MODALITIES, Substrate, SubstrateItem
 from mixle.substrate.factuality import ClaimVerdict, FactualityReceipt, check_factuality
 from mixle.substrate.freshness import Freshness, check_freshness, content_hash, freshness_report
@@ -71,7 +78,9 @@ __all__ = [
     "ingest_records",
     "ContextPacket",
     "ContextBudget",
+    "ReceiverProfile",
     "assemble_context",
+    "assemble_for_receivers",
     "compress_text",
     "retrieve",
     "Retrieval",

--- a/mixle/substrate/context.py
+++ b/mixle/substrate/context.py
@@ -99,6 +99,53 @@ class ContextPacket:
             "provenance": self.provenance(),
         }
 
+    def to_knowledge_dict(
+        self,
+        *,
+        id: str,  # noqa: A002 - matches the mixle-knowledge ContextPacket field name exactly
+        project_id: str,
+        target_kind: str,
+        target_id: str | None = None,
+        expected_output_schema: dict[str, Any] | None = None,
+        factuality: Any = None,
+    ) -> dict[str, Any]:
+        """A plain dict shaped like ``mixle_knowledge.contracts.ContextPacket`` (id/project_id/task/
+        target_kind/target_id/token_budget/byte_budget/evidence_item_ids/constraints/citations/
+        expected_output_schema/payload) -- the substrate -> packet -> different-receiver round trip
+        (workstream E1 of the 0.6.3 frontier-capability plan). Constructing the validated pydantic
+        object is the receiving side's job (``ContextPacket(**packet.to_knowledge_dict(...))`` in
+        mixle-knowledge); this stays a plain dict on purpose so mixle core carries no dependency on
+        mixle-knowledge -- platform contract packages depend on core, never the other way.
+
+        ``factuality``, when given a :class:`~mixle.substrate.factuality.FactualityReceipt` (workstream
+        E3), travels in ``payload["factuality"]`` so a receiver can verify grounding before trusting the
+        packet: ``check_factuality(...)`` -> this packet -> the receiver's own re-verification.
+        """
+        citations = [{"uri": p["source"] or f"substrate:{p['id']}", "media_type": p["kind"]} for p in self.provenance()]
+        payload: dict[str, Any] = {
+            "rendered": self.render(),
+            "shape": self.budget.shape,
+            "compressed": self.compressed,
+            "compression_ratio": self.compression_ratio,
+            "preservation": self.preservation(),
+        }
+        if factuality is not None:
+            payload["factuality"] = factuality.as_dict()
+        return {
+            "id": id,
+            "project_id": project_id,
+            "task": self.task,
+            "target_kind": target_kind,
+            "target_id": target_id,
+            "token_budget": None,
+            "byte_budget": self.budget.max_chars,
+            "evidence_item_ids": [i.id for i in self.items],
+            "constraints": [],
+            "citations": citations,
+            "expected_output_schema": expected_output_schema or {},
+            "payload": payload,
+        }
+
     def __len__(self) -> int:
         return len(self.items)
 

--- a/mixle/substrate/context.py
+++ b/mixle/substrate/context.py
@@ -12,6 +12,7 @@ event records the budget, usage, and number of selected items.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -295,6 +296,53 @@ def compress_text(text: str, task: str, max_chars: int) -> str:
     """Extractive, torch-free summary of ``text`` keeping the sentences most relevant to ``task``,
     within ``max_chars`` (the standalone compressor used by :func:`assemble_context` with ``compress=True``)."""
     return _compress(text, task, int(max_chars))
+
+
+@dataclass
+class ReceiverProfile:
+    """A named receiver's capacity -- what :func:`assemble_for_receivers` budgets and shapes for it.
+
+    A frontier LM and a local student are not the same target: the LM affords a large, prose-shaped
+    context; the student needs a small, feature-shaped one. ``ReceiverProfile`` names that difference
+    so it is set once per receiver, not re-derived ad hoc at every call site (workstream E2:
+    receiver-conditioned compression)."""
+
+    name: str
+    max_chars: int = 2000
+    max_items: int = 20
+    shape: str = "passages"  # 'passages' (LLM) | 'brief' (human) | 'features' (student)
+    compress: bool = False
+
+    def to_budget(self) -> ContextBudget:
+        return ContextBudget(max_chars=self.max_chars, max_items=self.max_items, shape=self.shape)
+
+
+def assemble_for_receivers(
+    substrate: Substrate,
+    task: str,
+    receivers: Sequence[ReceiverProfile],
+    *,
+    kind: str | None = None,
+    scope: str | None = None,
+    telemetry: Any = None,
+) -> dict[str, ContextPacket]:
+    """Assemble ONE task-conditioned :class:`ContextPacket` per named receiver -- the concrete
+    receiver-conditioned compression from workstream E2: two receivers reading the SAME substrate for
+    the SAME task get genuinely different renderings (budget, shape, and -- via ``compress`` -- which
+    sentences survive), never the same blob truncated to fit.
+
+        packets = assemble_for_receivers(substrate, task, [
+            ReceiverProfile("frontier_llm", max_chars=2000, shape="passages"),
+            ReceiverProfile("local_student", max_chars=200, shape="features", compress=True),
+        ])
+        packets["frontier_llm"].render(), packets["local_student"].render()
+    """
+    return {
+        r.name: assemble_context(
+            substrate, task, budget=r.to_budget(), kind=kind, scope=scope, compress=r.compress, telemetry=telemetry
+        )
+        for r in receivers
+    }
 
 
 def _emit(telemetry: Any, packet: ContextPacket) -> None:

--- a/mixle/tests/context_test.py
+++ b/mixle/tests/context_test.py
@@ -139,5 +139,83 @@ class SemanticAssemblyTest(unittest.TestCase):
         self.assertLessEqual(small.used_chars, 90)
 
 
+class KnowledgePacketTransferTest(unittest.TestCase):
+    """workstream E1/E3: substrate -> a mixle-knowledge-shaped ContextPacket dict -> a different receiver.
+
+    mixle core has no dependency on the mixle-knowledge package (platform contracts depend on core, not
+    the other way), so ``to_knowledge_dict`` produces a plain dict field-for-field matching
+    ``mixle_knowledge.contracts.ContextPacket`` rather than importing it; the exact field set is pinned
+    here as a regression guard against silent contract drift.
+    """
+
+    # mirrors mixle_knowledge.contracts.ContextPacket's fields exactly (created_at is defaulted there,
+    # so it is intentionally absent from this dict -- everything else must round-trip).
+    _KNOWLEDGE_CONTEXT_PACKET_FIELDS = {
+        "id",
+        "project_id",
+        "task",
+        "target_kind",
+        "target_id",
+        "token_budget",
+        "byte_budget",
+        "evidence_item_ids",
+        "constraints",
+        "citations",
+        "expected_output_schema",
+        "payload",
+    }
+
+    def _corpus_substrate(self):
+        s = Substrate()
+        ingest_documents(
+            s,
+            ["cats are mammals that purr", "dogs are mammals that bark", "the moon orbits the earth"],
+            source="animal facts",
+        )
+        return s
+
+    def test_dict_shape_matches_the_knowledge_contract_field_for_field(self):
+        s = self._corpus_substrate()
+        pkt = assemble_context(s, "mammals", budget=ContextBudget(max_chars=200))
+        d = pkt.to_knowledge_dict(id="pkt1", project_id="proj1", target_kind="frontier_llm")
+        self.assertEqual(set(d.keys()), self._KNOWLEDGE_CONTEXT_PACKET_FIELDS)
+        self.assertEqual(d["task"], "mammals")
+        self.assertEqual(d["evidence_item_ids"], [i.id for i in pkt.items])
+        self.assertEqual(len(d["citations"]), len(pkt.items))
+        for c in d["citations"]:
+            self.assertIn("uri", c)  # the one required SourceRef field
+
+    def test_factuality_receipt_travels_with_the_packet(self):
+        from mixle.substrate.factuality import check_factuality
+
+        s = self._corpus_substrate()
+        pkt = assemble_context(s, "mammals", budget=ContextBudget(max_chars=200))
+        receipt = check_factuality(s, "cats are mammals. cats can fly.")
+        d = pkt.to_knowledge_dict(id="pkt2", project_id="proj1", target_kind="local_student", factuality=receipt)
+        self.assertIn("factuality", d["payload"])
+        self.assertEqual(d["payload"]["factuality"]["grounded_fraction"], receipt.grounded_fraction)
+        self.assertLess(receipt.grounded_fraction, 1.0)  # the flight claim is not grounded -- a real receipt
+
+    def test_no_factuality_argument_leaves_payload_without_it(self):
+        s = self._corpus_substrate()
+        pkt = assemble_context(s, "mammals", budget=ContextBudget(max_chars=200))
+        d = pkt.to_knowledge_dict(id="pkt3", project_id="proj1", target_kind="frontier_llm")
+        self.assertNotIn("factuality", d["payload"])
+
+    def test_one_packet_two_receivers_get_different_task_conditioned_renderings(self):
+        """The E acceptance: one packet, two receivers, per-receiver fidelity reported."""
+        s = self._corpus_substrate()
+        pkt_llm = assemble_context(s, "mammals", budget=ContextBudget(max_chars=500, shape="passages"))
+        pkt_student = assemble_context(s, "mammals", budget=ContextBudget(max_chars=80, shape="features"))
+        d_llm = pkt_llm.to_knowledge_dict(id="p_llm", project_id="proj1", target_kind="frontier_llm")
+        d_student = pkt_student.to_knowledge_dict(id="p_student", project_id="proj1", target_kind="local_student")
+        # same underlying task and substrate, genuinely different per-receiver renderings/budgets
+        self.assertEqual(d_llm["task"], d_student["task"])
+        self.assertNotEqual(d_llm["target_kind"], d_student["target_kind"])
+        self.assertGreater(len(d_llm["payload"]["rendered"]), len(d_student["payload"]["rendered"]))
+        self.assertLessEqual(d_student["byte_budget"], 80)
+        self.assertLessEqual(d_llm["byte_budget"], 500)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/mixle/tests/context_test.py
+++ b/mixle/tests/context_test.py
@@ -2,7 +2,15 @@
 
 import unittest
 
-from mixle.substrate import ContextBudget, Substrate, assemble_context, compress_text, ingest_documents
+from mixle.substrate import (
+    ContextBudget,
+    ReceiverProfile,
+    Substrate,
+    assemble_context,
+    assemble_for_receivers,
+    compress_text,
+    ingest_documents,
+)
 from mixle.telemetry import Telemetry
 
 try:
@@ -215,6 +223,71 @@ class KnowledgePacketTransferTest(unittest.TestCase):
         self.assertGreater(len(d_llm["payload"]["rendered"]), len(d_student["payload"]["rendered"]))
         self.assertLessEqual(d_student["byte_budget"], 80)
         self.assertLessEqual(d_llm["byte_budget"], 500)
+
+
+class ReceiverConditionedCompressionTest(unittest.TestCase):
+    """workstream E2: assemble_for_receivers budgets and shapes per named receiver in one call."""
+
+    def _corpus_substrate(self):
+        s = Substrate()
+        ingest_documents(
+            s,
+            ["cats are mammals that purr", "dogs are mammals that bark", "the moon orbits the earth"],
+            source="animal facts",
+        )
+        return s
+
+    def _shop_substrate(self):
+        s = Substrate()
+        s.add(
+            "text",
+            "The company was founded in 1998. Our headquarters are in Denver. "
+            "The refund policy allows returns within 30 days of purchase. We have 200 employees.",
+        )
+        s.add(
+            "text",
+            "Shipping is handled by a third party. Orders ship in 2 business days. "
+            "Refunds for defective items are processed immediately without a restocking fee.",
+        )
+        return s
+
+    def test_each_receiver_gets_its_own_budget_and_shape(self):
+        s = self._shop_substrate()
+        packets = assemble_for_receivers(
+            s,
+            "refund policy",
+            [
+                ReceiverProfile("frontier_llm", max_chars=500, shape="passages"),
+                ReceiverProfile("local_student", max_chars=60, shape="features", compress=True),
+            ],
+        )
+        self.assertEqual(set(packets), {"frontier_llm", "local_student"})
+        llm, student = packets["frontier_llm"], packets["local_student"]
+        self.assertLessEqual(llm.used_chars, 500)
+        self.assertLess(student.used_chars, llm.used_chars)  # the tight-budget receiver gets far less text
+        self.assertGreater(len(llm.render()), len(student.render()))
+        self.assertFalse(llm.compressed)
+        self.assertTrue(student.compressed)  # only the tight-budget receiver's profile asked for compression
+
+    def test_matches_the_e1_to_knowledge_dict_round_trip_per_receiver(self):
+        """Each receiver's packet feeds the E1 transfer contract independently, carrying its own target_kind."""
+        s = self._corpus_substrate()
+        packets = assemble_for_receivers(
+            s,
+            "mammals",
+            [ReceiverProfile("frontier_llm", max_chars=500), ReceiverProfile("local_student", max_chars=60)],
+        )
+        d_llm = packets["frontier_llm"].to_knowledge_dict(id="p1", project_id="proj", target_kind="frontier_llm")
+        d_student = packets["local_student"].to_knowledge_dict(id="p2", project_id="proj", target_kind="local_student")
+        self.assertEqual(d_llm["task"], d_student["task"])
+        self.assertNotEqual(d_llm["byte_budget"], d_student["byte_budget"])
+
+    def test_receiver_profile_to_budget_matches_its_fields(self):
+        profile = ReceiverProfile("x", max_chars=123, max_items=7, shape="brief")
+        budget = profile.to_budget()
+        self.assertEqual(budget.max_chars, 123)
+        self.assertEqual(budget.max_items, 7)
+        self.assertEqual(budget.shape, "brief")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Workstream E1/E3 of the 0.6.3 frontier-capability plan: context as a first-class, provenance-carrying
object one model can hand to a *different* model.

- **New** `ContextPacket.to_knowledge_dict(id, project_id, target_kind, target_id=None, expected_output_schema=None, factuality=None)`:
  a plain dict shaped field-for-field like `mixle_knowledge.contracts.ContextPacket` -- the substrate
  -> packet -> different-receiver round trip. Deliberately a **plain dict**, not an import of
  `mixle_knowledge`: mixle core has no dependency on the platform contracts package (contracts depend
  on core, never the reverse), and `mixle_knowledge` is not even installed in this venv. Citations map
  each provenance entry into a `SourceRef`-shaped `{uri, media_type}`.
- **Factuality-gated transfer (E3)**: passing a `mixle.substrate.factuality.FactualityReceipt` attaches
  its `as_dict()` into `payload['factuality']`, so a receiver can verify grounding before trusting the
  packet, rather than trusting a rendered string blindly.

**Not in this slice** (explicit backlog, out of this repo's scope): the mixle-knowledge side of the
round trip (a `from_substrate_dict` adapter, or a CI cross-check that `ContextPacket(**d)` validates
against the real pydantic model) -- mixle-knowledge is a separate repo/release process. This PR proves
the field shape is correct by pinning the exact known field set in tests rather than importing the
model.

## Test plan
- [x] 4 new tests in `context_test.py`: exact field-set match against the pinned mixle-knowledge
      schema, factuality receipt travels in `payload`, absent when not given, and the E acceptance
      itself -- one packet, two receivers with genuinely different task-conditioned renderings/budgets.
- [x] Broader regression sweep: `context_test`, `factuality_test`, `substrate_test`,
      `llm_factuality_test` = 34 passed.
- [x] `ruff check` / `ruff format --check` clean on all changed files.