### PR TITLE
task/A2: the neural-leaf composition grid, made checkable

### DIFF
--- a/docs/neural-llm.rst
+++ b/docs/neural-llm.rst
@@ -345,6 +345,60 @@ The older names ``StreamingTransformerLeaf``, ``NeuralLeaf``,
 ``StreamingTransformer``, ``NeuralGaussian``, ``NeuralCategorical``, and
 ``DPOModel`` in new code.
 
+Composition Grid
+-----------------
+
+Every neural leaf's own docstring claims it "drops into a ``MixtureDistribution`` /
+``CompositeDistribution`` / HMM emission like any leaf." This table is that claim made checkable: which
+combinations are exercised by a real regression test, with a JSON/pickle round trip proven in the same
+test rather than assumed.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Leaf
+     - Mixture component
+     - Composite field
+     - HMM emission
+     - Serializes in each context
+   * - ``NeuralGaussian`` (conditional, ``p(y|x)``)
+     - tested
+     - untested (no architectural reason it would fail; not yet exercised)
+     - untested (as above)
+     - tested (Mixture only)
+   * - ``NeuralCategorical`` (conditional, ``p(y|x)``)
+     - tested
+     - tested
+     - tested
+     - tested in all three
+   * - ``NeuralDensity`` / ``Flow`` / ``VAE`` / ``MAF`` / ``DiscreteAR`` (unconditional)
+     - tested
+     - tested
+     - tested
+     - tested in all three
+   * - ``NeuralConditionalDensity`` (``mixture_density``, conditional)
+     - tested
+     - untested (not yet exercised)
+     - untested (as above)
+     - tested (Mixture only)
+   * - ``EnergyModel`` (unconditional, approximately normalized)
+     - tested
+     - tested
+     - untested (not yet exercised)
+     - tested (Mixture, Composite)
+
+One real, load-bearing limitation surfaced while closing this grid, not a test-writing inconvenience: a
+purely conditional leaf (``NeuralCategorical``, ``NeuralGaussian``, ``NeuralConditionalDensity``) has no
+``p(x)`` to draw from, so a Mixture/HMM whose *every* component or state is such a leaf cannot use the
+model's own ``sampler()`` -- ``NeuralCategorical.sample()`` raises by design (see its docstring). Fitting
+still works fine: ``optimize`` only needs ``log_density``/the accumulator contract, not sampling, so a
+conditionally-emitting HMM trains normally on externally supplied ``(x, y)`` sequences. See
+``mixle/tests/neural_composition_grid_test.py`` for the HMM/Composite tests (the Mixture-column entries
+were already covered by ``neural_leaf_serialization_test.py`` and friends). The two remaining "untested"
+cells are not known to be broken -- there is no architectural reason a conditional field would fail
+inside Composite, or an unconditional density would fail as an HMM emission -- they are simply not yet
+exercised; closing them is a small, well-defined follow-up.
+
 Examples And Tests
 ------------------
 

--- a/docs/neural-llm.rst
+++ b/docs/neural-llm.rst
@@ -363,9 +363,9 @@ test rather than assumed.
      - Serializes in each context
    * - ``NeuralGaussian`` (conditional, ``p(y|x)``)
      - tested
-     - untested (no architectural reason it would fail; not yet exercised)
-     - untested (as above)
-     - tested (Mixture only)
+     - tested
+     - tested
+     - tested in all three
    * - ``NeuralCategorical`` (conditional, ``p(y|x)``)
      - tested
      - tested
@@ -378,9 +378,9 @@ test rather than assumed.
      - tested in all three
    * - ``NeuralConditionalDensity`` (``mixture_density``, conditional)
      - tested
-     - untested (not yet exercised)
-     - untested (as above)
-     - tested (Mixture only)
+     - tested
+     - tested
+     - tested in all three
    * - ``EnergyModel`` (unconditional, approximately normalized)
      - tested
      - tested
@@ -394,10 +394,10 @@ model's own ``sampler()`` -- ``NeuralCategorical.sample()`` raises by design (se
 still works fine: ``optimize`` only needs ``log_density``/the accumulator contract, not sampling, so a
 conditionally-emitting HMM trains normally on externally supplied ``(x, y)`` sequences. See
 ``mixle/tests/neural_composition_grid_test.py`` for the HMM/Composite tests (the Mixture-column entries
-were already covered by ``neural_leaf_serialization_test.py`` and friends). The two remaining "untested"
-cells are not known to be broken -- there is no architectural reason a conditional field would fail
-inside Composite, or an unconditional density would fail as an HMM emission -- they are simply not yet
-exercised; closing them is a small, well-defined follow-up.
+were already covered by ``neural_leaf_serialization_test.py`` and friends). ``EnergyModel`` x HMM is the
+one remaining "untested" cell -- not known to be broken, there is no architectural reason an
+approximately-normalized unconditional density would fail as an HMM emission, simply not yet exercised;
+closing it is a small, well-defined follow-up.
 
 Examples And Tests
 ------------------

--- a/mixle/tests/neural_composition_grid_test.py
+++ b/mixle/tests/neural_composition_grid_test.py
@@ -1,0 +1,158 @@
+"""Workstream A2: the neural-leaf composition grid, made checkable.
+
+Every neural leaf's own module docstring claims it "drops into a MixtureDistribution /
+CompositeDistribution / HMM emission like any leaf." Mixture composition is already covered by
+neural_leaf_serialization_test.py and friends; this file closes the HMM-emission gap (untested for
+every leaf before this) and extends Composite-field coverage to a genuinely heterogeneous record mixing
+multiple neural leaf types with a classical family -- with a JSON round trip proven in every case, not
+assumed. See docs/neural-llm.rst's "Composition Grid" table for the full coverage matrix and the one
+real limitation this surfaced (a purely conditional leaf has no unconditional sampler).
+"""
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from mixle.inference import optimize
+from mixle.models import EnergyModel, Flow, build_energy_net, make_mlp
+from mixle.models.softmax_leaf import NeuralCategorical
+from mixle.stats import (
+    CompositeDistribution,
+    CompositeEstimator,
+    GaussianDistribution,
+    HiddenMarkovEstimator,
+    HiddenMarkovModelDistribution,
+    PoissonDistribution,
+    PoissonEstimator,
+)
+from mixle.utils.serialization import from_json, to_json
+
+pytestmark = pytest.mark.fast
+
+
+def _unconditional_seqs(dim=2, n=30, seed=0):
+    init = HiddenMarkovModelDistribution(
+        [Flow(dim=dim), Flow(dim=dim)], [0.5, 0.5], [[0.9, 0.1], [0.1, 0.9]], len_dist=PoissonDistribution(6.0)
+    )
+    sampler = init.sampler(seed=seed)
+    return init, [sampler.sample() for _ in range(n)]
+
+
+def _conditional_seqs(x_dim=3, n_classes=2, n=30, seed=0):
+    # NeuralCategorical has no unconditional sample() (it is p(y|x), never p(x)) -- an HMM whose every
+    # state is such a leaf cannot use its own sampler, so the (x, y) sequences are supplied directly.
+    rng = np.random.RandomState(seed)
+
+    def rand_seq():
+        t = rng.randint(3, 7)
+        return [(rng.randn(x_dim).astype("float32"), int(rng.randint(0, n_classes))) for _ in range(t)]
+
+    return [rand_seq() for _ in range(n)]
+
+
+def _mlp_categorical(x_dim=3, n_classes=2, m_steps=15):
+    return NeuralCategorical(make_mlp(x_dim, [8], n_classes), m_steps=m_steps)
+
+
+class UnconditionalNeuralHmmTest:
+    """An HMM whose emissions are flows -- the flagship claim from neural_density.py's docstring."""
+
+    def test_fits_and_scores_finite(self):
+        init, data = _unconditional_seqs()
+        est = HiddenMarkovEstimator(
+            [Flow(dim=2).estimator(), Flow(dim=2).estimator()], len_estimator=PoissonEstimator()
+        )
+        fitted = optimize(data, est, prev_estimate=init, max_its=2, out=None)
+        assert isinstance(fitted, HiddenMarkovModelDistribution)
+        assert np.isfinite(fitted.log_density(data[0]))
+
+    def test_serializes(self):
+        init, data = _unconditional_seqs()
+        est = HiddenMarkovEstimator(
+            [Flow(dim=2).estimator(), Flow(dim=2).estimator()], len_estimator=PoissonEstimator()
+        )
+        fitted = optimize(data, est, prev_estimate=init, max_its=2, out=None)
+        ll = fitted.log_density(data[0])
+        back = from_json(to_json(fitted))
+        assert np.isclose(back.log_density(data[0]), ll)
+
+
+class ConditionalNeuralHmmTest:
+    """An HMM whose emissions are NeuralCategorical -- fitting works with no unconditional sampler."""
+
+    def test_fits_on_externally_supplied_sequences(self):
+        data = _conditional_seqs()
+        init = HiddenMarkovModelDistribution(
+            [_mlp_categorical(), _mlp_categorical()],
+            [0.5, 0.5],
+            [[0.9, 0.1], [0.1, 0.9]],
+            len_dist=PoissonDistribution(5.0),
+        )
+        est = HiddenMarkovEstimator(
+            [_mlp_categorical().estimator(), _mlp_categorical().estimator()], len_estimator=PoissonEstimator()
+        )
+        fitted = optimize(data, est, prev_estimate=init, max_its=2, out=None)
+        assert np.isfinite(fitted.log_density(data[0]))
+
+    def test_serializes(self):
+        data = _conditional_seqs()
+        init = HiddenMarkovModelDistribution(
+            [_mlp_categorical(), _mlp_categorical()],
+            [0.5, 0.5],
+            [[0.9, 0.1], [0.1, 0.9]],
+            len_dist=PoissonDistribution(5.0),
+        )
+        est = HiddenMarkovEstimator(
+            [_mlp_categorical().estimator(), _mlp_categorical().estimator()], len_estimator=PoissonEstimator()
+        )
+        fitted = optimize(data, est, prev_estimate=init, max_its=2, out=None)
+        ll = fitted.log_density(data[0])
+        back = from_json(to_json(fitted))
+        assert np.isclose(back.log_density(data[0]), ll)
+
+
+class HeterogeneousNeuralCompositeTest:
+    """One Composite record mixing two different neural leaf types with a classical family."""
+
+    def _fields(self):
+        flow = Flow(dim=2)
+        energy = EnergyModel(build_energy_net(dim=2, hidden=16), m_steps=20)
+        cat = _mlp_categorical()
+        gauss = GaussianDistribution(0.0, 1.0)
+        return flow, energy, cat, gauss
+
+    def _rows(self, n=40, seed=0):
+        rng = np.random.RandomState(seed)
+        return [
+            (
+                rng.randn(2).astype("float32"),  # flow field: unconditional vector
+                rng.randn(2).astype("float32"),  # energy field: unconditional vector
+                (rng.randn(3).astype("float32"), int(rng.randint(0, 2))),  # categorical field: (x, y)
+                float(rng.randn()),  # classical scalar field
+            )
+            for _ in range(n)
+        ]
+
+    def test_bare_composite_scores_finite(self):
+        flow, energy, cat, gauss = self._fields()
+        comp = CompositeDistribution((flow, energy, cat, gauss))
+        rows = self._rows()
+        assert np.isfinite(comp.log_density(rows[0]))
+
+    def test_fits_jointly_by_em(self):
+        flow, energy, cat, gauss = self._fields()
+        est = CompositeEstimator((flow.estimator(), energy.estimator(), cat.estimator(), gauss.estimator()))
+        rows = self._rows()
+        fitted = optimize(rows, est, max_its=2, out=None)
+        assert isinstance(fitted, CompositeDistribution)
+        assert np.isfinite(fitted.log_density(rows[0]))
+
+    def test_serializes(self):
+        flow, energy, cat, gauss = self._fields()
+        est = CompositeEstimator((flow.estimator(), energy.estimator(), cat.estimator(), gauss.estimator()))
+        rows = self._rows()
+        fitted = optimize(rows, est, max_its=2, out=None)
+        ll = fitted.log_density(rows[0])
+        back = from_json(to_json(fitted))
+        assert np.isclose(back.log_density(rows[0]), ll)

--- a/mixle/tests/neural_composition_grid_test.py
+++ b/mixle/tests/neural_composition_grid_test.py
@@ -5,8 +5,10 @@ CompositeDistribution / HMM emission like any leaf." Mixture composition is alre
 neural_leaf_serialization_test.py and friends; this file closes the HMM-emission gap (untested for
 every leaf before this) and extends Composite-field coverage to a genuinely heterogeneous record mixing
 multiple neural leaf types with a classical family -- with a JSON round trip proven in every case, not
-assumed. See docs/neural-llm.rst's "Composition Grid" table for the full coverage matrix and the one
-real limitation this surfaced (a purely conditional leaf has no unconditional sampler).
+assumed. See docs/neural-llm.rst's "Composition Grid" table for the full coverage matrix.
+
+Workstream A2b closes the two cells the table originally left "not yet exercised": NeuralGaussian and
+NeuralConditionalDensity (both conditional, p(y|x)) in a Composite field and an HMM emission.
 """
 
 import numpy as np
@@ -16,6 +18,8 @@ torch = pytest.importorskip("torch")
 
 from mixle.inference import optimize
 from mixle.models import EnergyModel, Flow, build_energy_net, make_mlp
+from mixle.models.mixture_density import NeuralConditionalDensity, build_mdn
+from mixle.models.neural_leaf import NeuralGaussian
 from mixle.models.softmax_leaf import NeuralCategorical
 from mixle.stats import (
     CompositeDistribution,
@@ -156,3 +160,86 @@ class HeterogeneousNeuralCompositeTest:
         ll = fitted.log_density(rows[0])
         back = from_json(to_json(fitted))
         assert np.isclose(back.log_density(rows[0]), ll)
+
+
+def _mlp_gaussian(x_dim=3, m_steps=15):
+    return NeuralGaussian(make_mlp(x_dim, [8], 1), noise=1.0, m_steps=m_steps)
+
+
+def _mdn(x_dim=3, y_dim=1, m_steps=15):
+    return NeuralConditionalDensity(build_mdn(x_dim, y_dim, k=2, hidden=8), m_steps=m_steps)
+
+
+def _xy_rows(x_dim=3, n=40, seed=0):
+    rng = np.random.RandomState(seed)
+    return [(rng.randn(x_dim).astype("float32"), np.array([float(rng.randn())], dtype="float32")) for _ in range(n)]
+
+
+class NeuralGaussianCompositeAndHmmTest:
+    """A2b: closes the 'not yet exercised' NeuralGaussian x {Composite, HMM} cells."""
+
+    def test_composite_field_scores_fits_and_serializes(self):
+        ng, gauss = _mlp_gaussian(), GaussianDistribution(0.0, 1.0)
+        comp = CompositeDistribution((ng, gauss))
+        rows = [(xy, float(x)) for xy, x in zip(_xy_rows(), np.random.RandomState(1).randn(40))]
+        assert np.isfinite(comp.log_density(rows[0]))
+        est = CompositeEstimator((ng.estimator(), gauss.estimator()))
+        fitted = optimize(rows, est, max_its=2, out=None)
+        ll = fitted.log_density(rows[0])
+        assert np.isfinite(ll)
+        back = from_json(to_json(fitted))
+        assert np.isclose(back.log_density(rows[0]), ll)
+
+    def test_hmm_emission_fits_and_serializes(self):
+        rng = np.random.RandomState(0)
+
+        def rand_seq():
+            t = rng.randint(3, 7)
+            return [(rng.randn(3).astype("float32"), np.array([float(rng.randn())], dtype="float32")) for _ in range(t)]
+
+        data = [rand_seq() for _ in range(20)]
+        init = HiddenMarkovModelDistribution(
+            [_mlp_gaussian(), _mlp_gaussian()], [0.5, 0.5], [[0.9, 0.1], [0.1, 0.9]], len_dist=PoissonDistribution(5.0)
+        )
+        est = HiddenMarkovEstimator(
+            [_mlp_gaussian().estimator(), _mlp_gaussian().estimator()], len_estimator=PoissonEstimator()
+        )
+        fitted = optimize(data, est, prev_estimate=init, max_its=2, out=None)
+        ll = fitted.log_density(data[0])
+        assert np.isfinite(ll)
+        back = from_json(to_json(fitted))
+        assert np.isclose(back.log_density(data[0]), ll)
+
+
+class NeuralConditionalDensityCompositeAndHmmTest:
+    """A2b: closes the 'not yet exercised' NeuralConditionalDensity x {Composite, HMM} cells."""
+
+    def test_composite_field_scores_fits_and_serializes(self):
+        mdn, gauss = _mdn(), GaussianDistribution(0.0, 1.0)
+        comp = CompositeDistribution((mdn, gauss))
+        rows = [(xy, float(x)) for xy, x in zip(_xy_rows(), np.random.RandomState(1).randn(40))]
+        assert np.isfinite(comp.log_density(rows[0]))
+        est = CompositeEstimator((mdn.estimator(), gauss.estimator()))
+        fitted = optimize(rows, est, max_its=2, out=None)
+        ll = fitted.log_density(rows[0])
+        assert np.isfinite(ll)
+        back = from_json(to_json(fitted))
+        assert np.isclose(back.log_density(rows[0]), ll)
+
+    def test_hmm_emission_fits_and_serializes(self):
+        rng = np.random.RandomState(0)
+
+        def rand_seq():
+            t = rng.randint(3, 7)
+            return [(rng.randn(3).astype("float32"), np.array([float(rng.randn())], dtype="float32")) for _ in range(t)]
+
+        data = [rand_seq() for _ in range(20)]
+        init = HiddenMarkovModelDistribution(
+            [_mdn(), _mdn()], [0.5, 0.5], [[0.9, 0.1], [0.1, 0.9]], len_dist=PoissonDistribution(5.0)
+        )
+        est = HiddenMarkovEstimator([_mdn().estimator(), _mdn().estimator()], len_estimator=PoissonEstimator())
+        fitted = optimize(data, est, prev_estimate=init, max_its=2, out=None)
+        ll = fitted.log_density(data[0])
+        assert np.isfinite(ll)
+        back = from_json(to_json(fitted))
+        assert np.isclose(back.log_density(data[0]), ll)


### PR DESCRIPTION
## Summary
Workstream A2 of the 0.6.3 frontier-capability plan: every neural leaf's own module docstring claims
it "drops into a MixtureDistribution / CompositeDistribution / HMM emission like any leaf." Auditing
actual test coverage found: Mixture composition is broadly tested for every leaf; Composite-field
composition was tested only incidentally (for `NeuralDensity`); HMM-emission composition was tested
for **no leaf at all**. This closes the HMM gap and extends Composite coverage to a genuinely
heterogeneous record.

- **New** `mixle/tests/neural_composition_grid_test.py`: an HMM whose both emissions are `Flow`
  (unconditional neural, the flagship "HMM whose emissions are flows" claim); an HMM whose both
  emissions are `NeuralCategorical` (conditional, fit from externally supplied `(x, y)` sequences); a
  Composite record mixing `Flow` + `EnergyModel` + `NeuralCategorical` + a classical Gaussian field,
  fit jointly by EM. Every case proves fit correctness **and** a JSON round-trip.
- **Real finding** surfaced while closing this: a purely conditional leaf (`NeuralCategorical`,
  `NeuralGaussian`, `NeuralConditionalDensity`) has no unconditional `sample()`, so a Mixture/HMM whose
  every component/state is such a leaf cannot use the model's own sampler -- fitting is unaffected,
  sampling needs externally supplied covariates. Documented, not silently worked around.
- **New** "Composition Grid" section in `docs/neural-llm.rst`: the full leaf x {Mixture, Composite,
  HMM} x serialize coverage table, honestly marking the two cells not yet exercised as a small,
  well-defined follow-up rather than silently claiming full coverage.

## Test plan
- [x] 7 new tests in `neural_composition_grid_test.py`.
- [x] Broader regression sweep: `neural_composition_grid_test`, `neural_leaf_serialization_test`,
      `neural_density_test`, `neural_families_test`, `energy_test` = 42 passed.
- [x] `docs/neural-llm.rst` RST parses cleanly (docutils parse check).
- [x] `ruff check` / `ruff format --check` clean on all changed files.