### PR TITLE
task/I1-I3: VerifiableOracle + the design-test-learn loop

### DIFF
--- a/mixle/doe/__init__.py
+++ b/mixle/doe/__init__.py
@@ -113,6 +113,14 @@ from mixle.doe.optimal import (
     register_criterion,
 )
 from mixle.doe.optimizer import BayesianOptimizer
+from mixle.doe.oracle import (
+    VERIFIABILITY_TIERS,
+    DesignCandidate,
+    DesignRun,
+    OracleResult,
+    VerifiableOracle,
+    optimize_under_oracle,
+)
 from mixle.doe.propagate import propagate, register_propagator, unscented_transform
 from mixle.doe.sensitivity import dgsm, fast_indices, morris_screening, sobol_indices
 from mixle.doe.trust_region import TrustRegion, turbo_minimize
@@ -152,6 +160,12 @@ __all__ = [
     "minimize",
     "propose_next",
     "propose_batch",
+    "VerifiableOracle",
+    "OracleResult",
+    "DesignCandidate",
+    "DesignRun",
+    "optimize_under_oracle",
+    "VERIFIABILITY_TIERS",
     "optimal_design",
     "polynomial_features",
     "d_criterion",

--- a/mixle/doe/oracle.py
+++ b/mixle/doe/oracle.py
@@ -1,0 +1,153 @@
+"""``VerifiableOracle`` -- the honesty boundary for de novo optimization (workstream I).
+
+Given a design goal for which there is no data yet but there IS a way to check a candidate (a
+simulator, an executable test, held-out truth, an assay), :func:`optimize_under_oracle` proposes
+candidates, verifies them against the oracle, and keeps a full receipted history of what was tried and
+why -- the design-test-learn loop, made accountable, rather than "synthesize data and train" with no
+account of what verified it.
+
+The one hard precondition, checked before anything else: there must be a verifiable oracle.
+:class:`VerifiableOracle` rejects a "self-graded by a model" tier at CONSTRUCTION -- that is the banned
+reward this whole workstream exists to forbid -- and :func:`optimize_under_oracle` refuses to run at all
+without one (``oracle=None`` -> the honest "no verifiable objective; cannot optimize" refusal, never a
+fabricated candidate).
+
+This is a first, deliberately narrow slice: continuous/low-dimensional candidate spaces only, using the
+GP Bayesian-optimization loop already in :mod:`mixle.doe` (:class:`~mixle.doe.optimizer.BayesianOptimizer`)
+as the proposal model, proven here against a cheap closed-form oracle before any domain oracle exists (the
+plan's own stated build order). NOT in this slice: structured/discrete candidate spaces (a protein
+sequence, a program), amortizing the oracle into a calibrated surrogate, the shared expected-information-
+gain acquisition with workstreams C5/F6, and full workstream-H receipt objects -- each is a real, separate
+piece of machinery and is left as explicit follow-up rather than half-built here.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+
+from mixle.doe.designs import Bounds
+
+# The declared verifiability tiers, weakest to strongest. "self_graded" is deliberately NOT here: a
+# model grading its own candidates is the banned reward, rejected at VerifiableOracle construction.
+VERIFIABILITY_TIERS = frozenset({"executable", "simulation", "held_out_truth", "real_measurement"})
+
+
+@dataclass
+class OracleResult:
+    """One candidate's verification outcome: its score, a receipt of how it was scored, and its cost."""
+
+    score: float
+    receipt: dict[str, Any] = field(default_factory=dict)
+    cost: float = 1.0
+
+
+@dataclass
+class VerifiableOracle:
+    """A callable ``candidate -> OracleResult`` that declares its verifiability tier and fidelity.
+
+    ``score_fn`` does the actual verification (wrap a simulator, an executable check, a held-out
+    ground-truth lookup, or a real measurement pipeline; :mod:`mixle.task.toolcall`'s ``ToolCaller``
+    is the same "external check as a callable" shape for tool calls). Construction raises if ``tier``
+    is not one of :data:`VERIFIABILITY_TIERS` -- "self-graded by a model" is not a valid tier and is
+    rejected here, not silently accepted and discovered later.
+    """
+
+    name: str
+    tier: str
+    score_fn: Callable[[Any], OracleResult]
+    fidelity: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.tier not in VERIFIABILITY_TIERS:
+            raise ValueError(
+                f"VerifiableOracle tier {self.tier!r} is not a recognized verifiability tier "
+                f"{sorted(VERIFIABILITY_TIERS)}; in particular, an oracle 'self-graded by a model' is "
+                "the banned reward this workstream forbids, and is rejected at construction."
+            )
+
+    def __call__(self, candidate: Any) -> OracleResult:
+        return self.score_fn(candidate)
+
+
+@dataclass
+class DesignCandidate:
+    """One proposed-and-verified candidate: the point tried and what the oracle said about it."""
+
+    x: np.ndarray
+    result: OracleResult
+
+
+@dataclass
+class DesignRun:
+    """The full receipted history of a design loop: every candidate tried, and the oracle's identity."""
+
+    oracle_name: str
+    oracle_tier: str
+    oracle_fidelity: str | None
+    history: list[DesignCandidate] = field(default_factory=list)
+
+    @property
+    def oracle_calls(self) -> int:
+        return len(self.history)
+
+    @property
+    def best(self) -> DesignCandidate:
+        if not self.history:
+            raise ValueError("no candidates were proposed; the run history is empty.")
+        return max(self.history, key=lambda c: c.result.score)
+
+    def scores(self) -> np.ndarray:
+        return np.asarray([c.result.score for c in self.history], dtype=float)
+
+    def report(self) -> dict[str, Any]:
+        """Named receipt of the run: which oracle, at what tier/fidelity, the best candidate found."""
+        b = self.best
+        return {
+            "oracle": self.oracle_name,
+            "tier": self.oracle_tier,
+            "fidelity": self.oracle_fidelity,
+            "oracle_calls": self.oracle_calls,
+            "best_score": b.result.score,
+            "best_x": b.x.tolist(),
+            "best_cost": b.result.cost,
+            "best_receipt": dict(b.result.receipt),
+            "total_cost": float(sum(c.result.cost for c in self.history)),
+        }
+
+
+def optimize_under_oracle(
+    oracle: VerifiableOracle | None,
+    bounds: Bounds,
+    *,
+    n_init: int = 5,
+    n_iter: int = 15,
+    seed: Any = None,
+    **bo_kwargs: Any,
+) -> DesignRun:
+    """The I1-I3 design loop: propose K candidates, verify each with ``oracle``, keep the receipted
+    history, refit the proposal model on every observation, repeat under an ``n_init + n_iter`` budget.
+
+    ``oracle=None`` raises immediately with the honest refusal ("no verifiable objective; cannot
+    optimize") -- the workstream's one hard precondition, checked before any candidate is proposed.
+    Continuous/low-dimensional ``bounds`` only (see module docstring); the proposal model is
+    :class:`~mixle.doe.optimizer.BayesianOptimizer`, maximizing the oracle's score.
+    """
+    if oracle is None:
+        raise ValueError(
+            "no verifiable objective; cannot optimize. optimize_under_oracle requires a "
+            "VerifiableOracle -- this is the workstream's one hard precondition, not a missing default."
+        )
+    from mixle.doe.optimizer import BayesianOptimizer
+
+    opt = BayesianOptimizer(bounds, maximize=True, n_init=n_init, seed=seed, **bo_kwargs)
+    run = DesignRun(oracle_name=oracle.name, oracle_tier=oracle.tier, oracle_fidelity=oracle.fidelity)
+    for _ in range(int(n_init) + int(n_iter)):
+        x = np.asarray(opt.ask(), dtype=np.float64)
+        result = oracle(x)
+        opt.tell(x, result.score)
+        run.history.append(DesignCandidate(x=x, result=result))
+    return run

--- a/mixle/tests/doe_oracle_test.py
+++ b/mixle/tests/doe_oracle_test.py
@@ -1,0 +1,121 @@
+"""VerifiableOracle + optimize_under_oracle: the honesty boundary for de novo optimization (workstream
+I1-I3). Proven here against a cheap closed-form oracle (a scored parameter vector), per the plan's own
+build order, before any domain oracle exists.
+"""
+
+import unittest
+
+import numpy as np
+
+try:
+    import torch  # noqa: F401
+
+    _HAS_TORCH = True
+except ImportError:
+    _HAS_TORCH = False
+
+from mixle.doe.oracle import DesignRun, OracleResult, VerifiableOracle, optimize_under_oracle
+
+
+def _quadratic_bowl_oracle(target, noise=0.0, seed=0):
+    rng = np.random.RandomState(seed)
+
+    def score_fn(x):
+        d2 = float(np.sum((np.asarray(x, dtype=float) - target) ** 2))
+        noisy = -d2 + (rng.normal(0, noise) if noise else 0.0)
+        return OracleResult(score=noisy, receipt={"target_dist2": d2}, cost=1.0)
+
+    return VerifiableOracle(name="quadratic_bowl", tier="executable", score_fn=score_fn, fidelity="exact, noiseless")
+
+
+class VerifiableOracleConstructionTest(unittest.TestCase):
+    def test_valid_tiers_construct(self):
+        for tier in ("executable", "simulation", "held_out_truth", "real_measurement"):
+            VerifiableOracle(name="ok", tier=tier, score_fn=lambda x: OracleResult(0.0))  # must not raise
+
+    def test_self_graded_tier_is_rejected_at_construction(self):
+        with self.assertRaises(ValueError) as ctx:
+            VerifiableOracle(name="bad", tier="self_graded", score_fn=lambda x: OracleResult(0.0))
+        self.assertIn("self_graded", str(ctx.exception))
+
+    def test_unknown_tier_is_rejected(self):
+        with self.assertRaises(ValueError):
+            VerifiableOracle(name="bad", tier="vibes", score_fn=lambda x: OracleResult(0.0))
+
+    def test_oracle_is_callable(self):
+        oracle = VerifiableOracle(name="ok", tier="executable", score_fn=lambda x: OracleResult(score=float(x[0])))
+        result = oracle(np.array([3.0]))
+        self.assertIsInstance(result, OracleResult)
+        self.assertEqual(result.score, 3.0)
+
+
+class NoOracleGuardTest(unittest.TestCase):
+    def test_no_oracle_refuses_rather_than_fabricates(self):
+        with self.assertRaises(ValueError) as ctx:
+            optimize_under_oracle(None, [(-1.0, 1.0)])
+        self.assertIn("no verifiable objective", str(ctx.exception))
+
+
+@unittest.skipUnless(_HAS_TORCH, "the BO proposal model needs torch")
+class DesignLoopTest(unittest.TestCase):
+    def test_finds_the_target_and_returns_a_receipted_run(self):
+        target = np.array([0.5, -1.0])
+        oracle = _quadratic_bowl_oracle(target)
+        run = optimize_under_oracle(
+            oracle,
+            [(-3.0, 3.0), (-3.0, 3.0)],
+            n_init=6,
+            n_iter=20,
+            seed=0,
+            n_candidates=256,
+            fit_kwargs={"max_its": 60},
+        )
+        self.assertIsInstance(run, DesignRun)
+        self.assertEqual(run.oracle_calls, 26)
+        self.assertLess(run.best.result.receipt["target_dist2"], 0.5)  # genuinely converged, not a lucky init draw
+
+    def test_report_names_the_oracle_identity_and_fidelity(self):
+        oracle = _quadratic_bowl_oracle(np.array([1.0, 1.0]))
+        run = optimize_under_oracle(
+            oracle, [(-3.0, 3.0)] * 2, n_init=6, n_iter=10, seed=1, n_candidates=256, fit_kwargs={"max_its": 60}
+        )
+        rep = run.report()
+        self.assertEqual(rep["oracle"], "quadratic_bowl")
+        self.assertEqual(rep["tier"], "executable")
+        self.assertEqual(rep["fidelity"], "exact, noiseless")
+        self.assertEqual(rep["oracle_calls"], 16)
+        self.assertIn("target_dist2", rep["best_receipt"])
+
+    def test_beats_random_search_at_matched_oracle_call_budget(self):
+        """The I acceptance: on a known closed-form oracle, the loop beats random search at matched budget."""
+        target = np.array([0.5, -1.0])
+        bounds = [(-3.0, 3.0), (-3.0, 3.0)]
+        oracle = _quadratic_bowl_oracle(target)
+        budget = 26  # n_init=6 + n_iter=20, matching the loop's own call count
+
+        run = optimize_under_oracle(
+            oracle, bounds, n_init=6, n_iter=20, seed=0, n_candidates=256, fit_kwargs={"max_its": 60}
+        )
+        bo_dist2 = run.best.result.receipt["target_dist2"]
+
+        rng = np.random.RandomState(0)
+        random_pts = rng.uniform([b[0] for b in bounds], [b[1] for b in bounds], size=(budget, 2))
+        random_best = min(float(np.sum((p - target) ** 2)) for p in random_pts)
+
+        self.assertLess(bo_dist2, random_best)  # acquisition-driven search beats matched-budget random search
+
+    def test_negative_result_is_kept_in_the_history_not_hidden(self):
+        """A candidate the surrogate visited but that scored poorly stays in the run log."""
+        oracle = _quadratic_bowl_oracle(np.array([0.0, 0.0]))
+        run = optimize_under_oracle(
+            oracle, [(-3.0, 3.0)] * 2, n_init=6, n_iter=10, seed=2, n_candidates=256, fit_kwargs={"max_its": 60}
+        )
+        scores = run.scores()
+        self.assertEqual(len(scores), run.oracle_calls)
+        self.assertGreater(
+            scores.max() - scores.min(), 0.0
+        )  # some candidates were verifiably worse, and are still there
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Workstream I of the 0.6.3 frontier-capability plan: de novo optimization under a verifiable oracle,
built and proven against a cheap closed-form oracle first, per the plan's own stated build order --
before any domain oracle exists.

- **New** `VerifiableOracle`: a callable `candidate -> OracleResult(score, receipt, cost)` that
  declares its verifiability tier (`executable` / `simulation` / `held_out_truth` /
  `real_measurement`) and fidelity. Construction **rejects** a `self_graded` (or any unrecognized)
  tier -- the banned reward this workstream exists to forbid.
- **New** `optimize_under_oracle(oracle, bounds, n_init, n_iter, ...)`: the propose-verify-refit loop
  for continuous/low-dim candidate spaces, using the existing
  `mixle.doe.optimizer.BayesianOptimizer` ask-tell GP loop as the proposal model.
  `oracle=None` raises `"no verifiable objective; cannot optimize"` immediately -- the workstream's
  one hard precondition, never a fabricated candidate.
- **New** `DesignRun`/`DesignCandidate`: the full receipted history of every candidate tried,
  `.report()` naming the oracle's identity/tier/fidelity and the best candidate found -- a candidate
  the surrogate liked but scored poorly stays in the log, never hidden.
- Exported from `mixle.doe`.

**Not in this slice** (explicit backlog, matching the plan's own sequencing): structured/discrete
candidate spaces; amortizing the oracle into a calibrated surrogate (I4, reuses workstream D); the
shared expected-information-gain acquisition with workstreams C5/F6; full workstream-H receipt
objects. Each is real, separate machinery, not half-built here.

## Test plan
- [x] 9 new tests in `doe_oracle_test.py`: tier construction/rejection, the no-oracle guard, and the I
      acceptance itself -- on a known closed-form quadratic-bowl oracle, the loop converges
      near-exactly and **beats random search at matched oracle-call budget**; poorly-scoring
      candidates stay in the run log.
- [x] Broader regression sweep: `doe_oracle_test`, `doe_bayesopt_test`, `doe_optimal_test` = 45 passed.
- [x] `ruff check` / `ruff format --check` clean on all changed files.

Numerical note: matched the existing `doe_bayesopt_test.py`'s proven `fit_kwargs={'max_its': 60}`
pattern to avoid a pre-existing GP-surrogate Cholesky edge case on a near-noiseless objective -- not
something this PR fixes, since it's a pre-existing numerical-robustness issue in `mixle.doe` unrelated
to this workstream.