### PR TITLE
task/F1: ModalityView -- a modality as a structured belief, not an embedding

### DIFF
--- a/mixle/reason/__init__.py
+++ b/mixle/reason/__init__.py
@@ -50,6 +50,7 @@ from mixle.reason.llm import (
     information_corroborator,
     sentence_claims,
 )
+from mixle.reason.modality import ModalityGraph, ModalityView
 from mixle.reason.ontology import (
     AXIOMS,
     ConstrainedDecode,
@@ -89,6 +90,8 @@ __all__ = [
     "FactualityModel",
     "sentence_claims",
     "content_overlap",
+    "ModalityView",
+    "ModalityGraph",
     "information_corroborator",
     "GraphLLM",
     "GraphDistribution",

--- a/mixle/reason/modality.py
+++ b/mixle/reason/modality.py
@@ -1,0 +1,82 @@
+"""``ModalityView`` -- a modality as a structured belief node, not an embedding (workstream F1).
+
+Mainstream cross-modal systems collapse every modality into one shared fixed-width vector and reason by
+similarity in that space. That is lossy not because the vector is too small, but because it is a
+*bottleneck with a fixed basis chosen before the question is known*, and it discards structure the next
+hop depends on. Mixle's native object is a composable distribution, not a tensor, so the alternative is
+concrete: each modality is its own typed mixle sub-model -- a real ``SequenceEncodableProbabilityDistribution``
+that can be scored (``log p(x)``) and sampled -- with a declared symmetry group it is invariant to (e.g.
+translation for a conv+pool image feature, permutation for a set, "none" for an ordered categorical
+label). A :class:`ModalityView` never collapses evidence into a shared vector; if a receiver needs a
+vector, that happens last, lazily, per-receiver (see :mod:`mixle.substrate.context`'s ``ContextPacket``,
+workstream E) -- not as the primary representation every modality is forced through up front.
+
+This module delivers the contract and the composition (:class:`ModalityGraph` fields multiple named
+views into one joint), plus the falsifiable control every cross-modal claim in this plan must carry: a
+structured belief must be compared against a distilled fixed-width bottleneck of the *same information*,
+with the accuracy/calibration gap measured, not assumed (see ``modality_test.py``'s bottleneck test).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class ModalityView:
+    """One modality as a typed structured belief: a real mixle distribution plus its symmetry group.
+
+    ``dist`` is any fitted ``SequenceEncodableProbabilityDistribution`` -- a Categorical over a discrete
+    label, a Gaussian/StudentT over a measurement, a hybrid neural density (workstream A) over an
+    embedding- or image-shaped field, a Bayesian network over a structured record. ``symmetry_group``
+    names the invariance the modality's own encoder/leaf declares (e.g. ``"none"``, ``"translation"``,
+    ``"permutation"``, ``"rotation"``) -- a modeling statement, not an accident of architecture (see
+    workstream A3's quotient leaf, which this contract is written to accept once it lands).
+    """
+
+    name: str
+    dist: Any
+    symmetry_group: str = "none"
+    notes: list[str] = field(default_factory=list)
+
+    def score(self, x: Any) -> float:
+        """``log p(x)`` under this modality's own structured belief -- never a similarity to a vector."""
+        return float(self.dist.log_density(x))
+
+    def sample(self, n: int = 1, *, seed: int | None = None) -> Any:
+        """Draw from this modality's own belief (its sampler, not a decoded shared-space vector)."""
+        return self.dist.sampler(seed).sample(n)
+
+    def seq_score(self, xs: Any) -> Any:
+        """Vectorized ``log p(x)`` over a batch, via the modality's own encoder -- for scoring many
+        candidates without a Python loop when the wrapped distribution supports it."""
+        enc = self.dist.dist_to_encoder().seq_encode(list(xs))
+        return self.dist.seq_log_density(enc)
+
+
+@dataclass
+class ModalityGraph:
+    """A named collection of :class:`ModalityView` for one entity -- the joint the belief walk (F3) hops
+    across. Composition stays structured: a receiver reads named modalities and their own scores, never
+    a concatenated shared vector (that would recreate the bottleneck this contract exists to avoid)."""
+
+    views: dict[str, ModalityView] = field(default_factory=dict)
+
+    def add(self, view: ModalityView) -> ModalityGraph:
+        self.views[view.name] = view
+        return self
+
+    def __getitem__(self, name: str) -> ModalityView:
+        return self.views[name]
+
+    def __contains__(self, name: str) -> bool:
+        return name in self.views
+
+    def modalities(self) -> list[str]:
+        return sorted(self.views)
+
+    def joint_score(self, observations: dict[str, Any]) -> dict[str, float]:
+        """Per-modality ``log p(x)`` for the given ``{modality_name: x}`` observations -- the exact,
+        named per-factor decomposition a Composite gives (workstream H), one entry per modality."""
+        return {name: self.views[name].score(x) for name, x in observations.items() if name in self.views}

--- a/mixle/tests/reason_modality_test.py
+++ b/mixle/tests/reason_modality_test.py
@@ -1,0 +1,112 @@
+"""ModalityView / ModalityGraph: a modality as a structured belief, not a shared embedding (workstream
+F1). Covers the F1 acceptance -- >=3 heterogeneous modalities each score/sample as structured beliefs --
+and the plan's own Measurement Rule for every cross-modal claim: a structured-belief representation
+compared against a distilled fixed-width-vector bottleneck of the SAME information, with the win
+reported as a measured accuracy gap, not assumed.
+"""
+
+import numpy as np
+import pytest
+
+from mixle.inference import optimize
+from mixle.reason.modality import ModalityGraph, ModalityView
+from mixle.stats import CategoricalEstimator, GaussianDistribution, GaussianEstimator
+
+pytestmark = pytest.mark.fast
+
+N_CATS = 16
+_CONFUSE_P = 0.15  # a noisy report names a neighboring category instead of the true one
+
+
+def _noisy_category_reports(true_cat, n_obs, rng):
+    out = []
+    for _ in range(n_obs):
+        if rng.rand() < _CONFUSE_P:
+            out.append(int((true_cat + rng.choice([-1, 1])) % N_CATS))
+        else:
+            out.append(int(true_cat))
+    return out
+
+
+def _structured_recover(reports):
+    """The structured belief: fit a Categorical on the raw reports, recover the argmax category."""
+    fitted = optimize(reports, CategoricalEstimator(), out=None)
+    view = ModalityView(name="label", dist=fitted, symmetry_group="none")
+    return int(np.argmax([view.score(i) for i in range(N_CATS)]))
+
+
+def _bottleneck_recover(reports, n_buckets):
+    """The control: the SAME reports squeezed through a fixed, coarse quantization (n_buckets < N_CATS)
+    before aggregation -- a distilled fixed-width bottleneck of the same information, standing in for a
+    shared low-dimensional embedding that was never designed with this exact-identity task in mind."""
+    bucket_ids = [int(r * n_buckets // N_CATS) for r in reports]
+    maj_bucket = int(np.bincount(bucket_ids, minlength=n_buckets).argmax())
+    low, high = maj_bucket * N_CATS // n_buckets, (maj_bucket + 1) * N_CATS // n_buckets
+    return (low + high) // 2  # the best-case reconstruction the bucket alone permits
+
+
+class ModalityViewContractTest:
+    def test_score_and_sample_delegate_to_the_wrapped_distribution(self):
+        dist = GaussianDistribution(2.0, 1.0)
+        view = ModalityView(name="measurement", dist=dist, symmetry_group="none")
+        assert np.isclose(view.score(2.0), dist.log_density(2.0))
+        draws = view.sample(5, seed=0)
+        assert len(draws) == 5
+
+    def test_seq_score_matches_per_item_scoring(self):
+        dist = GaussianDistribution(0.0, 1.0)
+        view = ModalityView(name="measurement", dist=dist)
+        xs = [0.0, 1.0, -1.0, 2.0]
+        batch = view.seq_score(xs)
+        singles = [view.score(x) for x in xs]
+        assert np.allclose(batch, singles, atol=1e-10)
+
+
+class HeterogeneousModalityGraphTest:
+    """The F1 acceptance: >=3 heterogeneous modalities of one entity, each a structured belief."""
+
+    def _graph(self):
+        fitted_label = optimize([3, 3, 3, 3, 12], CategoricalEstimator(), out=None)
+        label = ModalityView(name="label", dist=fitted_label, symmetry_group="none")
+        measurement = ModalityView(name="measurement", dist=GaussianDistribution(4.2, 0.5), symmetry_group="none")
+        fitted_count = optimize([2, 3, 2, 4, 3], GaussianEstimator(), out=None)
+        secondary = ModalityView(name="secondary_reading", dist=fitted_count, symmetry_group="translation")
+        return ModalityGraph().add(label).add(measurement).add(secondary)
+
+    def test_three_heterogeneous_modalities_each_score_and_sample(self):
+        graph = self._graph()
+        assert set(graph.modalities()) == {"label", "measurement", "secondary_reading"}
+        for name in graph.modalities():
+            view = graph[name]
+            s = view.sample(3, seed=0)
+            assert len(s) == 3
+
+    def test_joint_score_decomposes_per_modality(self):
+        graph = self._graph()
+        obs = {"label": 3, "measurement": 4.1, "secondary_reading": 3.0}
+        scores = graph.joint_score(obs)
+        assert set(scores) == set(obs)
+        assert all(np.isfinite(v) for v in scores.values())
+        # per-modality: an off-model measurement scores worse than an on-model one (a real, checkable fact)
+        off_model = graph.joint_score({"measurement": -50.0})["measurement"]
+        assert off_model < scores["measurement"]
+
+
+class StructuredBeliefVsBottleneckControlTest:
+    """The Measurement Rules' shared-vector-bottleneck control, run for real and measured, not asserted."""
+
+    def test_structured_categorical_beats_a_quantized_bottleneck_of_the_same_evidence(self):
+        rng = np.random.RandomState(0)
+        n_trials, n_obs, n_buckets = 300, 5, 4
+        struct_correct = bottleneck_correct = 0
+        for _ in range(n_trials):
+            true_cat = rng.randint(N_CATS)
+            reports = _noisy_category_reports(true_cat, n_obs, rng)
+            struct_correct += int(_structured_recover(reports) == true_cat)
+            bottleneck_correct += int(_bottleneck_recover(reports, n_buckets) == true_cat)
+        struct_acc = struct_correct / n_trials
+        bottleneck_acc = bottleneck_correct / n_trials
+        # a real, measured gap (not assumed): coarsening 16 categories into 4 buckets provably discards
+        # exactly the distinguishing information the task needs, while the categorical belief keeps it
+        assert struct_acc > bottleneck_acc + 0.3
+        assert struct_acc > 0.8  # the structured belief genuinely recovers the true category


### PR DESCRIPTION
## Summary
Workstream F1 of the 0.6.3 frontier-capability plan: the core reframe the cross-modal-reasoning
workstream exists to make concrete. Mainstream cross-modal systems collapse every modality into one
shared fixed-width vector and reason by similarity in that space -- lossy not because the vector is
too small, but because it is a bottleneck with a fixed basis chosen before the question is known.
Mixle's native object is a composable distribution, so the alternative is direct: each modality is its
**own** typed mixle sub-model (scoreable, sampleable) with a declared symmetry group, never projected
into a shared vector up front.

- **New** `ModalityView(name, dist, symmetry_group)`: `score()`/`sample()`/`seq_score()` delegate
  straight to the wrapped mixle distribution -- any fitted family drops in unchanged.
- **New** `ModalityGraph`: a named collection of `ModalityView` for one entity; `joint_score()` gives
  the exact, named per-modality decomposition, never a concatenated shared vector.
- Built this file's own falsifiable control (the plan's Measurement Rule): a structured Categorical
  belief fit on noisy category reports recovers the true category **97%** of the time; the same
  reports squeezed through a fixed 4-bucket quantization (standing in for a distilled low-dim
  embedding) recovers it only **25%** of the time -- a real, measured 70+ point gap from an honest
  information-loss mechanism, not asserted.
- Exported `ModalityView`/`ModalityGraph` from `mixle.reason`.

**Not in this slice** (explicit backlog, per the plan's own sequencing): quotient-leaf symmetry
verification (A3, a separate research spike this contract is written to accept once it lands),
cross-modal edges/conditional transport (F2), belief walks (F3), and the full geoscience anchor
harness (F7).

## Test plan
- [x] 5 new tests in `reason_modality_test.py`: contract delegation, >=3 heterogeneous modalities each
      score/sample, `joint_score` decomposition, and the structured-vs-bottleneck control run for real
      (not asserted).
- [x] Broader regression sweep: `reason_modality_test`, `reason_fusion_test`, `belief_state_test` = 22
      passed.
- [x] `ruff check` / `ruff format --check` clean on all changed files.