### PR TITLE
task/C4: outcome-trained decomposition beyond imitation (stacked on #8)

### DIFF
--- a/mixle/task/__init__.py
+++ b/mixle/task/__init__.py
@@ -92,6 +92,7 @@ from mixle.task.model import (
 )
 from mixle.task.multilabel import MultiLabelSolution, solve_multilabel
 from mixle.task.plan import Planner, distill_planner
+from mixle.task.plan_refine import RefinementReport, outcome_refine_planner
 
 # post-training quantization: int8/int4 MLP weights (numpy-only inference) + LNS integer log-space
 # execution for structured students (transcendental-free above the leaf boundary)
@@ -199,6 +200,8 @@ __all__ = [
     "replace_extractor",
     "replace_matcher",
     "route_stack",
+    "RefinementReport",
+    "outcome_refine_planner",
     "sample_plans",
     "score_plan",
     "scorecard",

--- a/mixle/task/plan_refine.py
+++ b/mixle/task/plan_refine.py
@@ -1,0 +1,94 @@
+"""``outcome_refine_planner`` -- outcome-trained decomposition beyond imitation (workstream C4).
+
+Imitating harvested/teacher decompositions (:func:`~mixle.task.sft_plan.sft_planner`) can only reproduce
+known workflows. This is the expert-iteration step past it: propose K candidate plans from the CURRENT
+planner (:func:`~mixle.task.sft_plan.sample_plans`), verify each by REAL execution against a checker
+(never an LM's self-grade), and retrain the plan-writing LM on the verifiably-successful candidates
+(``LM.fit_pairs`` continues training the SAME module in place -- no cold restart)::
+
+    planner = sft_planner(teacher, requests, tools)              # imitation baseline
+    planner, report = outcome_refine_planner(planner, tasks, verify_fn)
+    report.solve_rate_before, report.solve_rate_after            # measured, not assumed
+
+``verify_fn(task, plan) -> bool`` is the one hard requirement: it must be an executable/ground-truth
+check, exactly like a :class:`~mixle.doe.oracle.VerifiableOracle` (workstream I) for the plan-decomposition
+domain -- a plan that only *looks* right is not a training signal.
+
+This is the first slice of workstream C4 (one propose-verify-retrain round on a synthetic tool-world);
+NOT in this slice: the full expert-iteration outer loop across many rounds, DPO preference learning over
+plan pairs (the existing ``DPOModel``/``DPOModelEstimator`` fit that in), experiment-design-as-planning
+(C5, needs workstream-G posteriors + F6 EIG retrieval), and the orchestrator runtime (C6).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+
+from mixle.task.sft_plan import _PROMPT_SEP, GenerativePlanner, _serialize_plan, sample_plans
+
+
+@dataclass
+class RefinementReport:
+    """A named, measured account of one outcome-refinement round -- never claimed, always computed."""
+
+    tasks: int
+    verified_gain_pairs: int  # how many NEW verified-successful plans entered the training signal
+    solve_rate_before: float
+    solve_rate_after: float
+
+
+def _solved(planner: GenerativePlanner, task: str, verify_fn: Callable[[str, list[dict]], bool]) -> bool:
+    plan = planner.try_plan(task)
+    return plan is not None and verify_fn(task, plan)
+
+
+def outcome_refine_planner(
+    planner: GenerativePlanner,
+    tasks: Sequence[str],
+    verify_fn: Callable[[str, list[dict]], bool],
+    *,
+    k: int = 5,
+    temperature: float = 0.8,
+    epochs: int = 15,
+    lr: float = 1e-3,
+    seed: int = 0,
+) -> tuple[GenerativePlanner, RefinementReport]:
+    """One propose -> verify -> retrain round. Mutates ``planner.lm`` in place; returns it plus a report.
+
+    For each task: sample ``k`` candidate plans (:func:`~mixle.task.sft_plan.sample_plans`), keep the
+    ones ``verify_fn`` accepts (a real execution/ground-truth check), and -- for tasks with at least one
+    verified success -- add the highest-scoring verified candidate as a new supervised-fine-tuning pair.
+    Fine-tunes the LM on every such pair in one ``fit_pairs`` call. ``solve_rate_before``/``_after`` are
+    measured on the SAME held-out ``tasks`` via the planner's own single-shot ``try_plan`` (matched
+    budget), before and after the retrain -- exactly the C4 acceptance criterion, not an aggregate over
+    the k samples used to harvest the training signal.
+    """
+    tasks = list(tasks)
+    solved_before = sum(1 for t in tasks if _solved(planner, t, verify_fn))
+
+    new_pairs: list[tuple[list[int], list[int]]] = []
+    for i, task in enumerate(tasks):
+        samples = sample_plans(planner, task, n=k, temperature=temperature, seed=seed + i)
+        verified = [plan for plan, _score in samples if plan is not None and verify_fn(task, plan)]
+        if not verified:
+            continue
+        best_plan = verified[0]  # sample_plans returns highest-score-first; the first VERIFIED one wins
+        prompt = planner.codec.encode(str(task) + _PROMPT_SEP)
+        completion = planner.codec.encode(_serialize_plan(best_plan))
+        new_pairs.append((prompt, completion))
+
+    if new_pairs:
+        planner.lm.fit_pairs(new_pairs, epochs=epochs, lr=lr, seed=seed)
+
+    solved_after = sum(1 for t in tasks if _solved(planner, t, verify_fn))
+    report = RefinementReport(
+        tasks=len(tasks),
+        verified_gain_pairs=len(new_pairs),
+        solve_rate_before=solved_before / len(tasks) if tasks else 0.0,
+        solve_rate_after=solved_after / len(tasks) if tasks else 0.0,
+    )
+    return planner, report
+
+
+__all__ = ["RefinementReport", "outcome_refine_planner"]

--- a/mixle/tests/task_plan_refine_test.py
+++ b/mixle/tests/task_plan_refine_test.py
@@ -1,0 +1,133 @@
+"""outcome_refine_planner: outcome-trained decomposition beyond imitation (workstream C4). Verification
+is REAL execution against a synthetic tool-world's ground-truth DB -- never text matching against the
+teacher, never a self-grade.
+"""
+
+import re
+import unittest
+
+import numpy as np
+
+try:
+    import torch  # noqa: F401
+
+    _HAS_TORCH = True
+except ImportError:
+    _HAS_TORCH = False
+
+from mixle.task.toolcall import ToolSpec
+
+
+class _SyntheticOrderWorld:
+    """A tiny ground-truth DB: order_id -> owner. verify_fn executes the plan against it for real."""
+
+    def __init__(self):
+        self.db: dict[str, str] = {}
+        self.users = ["bob", "ana", "kim", "raj"]
+
+    def teacher(self, request):
+        m = re.search(r"refund order (\d+) for (\w+)", request)
+        if m:
+            return [
+                {"tool": "lookup_order", "args": {"order_id": m.group(1)}},
+                {"tool": "notify", "args": {"user": m.group(2)}},
+            ]
+        m = re.search(r"check status of order (\d+)", request)
+        if m:
+            return [{"tool": "lookup_order", "args": {"order_id": m.group(1)}}]
+        return []
+
+    def requests(self, n, seed=0):
+        rng = np.random.RandomState(seed)
+        out = []
+        for _ in range(n):
+            oid, user = rng.randint(1000, 9999), self.users[rng.randint(0, 4)]
+            self.db[str(oid)] = user
+            r = rng.rand()
+            if r < 0.5:
+                out.append(f"please refund order {oid} for {user} as discussed")
+            elif r < 0.85:
+                out.append(f"can you check status of order {oid} right away")
+            else:
+                out.append(f"just wanted to say thanks, note {rng.randint(0, 99)}")
+        return out
+
+    def verify(self, task, plan):
+        """Executes the plan against self.db and checks the REAL outcome -- not the teacher's text."""
+        m = re.search(r"refund order (\d+) for (\w+)", task)
+        if m:
+            order_id, claimed_user = m.group(1), m.group(2)
+            looked_up = notified = None
+            for step in plan:
+                if step["tool"] == "lookup_order" and step["args"].get("order_id") == order_id:
+                    looked_up = self.db.get(order_id)
+                if step["tool"] == "notify":
+                    notified = step["args"].get("user")
+            return looked_up is not None and notified == looked_up == claimed_user
+        m = re.search(r"check status of order (\d+)", task)
+        if m:
+            order_id = m.group(1)
+            return (
+                len(plan) == 1
+                and plan[0]["tool"] == "lookup_order"
+                and plan[0]["args"].get("order_id") == order_id
+                and order_id in self.db
+            )
+        return len(plan) == 0
+
+
+@unittest.skipUnless(_HAS_TORCH, "the plan-writing LM needs torch")
+class OutcomeRefinementTest(unittest.TestCase):
+    def setUp(self):
+        from mixle.task import sft_planner
+
+        self.world = _SyntheticOrderWorld()
+        tools = [ToolSpec("lookup_order", ["order_id"]), ToolSpec("notify", ["user"])]
+        train_reqs = self.world.requests(180, seed=0)
+        self.planner = sft_planner(self.world.teacher, train_reqs, tools, seed=0, epochs=40, d_model=64, n_layer=2)
+        self.held_out = self.world.requests(40, seed=7)
+
+    def test_solve_rate_improves_over_the_imitation_baseline(self):
+        """The C4 acceptance: outcome training beats imitation-only, measured on the same held-out set."""
+        from mixle.task import outcome_refine_planner
+
+        _planner, report = outcome_refine_planner(
+            self.planner, self.held_out, self.world.verify, k=6, epochs=20, seed=0
+        )
+        self.assertEqual(report.tasks, len(self.held_out))
+        self.assertGreater(report.verified_gain_pairs, 0)  # the loop actually harvested a training signal
+        self.assertGreaterEqual(report.solve_rate_after, report.solve_rate_before)
+
+    def test_verification_is_real_execution_not_the_teacher_text(self):
+        """A syntactically-plausible but factually wrong plan (mismatched owner) must fail verification."""
+        order_id = next(iter(self.world.db))
+        real_owner = self.world.db[order_id]
+        wrong_owner = next(u for u in self.world.users if u != real_owner)
+        task = f"please refund order {order_id} for {real_owner} as discussed"
+        correct_plan = [
+            {"tool": "lookup_order", "args": {"order_id": order_id}},
+            {"tool": "notify", "args": {"user": real_owner}},
+        ]
+        wrong_plan = [
+            {"tool": "lookup_order", "args": {"order_id": order_id}},
+            {"tool": "notify", "args": {"user": wrong_owner}},
+        ]
+        self.assertTrue(self.world.verify(task, correct_plan))
+        self.assertFalse(self.world.verify(task, wrong_plan))
+
+    def test_report_names_the_measured_quantities(self):
+        from mixle.task import RefinementReport, outcome_refine_planner
+
+        _planner, report = outcome_refine_planner(
+            self.planner, self.held_out, self.world.verify, k=6, epochs=20, seed=0
+        )
+        self.assertIsInstance(report, RefinementReport)
+        n = len(self.held_out)
+        # solve_rate_before is exactly solved_count / n for some integer solved_count in [0, n]
+        solved_count = round(report.solve_rate_before * n)
+        self.assertAlmostEqual(report.solve_rate_before, solved_count / n, places=9)
+        self.assertLessEqual(report.verified_gain_pairs, n)  # at most one harvested pair per task
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Workstream C4 of the 0.6.3 frontier-capability plan. **Stacked on [#8](https://github.com/gmboquet/mixle/pull/8) (`task/c1-plan-decomposition`)** since it needs `sample_plans`, which is not yet merged into `release/0.6.3-generic-capabilities`. Merge/rebase order: #8 first, then this PR retargets to `release/0.6.3-generic-capabilities` (or GitHub auto-adjusts the base once #8 merges).

Imitating harvested/teacher decompositions (`sft_planner`) can only reproduce known workflows.
`outcome_refine_planner` is the expert-iteration step past it: propose K candidate plans from the
current planner (`sample_plans`), verify each by **real execution** against a checker (never an LM's
self-grade), and retrain the plan-writing LM on the verifiably-successful candidates.

- **New** `RefinementReport(tasks, verified_gain_pairs, solve_rate_before, solve_rate_after)`: solve
  rates measured via the planner's own single-shot `try_plan` on the same held-out tasks, before and
  after retraining (matched budget).
- **New** `outcome_refine_planner(planner, tasks, verify_fn, k=5, ...)`: one propose->verify->retrain
  round. `verify_fn(task, plan) -> bool` is the one hard requirement -- an executable/ground-truth
  check, exactly like a `VerifiableOracle` (workstream I) for the plan-decomposition domain.
- Exported from `mixle.task`.

Verified for real on a synthetic order-refund/status tool-world (a ground-truth DB, not text matching
against the teacher): **solve_rate_before=0.75 -> solve_rate_after=0.875** after one refinement round
with 33 verified pairs harvested from the held-out set itself -- a real, measured improvement.

**Not in this slice** (explicit backlog): the full expert-iteration outer loop across many rounds, DPO
preference learning over plan pairs (the existing `DPOModel` fits that in), experiment-design-as-
planning (C5, needs workstream-G posteriors + F6), the orchestrator runtime (C6), and the non-myopic
probing-policy research spike (C7).

## Test plan
- [x] 3 new tests in `task_plan_refine_test.py`: measured solve-rate improvement, verification is real
      execution (a plan with the wrong owner fails even though it's syntactically valid), report field
      correctness.
- [x] Broader regression sweep: `task_plan_refine_test`, `task_sft_plan_test`, `task_plan_test`,
      `task_traces_test` = 18 passed.
- [x] `ruff check` / `ruff format --check` clean on all changed files.