### PR TITLE
task/A2b: close the NeuralGaussian/NeuralConditionalDensity composition-grid gap (stacked on #10)

### DIFF
--- a/docs/neural-llm.rst
+++ b/docs/neural-llm.rst
@@ -363,9 +363,9 @@ test rather than assumed.
      - Serializes in each context
    * - ``NeuralGaussian`` (conditional, ``p(y|x)``)
      - tested
-     - untested (no architectural reason it would fail; not yet exercised)
-     - untested (as above)
-     - tested (Mixture only)
+     - tested
+     - tested
+     - tested in all three
    * - ``NeuralCategorical`` (conditional, ``p(y|x)``)
      - tested
      - tested
@@ -378,9 +378,9 @@ test rather than assumed.
      - tested in all three
    * - ``NeuralConditionalDensity`` (``mixture_density``, conditional)
      - tested
-     - untested (not yet exercised)
-     - untested (as above)
-     - tested (Mixture only)
+     - tested
+     - tested
+     - tested in all three
    * - ``EnergyModel`` (unconditional, approximately normalized)
      - tested
      - tested
@@ -394,10 +394,10 @@ model's own ``sampler()`` -- ``NeuralCategorical.sample()`` raises by design (se
 still works fine: ``optimize`` only needs ``log_density``/the accumulator contract, not sampling, so a
 conditionally-emitting HMM trains normally on externally supplied ``(x, y)`` sequences. See
 ``mixle/tests/neural_composition_grid_test.py`` for the HMM/Composite tests (the Mixture-column entries
-were already covered by ``neural_leaf_serialization_test.py`` and friends). The two remaining "untested"
-cells are not known to be broken -- there is no architectural reason a conditional field would fail
-inside Composite, or an unconditional density would fail as an HMM emission -- they are simply not yet
-exercised; closing them is a small, well-defined follow-up.
+were already covered by ``neural_leaf_serialization_test.py`` and friends). ``EnergyModel`` x HMM is the
+one remaining "untested" cell -- not known to be broken, there is no architectural reason an
+approximately-normalized unconditional density would fail as an HMM emission, simply not yet exercised;
+closing it is a small, well-defined follow-up.
 
 Examples And Tests
 ------------------

--- a/mixle/tests/neural_composition_grid_test.py
+++ b/mixle/tests/neural_composition_grid_test.py
@@ -5,8 +5,10 @@ CompositeDistribution / HMM emission like any leaf." Mixture composition is alre
 neural_leaf_serialization_test.py and friends; this file closes the HMM-emission gap (untested for
 every leaf before this) and extends Composite-field coverage to a genuinely heterogeneous record mixing
 multiple neural leaf types with a classical family -- with a JSON round trip proven in every case, not
-assumed. See docs/neural-llm.rst's "Composition Grid" table for the full coverage matrix and the one
-real limitation this surfaced (a purely conditional leaf has no unconditional sampler).
+assumed. See docs/neural-llm.rst's "Composition Grid" table for the full coverage matrix.
+
+Workstream A2b closes the two cells the table originally left "not yet exercised": NeuralGaussian and
+NeuralConditionalDensity (both conditional, p(y|x)) in a Composite field and an HMM emission.
 """
 
 import numpy as np
@@ -16,6 +18,8 @@ torch = pytest.importorskip("torch")
 
 from mixle.inference import optimize
 from mixle.models import EnergyModel, Flow, build_energy_net, make_mlp
+from mixle.models.mixture_density import NeuralConditionalDensity, build_mdn
+from mixle.models.neural_leaf import NeuralGaussian
 from mixle.models.softmax_leaf import NeuralCategorical
 from mixle.stats import (
     CompositeDistribution,
@@ -156,3 +160,86 @@ class HeterogeneousNeuralCompositeTest:
         ll = fitted.log_density(rows[0])
         back = from_json(to_json(fitted))
         assert np.isclose(back.log_density(rows[0]), ll)
+
+
+def _mlp_gaussian(x_dim=3, m_steps=15):
+    return NeuralGaussian(make_mlp(x_dim, [8], 1), noise=1.0, m_steps=m_steps)
+
+
+def _mdn(x_dim=3, y_dim=1, m_steps=15):
+    return NeuralConditionalDensity(build_mdn(x_dim, y_dim, k=2, hidden=8), m_steps=m_steps)
+
+
+def _xy_rows(x_dim=3, n=40, seed=0):
+    rng = np.random.RandomState(seed)
+    return [(rng.randn(x_dim).astype("float32"), np.array([float(rng.randn())], dtype="float32")) for _ in range(n)]
+
+
+class NeuralGaussianCompositeAndHmmTest:
+    """A2b: closes the 'not yet exercised' NeuralGaussian x {Composite, HMM} cells."""
+
+    def test_composite_field_scores_fits_and_serializes(self):
+        ng, gauss = _mlp_gaussian(), GaussianDistribution(0.0, 1.0)
+        comp = CompositeDistribution((ng, gauss))
+        rows = [(xy, float(x)) for xy, x in zip(_xy_rows(), np.random.RandomState(1).randn(40))]
+        assert np.isfinite(comp.log_density(rows[0]))
+        est = CompositeEstimator((ng.estimator(), gauss.estimator()))
+        fitted = optimize(rows, est, max_its=2, out=None)
+        ll = fitted.log_density(rows[0])
+        assert np.isfinite(ll)
+        back = from_json(to_json(fitted))
+        assert np.isclose(back.log_density(rows[0]), ll)
+
+    def test_hmm_emission_fits_and_serializes(self):
+        rng = np.random.RandomState(0)
+
+        def rand_seq():
+            t = rng.randint(3, 7)
+            return [(rng.randn(3).astype("float32"), np.array([float(rng.randn())], dtype="float32")) for _ in range(t)]
+
+        data = [rand_seq() for _ in range(20)]
+        init = HiddenMarkovModelDistribution(
+            [_mlp_gaussian(), _mlp_gaussian()], [0.5, 0.5], [[0.9, 0.1], [0.1, 0.9]], len_dist=PoissonDistribution(5.0)
+        )
+        est = HiddenMarkovEstimator(
+            [_mlp_gaussian().estimator(), _mlp_gaussian().estimator()], len_estimator=PoissonEstimator()
+        )
+        fitted = optimize(data, est, prev_estimate=init, max_its=2, out=None)
+        ll = fitted.log_density(data[0])
+        assert np.isfinite(ll)
+        back = from_json(to_json(fitted))
+        assert np.isclose(back.log_density(data[0]), ll)
+
+
+class NeuralConditionalDensityCompositeAndHmmTest:
+    """A2b: closes the 'not yet exercised' NeuralConditionalDensity x {Composite, HMM} cells."""
+
+    def test_composite_field_scores_fits_and_serializes(self):
+        mdn, gauss = _mdn(), GaussianDistribution(0.0, 1.0)
+        comp = CompositeDistribution((mdn, gauss))
+        rows = [(xy, float(x)) for xy, x in zip(_xy_rows(), np.random.RandomState(1).randn(40))]
+        assert np.isfinite(comp.log_density(rows[0]))
+        est = CompositeEstimator((mdn.estimator(), gauss.estimator()))
+        fitted = optimize(rows, est, max_its=2, out=None)
+        ll = fitted.log_density(rows[0])
+        assert np.isfinite(ll)
+        back = from_json(to_json(fitted))
+        assert np.isclose(back.log_density(rows[0]), ll)
+
+    def test_hmm_emission_fits_and_serializes(self):
+        rng = np.random.RandomState(0)
+
+        def rand_seq():
+            t = rng.randint(3, 7)
+            return [(rng.randn(3).astype("float32"), np.array([float(rng.randn())], dtype="float32")) for _ in range(t)]
+
+        data = [rand_seq() for _ in range(20)]
+        init = HiddenMarkovModelDistribution(
+            [_mdn(), _mdn()], [0.5, 0.5], [[0.9, 0.1], [0.1, 0.9]], len_dist=PoissonDistribution(5.0)
+        )
+        est = HiddenMarkovEstimator([_mdn().estimator(), _mdn().estimator()], len_estimator=PoissonEstimator())
+        fitted = optimize(data, est, prev_estimate=init, max_its=2, out=None)
+        ll = fitted.log_density(data[0])
+        assert np.isfinite(ll)
+        back = from_json(to_json(fitted))
+        assert np.isclose(back.log_density(data[0]), ll)


### PR DESCRIPTION
## Summary
Stacked on [#10](https://github.com/gmboquet/mixle/pull/10) (`task/a2-composition-grid`) -- this edits
the same doc table and test file, so it needs #10's content. Merge order: #10 first.

A2's composition-grid table honestly flagged two cells as "not yet exercised" rather than claiming
full coverage: `NeuralGaussian` and `NeuralConditionalDensity` (both conditional, `p(y|x)`) in a
Composite field and an HMM emission. This closes both.

- 4 new tests in `neural_composition_grid_test.py`: `NeuralGaussian` in a Composite field (mixed with
  a classical Gaussian field) and in a 2-state HMM emission; `NeuralConditionalDensity` (an MDN-backed
  conditional density) in the same two contexts. Every case proves fit correctness **and** a JSON
  round-trip.
- Updated `docs/neural-llm.rst`'s Composition Grid table: both leaves now read "tested in all three"
  across Mixture/Composite/HMM. Only `EnergyModel` x HMM remains an honest "not yet exercised" cell.

## Test plan
- [x] `neural_composition_grid_test.py` = 11 tests total (4 new), all pass.
- [x] Broader sweep: `neural_composition_grid_test`, `neural_leaf_serialization_test`,
      `neural_leaf_test` = 27 passed.
- [x] `docs/neural-llm.rst` RST parses cleanly.
- [x] `ruff check` / `ruff format --check` clean.