### PR TITLE
task/E2: receiver-conditioned compression (stacked on #9)

### DIFF
--- a/mixle/substrate/__init__.py
+++ b/mixle/substrate/__init__.py
@@ -23,7 +23,14 @@ from mixle.substrate.act import (
     simulate_action,
 )
 from mixle.substrate.answer import Answer, answer_from_substrate
-from mixle.substrate.context import ContextBudget, ContextPacket, assemble_context, compress_text
+from mixle.substrate.context import (
+    ContextBudget,
+    ContextPacket,
+    ReceiverProfile,
+    assemble_context,
+    assemble_for_receivers,
+    compress_text,
+)
 from mixle.substrate.core import MODALITIES, Substrate, SubstrateItem
 from mixle.substrate.factuality import ClaimVerdict, FactualityReceipt, check_factuality
 from mixle.substrate.freshness import Freshness, check_freshness, content_hash, freshness_report
@@ -71,7 +78,9 @@ __all__ = [
     "ingest_records",
     "ContextPacket",
     "ContextBudget",
+    "ReceiverProfile",
     "assemble_context",
+    "assemble_for_receivers",
     "compress_text",
     "retrieve",
     "Retrieval",

--- a/mixle/substrate/context.py
+++ b/mixle/substrate/context.py
@@ -12,6 +12,7 @@ event records the budget, usage, and number of selected items.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -295,6 +296,53 @@ def compress_text(text: str, task: str, max_chars: int) -> str:
     """Extractive, torch-free summary of ``text`` keeping the sentences most relevant to ``task``,
     within ``max_chars`` (the standalone compressor used by :func:`assemble_context` with ``compress=True``)."""
     return _compress(text, task, int(max_chars))
+
+
+@dataclass
+class ReceiverProfile:
+    """A named receiver's capacity -- what :func:`assemble_for_receivers` budgets and shapes for it.
+
+    A frontier LM and a local student are not the same target: the LM affords a large, prose-shaped
+    context; the student needs a small, feature-shaped one. ``ReceiverProfile`` names that difference
+    so it is set once per receiver, not re-derived ad hoc at every call site (workstream E2:
+    receiver-conditioned compression)."""
+
+    name: str
+    max_chars: int = 2000
+    max_items: int = 20
+    shape: str = "passages"  # 'passages' (LLM) | 'brief' (human) | 'features' (student)
+    compress: bool = False
+
+    def to_budget(self) -> ContextBudget:
+        return ContextBudget(max_chars=self.max_chars, max_items=self.max_items, shape=self.shape)
+
+
+def assemble_for_receivers(
+    substrate: Substrate,
+    task: str,
+    receivers: Sequence[ReceiverProfile],
+    *,
+    kind: str | None = None,
+    scope: str | None = None,
+    telemetry: Any = None,
+) -> dict[str, ContextPacket]:
+    """Assemble ONE task-conditioned :class:`ContextPacket` per named receiver -- the concrete
+    receiver-conditioned compression from workstream E2: two receivers reading the SAME substrate for
+    the SAME task get genuinely different renderings (budget, shape, and -- via ``compress`` -- which
+    sentences survive), never the same blob truncated to fit.
+
+        packets = assemble_for_receivers(substrate, task, [
+            ReceiverProfile("frontier_llm", max_chars=2000, shape="passages"),
+            ReceiverProfile("local_student", max_chars=200, shape="features", compress=True),
+        ])
+        packets["frontier_llm"].render(), packets["local_student"].render()
+    """
+    return {
+        r.name: assemble_context(
+            substrate, task, budget=r.to_budget(), kind=kind, scope=scope, compress=r.compress, telemetry=telemetry
+        )
+        for r in receivers
+    }
 
 
 def _emit(telemetry: Any, packet: ContextPacket) -> None:

--- a/mixle/tests/context_test.py
+++ b/mixle/tests/context_test.py
@@ -2,7 +2,15 @@
 
 import unittest
 
-from mixle.substrate import ContextBudget, Substrate, assemble_context, compress_text, ingest_documents
+from mixle.substrate import (
+    ContextBudget,
+    ReceiverProfile,
+    Substrate,
+    assemble_context,
+    assemble_for_receivers,
+    compress_text,
+    ingest_documents,
+)
 from mixle.telemetry import Telemetry
 
 try:
@@ -215,6 +223,71 @@ class KnowledgePacketTransferTest(unittest.TestCase):
         self.assertGreater(len(d_llm["payload"]["rendered"]), len(d_student["payload"]["rendered"]))
         self.assertLessEqual(d_student["byte_budget"], 80)
         self.assertLessEqual(d_llm["byte_budget"], 500)
+
+
+class ReceiverConditionedCompressionTest(unittest.TestCase):
+    """workstream E2: assemble_for_receivers budgets and shapes per named receiver in one call."""
+
+    def _corpus_substrate(self):
+        s = Substrate()
+        ingest_documents(
+            s,
+            ["cats are mammals that purr", "dogs are mammals that bark", "the moon orbits the earth"],
+            source="animal facts",
+        )
+        return s
+
+    def _shop_substrate(self):
+        s = Substrate()
+        s.add(
+            "text",
+            "The company was founded in 1998. Our headquarters are in Denver. "
+            "The refund policy allows returns within 30 days of purchase. We have 200 employees.",
+        )
+        s.add(
+            "text",
+            "Shipping is handled by a third party. Orders ship in 2 business days. "
+            "Refunds for defective items are processed immediately without a restocking fee.",
+        )
+        return s
+
+    def test_each_receiver_gets_its_own_budget_and_shape(self):
+        s = self._shop_substrate()
+        packets = assemble_for_receivers(
+            s,
+            "refund policy",
+            [
+                ReceiverProfile("frontier_llm", max_chars=500, shape="passages"),
+                ReceiverProfile("local_student", max_chars=60, shape="features", compress=True),
+            ],
+        )
+        self.assertEqual(set(packets), {"frontier_llm", "local_student"})
+        llm, student = packets["frontier_llm"], packets["local_student"]
+        self.assertLessEqual(llm.used_chars, 500)
+        self.assertLess(student.used_chars, llm.used_chars)  # the tight-budget receiver gets far less text
+        self.assertGreater(len(llm.render()), len(student.render()))
+        self.assertFalse(llm.compressed)
+        self.assertTrue(student.compressed)  # only the tight-budget receiver's profile asked for compression
+
+    def test_matches_the_e1_to_knowledge_dict_round_trip_per_receiver(self):
+        """Each receiver's packet feeds the E1 transfer contract independently, carrying its own target_kind."""
+        s = self._corpus_substrate()
+        packets = assemble_for_receivers(
+            s,
+            "mammals",
+            [ReceiverProfile("frontier_llm", max_chars=500), ReceiverProfile("local_student", max_chars=60)],
+        )
+        d_llm = packets["frontier_llm"].to_knowledge_dict(id="p1", project_id="proj", target_kind="frontier_llm")
+        d_student = packets["local_student"].to_knowledge_dict(id="p2", project_id="proj", target_kind="local_student")
+        self.assertEqual(d_llm["task"], d_student["task"])
+        self.assertNotEqual(d_llm["byte_budget"], d_student["byte_budget"])
+
+    def test_receiver_profile_to_budget_matches_its_fields(self):
+        profile = ReceiverProfile("x", max_chars=123, max_items=7, shape="brief")
+        budget = profile.to_budget()
+        self.assertEqual(budget.max_chars, 123)
+        self.assertEqual(budget.max_items, 7)
+        self.assertEqual(budget.shape, "brief")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Stacked on [#9](https://github.com/gmboquet/mixle/pull/9) (`task/e1-contextpacket-alignment`) -- extends the same `ContextPacket`/`ContextBudget` surface. Merge order: #9 first.

Budget and compress a packet to the receiving model's capacity: a frontier LM and a local student
reading the same substrate for the same task should get genuinely different renderings, not the same
blob truncated to fit.

- **New** `ReceiverProfile(name, max_chars, max_items, shape, compress)`: a named receiver's capacity,
  set once rather than re-derived ad hoc at every call site.
- **New** `assemble_for_receivers(substrate, task, receivers)`: assembles one task-conditioned
  `ContextPacket` per named receiver in a single call -- the E1 two-receiver test's ad hoc pattern
  (two separate `assemble_context` calls) made into a first-class, reusable primitive.
- Exported from `mixle.substrate`.

## Test plan
- [x] 3 new tests in `context_test.py`: each receiver gets its own budget/shape (a tight-budget
      receiver triggers real compression, a large-budget one doesn't), each receiver's packet still
      feeds E1's `to_knowledge_dict` independently, `ReceiverProfile.to_budget()` correctness.
- [x] Broader sweep: `context_test`, `factuality_test`, `substrate_test` = 34 passed.
- [x] `ruff check` / `ruff format --check` clean.