### PR TITLE
task/KNOW-a: harvest -> assimilate calibrated belief, anti-laundering (workstream E)

### DIFF
--- a/mixle/substrate/__init__.py
+++ b/mixle/substrate/__init__.py
@@ -23,6 +23,18 @@ from mixle.substrate.act import (
     simulate_action,
 )
 from mixle.substrate.answer import Answer, answer_from_substrate
+from mixle.substrate.belief import (
+    MODEL_ASSERTION,
+    MODEL_ASSERTION_CAP,
+    BeliefItem,
+    Claim,
+    EvidenceEntry,
+    assimilate,
+    credence_from_history,
+    harvest_knowledge,
+    retract,
+    retrieve_beliefs,
+)
 from mixle.substrate.context import (
     ContextBudget,
     ContextPacket,
@@ -143,4 +155,14 @@ __all__ = [
     "monitoring_harness",
     "register_harness",
     "find_harnesses",
+    "harvest_knowledge",
+    "assimilate",
+    "retract",
+    "retrieve_beliefs",
+    "credence_from_history",
+    "BeliefItem",
+    "Claim",
+    "EvidenceEntry",
+    "MODEL_ASSERTION",
+    "MODEL_ASSERTION_CAP",
 ]

--- a/mixle/substrate/belief.py
+++ b/mixle/substrate/belief.py
@@ -1,0 +1,292 @@
+"""Calibrated belief store: harvest claims from model output and assimilate them as CREDENCES.
+
+A model's output is a paragraph of assertions -- some grounded, some not. This module turns each
+assertion into a tracked belief with a probability (not a binary "fact" flag) that moves with the
+STRENGTH of its evidence: a verifiable source (a document, an executable check, a held-out truth, a
+real measurement) moves it strongly; the model's own say-so moves it weakly and is capped low. Every
+belief carries its full ``evidence_history`` so the current credence is always reproducible by
+replaying it, and evidence can be revised or :func:`retract`-ed, cascading to whatever depended on it.
+
+Anti-laundering is the load-bearing property: evidence that resolves back to the claim itself, or to
+another belief that has no independent (non-model-assertion) support of its own, contributes ZERO --
+a claim cannot bootstrap high credence by citing itself or an equally ungrounded peer.
+
+This is the write side of workstream E (harvest / credence assimilation / traceable history); the read
+side is :mod:`mixle.substrate.retrieve`. See ``notes/0.6.3-execution-playbook.md`` CARD KNOW-a.
+"""
+
+from __future__ import annotations
+
+import math
+import time
+import uuid
+from collections.abc import Callable, Sequence
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+from mixle.substrate.core import Substrate, SubstrateItem
+
+# The weakest evidence tier: a model asserting something about itself, with no external check. Kept
+# outside mixle.doe.oracle.VERIFIABILITY_TIERS because "a model graded itself" is exactly the tier that
+# workstream I rejects for de novo optimization -- here it is not rejected, only capped low.
+MODEL_ASSERTION = "model_assertion"
+
+# Evidence-tier strength, weakest to strongest: a model's own assertion moves credence the least; a
+# real measurement moves it the most. Reuses mixle.doe.oracle's verifiability vocabulary (a verified
+# oracle result is strong evidence) plus MODEL_ASSERTION as the floor tier.
+_TIER_STRENGTH: dict[str, float] = {
+    MODEL_ASSERTION: 0.05,
+    "executable": 0.3,
+    "simulation": 0.5,
+    "held_out_truth": 0.8,
+    "real_measurement": 1.0,
+}
+
+# A belief supported ONLY by model-assertion-tier evidence can never rise above this credence -- the
+# cap that keeps a model from bootstrapping high confidence in something it merely asserted.
+MODEL_ASSERTION_CAP = 0.5
+
+# Log-odds scale per unit of tier strength. Not fit to data -- a qualitative calibration knob so that
+# one real_measurement entry lands "high" and one model_assertion entry lands at the cap.
+_K = 3.0
+
+_BELIEF_TAG = "belief"
+
+
+@dataclass
+class Claim:
+    """One atomic proposition (or typed quantity) pulled from a model's output."""
+
+    text: str
+    produced_by: dict[str, Any] = field(default_factory=dict)
+    quantity: float | None = None
+
+
+@dataclass
+class EvidenceEntry:
+    """One piece of evidence that moved a belief's credence, in the order it was applied."""
+
+    source_id: str
+    tier: str
+    direction: str = "+"  # "+" supports the claim, "-" contradicts it
+    weight: float = 1.0
+    time: float = field(default_factory=time.time)
+
+
+@dataclass
+class BeliefItem:
+    """A claim's current credence plus the full evidence trail that produced it."""
+
+    id: str
+    claim: Claim
+    credence: float
+    evidence_history: list[EvidenceEntry] = field(default_factory=list)
+    scope: str = "local"
+
+
+def harvest_knowledge(
+    model_output: str,
+    *,
+    source: dict[str, Any],
+    extract: Callable[[str], list[str]] | None = None,
+) -> list[Claim]:
+    """Split ``model_output`` into atomic claims, each stamped with ``source`` (which model produced it,
+    its confidence, etc). Default extraction is sentence-level (:func:`mixle.reason.llm.sentence_claims`);
+    pass ``extract`` for a different atomic-proposition splitter."""
+    from mixle.reason.llm import sentence_claims
+
+    extract = extract or sentence_claims
+    return [Claim(text=c, produced_by=dict(source)) for c in extract(model_output)]
+
+
+def credence_from_history(evidence_history: Sequence[EvidenceEntry]) -> float:
+    """The credence implied by an evidence history alone -- a pure function, so replaying a belief's
+    stored ``evidence_history`` through this always reproduces its current ``credence`` exactly."""
+    if not evidence_history:
+        return 0.5  # neutral: no evidence yet
+    logit = 0.0
+    has_real_support = False
+    for e in evidence_history:
+        if e.weight <= 0:
+            continue
+        strength = _tier_strength(e.tier) * e.weight
+        sign = 1.0 if e.direction == "+" else -1.0
+        logit += sign * strength * _K
+        if e.tier != MODEL_ASSERTION:
+            has_real_support = True
+    credence = 1.0 / (1.0 + math.exp(-logit))
+    if not has_real_support:
+        credence = min(credence, MODEL_ASSERTION_CAP)
+    return credence
+
+
+def assimilate(
+    sub: Substrate,
+    claim: Claim,
+    evidence: dict[str, Any] | Sequence[dict[str, Any]],
+    *,
+    scope: str = "local",
+) -> BeliefItem:
+    """Bayesian-ish update of the belief in ``claim`` from ``evidence`` -- never a binary write.
+
+    Finds or creates the belief item (keyed on normalized claim text) and appends each evidence entry
+    (``{"source_id", "tier", "direction": "+"/"-", "weight"}``); ``tier`` must be one of
+    :data:`_TIER_STRENGTH` (``"model_assertion"`` plus :data:`mixle.doe.oracle.VERIFIABILITY_TIERS`).
+
+    Anti-laundering: an entry whose ``source_id`` resolves back to THIS belief (a cycle) or to another
+    belief item with no independent (non-model-assertion) support of its own is stored with an
+    effective weight of zero -- it cannot move the credence, though it stays in the trail for audit.
+    """
+    entries = [evidence] if isinstance(evidence, dict) else list(evidence)
+    key = _claim_key(claim.text)
+    existing = _find(sub, key, scope)
+    belief = (
+        _from_item(existing)
+        if existing is not None
+        else BeliefItem(id=uuid.uuid4().hex[:16], claim=claim, credence=0.5, evidence_history=[], scope=scope)
+    )
+
+    for raw in entries:
+        tier = raw["tier"]
+        _tier_strength(tier)  # validates; raises on an unrecognized tier rather than silently accepting one
+        source_id = str(raw.get("source_id", ""))
+        weight = float(raw.get("weight", 1.0))
+        if _launders(sub, source_id, belief.id, scope):
+            weight = 0.0
+        belief.evidence_history.append(
+            EvidenceEntry(
+                source_id=source_id,
+                tier=tier,
+                direction=raw.get("direction", "+"),
+                weight=weight,
+                time=float(raw["time"]) if "time" in raw else time.time(),
+            )
+        )
+
+    belief.credence = credence_from_history(belief.evidence_history)
+    sub.put(_to_item(belief))
+    return belief
+
+
+def retract(sub: Substrate, source_id: str, *, scope: str | None = None) -> list[BeliefItem]:
+    """Remove every evidence entry citing ``source_id``, recomputing credence, and CASCADE: if that
+    removal causes a belief to lose its only independent support, also strip citations of THAT belief
+    from whatever cited it, recursively. Returns every belief item touched by the cascade."""
+    changed: list[BeliefItem] = []
+    frontier = {source_id}
+    visited: set[str] = set()
+    while frontier:
+        cur = frontier.pop()
+        if cur in visited:
+            continue
+        visited.add(cur)
+        for item in sub.all(kind="record", scope=scope):
+            if _BELIEF_TAG not in item.tags:
+                continue
+            belief = _from_item(item)
+            new_history = [e for e in belief.evidence_history if e.source_id != cur]
+            if len(new_history) == len(belief.evidence_history):
+                continue
+            before_grounded = _has_real_support(belief)
+            belief.evidence_history = new_history
+            belief.credence = credence_from_history(new_history)
+            sub.put(_to_item(belief))
+            changed.append(belief)
+            if before_grounded and not _has_real_support(belief):
+                frontier.add(belief.id)  # this belief lost its grounding -- re-check its own citers
+    return changed
+
+
+def retrieve_beliefs(
+    sub: Substrate, query: str, *, k: int = 8, min_credence: float | None = None, scope: str | None = None
+) -> list[BeliefItem]:
+    """Beliefs relevant to ``query``, optionally thresholded on ``min_credence`` and re-ranked by
+    ``relevance * credence`` -- so a caller can weight by, or hard-filter on, how much the store
+    actually believes each item (never a "fact" vs "non-fact" partition, only credence)."""
+    hits = sub.search(query, k=max(int(k) * 3, int(k)), kind="record", scope=scope)
+    scored: list[tuple[BeliefItem, float]] = []
+    for item, sc in hits:
+        if _BELIEF_TAG not in item.tags:
+            continue
+        belief = _from_item(item)
+        if min_credence is not None and belief.credence < min_credence:
+            continue
+        scored.append((belief, sc * belief.credence))
+    scored.sort(key=lambda t: -t[1])
+    return [b for b, _ in scored[: int(k)]]
+
+
+# --- internals --------------------------------------------------------------------------------------
+
+
+def _tier_strength(tier: str) -> float:
+    if tier not in _TIER_STRENGTH:
+        raise ValueError(f"unknown evidence tier {tier!r}; expected one of {sorted(_TIER_STRENGTH)}")
+    return _TIER_STRENGTH[tier]
+
+
+def _has_real_support(belief: BeliefItem) -> bool:
+    return any(e.tier != MODEL_ASSERTION and e.weight > 0 for e in belief.evidence_history)
+
+
+def _claim_key(text: str) -> str:
+    return " ".join(text.lower().split())
+
+
+def _find(sub: Substrate, key: str, scope: str) -> SubstrateItem | None:
+    for item in sub.all(kind="record", scope=scope):
+        if _BELIEF_TAG in item.tags and item.payload.get("key") == key:
+            return item
+    return None
+
+
+def _launders(sub: Substrate, source_id: str, belief_id: str, scope: str, _seen: set[str] | None = None) -> bool:
+    """True iff citing ``source_id`` as evidence for ``belief_id`` would launder unearned credence:
+    a direct or indirect cycle back to ``belief_id``, or a reference to another belief item that has
+    no independent support of its own. A ``source_id`` that is not itself a belief item in the
+    substrate (a document, an oracle receipt, any genuine external reference) is never laundering."""
+    if source_id == belief_id:
+        return True
+    seen = _seen or set()
+    if source_id in seen:
+        return True  # a cycle among referenced claims that never reaches belief_id directly
+    ref_item = sub.get(source_id)
+    if ref_item is None or _BELIEF_TAG not in ref_item.tags:
+        return False
+    ref = _from_item(ref_item)
+    if not _has_real_support(ref):
+        return True
+    return False
+
+
+def _to_item(belief: BeliefItem) -> SubstrateItem:
+    return SubstrateItem(
+        id=belief.id,
+        kind="record",
+        text=belief.claim.text,
+        payload={
+            "key": _claim_key(belief.claim.text),
+            "claim": {
+                "text": belief.claim.text,
+                "produced_by": belief.claim.produced_by,
+                "quantity": belief.claim.quantity,
+            },
+            "credence": belief.credence,
+            "evidence_history": [asdict(e) for e in belief.evidence_history],
+        },
+        tags=[_BELIEF_TAG],
+        scope=belief.scope,
+        provenance={"kind": _BELIEF_TAG},
+    )
+
+
+def _from_item(item: SubstrateItem) -> BeliefItem:
+    p = item.payload
+    c = p["claim"]
+    return BeliefItem(
+        id=item.id,
+        claim=Claim(text=c["text"], produced_by=dict(c.get("produced_by", {})), quantity=c.get("quantity")),
+        credence=p["credence"],
+        evidence_history=[EvidenceEntry(**e) for e in p.get("evidence_history", [])],
+        scope=item.scope,
+    )

--- a/mixle/tests/substrate_belief_test.py
+++ b/mixle/tests/substrate_belief_test.py
@@ -1,0 +1,192 @@
+"""KNOW-a: harvest -> assimilate calibrated belief, anti-laundering, revision/retract, replay."""
+
+import random
+import unittest
+
+from mixle.substrate import Substrate
+from mixle.substrate.belief import (
+    MODEL_ASSERTION_CAP,
+    Claim,
+    EvidenceEntry,
+    assimilate,
+    credence_from_history,
+    harvest_knowledge,
+    retract,
+)
+
+
+class HarvestKnowledgeTest(unittest.TestCase):
+    def test_splits_atomic_claims_with_provenance(self):
+        text = "The rate is 5%. It rose from 3% last year."
+        claims = harvest_knowledge(text, source={"model": "teacher-v1", "confidence": 0.9})
+        self.assertEqual(len(claims), 2)
+        for c in claims:
+            self.assertIsInstance(c, Claim)
+            self.assertEqual(c.produced_by, {"model": "teacher-v1", "confidence": 0.9})
+        self.assertIn("5%", claims[0].text)
+
+
+class CredenceTierTest(unittest.TestCase):
+    def test_strong_source_beats_model_assertion_and_cap_holds(self):
+        strong_sub = Substrate()
+        strong = assimilate(
+            strong_sub,
+            Claim(text="The Eiffel Tower is in Paris.", produced_by={"model": "m"}),
+            {"source_id": "doc-1", "tier": "real_measurement", "direction": "+", "weight": 1.0},
+        )
+        self.assertGreater(strong.credence, 0.9)
+
+        weak_sub = Substrate()
+        weak = assimilate(
+            weak_sub,
+            Claim(text="The Eiffel Tower is in Paris.", produced_by={"model": "m"}),
+            {"source_id": "self-assert", "tier": "model_assertion", "direction": "+", "weight": 1.0},
+        )
+        self.assertLessEqual(weak.credence, MODEL_ASSERTION_CAP)
+        self.assertGreater(strong.credence, weak.credence)
+
+
+class AntiLaunderingTest(unittest.TestCase):
+    def test_self_reference_contributes_zero(self):
+        sub = Substrate()
+        claim = Claim(text="X causes Y.", produced_by={"model": "m"})
+        b1 = assimilate(
+            sub, claim, {"source_id": "self-assert", "tier": "model_assertion", "direction": "+", "weight": 1.0}
+        )
+        before = b1.credence
+
+        # cite the belief's own id as "evidence" for itself, at a strong declared tier
+        b2 = assimilate(sub, claim, {"source_id": b1.id, "tier": "held_out_truth", "direction": "+", "weight": 1.0})
+        self.assertEqual(b2.credence, before)
+        self.assertLessEqual(b2.credence, MODEL_ASSERTION_CAP)
+
+    def test_ungrounded_peer_in_same_batch_contributes_zero(self):
+        sub = Substrate()
+        claim = Claim(text="X causes Y.", produced_by={"model": "m"})
+        b1 = assimilate(
+            sub, claim, {"source_id": "self-assert", "tier": "model_assertion", "direction": "+", "weight": 1.0}
+        )
+        before = b1.credence
+
+        # a second claim whose ONLY support is also a bare model assertion (not independently grounded)
+        peer = assimilate(
+            sub,
+            Claim(text="Z is true because X causes Y.", produced_by={"model": "m"}),
+            {"source_id": "self-assert-2", "tier": "model_assertion", "direction": "+", "weight": 1.0},
+        )
+        self.assertLessEqual(peer.credence, MODEL_ASSERTION_CAP)
+
+        # laundering attempt: cite the ungrounded peer as if it were solid evidence
+        laundered = assimilate(
+            sub, claim, {"source_id": peer.id, "tier": "real_measurement", "direction": "+", "weight": 1.0}
+        )
+        self.assertEqual(laundered.credence, before)
+        self.assertLessEqual(laundered.credence, MODEL_ASSERTION_CAP)
+
+    def test_citing_an_independently_grounded_belief_is_not_laundering(self):
+        sub = Substrate()
+        grounded = assimilate(
+            sub,
+            Claim(text="The rate is 5%.", produced_by={"model": "m"}),
+            {"source_id": "doc-1", "tier": "held_out_truth", "direction": "+", "weight": 1.0},
+        )
+        self.assertGreater(grounded.credence, 0.5)
+
+        downstream = assimilate(
+            sub,
+            Claim(text="Therefore the estimate holds.", produced_by={"model": "m"}),
+            {"source_id": grounded.id, "tier": "held_out_truth", "direction": "+", "weight": 1.0},
+        )
+        self.assertGreater(downstream.credence, 0.5)
+
+
+class RevisionAndRetractTest(unittest.TestCase):
+    def test_contradicting_evidence_lowers_credence(self):
+        sub = Substrate()
+        claim = Claim(text="The rate is 5%.", produced_by={"model": "m"})
+        supported = assimilate(
+            sub, claim, {"source_id": "doc-1", "tier": "held_out_truth", "direction": "+", "weight": 1.0}
+        )
+        high = supported.credence
+
+        revised = assimilate(
+            sub, claim, {"source_id": "doc-2", "tier": "held_out_truth", "direction": "-", "weight": 1.0}
+        )
+        self.assertLess(revised.credence, high)
+
+    def test_retract_lowers_dependents_and_cascades(self):
+        sub = Substrate()
+        base = assimilate(
+            sub,
+            Claim(text="The rate is 5%.", produced_by={"model": "m"}),
+            {"source_id": "doc-1", "tier": "held_out_truth", "direction": "+", "weight": 1.0},
+        )
+        self.assertGreater(base.credence, 0.9)
+
+        downstream = assimilate(
+            sub,
+            Claim(text="Therefore the estimate holds.", produced_by={"model": "m"}),
+            {"source_id": base.id, "tier": "held_out_truth", "direction": "+", "weight": 1.0},
+        )
+        self.assertGreater(downstream.credence, 0.9)
+
+        changed = retract(sub, "doc-1")
+        changed_ids = {c.id for c in changed}
+
+        # base lost its only support -> back to neutral, no longer independently grounded
+        self.assertIn(base.id, changed_ids)
+        rebased = next(c for c in changed if c.id == base.id)
+        self.assertAlmostEqual(rebased.credence, 0.5, places=6)
+
+        # cascade: downstream cited base, which is no longer grounded, so its citation is now zeroed too
+        self.assertIn(downstream.id, changed_ids)
+        redown = next(c for c in changed if c.id == downstream.id)
+        self.assertAlmostEqual(redown.credence, 0.5, places=6)
+
+
+class TraceableHistoryTest(unittest.TestCase):
+    def test_replay_reproduces_stored_credence(self):
+        sub = Substrate()
+        b = assimilate(
+            sub,
+            Claim(text="Revenue grew 12% year over year.", produced_by={"model": "m"}),
+            [
+                {"source_id": "doc-1", "tier": "held_out_truth", "direction": "+", "weight": 1.0},
+                {"source_id": "doc-2", "tier": "simulation", "direction": "+", "weight": 0.6},
+                {"source_id": "assistant-1", "tier": "model_assertion", "direction": "+", "weight": 1.0},
+            ],
+        )
+        replayed = credence_from_history(b.evidence_history)
+        self.assertAlmostEqual(replayed, b.credence, places=9)
+
+
+class CalibrationTest(unittest.TestCase):
+    def test_coarse_reliability_across_evidence_profiles(self):
+        rng = random.Random(0)
+        sub = Substrate()
+        profiles = {
+            "strong": [{"source_id": "s", "tier": "real_measurement", "direction": "+", "weight": 1.0}],
+            "medium": [{"source_id": "s", "tier": "held_out_truth", "direction": "+", "weight": 1.0}],
+            "weak": [{"source_id": "s", "tier": "simulation", "direction": "+", "weight": 0.6}],
+        }
+        n_per_profile = 60
+        results: dict[str, list[bool]] = {name: [] for name in profiles}
+        target: dict[str, float] = {}
+
+        for name, evidence in profiles.items():
+            target[name] = credence_from_history([EvidenceEntry(**e) for e in evidence])
+            for i in range(n_per_profile):
+                truth = rng.random() < target[name]
+                claim = Claim(text=f"{name}-claim-{i}", produced_by={"model": "m"})
+                evidence_i = [dict(e, source_id=f"{e['source_id']}-{name}-{i}") for e in evidence]
+                b = assimilate(sub, claim, evidence_i)
+                self.assertAlmostEqual(b.credence, target[name], places=9)
+                results[name].append(truth)
+
+        for name, truths in results.items():
+            rate = sum(truths) / len(truths)
+            self.assertLess(abs(rate - target[name]), 0.15, msg=f"{name}: rate={rate} target={target[name]}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Workstream E steps 5-7 of the 0.6.3 frontier-capability plan (CARD KNOW-a in
`notes/0.6.3-execution-playbook.md`): turn a model's output into tracked **credences**, never a
binary "fact" flag.

New `mixle/substrate/belief.py`:

- `harvest_knowledge(model_output, source=...)` splits output into atomic `Claim`s (reuses
  `mixle.reason.llm.sentence_claims`), each stamped with which model/confidence produced it.
- `assimilate(sub, claim, evidence)` finds-or-creates a `BeliefItem` and Bayesian-updates its
  credence in log-odds space from evidence entries `{source_id, tier, direction, weight}`. Tiers
  reuse `mixle.doe.oracle`'s verifiability vocabulary (`executable`/`simulation`/`held_out_truth`/
  `real_measurement`) plus a new `MODEL_ASSERTION` floor tier: a belief supported *only* by model
  assertions is capped at 0.5 and can never bootstrap higher on its own say-so.
- **Anti-laundering** (load-bearing): an evidence entry whose `source_id` resolves back to the
  belief itself, or to another belief item with no independent (non-model-assertion) support of its
  own, is stored with effective weight zero.
- `retract(sub, source_id)` removes every entry citing that source and **cascades**: if a belief
  loses its only independent grounding, citations of *that* belief are stripped too, recursively.
- `credence_from_history` is a pure function of `evidence_history`, so replaying a belief's stored
  history always reproduces its current credence exactly.
- `retrieve_beliefs(sub, query, min_credence=...)` is a belief-scoped retrieval helper, kept out of
  the shared `mixle.substrate.retrieve.retrieve` to keep credence-aware ranking out of the generic
  cross-kind retrieval path (full flywheel integration is ACCUM-a, not this card).

## Test plan

- [x] `mixle/tests/substrate_belief_test.py` — 9 new tests, all passing: credence tracks evidence
      tier + the model-assertion cap holds; self-reference and same-batch-ungrounded-peer
      laundering both contribute zero while citing an independently grounded belief does not;
      contradicting evidence lowers credence; retract cascades through a dependent; replay
      reproduces stored credence exactly; a coarse calibration check across three evidence-strength
      profiles (n=60 each) lands within 0.15 of each profile's implied truth rate.
- [x] `pytest mixle/tests -k substrate` — 23 passed, 2 pre-existing unrelated skips (no regression
      in the wider substrate suite).
- [x] `ruff check` + `ruff format --check` clean on all three changed files.

Out of scope (per the card): the extractor model's own capture profile (D6-a); a full posterior
belief for quantities beyond the propositional Bernoulli credence (`Claim.quantity` is a placeholder
field, noted as a follow-up); the accumulation-flywheel measurement (ACCUM-a, needs F1-a/F6-a
retrieval); any mixle-knowledge contract change (no test required one).