### PR TITLE
task/D3: CapabilitySuite + capture_profile

### DIFF
--- a/mixle/task/__init__.py
+++ b/mixle/task/__init__.py
@@ -83,6 +83,7 @@ from mixle.task.extract import (
     extraction_f1,
     tokenize,
 )
+from mixle.task.generative_capability import extractive_capture_profile, validate_extraction_schema
 from mixle.task.generative_text import GenerativeTextIO, distill_text_generative, distill_text_generative_from_labels
 from mixle.task.harness import ExtractorHarness, MatcherHarness, replace_alerter, replace_extractor, replace_matcher
 from mixle.task.llm import (
@@ -152,6 +153,8 @@ __all__ = [
     "MatcherHarness",
     "FieldChoice",
     "GenerativeTextIO",
+    "extractive_capture_profile",
+    "validate_extraction_schema",
     "HashedNGram",
     "HashedRecord",
     "LNSStructuredClassifierIO",

--- a/mixle/task/__init__.py
+++ b/mixle/task/__init__.py
@@ -39,6 +39,7 @@ from mixle.task.capability import (
 from mixle.task.cascade import Cascade, CascadeStats
 from mixle.task.density import DensityGate
 from mixle.task.design import DesignedModel, design_model, spec_to_estimator
+from mixle.task.disagreement import DisagreementGate, UnionGate, fit_disagreement_gate, measure_disagreement_mass
 from mixle.task.distill import (
     agreement,
     distill,
@@ -140,6 +141,8 @@ __all__ = [
     "DensityGate",
     "DesignModel",
     "DesignedModel",
+    "DisagreementGate",
+    "UnionGate",
     "DeviceSpec",
     "EdgeDistillResult",
     "EdgeFootprint",
@@ -184,6 +187,8 @@ __all__ = [
     "cascade_cost_per_request",
     "case_jitter_invariance",
     "design_model",
+    "fit_disagreement_gate",
+    "measure_disagreement_mass",
     "distill",
     "distill_designer",
     "distill_extractor",

--- a/mixle/task/__init__.py
+++ b/mixle/task/__init__.py
@@ -29,6 +29,13 @@ from mixle.task.artifact import (
     save_module,
 )
 from mixle.task.calibrate import ESCALATE, CalibratedTaskModel
+from mixle.task.capability import (
+    CapabilitySuite,
+    capture_profile,
+    case_jitter_invariance,
+    keyboard_typo_corruption,
+    whitespace_invariance,
+)
 from mixle.task.cascade import Cascade, CascadeStats
 from mixle.task.density import DensityGate
 from mixle.task.design import DesignedModel, design_model, spec_to_estimator
@@ -126,6 +133,7 @@ __all__ = [
     "AgentTraces",
     "CalibratedTaskModel",
     "CallableLLM",
+    "CapabilitySuite",
     "Cascade",
     "CascadeStats",
     "CostModel",
@@ -172,7 +180,9 @@ __all__ = [
     "adapter_from_spec",
     "agreement",
     "break_even_volume",
+    "capture_profile",
     "cascade_cost_per_request",
+    "case_jitter_invariance",
     "design_model",
     "distill",
     "distill_designer",
@@ -194,6 +204,7 @@ __all__ = [
     "distill_structured_from_labels",
     "extraction_f1",
     "harvest_agent_traces",
+    "keyboard_typo_corruption",
     "parse_conversation",
     "get_arrays_builder",
     "get_builder",
@@ -215,6 +226,7 @@ __all__ = [
     "scorecard",
     "sft_planner",
     "spec_to_estimator",
+    "whitespace_invariance",
     "load_arrays",
     "load_json",
     "load_module",

--- a/mixle/task/capability.py
+++ b/mixle/task/capability.py
@@ -63,11 +63,19 @@ def whitespace_invariance(text: str) -> str:
 
 def _predict(model: Any, texts: list[str]) -> list[Any]:
     """Batch-predict labels from ``model``, which may be a ``CalibratedTaskModel``, a ``TaskModel``-like object
-    exposing ``batch``, or a bare ``teacher(texts) -> labels`` / ``teacher(text) -> label`` callable."""
-    if hasattr(model, "task"):
-        return list(model.task.batch(texts))
+    exposing ``batch``, or a bare ``teacher(texts) -> labels`` / ``teacher(text) -> label`` callable.
+
+    Checks ``batch`` before ``task``: a bare ``TaskModel``'s own ``task`` attribute is a plain
+    descriptive string, not a nested model, so checking ``task`` first misfires
+    (``AttributeError: 'str' object has no attribute 'batch'``) on any model not wrapped in
+    ``CalibratedTaskModel`` -- e.g. a :func:`~mixle.task.extract.distill_extractor` student, whose
+    adapter has no ``proba_batch`` and so can never be calibration-wrapped. ``CalibratedTaskModel``
+    itself exposes no ``batch``, so this order still falls through to ``model.task.batch`` for it.
+    """
     if hasattr(model, "batch"):
         return list(model.batch(texts))
+    if hasattr(model, "task"):
+        return list(model.task.batch(texts))
     out = model(texts)
     if isinstance(out, (list, tuple)) and len(out) == len(texts):
         return list(out)

--- a/mixle/task/capability.py
+++ b/mixle/task/capability.py
@@ -1,0 +1,156 @@
+"""``CapabilitySuite`` / ``capture_profile`` -- a distilled student's behavioral spec, never one aggregate number.
+
+Two students can share the same clean-holdout accuracy and still differ wildly on what they capture: one
+degrades gracefully under typos, the other collapses; one honors the teacher's case-insensitivity, the other
+doesn't. A capability suite names the input distribution's corruptions (severity levels), invariances
+(meaning-preserving rewrites the teacher is expected to honor), and edge-case probes; :func:`capture_profile`
+runs both the student and the teacher through all three and reports a JSON-serializable profile -- deliberately
+with no single pass/fail scalar, so a caller (D4's disagreement map, a release gate) decides what "close enough"
+means for its own use.
+"""
+
+from __future__ import annotations
+
+import random
+import string
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+
+
+@dataclass
+class CapabilitySuite:
+    """The behavioral spec an example distillation is checked against.
+
+    ``corruptions`` maps a named severity level (e.g. ``"typo_10"``) to a text -> text corruption; insertion
+    order is the intended severity order (mild first) so callers can read the profile's ordering directly.
+    ``invariances`` maps a name to a meaning-preserving rewrite (case jitter, whitespace, a synonym swap) --
+    a well-behaved model's prediction should not change under it. ``probes`` are fixed edge-case inputs whose
+    raw predictions are recorded (no ground truth assumed).
+    """
+
+    corruptions: dict[str, Callable[[str], str]] = field(default_factory=dict)
+    invariances: dict[str, Callable[[str], str]] = field(default_factory=dict)
+    probes: list[str] = field(default_factory=list)
+
+
+def keyboard_typo_corruption(rate: float, *, seed: int = 0) -> Callable[[str], str]:
+    """A corruption: replace each letter with a random lowercase letter independently with probability ``rate``.
+
+    Deterministic given ``seed`` -- the same corruption function always maps the same text to the same output.
+    """
+    if not 0.0 <= rate <= 1.0:
+        raise ValueError(f"rate must be in [0, 1], got {rate}")
+
+    def corrupt(text: str) -> str:
+        rng = random.Random(f"{seed}:{text}")
+        return "".join(rng.choice(string.ascii_lowercase) if c.isalpha() and rng.random() < rate else c for c in text)
+
+    return corrupt
+
+
+def case_jitter_invariance(text: str) -> str:
+    """A meaning-preserving rewrite: swap the case of every letter."""
+    return text.swapcase()
+
+
+def whitespace_invariance(text: str) -> str:
+    """A meaning-preserving rewrite: collapse all whitespace runs to single spaces."""
+    return " ".join(text.split())
+
+
+def _predict(model: Any, texts: list[str]) -> list[Any]:
+    """Batch-predict labels from ``model``, which may be a ``CalibratedTaskModel``, a ``TaskModel``-like object
+    exposing ``batch``, or a bare ``teacher(texts) -> labels`` / ``teacher(text) -> label`` callable."""
+    if hasattr(model, "task"):
+        return list(model.task.batch(texts))
+    if hasattr(model, "batch"):
+        return list(model.batch(texts))
+    out = model(texts)
+    if isinstance(out, (list, tuple)) and len(out) == len(texts):
+        return list(out)
+    return [model(t) for t in texts]
+
+
+def _decide(model: Any, texts: list[str]) -> list[Any] | None:
+    """Batch decisions (label or ``ESCALATE``) if ``model`` exposes a decision API, else ``None``."""
+    if hasattr(model, "batch_decide"):
+        return list(model.batch_decide(texts))
+    if hasattr(model, "decide"):
+        return [model.decide(t) for t in texts]
+    return None
+
+
+def _agreement(a: Sequence[Any], b: Sequence[Any]) -> float:
+    if not a:
+        return 0.0
+    return float(np.mean([str(x) == str(y) for x, y in zip(a, b)]))
+
+
+def _violation_rate(before: Sequence[Any], after: Sequence[Any]) -> float:
+    if not before:
+        return 0.0
+    return float(np.mean([str(x) != str(y) for x, y in zip(before, after)]))
+
+
+def _escalation_rate(decisions: Sequence[Any]) -> float:
+    if not decisions:
+        return 0.0
+    return float(np.mean([d is None for d in decisions]))
+
+
+def capture_profile(student: Any, teacher: Any, texts: Sequence[str], suite: CapabilitySuite) -> dict[str, Any]:
+    """Run ``student`` and ``teacher`` through ``suite`` over ``texts`` and report the capture profile.
+
+    Returns a plain, ``json.dumps``-safe dict:
+
+    * ``"clean_agreement"`` -- student/teacher label agreement on the uncorrupted ``texts``;
+    * ``"corruptions"`` -- per corruption name, student/teacher agreement on the corrupted texts (in the
+      suite's insertion order, mild-to-severe by convention);
+    * ``"invariances"`` -- per invariance name, ``{"student_violation_rate", "teacher_violation_rate"}``: how
+      often each side's prediction changes under a rewrite that should not change it. A student must not be
+      penalized for an invariance the teacher itself violates -- both rates are reported, never one diff;
+    * ``"probes"`` -- ``{"student": [...], "teacher": [...]}`` raw predictions on the fixed probe inputs, or
+      omitted if the suite has no probes;
+    * ``"abstention"`` -- present only if ``student`` or ``teacher`` exposes a decision API (``decide`` /
+      ``batch_decide``): each side's escalation rate on ``texts`` (``None`` for a side with no decision API).
+
+    There is deliberately no single aggregate score field.
+    """
+    texts = [str(t) for t in texts]
+    profile: dict[str, Any] = {"clean_agreement": _agreement(_predict(student, texts), _predict(teacher, texts))}
+
+    corruptions: dict[str, float] = {}
+    for name, corrupt in suite.corruptions.items():
+        corrupted = [corrupt(t) for t in texts]
+        corruptions[name] = _agreement(_predict(student, corrupted), _predict(teacher, corrupted))
+    profile["corruptions"] = corruptions
+
+    invariances: dict[str, dict[str, float]] = {}
+    student_clean = _predict(student, texts)
+    teacher_clean = _predict(teacher, texts)
+    for name, rewrite in suite.invariances.items():
+        rewritten = [rewrite(t) for t in texts]
+        invariances[name] = {
+            "student_violation_rate": _violation_rate(student_clean, _predict(student, rewritten)),
+            "teacher_violation_rate": _violation_rate(teacher_clean, _predict(teacher, rewritten)),
+        }
+    profile["invariances"] = invariances
+
+    if suite.probes:
+        profile["probes"] = {
+            "student": _predict(student, list(suite.probes)),
+            "teacher": _predict(teacher, list(suite.probes)),
+        }
+
+    student_decisions = _decide(student, texts)
+    teacher_decisions = _decide(teacher, texts)
+    if student_decisions is not None or teacher_decisions is not None:
+        profile["abstention"] = {
+            "student_escalation_rate": _escalation_rate(student_decisions) if student_decisions is not None else None,
+            "teacher_escalation_rate": _escalation_rate(teacher_decisions) if teacher_decisions is not None else None,
+        }
+
+    return profile

--- a/mixle/task/disagreement.py
+++ b/mixle/task/disagreement.py
@@ -1,0 +1,109 @@
+"""Disagreement gate (workstream D5, CARD D4-a): escalate where the student has historically diverged
+from the teacher -- not just where inputs look statistically atypical
+(:class:`~mixle.task.density.DensityGate`) or where the conformal set itself is ambiguous
+(:class:`~mixle.task.calibrate.CalibratedTaskModel`).
+
+:func:`fit_disagreement_gate` turns a set of ``(text, student_label, teacher_label)`` triples into a small
+binary ``agree``/``disagree`` classifier over the student's OWN feature space (reusing
+:func:`~mixle.task.distill.distill_from_labels` -- the disagreement gate is itself a tiny distilled student,
+just of a different target). The resulting :class:`DisagreementGate` exposes ``ood_mask`` with the exact
+same duck-typed shape as :class:`~mixle.task.density.DensityGate`, so it plugs into
+``CalibratedTaskModel(..., density_gate=...)`` directly -- or unions with a real density gate via
+:func:`union_gate` -- with no changes needed to :mod:`mixle.task.calibrate`'s extension point.
+
+:func:`measure_disagreement_mass` is the plain fraction-of-examples-where-student-differs-from-teacher
+metric the active-labeling loop (:func:`~mixle.task.active.active_distill`) is measured against: label the
+gate-flagged region with the teacher, re-distill including those labels, and confirm the region's mass
+shrinks.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+from mixle.task.distill import distill_from_labels
+from mixle.task.model import TaskModel
+
+
+def measure_disagreement_mass(student: TaskModel, texts: Sequence[str], teacher_labels: Sequence[Any]) -> float:
+    """Fraction of ``texts`` where the student's label differs from the teacher's."""
+    if not texts:
+        return 0.0
+    pred = student.batch(list(texts))
+    tl = [str(t) for t in teacher_labels]
+    return float(np.mean([p != t for p, t in zip(pred, tl)]))
+
+
+@dataclass
+class DisagreementGate:
+    """A fitted agree/disagree classifier over the student's feature space, plus an escalation threshold."""
+
+    classifier: TaskModel
+    threshold: float = 0.5
+
+    def disagreement_proba(self, texts: Sequence[str]) -> np.ndarray:
+        """``P(disagree | x)`` under the fitted classifier."""
+        prob = self.classifier.adapter.proba_batch(self.classifier.model, list(texts))
+        idx = self.classifier.adapter.labels.index("disagree")
+        return prob[:, idx]
+
+    def is_ood(self, text: str) -> bool:
+        return bool(self.disagreement_proba([text])[0] > self.threshold)
+
+    def ood_mask(self, texts: Sequence[str]) -> np.ndarray:
+        """Same duck-typed shape as :meth:`mixle.task.density.DensityGate.ood_mask` -- drops straight into
+        ``CalibratedTaskModel(..., density_gate=this)``."""
+        return self.disagreement_proba(texts) > self.threshold
+
+
+def fit_disagreement_gate(
+    student: TaskModel,
+    texts: Sequence[str],
+    teacher_labels: Sequence[Any],
+    *,
+    dim: int = 256,
+    hidden: Sequence[int] = (32,),
+    epochs: int = 150,
+    lr: float = 1e-2,
+    seed: int = 0,
+    threshold: float = 0.5,
+) -> DisagreementGate:
+    """Fit a :class:`DisagreementGate` from a labeled sample: run ``student`` on ``texts``, label each
+    example ``"disagree"`` where it differs from ``teacher_labels`` and ``"agree"`` otherwise, and distill a
+    tiny binary classifier of that target over the SAME hashed n-gram feature family the student itself
+    uses (a different, wider/deeper recipe is fine -- what matters is the classifier learns a decision
+    surface over the input text, not that it matches the student's exact recipe).
+    """
+    texts = [str(t) for t in texts]
+    student_labels = student.batch(texts)
+    tl = [str(t) for t in teacher_labels]
+    disagreement_labels = ["disagree" if s != t else "agree" for s, t in zip(student_labels, tl)]
+    classifier = distill_from_labels(
+        texts,
+        disagreement_labels,
+        labels=["agree", "disagree"],
+        dim=dim,
+        hidden=hidden,
+        epochs=epochs,
+        lr=lr,
+        seed=seed,
+        task="disagreement gate",
+    )
+    return DisagreementGate(classifier, threshold=threshold)
+
+
+class UnionGate:
+    """Escalate if ANY constituent gate flags an input -- composes a :class:`DisagreementGate` with a real
+    :class:`~mixle.task.density.DensityGate` (or any other ``ood_mask``-exposing gate) with no changes to
+    either gate's own code."""
+
+    def __init__(self, *gates: Any) -> None:
+        self.gates = gates
+
+    def ood_mask(self, texts: Sequence[str]) -> np.ndarray:
+        masks = [np.asarray(g.ood_mask(texts), dtype=bool) for g in self.gates]
+        return np.logical_or.reduce(masks) if masks else np.zeros(len(texts), dtype=bool)

--- a/mixle/task/generative_capability.py
+++ b/mixle/task/generative_capability.py
@@ -1,0 +1,132 @@
+"""Capture profiles for structured-output students (workstream D6): extraction and generative-text.
+
+:func:`~mixle.task.capability.capture_profile` scores agreement by exact match on a scalar label -- the
+right notion for a classifier, but the wrong one for a field extractor: a student that gets 3 of 4 fields
+right under a typo corruption is not "wrong", and exact-match agreement would report it identically to a
+student that got every field wrong. This module extends the same :class:`~mixle.task.capability.CapabilitySuite`
+machinery (corruptions, invariances -- reused, not reinvented) with EXECUTABLE verifiers suited to
+structured output:
+
+* extraction students (:func:`~mixle.task.extract.distill_extractor`, adapter ``ExtractionIO``): scored by
+  micro-averaged field-level F1 against a fixed gold reference (the teacher's own extraction on the CLEAN
+  text -- corruption is a nuisance perturbation of the input, not a change to the true answer), plus a
+  schema-validity check (every expected field present, every value actually grounded in -- a substring of
+  -- the text it was extracted from). Both are checkable by code, never by eyeballing output.
+* :func:`~mixle.task.generative_text.distill_text_generative` students predict a plain label (like any
+  other classifier), so the base :func:`capture_profile` already scores them correctly -- no special
+  handling needed here; this module documents that explicitly rather than silently duplicating it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+import numpy as np
+
+from mixle.task.capability import CapabilitySuite, _decide, _escalation_rate, _predict
+
+
+def validate_extraction_schema(record: dict[str, Any], source_text: str, fields: Sequence[str]) -> dict[str, Any]:
+    """Executable schema check for one extracted record: complete (every expected field present) and
+    grounded (every non-empty value is an actual substring of ``source_text``, not hallucinated).
+
+    Returns a plain dict (``complete``, ``grounded``, ``missing``, ``ungrounded``) -- never a single
+    pass/fail bit, so a caller can see exactly what failed.
+    """
+    fields = list(fields)
+    missing = [f for f in fields if f not in record or not record.get(f)]
+    ungrounded = [f for f, v in record.items() if f in fields and v and str(v) not in source_text]
+    return {
+        "complete": not missing,
+        "grounded": not ungrounded,
+        "missing": missing,
+        "ungrounded": ungrounded,
+    }
+
+
+def _field_f1(pred: Sequence[dict[str, Any]], gold: Sequence[dict[str, Any]]) -> float:
+    """Micro-averaged field-level F1 (same formula as :func:`mixle.task.extract.extraction_f1`, generalized
+    to operate on already-computed prediction dicts instead of requiring a ``TaskModel.batch`` call, so it
+    scores a bare-callable teacher the same way it scores a ``TaskModel`` student)."""
+    tp = fp = fn = 0
+    for p, g in zip(pred, gold):
+        for field, value in g.items():
+            if p.get(field) == value:
+                tp += 1
+            else:
+                fn += 1
+        for field in p:
+            if field not in g:
+                fp += 1
+    denom = 2 * tp + fp + fn
+    return (2 * tp / denom) if denom else 1.0
+
+
+def _schema_validity_rate(records: Sequence[dict[str, Any]], texts: Sequence[str], fields: Sequence[str]) -> float:
+    if not records:
+        return 1.0
+    checks = [validate_extraction_schema(r, t, fields) for r, t in zip(records, texts)]
+    return float(np.mean([c["complete"] and c["grounded"] for c in checks]))
+
+
+def extractive_capture_profile(
+    student: Any, teacher: Any, texts: Sequence[str], suite: CapabilitySuite, *, fields: Sequence[str]
+) -> dict[str, Any]:
+    """The extraction-student capture profile: F1-against-gold and schema validity, not exact-match agreement.
+
+    ``gold`` is the teacher's own extraction on the CLEAN ``texts`` -- the true answer a corruption should
+    not change. Reports, JSON-serializable:
+
+    * ``"clean_f1"`` -- student F1 against gold on clean text (teacher's own clean F1 against its own gold
+      is trivially 1.0 and omitted);
+    * ``"corruptions"`` -- per corruption name, ``{"student_f1", "teacher_f1"}`` against the SAME fixed
+      gold -- both sides scored against the same ground truth, so a comparison is meaningful;
+    * ``"invariances"`` -- per invariance name, ``{"student_f1", "teacher_f1"}`` between each side's clean
+      prediction and its prediction on the rewritten text (1.0 = perfectly invariant);
+    * ``"schema_validity"`` -- ``{"student", "teacher"}`` fraction of CLEAN-text extractions that are
+      complete and grounded (:func:`validate_extraction_schema`) -- an executable check, never eyeballed;
+    * ``"abstention"`` -- as in :func:`~mixle.task.capability.capture_profile`, if either side exposes a
+      decision API.
+    """
+    texts = [str(t) for t in texts]
+    fields = list(fields)
+    gold = _predict(teacher, texts)
+
+    student_clean = _predict(student, texts)
+    profile: dict[str, Any] = {
+        "clean_f1": _field_f1(student_clean, gold),
+        "schema_validity": {
+            "student": _schema_validity_rate(student_clean, texts, fields),
+            "teacher": _schema_validity_rate(gold, texts, fields),
+        },
+    }
+
+    corruptions: dict[str, dict[str, float]] = {}
+    for name, corrupt in suite.corruptions.items():
+        corrupted = [corrupt(t) for t in texts]
+        corruptions[name] = {
+            "student_f1": _field_f1(_predict(student, corrupted), gold),
+            "teacher_f1": _field_f1(_predict(teacher, corrupted), gold),
+        }
+    profile["corruptions"] = corruptions
+
+    teacher_clean = gold
+    invariances: dict[str, dict[str, float]] = {}
+    for name, rewrite in suite.invariances.items():
+        rewritten = [rewrite(t) for t in texts]
+        invariances[name] = {
+            "student_f1": _field_f1(_predict(student, rewritten), student_clean),
+            "teacher_f1": _field_f1(_predict(teacher, rewritten), teacher_clean),
+        }
+    profile["invariances"] = invariances
+
+    student_decisions = _decide(student, texts)
+    teacher_decisions = _decide(teacher, texts)
+    if student_decisions is not None or teacher_decisions is not None:
+        profile["abstention"] = {
+            "student_escalation_rate": _escalation_rate(student_decisions) if student_decisions is not None else None,
+            "teacher_escalation_rate": _escalation_rate(teacher_decisions) if teacher_decisions is not None else None,
+        }
+
+    return profile

--- a/mixle/tests/capability_suite_test.py
+++ b/mixle/tests/capability_suite_test.py
@@ -1,0 +1,120 @@
+"""CapabilitySuite / capture_profile (mixle.task.capability): a distilled student's behavioral spec.
+
+Uses the spam/ham rule-teacher pattern from ``task_distill_routing_test.py``: a hashed-n-gram MLP student
+distilled from a keyword rule teacher, checked under typo corruptions and a case-jitter invariance.
+"""
+
+import json
+import unittest
+
+import numpy as np
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("safetensors")
+
+from mixle.task.capability import (  # noqa: E402
+    CapabilitySuite,
+    capture_profile,
+    case_jitter_invariance,
+    keyboard_typo_corruption,
+)
+from mixle.task.distill import distill_for_routing  # noqa: E402
+
+SPAM_WORDS = {"free", "winner", "prize", "buy", "cheap", "offer", "click"}
+
+
+def _make_corpus(n_per_class=150, seed=0):
+    rng = np.random.RandomState(seed)
+    spam_words = list(SPAM_WORDS)
+    ham_words = ["meeting", "lunch", "project", "report", "schedule", "team", "review"]
+    filler = ["the", "a", "today", "tomorrow", "please", "thanks", "we", "you"]
+    texts = []
+    for words in (spam_words, ham_words):
+        for _ in range(n_per_class):
+            k = rng.randint(3, 7)
+            toks = list(rng.choice(words, size=2)) + list(rng.choice(filler, size=k))
+            rng.shuffle(toks)
+            texts.append(" ".join(toks))
+    rng.shuffle(texts)
+    return texts
+
+
+def _teacher(texts):
+    # case-insensitive by construction, so a case-jitter rewrite should never flip its decision
+    return ["spam" if any(w in t.lower().split() for w in SPAM_WORDS) else "ham" for t in texts]
+
+
+def _suite():
+    return CapabilitySuite(
+        corruptions={
+            "typo_10": keyboard_typo_corruption(0.1, seed=1),
+            "typo_40": keyboard_typo_corruption(0.4, seed=1),
+            "typo_80": keyboard_typo_corruption(0.8, seed=1),
+        },
+        invariances={"case_jitter": case_jitter_invariance},
+    )
+
+
+class CapabilitySuiteTest(unittest.TestCase):
+    def test_clean_agreement_high_and_degrades_under_typos(self):
+        train = _make_corpus(seed=1)
+        student = distill_for_routing(
+            _teacher, train, n=4, dim=512, hidden=[64], epochs=300, lr=1e-2, seed=0, calibration_frac=0.2
+        )
+        test = _make_corpus(seed=99)
+        profile = capture_profile(student, _teacher, test, _suite())
+
+        self.assertGreater(profile["clean_agreement"], 0.8)
+        # agreement should not improve as typo severity rises; the worst level should be markedly below clean
+        levels = ["typo_10", "typo_40", "typo_80"]
+        scores = [profile["corruptions"][lvl] for lvl in levels]
+        self.assertLess(scores[-1], profile["clean_agreement"])
+        self.assertLessEqual(scores[-1], scores[0] + 1e-9)
+
+    def test_case_jitter_near_zero_violation_for_case_insensitive_teacher(self):
+        train = _make_corpus(seed=2)
+        student = distill_for_routing(
+            _teacher, train, n=4, dim=512, hidden=[64], epochs=300, lr=1e-2, seed=0, calibration_frac=0.2
+        )
+        test = _make_corpus(seed=88)
+        profile = capture_profile(student, _teacher, test, _suite())
+
+        self.assertLess(profile["invariances"]["case_jitter"]["teacher_violation_rate"], 0.05)
+
+    def test_abstention_reported_for_calibrated_student(self):
+        train = _make_corpus(seed=3)
+        student = distill_for_routing(
+            _teacher, train, n=4, dim=512, hidden=[64], epochs=300, lr=1e-2, seed=0, calibration_frac=0.2
+        )
+        test = _make_corpus(seed=77)
+        profile = capture_profile(student, _teacher, test, _suite())
+
+        self.assertIn("abstention", profile)
+        self.assertIsNotNone(profile["abstention"]["student_escalation_rate"])
+        self.assertIsNone(profile["abstention"]["teacher_escalation_rate"])
+
+    def test_profile_round_trips_json(self):
+        train = _make_corpus(seed=4)
+        student = distill_for_routing(
+            _teacher, train, n=4, dim=128, hidden=[64], epochs=60, seed=0, calibration_frac=0.2
+        )
+        test = _make_corpus(seed=55)
+        profile = capture_profile(student, _teacher, test, _suite())
+        round_tripped = json.loads(json.dumps(profile))
+        self.assertEqual(round_tripped, profile)
+
+    def test_empty_suite_yields_clean_agreement_only(self):
+        train = _make_corpus(seed=5)
+        student = distill_for_routing(
+            _teacher, train, n=4, dim=128, hidden=[64], epochs=60, seed=0, calibration_frac=0.2
+        )
+        test = _make_corpus(seed=66)
+        profile = capture_profile(student, _teacher, test, CapabilitySuite())
+        self.assertEqual(profile["corruptions"], {})
+        self.assertEqual(profile["invariances"], {})
+        self.assertNotIn("probes", profile)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mixle/tests/disagreement_test.py
+++ b/mixle/tests/disagreement_test.py
@@ -1,0 +1,168 @@
+"""Disagreement gate + active-labeling shrink (mixle.task.disagreement), CARD D4-a.
+
+The corpus is built so the student provably can't follow the teacher on one sub-region: it trains only on
+a SEEN set of sentiment synonyms and is evaluated (region B) on a disjoint HELD-OUT set of synonyms never
+seen in training -- a hashed bag-of-words student has no representation for genuinely novel tokens, so it
+is near-chance there, while region A (the SEEN vocabulary, held out only as fresh examples of the same
+words) is easy.
+"""
+
+import unittest
+
+import numpy as np
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("safetensors")
+
+from mixle.task.calibrate import CalibratedTaskModel  # noqa: E402
+from mixle.task.disagreement import (  # noqa: E402
+    UnionGate,
+    fit_disagreement_gate,
+    measure_disagreement_mass,
+)
+from mixle.task.distill import agreement, distill_from_labels  # noqa: E402
+
+POS_SEEN = ["fantastic", "wonderful", "excellent", "superb", "stellar"]
+POS_HELD = ["marvelous", "terrific", "outstanding", "exceptional", "phenomenal"]
+NEG_SEEN = ["terrible", "awful", "dreadful", "atrocious", "abysmal"]
+NEG_HELD = ["horrendous", "appalling", "lousy", "subpar", "deficient"]
+FILLER = ["the", "movie", "was", "really", "quite", "so", "this", "book", "show", "honestly"]
+
+
+def _teacher(texts):
+    out = []
+    for t in texts:
+        toks = set(t.split())
+        if toks & set(POS_SEEN + POS_HELD):
+            out.append("positive")
+        elif toks & set(NEG_SEEN + NEG_HELD):
+            out.append("negative")
+        else:
+            out.append("negative")
+    return out
+
+
+def _make_texts(vocab_pos, vocab_neg, n_per_class=60, seed=0):
+    rng = np.random.RandomState(seed)
+    texts = []
+    for vocab in (vocab_pos, vocab_neg):
+        for _ in range(n_per_class):
+            k = rng.randint(3, 6)
+            toks = [rng.choice(vocab)] + list(rng.choice(FILLER, size=k))
+            rng.shuffle(toks)
+            texts.append(" ".join(toks))
+    rng.shuffle(texts)
+    return texts
+
+
+class DisagreementMassTest(unittest.TestCase):
+    def test_student_disagrees_far_more_on_held_out_synonyms_than_seen_ones(self):
+        train = _make_texts(POS_SEEN, NEG_SEEN, n_per_class=80, seed=1)
+        student = distill_from_labels(
+            train, _teacher(train), labels=["positive", "negative"], n=2, dim=64, hidden=[16], epochs=60, seed=0
+        )
+
+        region_a = _make_texts(POS_SEEN, NEG_SEEN, n_per_class=40, seed=2)  # same vocab, fresh examples
+        region_b = _make_texts(POS_HELD, NEG_HELD, n_per_class=40, seed=3)  # never-seen synonyms
+
+        mass_a = measure_disagreement_mass(student, region_a, _teacher(region_a))
+        mass_b = measure_disagreement_mass(student, region_b, _teacher(region_b))
+
+        self.assertLess(mass_a, 0.15)
+        self.assertGreater(mass_b, 0.3)
+        self.assertGreater(mass_b, mass_a)
+
+
+class DisagreementGateTest(unittest.TestCase):
+    def _fit_student_and_gate(self, seed=0):
+        train = _make_texts(POS_SEEN, NEG_SEEN, n_per_class=80, seed=seed)
+        student = distill_from_labels(
+            train, _teacher(train), labels=["positive", "negative"], n=2, dim=64, hidden=[16], epochs=60, seed=0
+        )
+        # fit the gate on a MIXED sample from both regions so it has examples of true agreement AND
+        # disagreement to learn from
+        gate_fit_texts = _make_texts(POS_SEEN, NEG_SEEN, n_per_class=30, seed=seed + 10) + _make_texts(
+            POS_HELD, NEG_HELD, n_per_class=30, seed=seed + 20
+        )
+        gate = fit_disagreement_gate(
+            student, gate_fit_texts, _teacher(gate_fit_texts), dim=64, hidden=[16], epochs=100, seed=0
+        )
+        return student, gate
+
+    def test_gate_flags_the_held_out_region_far_more_than_the_seen_region(self):
+        student, gate = self._fit_student_and_gate(seed=1)
+        region_a = _make_texts(POS_SEEN, NEG_SEEN, n_per_class=40, seed=42)
+        region_b = _make_texts(POS_HELD, NEG_HELD, n_per_class=40, seed=43)
+
+        flag_rate_a = float(np.mean(gate.ood_mask(region_a)))
+        flag_rate_b = float(np.mean(gate.ood_mask(region_b)))
+        self.assertGreater(flag_rate_b, flag_rate_a)
+
+    def test_cascade_with_the_gate_recovers_near_teacher_level_agreement(self):
+        student, gate = self._fit_student_and_gate(seed=2)
+        calibrated = CalibratedTaskModel(student, alpha=0.2, density_gate=gate).calibrate(
+            _make_texts(POS_SEEN, NEG_SEEN, n_per_class=30, seed=77),
+            _teacher(_make_texts(POS_SEEN, NEG_SEEN, n_per_class=30, seed=77)),
+        )
+        test = _make_texts(POS_SEEN, NEG_SEEN, n_per_class=20, seed=88) + _make_texts(
+            POS_HELD, NEG_HELD, n_per_class=20, seed=89
+        )
+        truth = _teacher(test)
+        served = []
+        for t, y in zip(test, truth):
+            decision = calibrated.decide(t)
+            served.append(y if decision is None else decision)  # ESCALATE -> teacher answers correctly
+        realized_agreement = float(np.mean([s == y for s, y in zip(served, truth)]))
+        unaided_agreement = agreement(student, truth, test)
+        self.assertGreater(realized_agreement, unaided_agreement)
+        self.assertGreater(realized_agreement, 0.85)
+
+    def test_union_gate_ors_two_gates(self):
+        class _AlwaysFlag:
+            def ood_mask(self, texts):
+                return np.ones(len(texts), dtype=bool)
+
+        class _NeverFlag:
+            def ood_mask(self, texts):
+                return np.zeros(len(texts), dtype=bool)
+
+        union = UnionGate(_NeverFlag(), _AlwaysFlag())
+        self.assertTrue(np.all(union.ood_mask(["a", "b", "c"])))
+        union_none = UnionGate(_NeverFlag(), _NeverFlag())
+        self.assertFalse(np.any(union_none.ood_mask(["a", "b"])))
+
+
+class ActiveLabelingShrinksTheRegionTest(unittest.TestCase):
+    def test_labeling_the_flagged_region_and_redistilling_shrinks_its_disagreement_mass(self):
+        train = _make_texts(POS_SEEN, NEG_SEEN, n_per_class=80, seed=5)
+        student = distill_from_labels(
+            train, _teacher(train), labels=["positive", "negative"], n=2, dim=64, hidden=[16], epochs=60, seed=0
+        )
+        flagged_region = _make_texts(POS_HELD, NEG_HELD, n_per_class=40, seed=6)
+        region_labels = _teacher(flagged_region)
+
+        mass_before = measure_disagreement_mass(student, flagged_region, region_labels)
+        self.assertGreater(mass_before, 0.3)
+
+        # sample the disagreement region, label it with the teacher, re-distill including those labels
+        augmented_texts = train + flagged_region
+        augmented_labels = _teacher(train) + region_labels
+        restudent = distill_from_labels(
+            augmented_texts,
+            augmented_labels,
+            labels=["positive", "negative"],
+            n=2,
+            dim=64,
+            hidden=[16],
+            epochs=60,
+            seed=0,
+        )
+        mass_after = measure_disagreement_mass(restudent, flagged_region, region_labels)
+
+        self.assertLess(mass_after, mass_before)
+        self.assertLess(mass_after, 0.1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mixle/tests/generative_capability_test.py
+++ b/mixle/tests/generative_capability_test.py
@@ -1,0 +1,124 @@
+"""Extraction-student capture profiles (workstream D6): F1-against-gold, not exact-match agreement.
+
+The load-bearing claim: exact-match agreement (the base capture_profile's notion) understates a
+partially-correct extractor's real capability -- a student that gets most fields right under a
+corruption looks the same as one that gets none right, once you demand an exact dict match. Field-level
+F1 against a fixed gold reference does not have that blind spot. Built with a real distilled
+ExtractionIO student, not a hand-rolled stand-in.
+"""
+
+import unittest
+
+import numpy as np
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("safetensors")
+
+from mixle.task.capability import (  # noqa: E402
+    CapabilitySuite,
+    capture_profile,
+    keyboard_typo_corruption,
+)
+from mixle.task.extract import distill_extractor  # noqa: E402
+from mixle.task.generative_capability import (  # noqa: E402
+    extractive_capture_profile,
+    validate_extraction_schema,
+)
+
+NAMES = ["alice", "bob", "carol", "david", "erin", "frank", "grace", "henry"]
+TEMPLATES = [
+    "hi my name is {n} nice to meet you",
+    "hello, i am {n} and i like tea",
+    "{n} said hello to the team today",
+    "please welcome {n} to the call",
+]
+
+
+def _teacher(texts):
+    out = []
+    for t in texts:
+        low = t.lower()
+        found = next((n for n in NAMES if n in low), None)
+        out.append({"name": found} if found else {})
+    return out
+
+
+def _corpus(n_per=18, seed=0):
+    rng = np.random.RandomState(seed)
+    texts = []
+    for name in NAMES:
+        for _ in range(n_per):
+            texts.append(TEMPLATES[rng.randint(len(TEMPLATES))].format(n=name))
+    rng.shuffle(texts)
+    return texts
+
+
+class ValidateExtractionSchemaTest(unittest.TestCase):
+    def test_complete_and_grounded_record_passes(self):
+        check = validate_extraction_schema({"name": "alice"}, "hi my name is alice", ["name"])
+        self.assertTrue(check["complete"])
+        self.assertTrue(check["grounded"])
+        self.assertEqual(check["missing"], [])
+        self.assertEqual(check["ungrounded"], [])
+
+    def test_missing_field_fails_completeness(self):
+        check = validate_extraction_schema({}, "hi there", ["name"])
+        self.assertFalse(check["complete"])
+        self.assertIn("name", check["missing"])
+
+    def test_hallucinated_value_fails_groundedness(self):
+        # "zach" is not a substring of the source text -- a hallucinated (or corrupted-span) value.
+        check = validate_extraction_schema({"name": "zach"}, "hi my name is alice", ["name"])
+        self.assertFalse(check["grounded"])
+        self.assertIn("name", check["ungrounded"])
+
+
+class ExtractiveCaptureProfileTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.texts = _corpus()
+        cls.student = distill_extractor(_teacher, cls.texts, ["name"], epochs=80, seed=0)
+
+    def test_clean_f1_is_high_and_schema_valid(self):
+        suite = CapabilitySuite()
+        profile = extractive_capture_profile(self.student, _teacher, self.texts, suite, fields=["name"])
+        self.assertGreater(profile["clean_f1"], 0.85)
+        # ExtractionIO always decodes a span of the text it was called on -- grounded by construction.
+        self.assertEqual(profile["schema_validity"]["student"], 1.0)
+        self.assertEqual(profile["schema_validity"]["teacher"], 1.0)
+
+    def test_profile_shows_measurable_degradation_under_corruption(self):
+        suite = CapabilitySuite(corruptions={"typo_40": keyboard_typo_corruption(0.4, seed=0)})
+        profile = extractive_capture_profile(self.student, _teacher, self.texts, suite, fields=["name"])
+        self.assertLess(profile["corruptions"]["typo_40"]["student_f1"], profile["clean_f1"])
+
+    def test_agreement_with_teacher_can_mask_true_performance_f1_against_gold_does_not(self):
+        # Same fixture, scored two ways under a heavy corruption. capture_profile's base metric is
+        # student-vs-TEACHER agreement on the corrupted input: if a corruption is severe enough that
+        # BOTH sides degrade to the same (wrong) extraction -- e.g. both fail to find the name and
+        # return {} -- the two "agree" perfectly even though neither is actually right. F1-against-a-
+        # fixed-gold does not have that blind spot: it is checked against the true answer, not against
+        # whatever the teacher also happens to say under the same corruption.
+        suite = CapabilitySuite(corruptions={"typo_70": keyboard_typo_corruption(0.7, seed=1)})
+        extractive = extractive_capture_profile(self.student, _teacher, self.texts, suite, fields=["name"])
+        base = capture_profile(self.student, _teacher, self.texts, suite)
+
+        f1_score = extractive["corruptions"]["typo_70"]["student_f1"]
+        exact_match_score = base["corruptions"]["typo_70"]
+        # heavy corruption: student and teacher both largely fail the same way (agreement looks fine)
+        self.assertGreater(exact_match_score, 0.9)
+        # ... but true field-level performance against the fixed gold is genuinely poor -- the gap
+        # base capture_profile's agreement number cannot see.
+        self.assertLess(f1_score, exact_match_score - 0.3)
+
+    def test_invariance_uses_f1_not_binary_violation(self):
+        suite = CapabilitySuite(invariances={"case_jitter": lambda t: t.swapcase()})
+        profile = extractive_capture_profile(self.student, _teacher, self.texts, suite, fields=["name"])
+        self.assertIn("case_jitter", profile["invariances"])
+        self.assertIn("student_f1", profile["invariances"]["case_jitter"])
+        self.assertIn("teacher_f1", profile["invariances"]["case_jitter"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Card D3-a (workstream D steps 3-4): `mixle.task.capability.CapabilitySuite` (corruptions, invariances, probes) + `capture_profile(student, teacher, texts, suite)`.
- Reports clean agreement, per-corruption student/teacher agreement, per-invariance violation rates for student AND teacher separately (a student isn't penalized for an invariance the teacher itself violates), and abstention/escalation rates when either side is `decide()`-able. Deliberately no single aggregate score — this is the "capture profile" artifact of workstream D.
- Includes `keyboard_typo_corruption` and `case_jitter_invariance`/`whitespace_invariance` helpers; exported from `mixle.task`.

## Test plan
- [x] `mixle/tests/capability_suite_test.py` — clean agreement high, agreement degrades under increasing typo severity, case-jitter invariance ~0 violation for a case-insensitive teacher, abstention reported for a calibrated student, profile round-trips `json.dumps`, empty suite yields just clean agreement.
- [x] `.venv/bin/python -m pytest mixle/tests/task_distill_test.py mixle/tests/task_distill_routing_test.py mixle/tests/capability_suite_test.py -q` — 15 passed.
- [x] `ruff check` / `ruff format --check` on changed files — clean.
