### PR TITLE
task/DIAGNOSE-a: diagnose() -- ledger to FaultReport, the critic role (workstream H5)

### DIFF
--- a/mixle/inference/__init__.py
+++ b/mixle/inference/__init__.py
@@ -94,7 +94,7 @@ from mixle.inference.event_study import (
     poisson_lograte_effect,
     tipping_drift,
 )
-from mixle.inference.explain import Explanation, explain, explain_margin, explain_margin_mixture
+from mixle.inference.explain import Explanation, FaultReport, diagnose, explain, explain_margin, explain_margin_mixture
 from mixle.inference.fisher import FisherView, FixedFisherView, to_fisher
 from mixle.inference.forecast import Forecast, forecast
 
@@ -313,6 +313,8 @@ __all__ = [
     "explain",
     "explain_margin",
     "explain_margin_mixture",
+    "FaultReport",
+    "diagnose",
     "InterventionalNetwork",
     "average_causal_effect",
     "counterfactual",

--- a/mixle/inference/explain.py
+++ b/mixle/inference/explain.py
@@ -39,6 +39,7 @@ decision margin between two named hypotheses -- into the same kind of per-factor
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -187,3 +188,86 @@ def explain_margin_mixture(model: Any, x: Any, answer: int, runner_up: int) -> E
     total = (wa + float(ca.log_density(x))) - (wr + float(cr.log_density(x)))
     correction = total - float(sum(v for _, v in parts))
     return Explanation(total, sorted(parts, key=lambda p: p[1]), correction=correction)
+
+
+# --- diagnose: ledger -> FaultReport (workstream H5, the refinement loop's critic role) ------------
+
+_FIX_VOCAB = frozenset({"add_edge", "upgrade_leaf", "split_region", "add_factor"})
+
+
+@dataclass
+class FaultReport:
+    """A structural diagnosis built ONLY from :func:`explain` ledgers over failing cases -- no model
+    opinion. ``dominant`` names the structural element(s) most responsible (empty when nothing rises
+    above ordinary case-to-case variability); ``suggested_fix`` is one of :data:`_FIX_VOCAB` (empty
+    when nothing is dominant); ``evidence`` is every element ranked by its adverse contribution."""
+
+    dominant: str
+    evidence: list[tuple[str, float]] = field(default_factory=list)
+    suggested_fix: str = ""
+    receipt: dict[str, Any] = field(default_factory=dict)
+
+
+def diagnose(
+    model: Any,
+    cases: Sequence[Any],
+    *,
+    background: Sequence[Any] | None = None,
+    min_z: float = 1.0,
+    co_occurrence_threshold: float = 0.5,
+) -> FaultReport:
+    """Aggregate :func:`explain` ledgers over ``cases`` (failing / low-margin / miscalibrated examples)
+    into a :class:`FaultReport` naming the structural element most responsible.
+
+    Each case's per-part contributions are compared to ``background`` (a reference sample of typical
+    cases; defaults to ``cases`` themselves, though a real, separately-supplied background is needed to
+    detect a fault that is systematic across every case, since self-baselining against the failing set
+    cancels a shift common to all of it) via a robust z-score (median/MAD per part name), so "adverse"
+    is relative to that part's own normal variability, not a raw log-density magnitude.
+
+    A single part scoring far from baseline is NOT, by itself, evidence of a structural defect --
+    ordinary tail draws look surprising even under a well-specified model. The one closed-vocabulary
+    fault this function actively detects is a missing dependency: two parts that are BOTH adverse on
+    (almost) exactly the same cases far more than chance predicts -- the signature of an unmodeled edge
+    between them, ranked by exact ledger numbers, never guessed. When no such co-anomalous pair is
+    found, the honest report is empty/low-severity, not a forced guess at ``upgrade_leaf`` (that
+    single-part detector, and ``split_region``/``add_factor``, are real, separate follow-up work --
+    see the module's diagnose_test.py and the KNOW-a/DIAGNOSE-a cards).
+    """
+    bg = list(background) if background is not None else list(cases)
+    if not bg or not cases:
+        return FaultReport("", [], "", {"n_cases": len(cases), "n_background": len(bg)})
+
+    bg_explanations = [explain(model, x) for x in bg]
+    names = sorted({name for ex in bg_explanations for name, _ in ex.parts})
+    baseline: dict[str, float] = {}
+    scale: dict[str, float] = {}
+    for name in names:
+        vals = np.asarray([v for ex in bg_explanations for n, v in ex.parts if n == name], dtype=np.float64)
+        med = float(np.median(vals))
+        mad = float(np.median(np.abs(vals - med))) * 1.4826  # normal-consistent MAD -> std-equivalent
+        baseline[name], scale[name] = med, max(mad, 1e-9)
+
+    rows: list[dict[str, float]] = []
+    for x in cases:
+        ex = explain(model, x)
+        rows.append({name: max(0.0, (baseline[name] - v) / scale[name]) for name, v in ex.parts if name in baseline})
+
+    mean_adverse = {name: float(np.mean([r.get(name, 0.0) for r in rows])) for name in names}
+    ranked = sorted(mean_adverse.items(), key=lambda kv: -kv[1])
+
+    dominant, fix, severity = "", "", 0.0
+    if len(ranked) > 1:
+        top_name, second_name = ranked[0][0], ranked[1][0]
+        both = sum(1 for r in rows if r.get(top_name, 0.0) > min_z and r.get(second_name, 0.0) > min_z)
+        either = sum(1 for r in rows if r.get(top_name, 0.0) > min_z or r.get(second_name, 0.0) > min_z)
+        co_occurrence = (both / either) if either else 0.0
+        if either > 0 and co_occurrence >= co_occurrence_threshold:
+            dominant, fix, severity = f"{top_name}+{second_name}", "add_edge", co_occurrence
+
+    return FaultReport(
+        dominant=dominant,
+        evidence=ranked,
+        suggested_fix=fix,
+        receipt={"n_cases": len(cases), "n_background": len(bg), "severity": round(severity, 4)},
+    )

--- a/mixle/tests/diagnose_test.py
+++ b/mixle/tests/diagnose_test.py
@@ -1,0 +1,105 @@
+"""DIAGNOSE-a: diagnose() aggregates explain() ledgers over failing cases into a FaultReport --
+planted-fault recovery for a missing dependency, and a well-specified model showing nothing dominant.
+
+The merged H1-a `explain`/`explain_margin` do NOT take the (models, priors) dict-of-classifiers shape
+the original card sketched before H1-a landed; the real API is `explain(model, x) -> Explanation`
+(see mixle/inference/explain.py). `diagnose` composes with THAT real signature, calling `explain` once
+per case and aggregating -- same spirit (H1's ledger feeds H5's critic), adapted to the shipped API.
+"""
+
+import unittest
+
+import numpy as np
+
+from mixle.inference import diagnose
+from mixle.inference.bayesian_network import HeterogeneousBayesianNetwork, _LinearGaussianFactor, _MarginalFactor
+from mixle.stats import GaussianDistribution
+
+
+def _split_cases():
+    """A grid of (a, b) pairs where b = a + 0.05 -- a genuine, tight correlation between the two
+    fields. 'background' is the interior (typical) range; 'failing' is the tail, where a model that
+    does not know about the correlation is most surprised."""
+    a_grid = np.linspace(-3.0, 3.0, 41)
+    pairs = [(float(a), float(a) + 0.05) for a in a_grid]
+    background = [p for p in pairs if abs(p[0]) <= 1.5]
+    failing = [p for p in pairs if abs(p[0]) > 2.2]
+    return background, failing
+
+
+def _buggy_net():
+    """The planted fault: b is truly b = a + noise, but modeled as fully independent of a."""
+    return HeterogeneousBayesianNetwork(
+        [
+            _MarginalFactor(0, GaussianDistribution(0.0, 1.0)),
+            _MarginalFactor(1, GaussianDistribution(0.0, 1.0)),
+        ]
+    )
+
+
+def _well_specified_net():
+    """The SAME data, correctly modeled: b's factor is conditioned on a."""
+    return HeterogeneousBayesianNetwork(
+        [
+            _MarginalFactor(0, GaussianDistribution(0.0, 1.0)),
+            _LinearGaussianFactor(1, [0], {}, np.array([1.0, 0.0]), 0.1),
+        ]
+    )
+
+
+class PlantedFaultRecoveryTest(unittest.TestCase):
+    def test_missing_edge_is_named_dominant_with_add_edge(self):
+        background, failing = _split_cases()
+        report = diagnose(_buggy_net(), failing, background=background)
+
+        self.assertEqual(report.suggested_fix, "add_edge")
+        self.assertIn("field[0]", report.dominant)
+        self.assertIn("field[1]", report.dominant)
+        self.assertGreater(report.receipt["severity"], 0.9)  # both fields adverse on (almost) every case
+
+    def test_well_specified_model_on_same_data_reports_nothing_dominant(self):
+        background, failing = _split_cases()
+        report = diagnose(_well_specified_net(), failing, background=background)
+
+        self.assertEqual(report.dominant, "")
+        self.assertEqual(report.suggested_fix, "")
+        self.assertEqual(report.receipt["severity"], 0.0)
+
+    def test_evidence_is_ranked_and_exact_field_names_present(self):
+        background, failing = _split_cases()
+        report = diagnose(_buggy_net(), failing, background=background)
+        names = [n for n, _ in report.evidence]
+        self.assertEqual(names, sorted(names, key=lambda n: -dict(report.evidence)[n]))
+        self.assertEqual({n.split("|")[0] for n in names}, {"field[0]", "field[1]"})
+
+
+class DeterminismTest(unittest.TestCase):
+    def test_same_seeded_cases_give_bit_identical_reports(self):
+        rng1 = np.random.default_rng(0)
+        rng2 = np.random.default_rng(0)
+
+        def make_cases(rng):
+            a = rng.uniform(-3.0, 3.0, size=30)
+            return [(float(x), float(x) + 0.05) for x in a]
+
+        cases1, cases2 = make_cases(rng1), make_cases(rng2)
+        background, _ = _split_cases()
+
+        r1 = diagnose(_buggy_net(), cases1, background=background)
+        r2 = diagnose(_buggy_net(), cases2, background=background)
+
+        self.assertEqual(r1.dominant, r2.dominant)
+        self.assertEqual(r1.suggested_fix, r2.suggested_fix)
+        self.assertEqual(r1.evidence, r2.evidence)
+        self.assertEqual(r1.receipt, r2.receipt)
+
+
+class EmptyInputTest(unittest.TestCase):
+    def test_no_cases_returns_empty_report_not_a_crash(self):
+        report = diagnose(_buggy_net(), [])
+        self.assertEqual(report.dominant, "")
+        self.assertEqual(report.evidence, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Workstream H5 of the 0.6.3 frontier-capability plan (CARD DIAGNOSE-a in
`notes/0.6.3-execution-playbook.md`, unblocked now that H1-a (#7) is merged): aggregate `explain()`
ledgers over failing/low-margin cases into an auditable `FaultReport`, built only from exact ledger
numbers, no model opinion.

New in `mixle/inference/explain.py`:

- `FaultReport(dominant, evidence, suggested_fix, receipt)` -- `suggested_fix` is one of the closed
  vocabulary `{add_edge, upgrade_leaf, split_region, add_factor}`.
- `diagnose(model, cases, *, background=None, min_z=1.0, co_occurrence_threshold=0.5)`: for each case,
  `explain(model, x)` is called and each part's contribution is scored against a robust per-part
  baseline (median/MAD over `background`) as a "how many typical deviations worse than normal" adverse
  score. The fault this function actively detects: a **pair** of parts that are both adverse on
  (almost) exactly the same cases far more than chance -- the signature of an unmodeled dependency
  between them -- reported as `dominant` with `suggested_fix="add_edge"`. A single part scoring far
  from baseline, with **no co-anomalous partner**, is not treated as a defect (ordinary tail draws look
  surprising even under a well-specified model), so the honest report is empty/zero-severity rather
  than a forced guess.

**Deviation from the card (please read):** the card was written before H1-a landed and assumed
`explain(models: dict, priors: dict, x)` -- a per-label classifier signature. The actual merged H1-a
is `explain(model, x) -> Explanation` (single model, per-part attribution) plus
`explain_margin`/`explain_margin_mixture` for decision margins. `diagnose()` composes with the shipped
signature (same module, calls `explain()` per case -- same spirit: H1's exact ledger feeds H5's critic)
rather than a signature that was never built. Flagging this explicitly since it's a real plan/reality
gap, not something to smooth over silently.

Also **not** implemented in this slice: a standalone single-part detector for
`upgrade_leaf`/`split_region`/`add_factor`. Building one that doesn't false-positive on ordinary
sampling-tail variation (vs. a real single-leaf misfit) is separate work; the vocabulary stays open for
it. This card lands only the co-anomaly (`add_edge`) detector the acceptance test actually exercises.

## Test plan

- [x] `mixle/tests/diagnose_test.py` -- 5 new tests: planted-fault recovery via a
      `HeterogeneousBayesianNetwork` (reusing the exact `_MarginalFactor`/`_LinearGaussianFactor`
      primitives `explain_test.py` already uses) -- a genuinely correlated `(a, b)` pair modeled as
      independent (missing edge) is named dominant with `suggested_fix == "add_edge"` on tail cases;
      the SAME cases against a well-specified model (b's factor correctly conditioned on a) report
      nothing dominant, severity `0.0`; evidence is ranked with exact field names; two
      independently-seeded case sets give bit-identical reports (determinism); an empty case list
      returns an empty report, not a crash.
- [x] `pytest mixle/tests -k "explain or diagnose"` -- 20 passed, 2 pre-existing unrelated skips (no
      regression in the existing H1-a explain/explain_margin tests).
- [x] `ruff check` + `ruff format --check` clean on all three changed files.