### PR TITLE
task/COMPOSE-a: composition operator chaining two models into one ledger-carrying callable

### DIFF
--- a/mixle/task/__init__.py
+++ b/mixle/task/__init__.py
@@ -30,6 +30,7 @@ from mixle.task.artifact import (
 )
 from mixle.task.calibrate import ESCALATE, CalibratedTaskModel
 from mixle.task.cascade import Cascade, CascadeStats
+from mixle.task.compose import ComposedAnswer, ComposedModel, compose
 from mixle.task.density import DensityGate
 from mixle.task.design import DesignedModel, design_model, spec_to_estimator
 from mixle.task.distill import (
@@ -128,6 +129,8 @@ __all__ = [
     "CallableLLM",
     "Cascade",
     "CascadeStats",
+    "ComposedAnswer",
+    "ComposedModel",
     "CostModel",
     "DensityGate",
     "DesignModel",
@@ -174,6 +177,7 @@ __all__ = [
     "agreement",
     "break_even_volume",
     "cascade_cost_per_request",
+    "compose",
     "design_model",
     "distill",
     "distill_designer",

--- a/mixle/task/compose.py
+++ b/mixle/task/compose.py
@@ -1,0 +1,89 @@
+"""``compose`` -- chain two models/teachers ``a: x -> y`` and ``b: y -> z`` into one callable ``x -> z``,
+carrying a per-stage evidence ledger (the shared composition primitive workstream D10/AMPLIFY-a's
+"2-teacher composition" and workstream F's belief walks build on; built once here, reused there).
+
+``a`` and ``b`` are any callables -- a :class:`~mixle.task.model.TaskModel`, a
+:class:`~mixle.task.calibrate.CalibratedTaskModel`, a teacher LLM, or a plain function. A stage that
+additionally exposes ``.score(input) -> float`` (a log-confidence or log-density) contributes that
+number to the ledger; a stage without one contributes ``0.0`` (honest "unscored", never fabricated).
+The ledger is purely additive by construction -- ``ComposedAnswer.check()`` asserts
+``sum(contributions) == total_contribution`` exactly, the same identity
+:mod:`mixle.inference.explain` uses for a single model's evidence.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class ComposedAnswer:
+    """A composed ``x -> z`` answer plus the per-stage receipt that attributes it to both stages."""
+
+    answer: Any
+    intermediate: Any
+    stages: list[tuple[str, Any, float]]  # (stage_name, stage_output, contribution)
+    total_contribution: float
+
+    def check(self, tol: float = 1e-9) -> bool:
+        """``sum(contributions) == total_contribution`` -- the ledger is exact by construction."""
+        return abs(sum(c for _, _, c in self.stages) - self.total_contribution) <= tol
+
+
+def _stage_contribution(stage: Callable[..., Any], stage_input: Any) -> float:
+    if hasattr(stage, "score"):
+        return float(stage.score(stage_input))
+    if hasattr(stage, "confidence"):
+        return float(stage.confidence(stage_input))
+    return 0.0
+
+
+class ComposedModel:
+    """Chain ``a: x -> y`` then ``b: y -> z`` as one callable ``x -> z``.
+
+    ``composed(x)`` returns the bare answer ``z`` (so a ``ComposedModel`` can stand in anywhere a plain
+    teacher callable is expected -- including as the ``a`` or ``b`` of another ``compose()``, chaining
+    further). ``composed.answer(x)`` returns the ledger-carrying :class:`ComposedAnswer` instead.
+    """
+
+    def __init__(
+        self,
+        a: Callable[[Any], Any],
+        b: Callable[[Any], Any],
+        *,
+        name_a: str = "stage_a",
+        name_b: str = "stage_b",
+    ) -> None:
+        self.a = a
+        self.b = b
+        self.name_a = str(name_a)
+        self.name_b = str(name_b)
+
+    def __call__(self, x: Any) -> Any:
+        return self.b(self.a(x))
+
+    def answer(self, x: Any) -> ComposedAnswer:
+        y = self.a(x)
+        z = self.b(y)
+        contribution_a = _stage_contribution(self.a, x)
+        contribution_b = _stage_contribution(self.b, y)
+        stages = [(self.name_a, y, contribution_a), (self.name_b, z, contribution_b)]
+        return ComposedAnswer(
+            answer=z,
+            intermediate=y,
+            stages=stages,
+            total_contribution=contribution_a + contribution_b,
+        )
+
+
+def compose(
+    a: Callable[[Any], Any],
+    b: Callable[[Any], Any],
+    *,
+    name_a: str = "stage_a",
+    name_b: str = "stage_b",
+) -> ComposedModel:
+    """Chain ``a: x -> y`` and ``b: y -> z`` into one ledger-carrying ``x -> z`` callable."""
+    return ComposedModel(a, b, name_a=name_a, name_b=name_b)

--- a/mixle/tests/task_compose_test.py
+++ b/mixle/tests/task_compose_test.py
@@ -1,0 +1,91 @@
+"""compose(): chaining two models/teachers into one ledger-carrying callable (workstream D10)."""
+
+import unittest
+
+from mixle.task.compose import ComposedAnswer, compose
+
+# Synthetic 2-stage world: neither stage alone maps a species name to its habitat.
+_SPECIES_TO_TAXON = {
+    "cat": "mammal",
+    "dog": "mammal",
+    "shark": "fish",
+    "tuna": "fish",
+    "eagle": "bird",
+    "sparrow": "bird",
+}
+_TAXON_TO_HABITAT = {"mammal": "land", "fish": "water", "bird": "air"}
+_TAXON_CONFIDENCE = {"mammal": 0.9, "fish": 0.8, "bird": 0.7}
+_HABITAT_CONFIDENCE = {"land": -0.1, "water": -0.2, "bird": -0.3, "air": -0.05}
+
+
+class _Classifier:
+    """A tiny scored callable: ``__call__`` predicts, ``score`` returns a log-confidence for its input."""
+
+    def __init__(self, table: dict, confidence: dict) -> None:
+        self.table = table
+        self.confidence = confidence
+
+    def __call__(self, x):
+        return self.table[x]
+
+    def score(self, x):
+        return float(self.confidence.get(x, self.confidence.get(self.table[x], 0.0)))
+
+
+def _taxon_classifier() -> _Classifier:
+    return _Classifier(_SPECIES_TO_TAXON, _TAXON_CONFIDENCE)
+
+
+def _habitat_classifier() -> _Classifier:
+    return _Classifier(_TAXON_TO_HABITAT, _HABITAT_CONFIDENCE)
+
+
+class ComposeTest(unittest.TestCase):
+    def test_composed_answers_what_neither_stage_answers_alone(self):
+        species_to_taxon = _taxon_classifier()
+        taxon_to_habitat = _habitat_classifier()
+        composed = compose(species_to_taxon, taxon_to_habitat, name_a="species_to_taxon", name_b="taxon_to_habitat")
+
+        for species, expected_taxon in _SPECIES_TO_TAXON.items():
+            expected_habitat = _TAXON_TO_HABITAT[expected_taxon]
+            self.assertEqual(composed(species), expected_habitat)
+            # neither stage alone answers species -> habitat: stage a stops at the taxon,
+            # and stage b cannot even accept a species name as input.
+            self.assertEqual(species_to_taxon(species), expected_taxon)
+            self.assertNotEqual(species_to_taxon(species), expected_habitat)
+            with self.assertRaises(KeyError):
+                taxon_to_habitat(species)
+
+    def test_receipt_attributes_the_answer_to_both_stages(self):
+        composed = compose(
+            _taxon_classifier(), _habitat_classifier(), name_a="species_to_taxon", name_b="taxon_to_habitat"
+        )
+        result = composed.answer("shark")
+
+        self.assertIsInstance(result, ComposedAnswer)
+        self.assertEqual(result.answer, "water")
+        self.assertEqual(result.intermediate, "fish")
+        self.assertEqual([name for name, _, _ in result.stages], ["species_to_taxon", "taxon_to_habitat"])
+        self.assertEqual([out for _, out, _ in result.stages], ["fish", "water"])
+        # both stages contributed a nonzero, distinct piece of evidence to the final answer
+        contributions = [c for _, _, c in result.stages]
+        self.assertTrue(all(c != 0.0 for c in contributions))
+        self.assertTrue(result.check())
+        self.assertAlmostEqual(sum(contributions), result.total_contribution)
+
+    def test_unscored_stage_contributes_zero_honestly(self):
+        # a plain function has no .score/.confidence -- the ledger must not fabricate a number for it
+        composed = compose(lambda x: x.upper(), lambda x: f"{x}!")
+        result = composed.answer("hi")
+        self.assertEqual(result.answer, "HI!")
+        self.assertEqual([c for _, _, c in result.stages], [0.0, 0.0])
+        self.assertTrue(result.check())
+
+    def test_chained_composition_of_composed_models(self):
+        stage1 = compose(_taxon_classifier(), _habitat_classifier())
+        habitat_to_upper = compose(stage1, lambda h: h.upper())
+        self.assertEqual(habitat_to_upper("eagle"), "AIR")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Workstream D10 shared primitive: `compose(a, b) -> ComposedModel` chains `a: x -> y` and `b: y -> z` into one `x -> z` callable.
- `ComposedModel(x)` returns the bare answer (so it composes further / stands in for any teacher callable); `ComposedModel.answer(x)` returns a `ComposedAnswer` with a per-stage receipt (`stages`, `total_contribution`) that is additive and exact (`check()`), matching the ledger identity used in `mixle.inference.explain`.
- A stage exposing `.score`/`.confidence` contributes a real number; a plain callable contributes an honest `0.0` rather than a fabricated confidence.
- Substrate for AMPLIFY-a's 2-teacher composition and workstream F's belief walks (per `notes/0.6.3-execution-playbook.md`, CARD COMPOSE-a) -- built once here, to be reused rather than reimplemented.

## Test plan
- [x] `.venv/bin/python -m pytest mixle/tests/task_compose_test.py -q` -- 4 passed
- [x] `.venv/bin/python -m ruff check mixle/task/compose.py mixle/tests/task_compose_test.py mixle/task/__init__.py` -- clean
- [x] `.venv/bin/python -m ruff format --check` on the same files -- clean
- [ ] Full gate (`pytest -q -m "not optional and not benchmark"`) not run in this session per instructions to only run targeted tests; recommend running before merge.
