### PR TITLE
task/B1: density-gated routing option

### DIFF
--- a/mixle/task/distill.py
+++ b/mixle/task/distill.py
@@ -23,6 +23,7 @@ from typing import Any
 import numpy as np
 
 from mixle.task.calibrate import CalibratedTaskModel
+from mixle.task.density import DensityGate
 from mixle.task.model import (
     HashedNGram,
     HashedRecord,
@@ -135,6 +136,8 @@ def distill_for_routing(
     seed: int = 0,
     task: str = "",
     device: str = "cpu",
+    density_gate: bool = False,
+    density_gate_alpha: float = 0.05,
 ) -> CalibratedTaskModel:
     """Label ``texts`` with ``teacher``, fit a student, and calibrate it for routing -- all in one call.
 
@@ -144,6 +147,9 @@ def distill_for_routing(
     ``ESCALATE``. Pass it straight to :class:`~mixle.task.cascade.Cascade` (with ``teacher``) or
     :class:`~mixle.task.router.Router` for tiered serving -- no separate calibration split to manage by hand.
     Deterministic given ``seed``; the calibration slice is disjoint from the student's training data.
+
+    ``density_gate=True`` additionally escalates inputs a softmax cannot see are atypical: see
+    :func:`distill_from_labels_for_routing`.
     """
     texts = [str(t) for t in texts]
     teacher_labels = _as_batched(teacher)(texts)
@@ -161,6 +167,8 @@ def distill_for_routing(
         seed=seed,
         task=task,
         device=device,
+        density_gate=density_gate,
+        density_gate_alpha=density_gate_alpha,
     )
 
 
@@ -179,6 +187,8 @@ def distill_from_labels_for_routing(
     seed: int = 0,
     task: str = "",
     device: str = "cpu",
+    density_gate: bool = False,
+    density_gate_alpha: float = 0.05,
 ) -> CalibratedTaskModel:
     """Teacher-free training core of :func:`distill_for_routing`: fit + calibrate from labels already in hand.
 
@@ -187,6 +197,12 @@ def distill_from_labels_for_routing(
     (:meth:`~mixle.task.calibrate.CalibratedTaskModel.calibrate`) on the latter. ``labels`` (if given, else
     inferred from all of ``teacher_labels`` before the split) is shared by both slices so a class that lands
     entirely on one side of the split doesn't shrink the label set out from under the other.
+
+    ``density_gate=True`` fits a :class:`~mixle.task.density.DensityGate` on the *training* slice's features
+    (reusing the student's own featurizer, so there is no second feature space to keep in sync), calibrates its
+    OOD floor (``density_gate_alpha``) on the disjoint *calibration* slice, and wires it into the returned
+    model -- an input whose ``log p(x)`` falls below that floor escalates even if the conformal set is a
+    confident singleton.
     """
     label_list = list(labels) if labels is not None else sorted({str(y) for y in teacher_labels})
     train_texts, train_labels, cal_texts, cal_labels = _split_for_calibration(
@@ -205,7 +221,12 @@ def distill_from_labels_for_routing(
         task=task,
         device=device,
     )
-    return CalibratedTaskModel(student, alpha=alpha).calibrate(cal_texts, cal_labels)
+    gate = (
+        _fit_density_gate(student, train_texts, cal_texts, alpha=density_gate_alpha, seed=seed)
+        if density_gate
+        else None
+    )
+    return CalibratedTaskModel(student, alpha=alpha, density_gate=gate).calibrate(cal_texts, cal_labels)
 
 
 def distill_records(
@@ -287,6 +308,8 @@ def distill_records_for_routing(
     seed: int = 0,
     task: str = "",
     device: str = "cpu",
+    density_gate: bool = False,
+    density_gate_alpha: float = 0.05,
 ) -> CalibratedTaskModel:
     """The structured-record sibling of :func:`distill_for_routing`: fit + calibrate a record classifier
     in one call, returning a routing-ready :class:`~mixle.task.calibrate.CalibratedTaskModel`."""
@@ -305,6 +328,8 @@ def distill_records_for_routing(
         seed=seed,
         task=task,
         device=device,
+        density_gate=density_gate,
+        density_gate_alpha=density_gate_alpha,
     )
 
 
@@ -322,9 +347,12 @@ def distill_records_from_labels_for_routing(
     seed: int = 0,
     task: str = "",
     device: str = "cpu",
+    density_gate: bool = False,
+    density_gate_alpha: float = 0.05,
 ) -> CalibratedTaskModel:
     """Teacher-free training core of :func:`distill_records_for_routing` (mirrors
-    :func:`distill_from_labels_for_routing` for structured records)."""
+    :func:`distill_from_labels_for_routing` for structured records). ``density_gate=True`` fits the OOD gate
+    on the training slice's record features and calibrates it on the calibration slice, same as the text path."""
     label_list = list(labels) if labels is not None else sorted({str(y) for y in teacher_labels})
     train_records, train_labels, cal_records, cal_labels = _split_for_calibration(
         records, teacher_labels, calibration_frac, seed
@@ -341,7 +369,12 @@ def distill_records_from_labels_for_routing(
         task=task,
         device=device,
     )
-    return CalibratedTaskModel(student, alpha=alpha).calibrate(cal_records, cal_labels)
+    gate = (
+        _fit_density_gate(student, train_records, cal_records, alpha=density_gate_alpha, seed=seed)
+        if density_gate
+        else None
+    )
+    return CalibratedTaskModel(student, alpha=alpha, density_gate=gate).calibrate(cal_records, cal_labels)
 
 
 def distill_structured(
@@ -484,6 +517,24 @@ def _split_for_calibration(
         [items[i] for i in cal_idx],
         [teacher_labels[i] for i in cal_idx],
     )
+
+
+def _fit_density_gate(
+    student: TaskModel, train_items: Sequence[Any], cal_items: Sequence[Any], *, alpha: float, seed: int
+) -> DensityGate:
+    """Fit an OOD gate on the student's own featurizer: density from ``train_items``, floor from ``cal_items``.
+
+    Fitting the density and its floor on the *same* slice would let the gate calibrate against the exact data
+    it was fit on -- optimistic, the same mistake conformal calibration avoids. So the density is fit on
+    ``train_items`` (disjoint from the calibration slice used to set the conformal threshold), then the floor is
+    set from the ``alpha``-quantile of ``cal_items``' log-density under that fitted density: a genuinely
+    held-out threshold, consistent with how :meth:`~mixle.task.calibrate.CalibratedTaskModel.calibrate` treats
+    the same split.
+    """
+    gate = DensityGate(student.adapter.featurizer)
+    gate.fit(train_items, seed=seed)
+    gate.log_threshold = float(np.quantile(gate.log_density(cal_items), alpha))
+    return gate
 
 
 # Early-stopping schedule for _fit_mlp: check the training loss every _ES_CHECK_EVERY gradient steps, stop once

--- a/mixle/task/tune.py
+++ b/mixle/task/tune.py
@@ -24,7 +24,7 @@ from typing import Any
 import numpy as np
 
 from mixle.task.calibrate import CalibratedTaskModel
-from mixle.task.distill import _split_for_calibration, agreement, distill
+from mixle.task.distill import _fit_density_gate, _split_for_calibration, agreement, distill
 from mixle.task.model import TaskModel
 
 
@@ -167,6 +167,8 @@ def tune_recipe_for_routing(
     alpha: float = 0.1,
     seed: int = 0,
     task: str = "",
+    density_gate: bool = False,
+    density_gate_alpha: float = 0.05,
 ) -> CalibratedTuneResult:
     """Bayesian-optimize the distillation recipe, then calibrate the winner for routing -- all in one call.
 
@@ -181,6 +183,9 @@ def tune_recipe_for_routing(
     cache, so ``train_texts`` -- identical across every candidate recipe -- is queried only once for the whole
     search rather than once per trial, and the calibration/search overlap in ``val_texts`` is never re-queried
     either. Every distinct input is priced exactly once, however many candidates the search evaluates.
+
+    ``density_gate=True`` wires the same OOD escalation as :func:`~mixle.task.distill.distill_for_routing`: a
+    gate fit on ``train_texts``, its floor calibrated on the disjoint ``cal_texts`` slice.
     """
     val_texts = [str(t) for t in val_texts]
     val_truth = _teacher_labels(teacher, val_texts)
@@ -202,7 +207,12 @@ def tune_recipe_for_routing(
         seed=seed,
         task=task,
     )
-    calibrated = CalibratedTaskModel(result.model, alpha=alpha).calibrate(cal_texts, cal_labels)
+    gate = (
+        _fit_density_gate(result.model, train_texts, cal_texts, alpha=density_gate_alpha, seed=seed)
+        if density_gate
+        else None
+    )
+    calibrated = CalibratedTaskModel(result.model, alpha=alpha, density_gate=gate).calibrate(cal_texts, cal_labels)
     return CalibratedTuneResult(
         model=calibrated,
         recipe=result.recipe,

--- a/mixle/tests/task_distill_routing_test.py
+++ b/mixle/tests/task_distill_routing_test.py
@@ -138,5 +138,89 @@ class DistillRecordsForRoutingTest(unittest.TestCase):
             self.assertTrue(d is ESCALATE or d in calibrated.labels)
 
 
+class DensityGateRoutingTest(unittest.TestCase):
+    """CARD B1-a: density_gate=True on the *_for_routing family escalates inputs a softmax can't see are OOD."""
+
+    def _ood_text(self, seed: int) -> str:
+        # long random-unicode-ish text sharing no vocabulary with the spam/ham corpus
+        rng = np.random.RandomState(seed)
+        return " ".join("".join(chr(rng.randint(0x3B1, 0x3C9)) for _ in range(8)) for _ in range(12))
+
+    def test_gate_on_escalates_ood_input(self):
+        train = _make_corpus(seed=10)
+        gated = distill_for_routing(
+            _teacher,
+            train,
+            n=4,
+            dim=512,
+            hidden=[64],
+            epochs=300,
+            lr=1e-2,
+            seed=0,
+            calibration_frac=0.2,
+            density_gate=True,
+        )
+        self.assertIsNotNone(gated.density_gate)
+        ood = self._ood_text(0)
+        self.assertIs(gated.decide(ood), ESCALATE)
+
+    def test_escalation_rate_gate_on_gte_off(self):
+        train = _make_corpus(seed=11)
+        ungated = distill_for_routing(
+            _teacher,
+            train,
+            n=4,
+            dim=512,
+            hidden=[64],
+            epochs=300,
+            lr=1e-2,
+            seed=0,
+            calibration_frac=0.2,
+            density_gate=False,
+        )
+        gated = distill_for_routing(
+            _teacher,
+            train,
+            n=4,
+            dim=512,
+            hidden=[64],
+            epochs=300,
+            lr=1e-2,
+            seed=0,
+            calibration_frac=0.2,
+            density_gate=True,
+        )
+        mixed = _make_corpus(seed=88) + [self._ood_text(i) for i in range(20)]
+        self.assertGreaterEqual(gated.escalation_rate(mixed), ungated.escalation_rate(mixed))
+
+    def test_deterministic_given_seed(self):
+        train = _make_corpus(seed=12)
+        a = distill_for_routing(
+            _teacher,
+            train,
+            n=4,
+            dim=128,
+            hidden=[32],
+            epochs=60,
+            seed=7,
+            calibration_frac=0.25,
+            density_gate=True,
+        )
+        b = distill_for_routing(
+            _teacher,
+            train,
+            n=4,
+            dim=128,
+            hidden=[32],
+            epochs=60,
+            seed=7,
+            calibration_frac=0.25,
+            density_gate=True,
+        )
+        self.assertAlmostEqual(a.density_gate.log_threshold, b.density_gate.log_threshold, places=9)
+        test = _make_corpus(seed=44) + [self._ood_text(1)]
+        self.assertEqual([a.decide(t) for t in test], [b.decide(t) for t in test])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/mixle/tests/task_tune_test.py
+++ b/mixle/tests/task_tune_test.py
@@ -122,6 +122,18 @@ class TuneRecipeForRoutingTest(unittest.TestCase):
         tune_recipe_for_routing(counting_teacher, train, val, n_init=3, n_iter=4, calibration_frac=0.3, seed=0)
         self.assertEqual(calls["n"], len(val) + len(train))
 
+    def test_density_gate_wires_an_ood_escalation(self):
+        # CARD B1-a: density_gate=True on tune_recipe_for_routing mirrors distill_for_routing's OOD gate.
+        train = _make_corpus(seed=16)
+        val = _make_corpus(n_per_class=60, seed=17)
+        res = tune_recipe_for_routing(
+            _teacher, train, val, n_init=3, n_iter=4, calibration_frac=0.3, seed=0, density_gate=True
+        )
+        self.assertIsNotNone(res.model.density_gate)
+        rng = np.random.RandomState(0)
+        ood = " ".join("".join(chr(rng.randint(0x3B1, 0x3C9)) for _ in range(8)) for _ in range(12))
+        self.assertIs(res.model.decide(ood), ESCALATE)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Card B1-a (workstream B1), unblocked now that #4/#5 (distill_for_routing / early-stopping) are merged.
- `density_gate: bool = False` (+ `density_gate_alpha: float = 0.05`) added to `distill_for_routing`, `distill_from_labels_for_routing`, `distill_records_for_routing`, `distill_records_from_labels_for_routing`, and `tune_recipe_for_routing`.
- When enabled: a `DensityGate` is fit on the training slice's features (reusing the student's own featurizer -- no second feature space to keep in sync), its OOD floor is calibrated on the disjoint calibration slice (not the same slice it was fit on -- same held-out discipline as the conformal threshold), and it's wired into the returned `CalibratedTaskModel`. An input whose `log p(x)` falls below the floor now escalates even when the conformal set is a confident singleton.

## Test plan
- [x] Extended `mixle/tests/task_distill_routing_test.py` (`DensityGateRoutingTest`): a clearly OOD input (long unicode text vs. the spam/ham corpus) escalates with the gate on; `escalation_rate` with gate-on >= gate-off on a mixed in/out sample; deterministic given seed (threshold + decisions).
- [x] Extended `mixle/tests/task_tune_test.py`: `tune_recipe_for_routing(..., density_gate=True)` wires the gate and escalates the same OOD probe.
- [x] `.venv/bin/python -m pytest mixle/tests/task_distill_routing_test.py mixle/tests/task_distill_test.py mixle/tests/task_tune_test.py -q` -- 23 passed (pre-existing + new tests), plus the new `test_density_gate_wires_an_ood_escalation` -- 1 passed.
- [x] `ruff check` / `ruff format --check` on changed files -- clean.
