### PR TITLE
task/D2: student capacity ladder + ceiling probe

### DIFF
--- a/mixle/task/__init__.py
+++ b/mixle/task/__init__.py
@@ -29,6 +29,16 @@ from mixle.task.artifact import (
     save_module,
 )
 from mixle.task.calibrate import ESCALATE, CalibratedTaskModel
+from mixle.task.capacity import (
+    DEFAULT_RUNGS,
+    KNOWN_RUNGS,
+    EmbeddingHeadIO,
+    LadderResult,
+    RungResult,
+    WordEmbeddingFeaturizer,
+    capacity_ladder,
+    climb_to,
+)
 from mixle.task.cascade import Cascade, CascadeStats
 from mixle.task.density import DensityGate
 from mixle.task.design import DesignedModel, design_model, spec_to_estimator
@@ -129,6 +139,7 @@ __all__ = [
     "Cascade",
     "CascadeStats",
     "CostModel",
+    "DEFAULT_RUNGS",
     "DensityGate",
     "DesignModel",
     "DesignedModel",
@@ -136,6 +147,7 @@ __all__ = [
     "EdgeDistillResult",
     "EdgeFootprint",
     "EdgeSpace",
+    "EmbeddingHeadIO",
     "ExtractionIO",
     "ExtractorHarness",
     "MatcherHarness",
@@ -143,7 +155,9 @@ __all__ = [
     "GenerativeTextIO",
     "HashedNGram",
     "HashedRecord",
+    "KNOWN_RUNGS",
     "LNSStructuredClassifierIO",
+    "LadderResult",
     "ModelRecommendation",
     "OpenAICompatLLM",
     "QuantizedClassifierIO",
@@ -152,6 +166,7 @@ __all__ = [
     "RecordClassifierIO",
     "RoutePlan",
     "Router",
+    "RungResult",
     "Scorecard",
     "RouterStats",
     "RegressionSolution",
@@ -167,12 +182,15 @@ __all__ = [
     "ToolSpec",
     "TextClassifierIO",
     "TuneResult",
+    "WordEmbeddingFeaturizer",
     "acquisition_scores",
     "active_distill",
     "adapter_from_spec",
     "agreement",
     "break_even_volume",
+    "capacity_ladder",
     "cascade_cost_per_request",
+    "climb_to",
     "design_model",
     "distill",
     "distill_designer",

--- a/mixle/task/capacity.py
+++ b/mixle/task/capacity.py
@@ -1,0 +1,270 @@
+"""The capacity ladder: fit a student at each rung of increasing representation family, and report where
+it stops matching the teacher.
+
+Distillation (:mod:`mixle.task.distill`) and recipe search (:mod:`mixle.task.tune`) both assume the
+student's representation *family* is fixed (hashed n-grams) and search knobs within it. Some teachers
+need a richer family -- a rule that generalizes across synonyms a hashed n-gram featurizer cannot see, for
+instance. :func:`capacity_ladder` climbs a small ordered set of representation families ("rungs"), measures
+each rung's held-out agreement with the teacher, and returns the smallest rung that meets a target -- or an
+honest "not capturable at these rungs" with every rung's measured ceiling attached, never an exception.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+from mixle.task.distill import _fit_mlp, _split_for_calibration, agreement, distill_from_labels
+from mixle.task.model import HashedNGram, TaskModel, _ClassifierIO
+
+#: the two rungs this card builds; later rungs are recognized names that may be stubs in this environment.
+DEFAULT_RUNGS: tuple[str, ...] = ("hashed_ngram", "embedding_head")
+
+#: every rung name this module understands, in increasing-capacity order (used by :func:`climb_to`).
+KNOWN_RUNGS: tuple[str, ...] = ("hashed_ngram", "embedding_head", "strong_encoder", "small_lm")
+
+_BUILT_RUNGS = frozenset({"hashed_ngram", "embedding_head"})
+
+
+class WordEmbeddingFeaturizer:
+    """Average per-word embedding vectors from a fixed lookup table -- a dependency-free "embedding head" featurizer.
+
+    Unlike :class:`~mixle.task.model.HashedNGram` (which treats distinct surface tokens as unrelated hash buckets),
+    two words given nearby vectors in ``vectors`` produce nearby features regardless of their spelling -- the
+    property a synonym-generalizing rule needs. A word missing from ``vectors`` falls back to a deterministic
+    hashed sub-vector, so out-of-vocabulary text still produces a valid feature; it just earns no semantic
+    generalization it was never given a vector for.
+    """
+
+    def __init__(self, vectors: dict[str, Sequence[float]] | None, dim: int, seed: int = 0) -> None:
+        self.vectors = {str(k): np.asarray(v, dtype=np.float32) for k, v in (vectors or {}).items()}
+        self.dim = int(dim)
+        self.seed = int(seed)
+        self._fallback = HashedNGram(n=3, dim=self.dim, seed=self.seed)
+
+    def transform(self, texts: list[str]) -> np.ndarray:
+        out = np.zeros((len(texts), self.dim), dtype=np.float32)
+        for i, t in enumerate(texts):
+            words = str(t).lower().split()
+            vecs = [self.vectors[w] for w in words if w in self.vectors]
+            out[i] = np.mean(vecs, axis=0) if vecs else self._fallback.transform([t])[0]
+        norms = np.linalg.norm(out, axis=1, keepdims=True)
+        return out / np.where(norms > 0, norms, 1.0)
+
+    def to_spec(self) -> dict[str, Any]:
+        return {"vectors": {k: v.tolist() for k, v in self.vectors.items()}, "dim": self.dim, "seed": self.seed}
+
+    @classmethod
+    def from_spec(cls, spec: dict[str, Any]) -> WordEmbeddingFeaturizer:
+        return cls(spec["vectors"], spec["dim"], spec["seed"])
+
+
+class EmbeddingHeadIO(_ClassifierIO):
+    """``str -> label`` classifier over :class:`WordEmbeddingFeaturizer` features -- the "embedding_head" rung."""
+
+    kind = "embedding_head_classifier"
+    _featurizer_cls = WordEmbeddingFeaturizer
+
+    def __init__(self, featurizer: WordEmbeddingFeaturizer, labels: list[str]) -> None:
+        super().__init__(featurizer, labels)
+
+
+@dataclass
+class RungResult:
+    """One rung's measured outcome: its held-out agreement score, the fitted student (if built), and a note."""
+
+    rung: str
+    score: float | None
+    model: TaskModel | None
+    note: str = ""
+
+
+@dataclass
+class LadderResult:
+    """The ladder's outcome: every rung's measured score, and the smallest rung meeting ``target`` (or ``None``)."""
+
+    target: float
+    rungs: list[RungResult]
+    winner: str | None
+
+    def ceiling(self, rung: str) -> float | None:
+        """The measured score of ``rung``, or ``None`` if it was not built (e.g. a stub rung in this environment)."""
+        for r in self.rungs:
+            if r.rung == rung:
+                return r.score
+        return None
+
+
+def capacity_ladder(
+    teacher_or_labels: Callable[..., Any] | Sequence[Any],
+    texts: Sequence[str],
+    *,
+    target: float,
+    rungs: Sequence[str] = DEFAULT_RUNGS,
+    val_texts: Sequence[str] | None = None,
+    val_labels: Sequence[Any] | None = None,
+    labels: Sequence[str] | None = None,
+    word_vectors: dict[str, Sequence[float]] | None = None,
+    calibration_frac: float = 0.3,
+    n: int = 3,
+    dim: int = 256,
+    hidden: Sequence[int] = (64,),
+    epochs: int = 200,
+    lr: float = 1e-2,
+    seed: int = 0,
+    device: str = "cpu",
+) -> LadderResult:
+    """Fit a student at each rung of ``rungs`` (increasing representation family) and measure held-out agreement.
+
+    ``teacher_or_labels`` is either a callable teacher (labels ``texts`` and, if given separately, ``val_texts``)
+    or a sequence of labels already aligned with ``texts`` -- mirroring the ``distill``/``distill_from_labels``
+    duality. When ``val_texts``/``val_labels`` are not given, a ``calibration_frac`` held-out slice of
+    ``(texts, teacher labels)`` is used (same split machinery as routing calibration), so a paraphrase/synonym
+    generalization gap between train and held-out is measurable even with a single corpus.
+
+    ``word_vectors`` (word -> dense vector) is the only thing that makes the ``"embedding_head"`` rung
+    semantically richer than ``"hashed_ngram"`` -- without it, that rung still builds (never skipped, it is one
+    of the two minimum rungs) but falls back to hashed features per out-of-vocabulary word, so it will not beat
+    ``"hashed_ngram"``. ``"strong_encoder"``/``"small_lm"`` are recognized rung *names* with no estimator wired in
+    this environment: they are skipped with a note, never raised as an error.
+
+    Returns a :class:`LadderResult` with every rung's measured score and either the smallest rung meeting
+    ``target`` or ``winner=None`` with every built rung's ceiling attached -- "target unmet" is a valid, honest
+    result, never an exception.
+    """
+    texts = [str(t) for t in texts]
+    label_list, train_texts, train_labels, hold_texts, hold_labels = _prepare_split(
+        teacher_or_labels, texts, val_texts, val_labels, labels, calibration_frac, seed
+    )
+
+    results: list[RungResult] = []
+    for rung in rungs:
+        if rung not in KNOWN_RUNGS:
+            raise ValueError(f"unknown rung {rung!r}; expected one of {KNOWN_RUNGS}")
+        if rung not in _BUILT_RUNGS:
+            results.append(RungResult(rung, None, None, note=f"rung {rung!r} not built in this environment"))
+            continue
+        student = _fit_rung(
+            rung,
+            train_texts,
+            train_labels,
+            label_list,
+            word_vectors=word_vectors,
+            n=n,
+            dim=dim,
+            hidden=hidden,
+            epochs=epochs,
+            lr=lr,
+            seed=seed,
+            device=device,
+        )
+        score = agreement(student, hold_labels, hold_texts)
+        results.append(RungResult(rung, score, student))
+
+    winner = next((r.rung for r in results if r.score is not None and r.score >= target), None)
+    return LadderResult(target=target, rungs=results, winner=winner)
+
+
+def climb_to(fault: Any, *, rungs: Sequence[str] = KNOWN_RUNGS) -> str:
+    """Given a refinement-loop fault localized to a saturated leaf's current rung, return the next rung up.
+
+    ``fault`` is either a bare rung name or an object naming its current rung via a ``rung`` or ``dominant``
+    attribute (the shape :func:`~mixle.inference.explain.diagnose`'s ``FaultReport`` will eventually carry) --
+    this lets a caller climb straight to the next rung for the one saturated leaf, without re-running the whole
+    ladder. Raises ``ValueError`` if the current rung is already the top of ``rungs``.
+    """
+    current = fault if isinstance(fault, str) else getattr(fault, "rung", None) or getattr(fault, "dominant", None)
+    if current not in rungs:
+        raise ValueError(f"unknown current rung {current!r}; expected one of {rungs}")
+    idx = rungs.index(current)
+    if idx + 1 >= len(rungs):
+        raise ValueError(f"rung {current!r} is already the ceiling of {rungs}")
+    return rungs[idx + 1]
+
+
+def _prepare_split(
+    teacher_or_labels: Callable[..., Any] | Sequence[Any],
+    texts: list[str],
+    val_texts: Sequence[str] | None,
+    val_labels: Sequence[Any] | None,
+    labels: Sequence[str] | None,
+    calibration_frac: float,
+    seed: int,
+) -> tuple[list[str], list[str], list[Any], list[str], list[Any]]:
+    teacher = teacher_or_labels if callable(teacher_or_labels) else None
+    if teacher is not None:
+        train_labels_all = _teacher_labels(teacher, texts)
+    else:
+        train_labels_all = list(teacher_or_labels)
+
+    if val_texts is not None:
+        hold_texts = [str(t) for t in val_texts]
+        hold_labels = list(val_labels) if val_labels is not None else _teacher_labels(teacher, hold_texts)
+        train_texts, train_labels = texts, train_labels_all
+        label_list = list(labels) if labels is not None else sorted({str(y) for y in (*train_labels, *hold_labels)})
+    else:
+        train_texts, train_labels, hold_texts, hold_labels = _split_for_calibration(
+            texts, train_labels_all, calibration_frac, seed
+        )
+        label_list = list(labels) if labels is not None else sorted({str(y) for y in train_labels_all})
+    return label_list, train_texts, train_labels, hold_texts, hold_labels
+
+
+def _teacher_labels(teacher: Callable[..., Any], texts: list[str]) -> list[Any]:
+    out = teacher(texts)
+    if isinstance(out, (list, tuple)) and len(out) == len(texts):
+        return list(out)
+    return [teacher(t) for t in texts]
+
+
+def _fit_rung(
+    rung: str,
+    train_texts: list[str],
+    train_labels: Sequence[Any],
+    label_list: list[str],
+    *,
+    word_vectors: dict[str, Sequence[float]] | None,
+    n: int,
+    dim: int,
+    hidden: Sequence[int],
+    epochs: int,
+    lr: float,
+    seed: int,
+    device: str,
+) -> TaskModel:
+    if rung == "hashed_ngram":
+        return distill_from_labels(
+            train_texts,
+            train_labels,
+            labels=label_list,
+            n=n,
+            dim=dim,
+            hidden=hidden,
+            epochs=epochs,
+            lr=lr,
+            seed=seed,
+            task="capacity ladder: hashed_ngram",
+            device=device,
+        )
+    if rung == "embedding_head":
+        vec_dim = dim
+        if word_vectors:
+            vec_dim = len(next(iter(word_vectors.values())))
+        label_index = {y: i for i, y in enumerate(label_list)}
+        y = np.asarray([label_index[str(t)] for t in train_labels], dtype=np.int64)
+        featurizer = WordEmbeddingFeaturizer(word_vectors, dim=vec_dim, seed=seed)
+        module, cfg = _fit_mlp(featurizer.transform(train_texts), y, len(label_list), hidden, epochs, lr, seed, device)
+        student = TaskModel(
+            module,
+            EmbeddingHeadIO(featurizer, label_list),
+            builder="mixle.mlp",
+            config=cfg,
+            task="capacity ladder: embedding_head",
+            meta={"distilled": True, "n_examples": len(train_texts), "labels": label_list, "recipe": cfg},
+        )
+        student.meta["train_agreement"] = agreement(student, train_labels, train_texts)
+        return student
+    raise ValueError(f"rung {rung!r} has no fitting path wired")

--- a/mixle/tests/capacity_ladder_test.py
+++ b/mixle/tests/capacity_ladder_test.py
@@ -1,0 +1,192 @@
+"""Capacity ladder (mixle.task.capacity): climb representation families, measure each rung's ceiling.
+
+A paraphrase-style rule teacher is the load-bearing fixture: it labels by a sentiment *word*, and its
+canonical vocabulary includes synonyms never shown to the student during training. A hashed character
+n-gram featurizer cannot generalize across those synonyms (no shared n-grams); an embedding-head featurizer
+given vectors that place synonyms near each other can. That gap is exactly what the ladder should surface.
+"""
+
+import unittest
+
+import numpy as np
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("safetensors")
+
+from mixle.task.capacity import (  # noqa: E402
+    DEFAULT_RUNGS,
+    KNOWN_RUNGS,
+    capacity_ladder,
+    climb_to,
+)
+
+_POS_TRAIN = ["good", "nice"]
+_NEG_TRAIN = ["bad", "poor"]
+_POS_UNSEEN = ["great", "lovely"]
+_NEG_UNSEEN = ["terrible", "awful"]
+_FILLER = ["the", "movie", "today", "was", "really", "quite", "very", "a", "this"]
+
+_CANONICAL = {w: "positive" for w in (*_POS_TRAIN, *_POS_UNSEEN)}
+_CANONICAL.update({w: "negative" for w in (*_NEG_TRAIN, *_NEG_UNSEEN)})
+
+
+def _sentences(sentiment_words, n_per_word, rng):
+    out = []
+    for w in sentiment_words:
+        for _ in range(n_per_word):
+            k = rng.randint(2, 5)
+            toks = list(rng.choice(_FILLER, size=k)) + [w]
+            rng.shuffle(toks)
+            out.append(" ".join(toks))
+    return out
+
+
+def _teacher(texts):
+    labels = []
+    for t in texts:
+        words = t.lower().split()
+        hit = next((w for w in words if w in _CANONICAL), None)
+        labels.append(_CANONICAL[hit] if hit is not None else "negative")
+    return labels
+
+
+def _corpus():
+    rng = np.random.RandomState(0)
+    train_texts = _sentences(_POS_TRAIN, 40, rng) + _sentences(_NEG_TRAIN, 40, rng)
+    rng.shuffle(train_texts)
+    val_texts = _sentences(_POS_UNSEEN, 20, rng) + _sentences(_NEG_UNSEEN, 20, rng)
+    rng.shuffle(val_texts)
+    return train_texts, val_texts
+
+
+def _word_vectors():
+    vecs = {}
+    for w in (*_POS_TRAIN, *_POS_UNSEEN):
+        vecs[w] = [1.0, 0.0]
+    for w in (*_NEG_TRAIN, *_NEG_UNSEEN):
+        vecs[w] = [-1.0, 0.0]
+    return vecs
+
+
+class CapacityLadderTest(unittest.TestCase):
+    def test_hashed_ngram_cannot_generalize_across_synonyms(self):
+        train_texts, val_texts = _corpus()
+        result = capacity_ladder(
+            _teacher,
+            train_texts,
+            target=0.85,
+            rungs=("hashed_ngram",),
+            val_texts=val_texts,
+            hidden=(32,),
+            epochs=150,
+            seed=0,
+        )
+        self.assertEqual(len(result.rungs), 1)
+        self.assertIsNotNone(result.ceiling("hashed_ngram"))
+        self.assertLess(result.ceiling("hashed_ngram"), 0.7)
+        self.assertIsNone(result.winner)
+
+    def test_embedding_head_generalizes_with_synonym_vectors(self):
+        train_texts, val_texts = _corpus()
+        result = capacity_ladder(
+            _teacher,
+            train_texts,
+            target=0.85,
+            rungs=DEFAULT_RUNGS,
+            val_texts=val_texts,
+            word_vectors=_word_vectors(),
+            hidden=(32,),
+            epochs=150,
+            seed=0,
+        )
+        self.assertEqual([r.rung for r in result.rungs], list(DEFAULT_RUNGS))
+        self.assertGreaterEqual(result.ceiling("embedding_head"), 0.85)
+        self.assertEqual(result.winner, "embedding_head")
+        # the ladder picked the smallest rung meeting target, not just any rung that happens to meet it
+        self.assertLess(result.ceiling("hashed_ngram"), result.ceiling("embedding_head"))
+
+    def test_target_unmet_returns_honest_none_not_exception(self):
+        train_texts, val_texts = _corpus()
+        result = capacity_ladder(
+            _teacher,
+            train_texts,
+            target=0.999,
+            rungs=("hashed_ngram",),
+            val_texts=val_texts,
+            hidden=(32,),
+            epochs=80,
+            seed=0,
+        )
+        self.assertIsNone(result.winner)
+        self.assertIsNotNone(result.ceiling("hashed_ngram"))
+
+    def test_unbuilt_rung_is_skipped_with_a_note_not_a_crash(self):
+        train_texts, val_texts = _corpus()
+        result = capacity_ladder(
+            _teacher,
+            train_texts,
+            target=0.85,
+            rungs=("hashed_ngram", "strong_encoder"),
+            val_texts=val_texts,
+            hidden=(32,),
+            epochs=80,
+            seed=0,
+        )
+        stub = next(r for r in result.rungs if r.rung == "strong_encoder")
+        self.assertIsNone(stub.score)
+        self.assertIsNone(stub.model)
+        self.assertTrue(stub.note)
+
+    def test_unknown_rung_name_raises(self):
+        train_texts, val_texts = _corpus()
+        with self.assertRaises(ValueError):
+            capacity_ladder(
+                _teacher,
+                train_texts,
+                target=0.85,
+                rungs=("not_a_real_rung",),
+                val_texts=val_texts,
+            )
+
+    def test_determinism_given_seed(self):
+        train_texts, val_texts = _corpus()
+        kwargs = dict(
+            target=0.85,
+            rungs=DEFAULT_RUNGS,
+            val_texts=val_texts,
+            word_vectors=_word_vectors(),
+            hidden=(32,),
+            epochs=100,
+            seed=7,
+        )
+        r1 = capacity_ladder(_teacher, train_texts, **kwargs)
+        r2 = capacity_ladder(_teacher, train_texts, **kwargs)
+        self.assertEqual(r1.winner, r2.winner)
+        for a, b in zip(r1.rungs, r2.rungs):
+            self.assertEqual(a.score, b.score)
+
+    def test_climb_to_returns_next_rung(self):
+        self.assertEqual(climb_to("hashed_ngram"), "embedding_head")
+        self.assertEqual(climb_to("embedding_head"), "strong_encoder")
+
+    def test_climb_to_accepts_fault_like_object_and_rejects_ceiling(self):
+        class _Fault:
+            dominant = "small_lm"
+
+        with self.assertRaises(ValueError):
+            climb_to(_Fault())  # already at the top of KNOWN_RUNGS
+
+        class _Fault2:
+            rung = "hashed_ngram"
+
+        self.assertEqual(climb_to(_Fault2()), "embedding_head")
+
+    def test_climb_to_rejects_unknown_rung(self):
+        with self.assertRaises(ValueError):
+            climb_to("not_a_rung")
+        self.assertEqual(KNOWN_RUNGS[-1], "small_lm")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Card D2-a from `notes/0.6.3-execution-playbook.md`: `mixle.task.capacity.capacity_ladder` fits a student at each rung of increasing representation family (`hashed_ngram`, `embedding_head`; `strong_encoder`/`small_lm` are recognized stub rungs), measures held-out agreement with the teacher per rung, and returns the smallest rung meeting a target or an honest `None` with every rung's ceiling attached.
- `climb_to(fault)` returns the next rung up for a saturated leaf, given a bare rung name or a fault-like object (`.rung`/`.dominant`), without re-running the whole ladder.
- New `WordEmbeddingFeaturizer`/`EmbeddingHeadIO` back the `embedding_head` rung: average per-word vectors from a caller-supplied table (hashed n-gram fallback for OOV words) — the synonym-generalization gap a hashed n-gram featurizer can't close.

## Test plan
- [x] `mixle/tests/capacity_ladder_test.py` (9 new tests): hashed_ngram fails to generalize across an unseen-synonym vocabulary (score < 0.7); embedding_head with synonym-clustered vectors meets target (>= 0.85) and is picked as winner; target-unmet returns honest `None` + ceiling, not an exception; unbuilt rung (`strong_encoder`) is skipped with a note; unknown rung name raises; determinism given seed; `climb_to` behavior (next rung, ceiling rejection, fault-like object, unknown rung).
- [x] Targeted regression: `task_distill_test.py`, `task_tune_test.py`, `task_cascade_test.py`, `task_router_test.py`, `task_calibrate_test.py` — all green, no behavior change.
- [x] `ruff check` / `ruff format --check` clean on changed files.
- [x] Full gate: `pytest -q -m "not optional and not benchmark"` — 4686 passed, 6 skipped (expected compiled-kernel/Spark skips), 0 failed.
