### PR TITLE
task/SYS-a: the System facade -- answer/ingest/improve thin shell

### DIFF
--- a/mixle/fault.py
+++ b/mixle/fault.py
@@ -1,0 +1,78 @@
+"""Degradation policy (workstream J: FAULT-a) -- named failure modes, each flagged on the receipt.
+
+A subsystem failure must never silently serve a worse answer as if nothing happened. This module is the
+shared fault boundary every degraded path goes through: :func:`with_fallback` runs the primary path and, on
+any exception, runs a named fallback instead -- the result is either NOT degraded (primary succeeded) or
+degraded under an explicit, named mode with the triggering reason attached. :func:`abstain_on_timeout` and
+:func:`route_past` are the same discipline specialized to two more named modes.
+
+The four named modes (per the card): ``teacher_down`` (fall back to captured+store-only reasoning -- see
+:meth:`mixle.system.System.answer`), ``store_down`` (reason without accumulated knowledge -- see
+:meth:`mixle.system.System.ingest`), ``oracle_timeout`` (abstain/escalate rather than guess), and
+``model_error`` (route past the failing tier to the next one). The last two are validated here as standalone
+primitives: neither an oracle nor a multi-tier local-model router is wired into :class:`~mixle.system.System`
+yet, so there is nothing live to attach them to without inventing an integration this card doesn't own.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class DegradedResult:
+    """The outcome of a fault-boundary call: a value, whether it came from a fallback, and, if so, why."""
+
+    value: Any
+    degraded: bool
+    mode: str | None = None
+    reason: str | None = None
+
+    def to_receipt_fields(self) -> dict[str, Any]:
+        """The ``degraded_mode``/``degraded_reason`` fields a caller merges onto its own receipt dict."""
+        return {"degraded_mode": self.mode, "degraded_reason": self.reason}
+
+
+def with_fallback(fn: Callable[[], Any], fallback: Callable[[Exception], Any], *, mode: str) -> DegradedResult:
+    """Run ``fn()``; on any exception, run ``fallback(exc)`` instead and flag the result under ``mode``.
+
+    Either ``fn()`` succeeds and the result is NOT degraded, or the fallback runs and the result IS flagged
+    with ``mode`` and the triggering exception's message as ``reason`` -- never a silent, unflagged
+    "somehow it still worked" path. If ``fallback`` itself raises, that exception propagates: a fallback that
+    cannot produce anything is a real failure to report, not something to paper over with a second guess.
+    """
+    try:
+        return DegradedResult(value=fn(), degraded=False)
+    except Exception as exc:  # noqa: BLE001 -- catch-any is the point: flag whatever the primary path raised
+        return DegradedResult(value=fallback(exc), degraded=True, mode=mode, reason=str(exc))
+
+
+def abstain_on_timeout(fn: Callable[[], Any], *, timeout_error: type[BaseException] = TimeoutError) -> DegradedResult:
+    """``oracle_timeout`` mode: run ``fn()``; if it raises ``timeout_error``, abstain (``value=None``) rather
+    than guess. Any OTHER exception propagates -- only a timeout is a license to abstain, not any failure."""
+    try:
+        return DegradedResult(value=fn(), degraded=False)
+    except timeout_error as exc:
+        return DegradedResult(value=None, degraded=True, mode="oracle_timeout", reason=str(exc))
+
+
+def route_past(tiers: Sequence[Callable[[], Any]], *, names: Sequence[str] | None = None) -> DegradedResult:
+    """``model_error`` mode: try each tier in order; a raising tier is skipped (not fatal) in favor of the
+    next. Degraded (flagged with which tier(s) failed) unless the FIRST tier answers cleanly. Raises the
+    last tier's exception if every tier fails -- there is no further fallback to route past."""
+    names = list(names) if names is not None else [f"tier{i}" for i in range(len(tiers))]
+    failed: list[str] = []
+    last_exc: Exception | None = None
+    for name, tier in zip(names, tiers):
+        try:
+            value = tier()
+        except Exception as exc:  # noqa: BLE001 -- route past this tier to the next, whatever it raised
+            failed.append(name)
+            last_exc = exc
+            continue
+        if not failed:
+            return DegradedResult(value=value, degraded=False)
+        return DegradedResult(value=value, degraded=True, mode="model_error", reason=f"routed past {failed}")
+    raise last_exc  # every tier failed -- nothing left to route past to

--- a/mixle/scorecard.py
+++ b/mixle/scorecard.py
@@ -1,0 +1,100 @@
+"""System scorecard (workstream J: SCORE-a) -- one fixed held-out question set, evaluated every
+improve-round, a worsening round caught and reported rather than silently accepted.
+
+Named ``SystemScorecard`` (not ``Scorecard``) to avoid colliding with
+:class:`mixle.task.scorecard.Scorecard` -- a different, narrower comparison (one student solution vs its
+teacher on a task); this one evaluates a whole :class:`~mixle.system.System` (teacher, captured cache,
+degraded modes, budget, all of it) end to end.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+from mixle.system import Query, System
+
+
+def _default_scorer(reply: str | None, expected: str) -> bool:
+    return reply is not None and expected.strip().lower() in reply.strip().lower()
+
+
+@dataclass
+class SystemScorecard:
+    """One evaluation of a :class:`~mixle.system.System` against a fixed held-out question set."""
+
+    quality: float
+    calibration: float
+    realized_cost: float
+    grounded_fraction: float
+    n: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return dict(self.__dict__)
+
+
+def evaluate(
+    system: System,
+    question_set: Sequence[tuple[Query, str]],
+    *,
+    scorer: Callable[[str | None, str], bool] | None = None,
+) -> SystemScorecard:
+    """Evaluate ``system`` over a fixed ``[(query, expected_answer), ...]`` set.
+
+    * ``quality`` -- fraction of questions ``scorer`` judges correct (default: case-insensitive
+      substring match of ``expected`` in the reply).
+    * ``grounded_fraction`` -- fraction answered WITHOUT a degraded mode (teacher or captured, not a
+      store-only fallback / refusal / failure): the fraction of answers you can actually trust came
+      from a real answer path, not a fault-boundary guess.
+    * ``realized_cost`` -- total spend units (:meth:`~mixle.spend.Spend.total_units`) across the set.
+    * ``calibration`` -- a coarse proxy (currently equal to ``quality``) until ``answer`` carries a real
+      per-answer confidence to calibrate against; extend THIS function, not call sites, once that lands.
+    """
+    n = len(question_set)
+    if n == 0:
+        return SystemScorecard(quality=0.0, calibration=0.0, realized_cost=0.0, grounded_fraction=0.0, n=0)
+    scorer = scorer or _default_scorer
+    correct = 0
+    grounded = 0
+    cost = 0.0
+    for query, expected in question_set:
+        reply, receipt = system.answer(query)
+        if scorer(reply, expected):
+            correct += 1
+        if receipt.get("status") == "answered" and receipt.get("degraded_mode") is None:
+            grounded += 1
+        spend = receipt.get("spend") or {}
+        cost += float(spend.get("frontier_calls", 0)) + float(spend.get("oracle_calls", 0))
+    quality = correct / n
+    return SystemScorecard(
+        quality=quality, calibration=quality, realized_cost=cost, grounded_fraction=grounded / n, n=n
+    )
+
+
+@dataclass
+class RegressionReport:
+    """Whether ``current`` is worse than ``baseline`` on any tracked axis, and exactly why."""
+
+    regressed: bool
+    reasons: list[str] = field(default_factory=list)
+
+
+def detect_regression(
+    baseline: SystemScorecard, current: SystemScorecard, *, tolerance: float = 1e-9
+) -> RegressionReport:
+    """Compare two scorecards from the SAME held-out set across improve-rounds.
+
+    Never silently accepts a round that answers worse, less groundedly, or for more cost than the round
+    before it -- each tracked axis that got worse (beyond ``tolerance``) is named in ``reasons``.
+    """
+    reasons: list[str] = []
+    if current.quality < baseline.quality - tolerance:
+        reasons.append(f"quality regressed: {baseline.quality:.3f} -> {current.quality:.3f}")
+    if current.grounded_fraction < baseline.grounded_fraction - tolerance:
+        reasons.append(
+            f"grounded_fraction regressed: {baseline.grounded_fraction:.3f} -> {current.grounded_fraction:.3f}"
+        )
+    if current.realized_cost > baseline.realized_cost + tolerance:
+        reasons.append(f"realized_cost increased: {baseline.realized_cost:.3f} -> {current.realized_cost:.3f}")
+    return RegressionReport(regressed=bool(reasons), reasons=reasons)

--- a/mixle/spend.py
+++ b/mixle/spend.py
@@ -1,0 +1,49 @@
+"""``Spend`` -- the unified budget ledger every subsystem accumulates into (workstream J: SPEND-a).
+
+One cost total, summed across every card that spends something on a query: workstream B's cascade/router
+tiers (``frontier_calls``), workstream C6/I's oracle-scored search loops (``oracle_calls``), and wall-clock /
+dollar cost wherever those are tracked. ``System.answer`` carries the incremental ``Spend`` of *this* call plus
+the running ``total_spend`` on every receipt, and treats ``budget`` as a hard ceiling: a request that cannot
+afford even the cheapest answer path is refused -- with the shortfall named on the receipt -- rather than
+silently served over budget.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Spend:
+    """A summable cost total. ``total_units()`` is the scalar figure ``budget=`` is checked against."""
+
+    frontier_calls: int = 0
+    oracle_calls: int = 0
+    wall_ms: float = 0.0
+    dollars: float = 0.0
+
+    def __add__(self, other: Spend) -> Spend:
+        return Spend(
+            frontier_calls=self.frontier_calls + other.frontier_calls,
+            oracle_calls=self.oracle_calls + other.oracle_calls,
+            wall_ms=self.wall_ms + other.wall_ms,
+            dollars=self.dollars + other.dollars,
+        )
+
+    def total_units(self) -> float:
+        """The scalar cost a ``budget=`` integer is measured against.
+
+        Currently ``frontier_calls + oracle_calls`` -- the two countable, per-call costs every existing
+        card (B's cascade tiers, I's oracle budget) already measures budget in. ``wall_ms``/``dollars`` are
+        carried and reported on every receipt but not yet priced into the hard-ceiling check; extend this
+        method (not the call sites) when a real dollar cost model lands.
+        """
+        return float(self.frontier_calls + self.oracle_calls)
+
+    def to_dict(self) -> dict[str, float | int]:
+        return {
+            "frontier_calls": self.frontier_calls,
+            "oracle_calls": self.oracle_calls,
+            "wall_ms": self.wall_ms,
+            "dollars": self.dollars,
+        }

--- a/mixle/system.py
+++ b/mixle/system.py
@@ -20,6 +20,14 @@ FAULT-a wires two named degraded modes (:mod:`mixle.fault`) into the same two ve
 back to captured+store-only reasoning when the teacher raises (``teacher_down``); ``ingest`` falls back
 to acknowledging-without-accumulating when the store write itself raises (``store_down``). Both flag
 ``degraded_mode``/``degraded_reason`` on the returned receipt/report rather than silently serving worse.
+
+SEED-a closes the cold-start loop: every teacher-produced answer is harvested (query text -> reply);
+``improve`` promotes whatever has been harvested into a captured cache (nothing fancier -- this thin
+shell's "capture" is a verbatim lookup, not a trained model); ``answer`` checks the captured cache
+FIRST, before spending anything, so a repeat of the exact same query after an ``improve`` call is
+served free (``captured=True``, zero frontier calls) instead of re-querying the teacher. Capture only
+promotes after an explicit ``improve()`` -- a repeat query *before* ``improve`` still pays for a fresh
+teacher call, so the measured saving is attributable to ``improve``, not an implicit cache.
 """
 
 from __future__ import annotations
@@ -91,9 +99,16 @@ class System:
     def __init__(self, config: SystemConfig) -> None:
         self.config = config
         self.total_spend = Spend()
+        self._harvest: dict[tuple[str, str, str], str] = {}
+        self._captured: dict[tuple[str, str, str], str] = {}
 
     def answer(self, query: Query, *, budget: int | None = None) -> tuple[str | None, dict[str, Any]]:
         """Thin shell: route straight to the teacher, wrap the reply in a minimal H-style receipt.
+
+        Checks the captured cache first (see :meth:`improve`): an exact repeat of a query (same text,
+        task, AND scope -- two queries that merely share text but differ in task/scope are different
+        questions and must not share a cache entry) already promoted by a prior ``improve()`` call is
+        served free, no budget spent, ``captured=True``.
 
         ``budget`` is a hard ceiling (:class:`~mixle.spend.Spend.total_units`): if it cannot afford even
         one frontier call, the request is refused -- ``reply`` is ``None`` and the receipt names the exact
@@ -106,6 +121,20 @@ class System:
         nothing relevant in it), the failure is reported honestly (``status="failed"``), never masked as a
         normal answer.
         """
+        cache_key = (query.text, query.task, query.scope)
+        if cache_key in self._captured:
+            return self._captured[cache_key], {
+                "produced_by": "captured",
+                "status": "answered",
+                "spend": Spend().to_dict(),
+                "total_spend": self.total_spend.to_dict(),
+                "budget": self.config.default_budget if budget is None else int(budget),
+                "captured": True,
+                "task": query.task,
+                "degraded_mode": None,
+                "degraded_reason": None,
+            }
+
         requested = self.config.default_budget if budget is None else int(budget)
         cost = Spend(frontier_calls=1)
         if requested < cost.total_units():
@@ -149,6 +178,8 @@ class System:
             }
         actual_cost = Spend() if result.degraded else cost
         self.total_spend = self.total_spend + actual_cost
+        if not result.degraded:
+            self._harvest[cache_key] = result.value
         receipt = {
             "produced_by": "store" if result.degraded else "teacher",
             "status": "answered",
@@ -203,9 +234,25 @@ class System:
         return {"status": "ok_fallback", "assimilated": False, "item_id": item.id}
 
     def improve(self, budget: int) -> dict[str, Any]:
-        """Stub until an orchestrator/router/registry registers into the system: nothing to improve yet."""
+        """Promote every harvested (query, reply) pair from :meth:`answer` into the captured cache.
+
+        Honestly reports there is nothing to improve when nothing has been harvested yet (an orchestrator/
+        router/registry with a real training step is future work); otherwise this is the cold-start
+        capture step SEED-a measures: after this call, a repeat of any just-captured query is answered
+        for free (see :meth:`answer`).
+        """
+        if not self._harvest:
+            return {
+                "status": "nothing_to_improve",
+                "reason": "no improvement subsystem registered yet",
+                "budget": int(budget),
+            }
+        n_captured = len(self._harvest)
+        self._captured.update(self._harvest)
+        self._harvest.clear()
         return {
-            "status": "nothing_to_improve",
-            "reason": "no improvement subsystem registered yet",
+            "status": "captured",
+            "reason": f"promoted {n_captured} harvested (query, reply) pair(s) into the captured cache",
             "budget": int(budget),
+            "n_captured": n_captured,
         }

--- a/mixle/system.py
+++ b/mixle/system.py
@@ -9,6 +9,17 @@ hard import of a card that may not be built yet); ``improve`` honestly reports t
 improve until an orchestrator/router/registry registers into it. Later cards (REG-a the registry,
 SPEND-a the budget ledger, FAULT-a degraded modes, SCORE-a the scorecard) extend these same three verbs
 rather than adding new ones.
+
+SPEND-a wires a real :class:`~mixle.spend.Spend` ledger into ``answer``: ``budget`` is a hard ceiling
+measured in :meth:`~mixle.spend.Spend.total_units` -- a request that cannot afford even the cheapest
+answer path is refused (with the shortfall named on the receipt), never silently served over budget.
+Every successful call's incremental spend is added to :attr:`System.total_spend`, and both the
+incremental and running totals ride on the receipt.
+
+FAULT-a wires two named degraded modes (:mod:`mixle.fault`) into the same two verbs: ``answer`` falls
+back to captured+store-only reasoning when the teacher raises (``teacher_down``); ``ingest`` falls back
+to acknowledging-without-accumulating when the store write itself raises (``store_down``). Both flag
+``degraded_mode``/``degraded_reason`` on the returned receipt/report rather than silently serving worse.
 """
 
 from __future__ import annotations
@@ -18,6 +29,8 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
+from mixle.fault import with_fallback
+from mixle.spend import Spend
 from mixle.task.llm import LLM, OpenAICompatLLM
 
 
@@ -77,34 +90,104 @@ class System:
 
     def __init__(self, config: SystemConfig) -> None:
         self.config = config
+        self.total_spend = Spend()
 
-    def answer(self, query: Query, *, budget: int | None = None) -> tuple[str, dict[str, Any]]:
-        """Thin shell: route straight to the teacher, wrap the reply in a minimal H-style receipt."""
-        spent_budget = self.config.default_budget if budget is None else int(budget)
-        reply = _complete(self.config.teacher, query.text)
+    def answer(self, query: Query, *, budget: int | None = None) -> tuple[str | None, dict[str, Any]]:
+        """Thin shell: route straight to the teacher, wrap the reply in a minimal H-style receipt.
+
+        ``budget`` is a hard ceiling (:class:`~mixle.spend.Spend.total_units`): if it cannot afford even
+        one frontier call, the request is refused -- ``reply`` is ``None`` and the receipt names the exact
+        ``shortfall`` -- rather than silently answering over budget. A served answer's cost is added to
+        :attr:`total_spend`, which every receipt also carries as ``total_spend``.
+
+        If the teacher call itself raises, this falls back to ``teacher_down`` degraded mode: answer from
+        the store alone (a plain retrieval over ``config.store``) when one is configured and has anything
+        relevant, flagging ``degraded_mode="teacher_down"`` on the receipt; if there is no store (or
+        nothing relevant in it), the failure is reported honestly (``status="failed"``), never masked as a
+        normal answer.
+        """
+        requested = self.config.default_budget if budget is None else int(budget)
+        cost = Spend(frontier_calls=1)
+        if requested < cost.total_units():
+            return None, {
+                "produced_by": None,
+                "status": "refused",
+                "reason": "budget insufficient for one frontier call",
+                "budget": requested,
+                "shortfall": cost.total_units() - requested,
+                "spend": Spend().to_dict(),
+                "total_spend": self.total_spend.to_dict(),
+                "captured": False,
+                "task": query.task,
+            }
+
+        def _call_teacher() -> str:
+            return _complete(self.config.teacher, query.text)
+
+        def _teacher_down_fallback(exc: Exception) -> str:
+            if self.config.store is not None:
+                from mixle.substrate.retrieve import retrieve
+
+                hits = retrieve(self.config.store, query.text, k=3, scope=self.config.scope)
+                texts = [it.text for it in hits.items if it.text]
+                if texts:
+                    return "[degraded: store-only] " + " ".join(texts)
+            raise RuntimeError(f"teacher unavailable ({exc}) and no usable store to fall back on") from exc
+
+        try:
+            result = with_fallback(_call_teacher, _teacher_down_fallback, mode="teacher_down")
+        except Exception as exc:
+            return None, {
+                "produced_by": None,
+                "status": "failed",
+                "reason": str(exc),
+                "budget": requested,
+                "spend": Spend().to_dict(),
+                "total_spend": self.total_spend.to_dict(),
+                "captured": False,
+                "task": query.task,
+            }
+        actual_cost = Spend() if result.degraded else cost
+        self.total_spend = self.total_spend + actual_cost
         receipt = {
-            "produced_by": "teacher",
-            "spend": {"frontier_calls": 1},
-            "budget": spent_budget,
+            "produced_by": "store" if result.degraded else "teacher",
+            "status": "answered",
+            "spend": actual_cost.to_dict(),
+            "total_spend": self.total_spend.to_dict(),
+            "budget": requested,
             "captured": False,  # no local model has captured this capability yet (workstream D)
             "task": query.task,
+            **result.to_receipt_fields(),
         }
-        return reply, receipt
+        return result.value, receipt
 
     def ingest(self, model_output: str, *, source: dict[str, Any]) -> dict[str, Any]:
         """Turn a model output into stored knowledge. Uses the belief store (workstream E, KNOW-a) when
         it is importable; otherwise degrades to a plain substrate item rather than hard-depending on a
-        card that may not be built yet."""
+        card that may not be built yet.
+
+        If the store write itself raises (the store is down/unreachable, as opposed to KNOW-a simply not
+        being installed), this falls back to ``store_down`` degraded mode: the model output is
+        acknowledged but NOT accumulated, and the report is flagged ``degraded_mode="store_down"`` rather
+        than silently reporting success or losing the output without a trace.
+        """
         if self.config.store is None:
             return {"status": "no_store", "assimilated": False}
-        try:
-            from mixle.substrate.belief import assimilate, harvest_knowledge
-        except ImportError:
-            return self._ingest_fallback(model_output, source=source)
 
-        claims = harvest_knowledge(model_output, source=source)
-        items = [assimilate(self.config.store, claim, []) for claim in claims]
-        return {"status": "ok", "n_claims": len(claims), "items": items}
+        def _write() -> dict[str, Any]:
+            try:
+                from mixle.substrate.belief import assimilate, harvest_knowledge
+            except ImportError:
+                return self._ingest_fallback(model_output, source=source)
+            claims = harvest_knowledge(model_output, source=source)
+            items = [assimilate(self.config.store, claim, []) for claim in claims]
+            return {"status": "ok", "n_claims": len(claims), "items": items}
+
+        def _store_down_fallback(exc: Exception) -> dict[str, Any]:
+            return {"status": "degraded_no_accumulation", "assimilated": False}
+
+        result = with_fallback(_write, _store_down_fallback, mode="store_down")
+        return {**result.value, **result.to_receipt_fields()} if result.degraded else result.value
 
     def _ingest_fallback(self, model_output: str, *, source: dict[str, Any]) -> dict[str, Any]:
         from mixle.substrate.core import SubstrateItem

--- a/mixle/system.py
+++ b/mixle/system.py
@@ -9,6 +9,12 @@ hard import of a card that may not be built yet); ``improve`` honestly reports t
 improve until an orchestrator/router/registry registers into it. Later cards (REG-a the registry,
 SPEND-a the budget ledger, FAULT-a degraded modes, SCORE-a the scorecard) extend these same three verbs
 rather than adding new ones.
+
+SPEND-a wires a real :class:`~mixle.spend.Spend` ledger into ``answer``: ``budget`` is a hard ceiling
+measured in :meth:`~mixle.spend.Spend.total_units` -- a request that cannot afford even the cheapest
+answer path is refused (with the shortfall named on the receipt), never silently served over budget.
+Every successful call's incremental spend is added to :attr:`System.total_spend`, and both the
+incremental and running totals ride on the receipt.
 """
 
 from __future__ import annotations
@@ -18,6 +24,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
+from mixle.spend import Spend
 from mixle.task.llm import LLM, OpenAICompatLLM
 
 
@@ -77,15 +84,38 @@ class System:
 
     def __init__(self, config: SystemConfig) -> None:
         self.config = config
+        self.total_spend = Spend()
 
-    def answer(self, query: Query, *, budget: int | None = None) -> tuple[str, dict[str, Any]]:
-        """Thin shell: route straight to the teacher, wrap the reply in a minimal H-style receipt."""
-        spent_budget = self.config.default_budget if budget is None else int(budget)
+    def answer(self, query: Query, *, budget: int | None = None) -> tuple[str | None, dict[str, Any]]:
+        """Thin shell: route straight to the teacher, wrap the reply in a minimal H-style receipt.
+
+        ``budget`` is a hard ceiling (:class:`~mixle.spend.Spend.total_units`): if it cannot afford even
+        one frontier call, the request is refused -- ``reply`` is ``None`` and the receipt names the exact
+        ``shortfall`` -- rather than silently answering over budget. A served answer's cost is added to
+        :attr:`total_spend`, which every receipt also carries as ``total_spend``.
+        """
+        requested = self.config.default_budget if budget is None else int(budget)
+        cost = Spend(frontier_calls=1)
+        if requested < cost.total_units():
+            return None, {
+                "produced_by": None,
+                "status": "refused",
+                "reason": "budget insufficient for one frontier call",
+                "budget": requested,
+                "shortfall": cost.total_units() - requested,
+                "spend": Spend().to_dict(),
+                "total_spend": self.total_spend.to_dict(),
+                "captured": False,
+                "task": query.task,
+            }
         reply = _complete(self.config.teacher, query.text)
+        self.total_spend = self.total_spend + cost
         receipt = {
             "produced_by": "teacher",
-            "spend": {"frontier_calls": 1},
-            "budget": spent_budget,
+            "status": "answered",
+            "spend": cost.to_dict(),
+            "total_spend": self.total_spend.to_dict(),
+            "budget": requested,
             "captured": False,  # no local model has captured this capability yet (workstream D)
             "task": query.task,
         }

--- a/mixle/system.py
+++ b/mixle/system.py
@@ -1,0 +1,128 @@
+"""``System`` -- the facade every subsystem eventually plugs into (workstream J1/J8).
+
+Three verbs, nothing else: ``answer`` (serve a query), ``ingest`` (turn a model output into stored,
+credence-weighted knowledge), ``improve`` (spend a budget making the system better). This is
+deliberately a THIN SHELL: in this card ``answer`` just routes straight to the configured teacher and
+wraps the reply in a minimal receipt; ``ingest`` writes what it can with whatever pieces already exist
+(the belief store from workstream E when it is importable, a plain substrate item otherwise -- never a
+hard import of a card that may not be built yet); ``improve`` honestly reports there is nothing to
+improve until an orchestrator/router/registry registers into it. Later cards (REG-a the registry,
+SPEND-a the budget ledger, FAULT-a degraded modes, SCORE-a the scorecard) extend these same three verbs
+rather than adding new ones.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from mixle.task.llm import LLM, OpenAICompatLLM
+
+
+@dataclass
+class SystemConfig:
+    """Everything a :class:`System` needs to run. Secrets (endpoints, keys) come from the environment,
+    never hardcoded -- see :meth:`from_env`."""
+
+    teacher: LLM | Callable[..., str]
+    registry_dir: str | None = None
+    store: Any = None  # a mixle.substrate.Substrate handle, or None (ingest/retrieval degrade honestly)
+    default_budget: int = 1
+    scope: str = "local"
+
+    @classmethod
+    def from_env(cls, *, store: Any = None, registry_dir: str | None = None) -> SystemConfig:
+        """Build a config whose teacher is an :class:`OpenAICompatLLM` sourced entirely from env vars.
+
+        Reads ``MIXLE_TEACHER_BASE_URL`` (required), ``MIXLE_TEACHER_MODEL`` (required), and the
+        optional ``MIXLE_TEACHER_API_KEY``. Raises ``ValueError`` naming the missing variable rather
+        than silently constructing a broken teacher.
+        """
+        base_url = os.environ.get("MIXLE_TEACHER_BASE_URL")
+        model = os.environ.get("MIXLE_TEACHER_MODEL")
+        if not base_url:
+            raise ValueError("SystemConfig.from_env needs MIXLE_TEACHER_BASE_URL set")
+        if not model:
+            raise ValueError("SystemConfig.from_env needs MIXLE_TEACHER_MODEL set")
+        teacher = OpenAICompatLLM(base_url, model, api_key=os.environ.get("MIXLE_TEACHER_API_KEY"))
+        return cls(teacher=teacher, registry_dir=registry_dir, store=store)
+
+
+@dataclass
+class Query:
+    """The typed problem contract for :meth:`System.answer`.
+
+    Field names align with the ``mixle-knowledge`` ``ContextPacket``/manifest contracts (``task``,
+    ``expected_output`` <-> ``expected_output_schema``, ``scope``) so a ``Query`` can be built directly
+    from one when a caller already holds a manifest.
+    """
+
+    text: str
+    task: str = ""
+    fingerprint: Any = None
+    expected_output: dict[str, Any] | None = None
+    scope: str = "local"
+
+
+def _complete(teacher: LLM | Callable[..., str], prompt: str) -> str:
+    if hasattr(teacher, "complete"):
+        return teacher.complete(prompt)
+    return teacher(prompt)
+
+
+class System:
+    """Constructed from a :class:`SystemConfig`; exposes ``answer``/``ingest``/``improve``."""
+
+    def __init__(self, config: SystemConfig) -> None:
+        self.config = config
+
+    def answer(self, query: Query, *, budget: int | None = None) -> tuple[str, dict[str, Any]]:
+        """Thin shell: route straight to the teacher, wrap the reply in a minimal H-style receipt."""
+        spent_budget = self.config.default_budget if budget is None else int(budget)
+        reply = _complete(self.config.teacher, query.text)
+        receipt = {
+            "produced_by": "teacher",
+            "spend": {"frontier_calls": 1},
+            "budget": spent_budget,
+            "captured": False,  # no local model has captured this capability yet (workstream D)
+            "task": query.task,
+        }
+        return reply, receipt
+
+    def ingest(self, model_output: str, *, source: dict[str, Any]) -> dict[str, Any]:
+        """Turn a model output into stored knowledge. Uses the belief store (workstream E, KNOW-a) when
+        it is importable; otherwise degrades to a plain substrate item rather than hard-depending on a
+        card that may not be built yet."""
+        if self.config.store is None:
+            return {"status": "no_store", "assimilated": False}
+        try:
+            from mixle.substrate.belief import assimilate, harvest_knowledge
+        except ImportError:
+            return self._ingest_fallback(model_output, source=source)
+
+        claims = harvest_knowledge(model_output, source=source)
+        items = [assimilate(self.config.store, claim, []) for claim in claims]
+        return {"status": "ok", "n_claims": len(claims), "items": items}
+
+    def _ingest_fallback(self, model_output: str, *, source: dict[str, Any]) -> dict[str, Any]:
+        from mixle.substrate.core import SubstrateItem
+
+        item = SubstrateItem(
+            kind="text",
+            text=model_output,
+            provenance=dict(source),
+            scope=self.config.scope,
+            tags=["model_assertion", "unassimilated"],
+        )
+        self.config.store.put(item)
+        return {"status": "ok_fallback", "assimilated": False, "item_id": item.id}
+
+    def improve(self, budget: int) -> dict[str, Any]:
+        """Stub until an orchestrator/router/registry registers into the system: nothing to improve yet."""
+        return {
+            "status": "nothing_to_improve",
+            "reason": "no improvement subsystem registered yet",
+            "budget": int(budget),
+        }

--- a/mixle/system.py
+++ b/mixle/system.py
@@ -15,6 +15,11 @@ measured in :meth:`~mixle.spend.Spend.total_units` -- a request that cannot affo
 answer path is refused (with the shortfall named on the receipt), never silently served over budget.
 Every successful call's incremental spend is added to :attr:`System.total_spend`, and both the
 incremental and running totals ride on the receipt.
+
+FAULT-a wires two named degraded modes (:mod:`mixle.fault`) into the same two verbs: ``answer`` falls
+back to captured+store-only reasoning when the teacher raises (``teacher_down``); ``ingest`` falls back
+to acknowledging-without-accumulating when the store write itself raises (``store_down``). Both flag
+``degraded_mode``/``degraded_reason`` on the returned receipt/report rather than silently serving worse.
 """
 
 from __future__ import annotations
@@ -24,6 +29,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
+from mixle.fault import with_fallback
 from mixle.spend import Spend
 from mixle.task.llm import LLM, OpenAICompatLLM
 
@@ -93,6 +99,12 @@ class System:
         one frontier call, the request is refused -- ``reply`` is ``None`` and the receipt names the exact
         ``shortfall`` -- rather than silently answering over budget. A served answer's cost is added to
         :attr:`total_spend`, which every receipt also carries as ``total_spend``.
+
+        If the teacher call itself raises, this falls back to ``teacher_down`` degraded mode: answer from
+        the store alone (a plain retrieval over ``config.store``) when one is configured and has anything
+        relevant, flagging ``degraded_mode="teacher_down"`` on the receipt; if there is no store (or
+        nothing relevant in it), the failure is reported honestly (``status="failed"``), never masked as a
+        normal answer.
         """
         requested = self.config.default_budget if budget is None else int(budget)
         cost = Spend(frontier_calls=1)
@@ -108,33 +120,74 @@ class System:
                 "captured": False,
                 "task": query.task,
             }
-        reply = _complete(self.config.teacher, query.text)
-        self.total_spend = self.total_spend + cost
+
+        def _call_teacher() -> str:
+            return _complete(self.config.teacher, query.text)
+
+        def _teacher_down_fallback(exc: Exception) -> str:
+            if self.config.store is not None:
+                from mixle.substrate.retrieve import retrieve
+
+                hits = retrieve(self.config.store, query.text, k=3, scope=self.config.scope)
+                texts = [it.text for it in hits.items if it.text]
+                if texts:
+                    return "[degraded: store-only] " + " ".join(texts)
+            raise RuntimeError(f"teacher unavailable ({exc}) and no usable store to fall back on") from exc
+
+        try:
+            result = with_fallback(_call_teacher, _teacher_down_fallback, mode="teacher_down")
+        except Exception as exc:
+            return None, {
+                "produced_by": None,
+                "status": "failed",
+                "reason": str(exc),
+                "budget": requested,
+                "spend": Spend().to_dict(),
+                "total_spend": self.total_spend.to_dict(),
+                "captured": False,
+                "task": query.task,
+            }
+        actual_cost = Spend() if result.degraded else cost
+        self.total_spend = self.total_spend + actual_cost
         receipt = {
-            "produced_by": "teacher",
+            "produced_by": "store" if result.degraded else "teacher",
             "status": "answered",
-            "spend": cost.to_dict(),
+            "spend": actual_cost.to_dict(),
             "total_spend": self.total_spend.to_dict(),
             "budget": requested,
             "captured": False,  # no local model has captured this capability yet (workstream D)
             "task": query.task,
+            **result.to_receipt_fields(),
         }
-        return reply, receipt
+        return result.value, receipt
 
     def ingest(self, model_output: str, *, source: dict[str, Any]) -> dict[str, Any]:
         """Turn a model output into stored knowledge. Uses the belief store (workstream E, KNOW-a) when
         it is importable; otherwise degrades to a plain substrate item rather than hard-depending on a
-        card that may not be built yet."""
+        card that may not be built yet.
+
+        If the store write itself raises (the store is down/unreachable, as opposed to KNOW-a simply not
+        being installed), this falls back to ``store_down`` degraded mode: the model output is
+        acknowledged but NOT accumulated, and the report is flagged ``degraded_mode="store_down"`` rather
+        than silently reporting success or losing the output without a trace.
+        """
         if self.config.store is None:
             return {"status": "no_store", "assimilated": False}
-        try:
-            from mixle.substrate.belief import assimilate, harvest_knowledge
-        except ImportError:
-            return self._ingest_fallback(model_output, source=source)
 
-        claims = harvest_knowledge(model_output, source=source)
-        items = [assimilate(self.config.store, claim, []) for claim in claims]
-        return {"status": "ok", "n_claims": len(claims), "items": items}
+        def _write() -> dict[str, Any]:
+            try:
+                from mixle.substrate.belief import assimilate, harvest_knowledge
+            except ImportError:
+                return self._ingest_fallback(model_output, source=source)
+            claims = harvest_knowledge(model_output, source=source)
+            items = [assimilate(self.config.store, claim, []) for claim in claims]
+            return {"status": "ok", "n_claims": len(claims), "items": items}
+
+        def _store_down_fallback(exc: Exception) -> dict[str, Any]:
+            return {"status": "degraded_no_accumulation", "assimilated": False}
+
+        result = with_fallback(_write, _store_down_fallback, mode="store_down")
+        return {**result.value, **result.to_receipt_fields()} if result.degraded else result.value
 
     def _ingest_fallback(self, model_output: str, *, source: dict[str, Any]) -> dict[str, Any]:
         from mixle.substrate.core import SubstrateItem

--- a/mixle/tests/fault_test.py
+++ b/mixle/tests/fault_test.py
@@ -1,0 +1,89 @@
+"""Degradation policy primitives (mixle.fault), CARD FAULT-a: named modes, each flagged, never silent."""
+
+import unittest
+
+from mixle.fault import DegradedResult, abstain_on_timeout, route_past, with_fallback
+
+
+class WithFallbackTest(unittest.TestCase):
+    def test_primary_success_is_not_degraded(self):
+        result = with_fallback(lambda: 42, lambda exc: 0, mode="unused")
+        self.assertEqual(result, DegradedResult(value=42, degraded=False))
+
+    def test_primary_failure_flags_the_named_mode_and_reason(self):
+        def boom():
+            raise ValueError("teacher endpoint unreachable")
+
+        result = with_fallback(boom, lambda exc: "fallback answer", mode="teacher_down")
+        self.assertTrue(result.degraded)
+        self.assertEqual(result.mode, "teacher_down")
+        self.assertEqual(result.value, "fallback answer")
+        self.assertIn("teacher endpoint unreachable", result.reason)
+
+    def test_fallback_that_also_fails_propagates(self):
+        def boom():
+            raise ValueError("primary down")
+
+        def fallback_boom(exc):
+            raise RuntimeError("fallback has nothing either")
+
+        with self.assertRaises(RuntimeError):
+            with_fallback(boom, fallback_boom, mode="teacher_down")
+
+    def test_to_receipt_fields_shape(self):
+        result = DegradedResult(value=1, degraded=True, mode="store_down", reason="disk full")
+        self.assertEqual(result.to_receipt_fields(), {"degraded_mode": "store_down", "degraded_reason": "disk full"})
+
+
+class AbstainOnTimeoutTest(unittest.TestCase):
+    def test_timeout_abstains_with_none_value(self):
+        def slow():
+            raise TimeoutError("oracle call exceeded budget")
+
+        result = abstain_on_timeout(slow)
+        self.assertTrue(result.degraded)
+        self.assertEqual(result.mode, "oracle_timeout")
+        self.assertIsNone(result.value)
+
+    def test_non_timeout_failure_propagates(self):
+        def broken():
+            raise ValueError("not a timeout")
+
+        with self.assertRaises(ValueError):
+            abstain_on_timeout(broken)
+
+    def test_success_is_not_degraded(self):
+        result = abstain_on_timeout(lambda: "score")
+        self.assertFalse(result.degraded)
+        self.assertEqual(result.value, "score")
+
+
+class RoutePastTest(unittest.TestCase):
+    def test_first_tier_success_is_not_degraded(self):
+        result = route_past([lambda: "cheap tier answer", lambda: "frontier answer"], names=["local", "frontier"])
+        self.assertFalse(result.degraded)
+        self.assertEqual(result.value, "cheap tier answer")
+
+    def test_failing_tier_is_routed_past_and_flagged(self):
+        def broken():
+            raise RuntimeError("local model errored")
+
+        result = route_past([broken, lambda: "frontier answer"], names=["local", "frontier"])
+        self.assertTrue(result.degraded)
+        self.assertEqual(result.mode, "model_error")
+        self.assertEqual(result.value, "frontier answer")
+        self.assertIn("local", result.reason)
+
+    def test_every_tier_failing_raises_the_last_exception(self):
+        def boom_a():
+            raise RuntimeError("tier a down")
+
+        def boom_b():
+            raise ValueError("tier b down")
+
+        with self.assertRaises(ValueError):
+            route_past([boom_a, boom_b], names=["a", "b"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mixle/tests/scorecard_test.py
+++ b/mixle/tests/scorecard_test.py
@@ -1,0 +1,94 @@
+"""System scorecard (mixle.scorecard), CARD SCORE-a: evaluate() over a fixed set; catch a worsening round."""
+
+import unittest
+
+from mixle.scorecard import detect_regression, evaluate
+from mixle.substrate.core import Substrate, SubstrateItem
+from mixle.system import Query, System, SystemConfig
+
+
+class EvaluateTest(unittest.TestCase):
+    def test_quality_and_grounded_fraction_on_a_perfect_system(self):
+        system = System(SystemConfig(teacher=lambda p: "yes, absolutely"))
+        question_set = [(Query("q1"), "yes"), (Query("q2"), "yes")]
+        card = evaluate(system, question_set)
+        self.assertEqual(card.quality, 1.0)
+        self.assertEqual(card.grounded_fraction, 1.0)
+        self.assertEqual(card.realized_cost, 2.0)
+        self.assertEqual(card.n, 2)
+
+    def test_quality_reflects_wrong_answers(self):
+        system = System(SystemConfig(teacher=lambda p: "no idea"))
+        question_set = [(Query("q1"), "yes"), (Query("q2"), "yes")]
+        card = evaluate(system, question_set)
+        self.assertEqual(card.quality, 0.0)
+
+    def test_empty_question_set_is_honest_not_a_div_by_zero_crash(self):
+        system = System(SystemConfig(teacher=lambda p: "x"))
+        card = evaluate(system, [])
+        self.assertEqual(card.n, 0)
+        self.assertEqual(card.quality, 0.0)
+
+    def test_teacher_down_answers_are_not_counted_grounded(self):
+        def broken_teacher(prompt):
+            raise ConnectionError("down")
+
+        store = Substrate()
+        store.put(SubstrateItem(kind="text", text="yes it is confirmed"))
+        system = System(SystemConfig(teacher=broken_teacher, store=store))
+        card = evaluate(system, [(Query("q1"), "yes")])
+        self.assertEqual(card.grounded_fraction, 0.0)
+
+
+class RegressionDetectionTest(unittest.TestCase):
+    def test_a_deliberately_worsening_round_is_caught(self):
+        question_set = [(Query("q1"), "yes"), (Query("q2"), "yes")]
+
+        good_system = System(SystemConfig(teacher=lambda p: "yes, absolutely"))
+        baseline = evaluate(good_system, question_set)
+
+        bad_system = System(SystemConfig(teacher=lambda p: "no idea"))
+        worse = evaluate(bad_system, question_set)
+
+        report = detect_regression(baseline, worse)
+        self.assertTrue(report.regressed)
+        self.assertTrue(any("quality regressed" in r for r in report.reasons))
+
+    def test_a_grounded_fraction_drop_is_caught(self):
+        question_set = [(Query("q1"), "yes")]
+        good_system = System(SystemConfig(teacher=lambda p: "yes"))
+        baseline = evaluate(good_system, question_set)
+
+        def broken_teacher(prompt):
+            raise ConnectionError("down")
+
+        store = Substrate()
+        store.put(SubstrateItem(kind="text", text="yes indeed"))
+        degraded_system = System(SystemConfig(teacher=broken_teacher, store=store))
+        current = evaluate(degraded_system, question_set)
+
+        report = detect_regression(baseline, current)
+        self.assertTrue(report.regressed)
+        self.assertTrue(any("grounded_fraction regressed" in r for r in report.reasons))
+
+    def test_a_non_regressing_round_is_not_flagged(self):
+        question_set = [(Query("q1"), "yes")]
+        system = System(SystemConfig(teacher=lambda p: "yes, absolutely"))
+        baseline = evaluate(system, question_set)
+        current = evaluate(system, question_set)
+        report = detect_regression(baseline, current)
+        self.assertFalse(report.regressed)
+        self.assertEqual(report.reasons, [])
+
+    def test_an_improving_round_is_not_flagged(self):
+        question_set = [(Query("q1"), "yes")]
+        bad_system = System(SystemConfig(teacher=lambda p: "no idea"))
+        baseline = evaluate(bad_system, question_set)
+        good_system = System(SystemConfig(teacher=lambda p: "yes, absolutely"))
+        improved = evaluate(good_system, question_set)
+        report = detect_regression(baseline, improved)
+        self.assertFalse(report.regressed)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mixle/tests/spend_test.py
+++ b/mixle/tests/spend_test.py
@@ -1,0 +1,29 @@
+"""Spend ledger (mixle.spend), CARD SPEND-a: a summable cost total shared across every spending subsystem."""
+
+import unittest
+
+from mixle.spend import Spend
+
+
+class SpendTest(unittest.TestCase):
+    def test_add_sums_every_field(self):
+        a = Spend(frontier_calls=1, oracle_calls=2, wall_ms=10.0, dollars=0.5)
+        b = Spend(frontier_calls=3, oracle_calls=0, wall_ms=5.0, dollars=1.5)
+        total = a + b
+        self.assertEqual(total, Spend(frontier_calls=4, oracle_calls=2, wall_ms=15.0, dollars=2.0))
+
+    def test_zero_value_is_the_additive_identity(self):
+        a = Spend(frontier_calls=2, oracle_calls=1, wall_ms=3.0, dollars=0.1)
+        self.assertEqual(a + Spend(), a)
+
+    def test_total_units_counts_frontier_and_oracle_calls_only(self):
+        s = Spend(frontier_calls=2, oracle_calls=3, wall_ms=999.0, dollars=999.0)
+        self.assertEqual(s.total_units(), 5.0)
+
+    def test_to_dict_round_trips_construction(self):
+        s = Spend(frontier_calls=1, oracle_calls=2, wall_ms=3.0, dollars=4.0)
+        self.assertEqual(Spend(**s.to_dict()), s)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mixle/tests/system_test.py
+++ b/mixle/tests/system_test.py
@@ -17,7 +17,9 @@ class SystemAnswerTest(unittest.TestCase):
 
         self.assertEqual(reply, "answer to: what is 2+2?")
         self.assertEqual(receipt["produced_by"], "teacher")
-        self.assertEqual(receipt["spend"], {"frontier_calls": 1})
+        # SPEND-a: spend is now the full Spend ledger shape (frontier_calls/oracle_calls/wall_ms/dollars),
+        # not the earlier ad hoc {"frontier_calls": 1} dict.
+        self.assertEqual(receipt["spend"], {"frontier_calls": 1, "oracle_calls": 0, "wall_ms": 0.0, "dollars": 0.0})
         self.assertEqual(receipt["task"], "qa")
         self.assertFalse(receipt["captured"])
 
@@ -34,6 +36,47 @@ class SystemAnswerTest(unittest.TestCase):
         system = System(SystemConfig(teacher=_fake_teacher, default_budget=1))
         _, receipt = system.answer(Query("x"), budget=5)
         self.assertEqual(receipt["budget"], 5)
+
+
+class SystemSpendLedgerTest(unittest.TestCase):
+    """CARD SPEND-a: budget is a hard ceiling; every call's cost accumulates into System.total_spend."""
+
+    def test_total_spend_accumulates_across_calls(self):
+        system = System(SystemConfig(teacher=_fake_teacher))
+        for _ in range(3):
+            system.answer(Query("x"))
+        self.assertEqual(system.total_spend.to_dict()["frontier_calls"], 3)
+
+    def test_over_budget_request_is_refused_not_silently_served(self):
+        calls = {"n": 0}
+
+        def counting_teacher(prompt):
+            calls["n"] += 1
+            return f"answer to: {prompt}"
+
+        system = System(SystemConfig(teacher=counting_teacher))
+        reply, receipt = system.answer(Query("x"), budget=0)
+
+        self.assertIsNone(reply)
+        self.assertEqual(calls["n"], 0)  # the teacher was never called -- no silent overspend
+        self.assertEqual(receipt["status"], "refused")
+        self.assertEqual(receipt["shortfall"], 1.0)
+        self.assertEqual(receipt["spend"], {"frontier_calls": 0, "oracle_calls": 0, "wall_ms": 0.0, "dollars": 0.0})
+        self.assertEqual(system.total_spend.to_dict()["frontier_calls"], 0)
+
+    def test_a_refusal_does_not_perturb_a_later_successful_calls_running_total(self):
+        system = System(SystemConfig(teacher=_fake_teacher))
+        system.answer(Query("a"))
+        system.answer(Query("b"), budget=0)  # refused; must not silently count against total_spend
+        system.answer(Query("c"))
+        self.assertEqual(system.total_spend.to_dict()["frontier_calls"], 2)
+
+    def test_receipt_carries_both_incremental_and_running_spend(self):
+        system = System(SystemConfig(teacher=_fake_teacher))
+        system.answer(Query("a"))
+        _, receipt = system.answer(Query("b"))
+        self.assertEqual(receipt["spend"]["frontier_calls"], 1)
+        self.assertEqual(receipt["total_spend"]["frontier_calls"], 2)
 
 
 class SystemIngestTest(unittest.TestCase):

--- a/mixle/tests/system_test.py
+++ b/mixle/tests/system_test.py
@@ -148,6 +148,78 @@ class SystemImproveTest(unittest.TestCase):
         self.assertEqual(report["budget"], 10)
 
 
+class SystemColdStartCaptureTest(unittest.TestCase):
+    """CARD SEED-a: from an empty system, answer then improve, and the second identical answer is free."""
+
+    def _counting_teacher(self):
+        calls = {"n": 0}
+
+        def teacher(prompt):
+            calls["n"] += 1
+            return f"answer to: {prompt}"
+
+        return teacher, calls
+
+    def test_second_identical_query_after_improve_costs_no_frontier_calls(self):
+        teacher, calls = self._counting_teacher()
+        system = System(SystemConfig(teacher=teacher))
+        query = Query("what is the capital of Freedonia?")
+
+        reply1, receipt1 = system.answer(query)
+        self.assertEqual(calls["n"], 1)
+        self.assertFalse(receipt1["captured"])
+
+        report = system.improve(10)
+        self.assertEqual(report["status"], "captured")
+        self.assertEqual(report["n_captured"], 1)
+
+        reply2, receipt2 = system.answer(query)
+        self.assertEqual(calls["n"], 1)  # no new frontier call -- served from the captured cache
+        self.assertEqual(reply2, reply1)
+        self.assertTrue(receipt2["captured"])
+        self.assertEqual(receipt2["produced_by"], "captured")
+        self.assertEqual(receipt2["spend"], {"frontier_calls": 0, "oracle_calls": 0, "wall_ms": 0.0, "dollars": 0.0})
+
+    def test_repeat_query_before_improve_still_pays_for_a_fresh_teacher_call(self):
+        teacher, calls = self._counting_teacher()
+        system = System(SystemConfig(teacher=teacher))
+        query = Query("what is the capital of Freedonia?")
+        system.answer(query)
+        system.answer(query)
+        self.assertEqual(calls["n"], 2)
+
+    def test_capture_is_specific_to_the_captured_query_text(self):
+        teacher, calls = self._counting_teacher()
+        system = System(SystemConfig(teacher=teacher))
+        system.answer(Query("query one"))
+        system.improve(10)
+        system.answer(Query("query two"))  # a different query -- still a real teacher call
+        self.assertEqual(calls["n"], 2)
+
+    def test_improve_with_nothing_harvested_yet_is_still_honest(self):
+        system = System(SystemConfig(teacher=_fake_teacher))
+        report = system.improve(10)
+        self.assertEqual(report["status"], "nothing_to_improve")
+
+    def test_same_text_different_task_does_not_share_a_captured_cache_entry(self):
+        # regression: two queries with identical text but a different task (or scope) are different
+        # questions and must not silently answer one from the other's captured cache
+        teacher, calls = self._counting_teacher()
+        system = System(SystemConfig(teacher=teacher))
+        system.answer(Query("classify this", task="sentiment"))
+        system.improve(10)
+        system.answer(Query("classify this", task="topic"))
+        self.assertEqual(calls["n"], 2)
+
+    def test_same_text_different_scope_does_not_share_a_captured_cache_entry(self):
+        teacher, calls = self._counting_teacher()
+        system = System(SystemConfig(teacher=teacher))
+        system.answer(Query("classify this", scope="team-a"))
+        system.improve(10)
+        system.answer(Query("classify this", scope="team-b"))
+        self.assertEqual(calls["n"], 2)
+
+
 class SystemConfigFromEnvTest(unittest.TestCase):
     def test_from_env_requires_base_url_and_model(self):
         with self.assertRaises(ValueError) as ctx:

--- a/mixle/tests/system_test.py
+++ b/mixle/tests/system_test.py
@@ -2,7 +2,7 @@
 
 import unittest
 
-from mixle.substrate.core import Substrate
+from mixle.substrate.core import Substrate, SubstrateItem
 from mixle.system import Query, System, SystemConfig
 
 
@@ -77,6 +77,48 @@ class SystemSpendLedgerTest(unittest.TestCase):
         _, receipt = system.answer(Query("b"))
         self.assertEqual(receipt["spend"]["frontier_calls"], 1)
         self.assertEqual(receipt["total_spend"]["frontier_calls"], 2)
+
+
+class SystemFaultModesTest(unittest.TestCase):
+    """CARD FAULT-a: teacher_down / store_down degrade to a named, flagged mode -- never silently."""
+
+    def _broken_teacher(self, prompt: str) -> str:
+        raise ConnectionError("teacher endpoint unreachable")
+
+    def test_teacher_down_falls_back_to_store_only_and_flags_it(self):
+        store = Substrate()
+        store.put(SubstrateItem(kind="text", text="the rollout finished on schedule"))
+        system = System(SystemConfig(teacher=self._broken_teacher, store=store))
+
+        reply, receipt = system.answer(Query("rollout status"))
+        self.assertIn("degraded: store-only", reply)
+        self.assertIn("rollout finished on schedule", reply)
+        self.assertEqual(receipt["status"], "answered")
+        self.assertEqual(receipt["degraded_mode"], "teacher_down")
+        self.assertIn("teacher endpoint unreachable", receipt["degraded_reason"])
+        self.assertEqual(receipt["produced_by"], "store")
+        # a degraded, store-only answer didn't actually spend a frontier call
+        self.assertEqual(receipt["spend"]["frontier_calls"], 0)
+
+    def test_teacher_down_with_no_usable_store_fails_honestly(self):
+        system = System(SystemConfig(teacher=self._broken_teacher))
+        reply, receipt = system.answer(Query("rollout status"))
+        self.assertIsNone(reply)
+        self.assertEqual(receipt["status"], "failed")
+        self.assertIn("teacher unavailable", receipt["reason"])
+
+    def test_store_down_falls_back_to_no_accumulation_and_flags_it(self):
+        class _BrokenStore:
+            def put(self, item):
+                raise OSError("store unreachable")
+
+        system = System(SystemConfig(teacher=_fake_teacher, store=_BrokenStore()))
+        report = system.ingest("the sky is blue", source={"model": "teacher-v1"})
+
+        self.assertEqual(report["status"], "degraded_no_accumulation")
+        self.assertFalse(report["assimilated"])
+        self.assertEqual(report["degraded_mode"], "store_down")
+        self.assertIn("store unreachable", report["degraded_reason"])
 
 
 class SystemIngestTest(unittest.TestCase):

--- a/mixle/tests/system_test.py
+++ b/mixle/tests/system_test.py
@@ -2,7 +2,7 @@
 
 import unittest
 
-from mixle.substrate.core import Substrate
+from mixle.substrate.core import Substrate, SubstrateItem
 from mixle.system import Query, System, SystemConfig
 
 
@@ -17,7 +17,9 @@ class SystemAnswerTest(unittest.TestCase):
 
         self.assertEqual(reply, "answer to: what is 2+2?")
         self.assertEqual(receipt["produced_by"], "teacher")
-        self.assertEqual(receipt["spend"], {"frontier_calls": 1})
+        # SPEND-a: spend is now the full Spend ledger shape (frontier_calls/oracle_calls/wall_ms/dollars),
+        # not the earlier ad hoc {"frontier_calls": 1} dict.
+        self.assertEqual(receipt["spend"], {"frontier_calls": 1, "oracle_calls": 0, "wall_ms": 0.0, "dollars": 0.0})
         self.assertEqual(receipt["task"], "qa")
         self.assertFalse(receipt["captured"])
 
@@ -34,6 +36,89 @@ class SystemAnswerTest(unittest.TestCase):
         system = System(SystemConfig(teacher=_fake_teacher, default_budget=1))
         _, receipt = system.answer(Query("x"), budget=5)
         self.assertEqual(receipt["budget"], 5)
+
+
+class SystemSpendLedgerTest(unittest.TestCase):
+    """CARD SPEND-a: budget is a hard ceiling; every call's cost accumulates into System.total_spend."""
+
+    def test_total_spend_accumulates_across_calls(self):
+        system = System(SystemConfig(teacher=_fake_teacher))
+        for _ in range(3):
+            system.answer(Query("x"))
+        self.assertEqual(system.total_spend.to_dict()["frontier_calls"], 3)
+
+    def test_over_budget_request_is_refused_not_silently_served(self):
+        calls = {"n": 0}
+
+        def counting_teacher(prompt):
+            calls["n"] += 1
+            return f"answer to: {prompt}"
+
+        system = System(SystemConfig(teacher=counting_teacher))
+        reply, receipt = system.answer(Query("x"), budget=0)
+
+        self.assertIsNone(reply)
+        self.assertEqual(calls["n"], 0)  # the teacher was never called -- no silent overspend
+        self.assertEqual(receipt["status"], "refused")
+        self.assertEqual(receipt["shortfall"], 1.0)
+        self.assertEqual(receipt["spend"], {"frontier_calls": 0, "oracle_calls": 0, "wall_ms": 0.0, "dollars": 0.0})
+        self.assertEqual(system.total_spend.to_dict()["frontier_calls"], 0)
+
+    def test_a_refusal_does_not_perturb_a_later_successful_calls_running_total(self):
+        system = System(SystemConfig(teacher=_fake_teacher))
+        system.answer(Query("a"))
+        system.answer(Query("b"), budget=0)  # refused; must not silently count against total_spend
+        system.answer(Query("c"))
+        self.assertEqual(system.total_spend.to_dict()["frontier_calls"], 2)
+
+    def test_receipt_carries_both_incremental_and_running_spend(self):
+        system = System(SystemConfig(teacher=_fake_teacher))
+        system.answer(Query("a"))
+        _, receipt = system.answer(Query("b"))
+        self.assertEqual(receipt["spend"]["frontier_calls"], 1)
+        self.assertEqual(receipt["total_spend"]["frontier_calls"], 2)
+
+
+class SystemFaultModesTest(unittest.TestCase):
+    """CARD FAULT-a: teacher_down / store_down degrade to a named, flagged mode -- never silently."""
+
+    def _broken_teacher(self, prompt: str) -> str:
+        raise ConnectionError("teacher endpoint unreachable")
+
+    def test_teacher_down_falls_back_to_store_only_and_flags_it(self):
+        store = Substrate()
+        store.put(SubstrateItem(kind="text", text="the rollout finished on schedule"))
+        system = System(SystemConfig(teacher=self._broken_teacher, store=store))
+
+        reply, receipt = system.answer(Query("rollout status"))
+        self.assertIn("degraded: store-only", reply)
+        self.assertIn("rollout finished on schedule", reply)
+        self.assertEqual(receipt["status"], "answered")
+        self.assertEqual(receipt["degraded_mode"], "teacher_down")
+        self.assertIn("teacher endpoint unreachable", receipt["degraded_reason"])
+        self.assertEqual(receipt["produced_by"], "store")
+        # a degraded, store-only answer didn't actually spend a frontier call
+        self.assertEqual(receipt["spend"]["frontier_calls"], 0)
+
+    def test_teacher_down_with_no_usable_store_fails_honestly(self):
+        system = System(SystemConfig(teacher=self._broken_teacher))
+        reply, receipt = system.answer(Query("rollout status"))
+        self.assertIsNone(reply)
+        self.assertEqual(receipt["status"], "failed")
+        self.assertIn("teacher unavailable", receipt["reason"])
+
+    def test_store_down_falls_back_to_no_accumulation_and_flags_it(self):
+        class _BrokenStore:
+            def put(self, item):
+                raise OSError("store unreachable")
+
+        system = System(SystemConfig(teacher=_fake_teacher, store=_BrokenStore()))
+        report = system.ingest("the sky is blue", source={"model": "teacher-v1"})
+
+        self.assertEqual(report["status"], "degraded_no_accumulation")
+        self.assertFalse(report["assimilated"])
+        self.assertEqual(report["degraded_mode"], "store_down")
+        self.assertIn("store unreachable", report["degraded_reason"])
 
 
 class SystemIngestTest(unittest.TestCase):

--- a/mixle/tests/system_test.py
+++ b/mixle/tests/system_test.py
@@ -1,0 +1,74 @@
+"""System facade -- the thin shell three verbs (answer/ingest/improve) sit behind (workstream J1/J8)."""
+
+import unittest
+
+from mixle.substrate.core import Substrate
+from mixle.system import Query, System, SystemConfig
+
+
+def _fake_teacher(prompt: str) -> str:
+    return f"answer to: {prompt}"
+
+
+class SystemAnswerTest(unittest.TestCase):
+    def test_answer_routes_to_teacher_and_returns_a_receipt(self):
+        system = System(SystemConfig(teacher=_fake_teacher))
+        reply, receipt = system.answer(Query("what is 2+2?", task="qa"))
+
+        self.assertEqual(reply, "answer to: what is 2+2?")
+        self.assertEqual(receipt["produced_by"], "teacher")
+        self.assertEqual(receipt["spend"], {"frontier_calls": 1})
+        self.assertEqual(receipt["task"], "qa")
+        self.assertFalse(receipt["captured"])
+
+    def test_answer_accepts_a_class_based_llm(self):
+        class _LLM:
+            def complete(self, prompt, *, system=None, **kwargs):
+                return f"llm:{prompt}"
+
+        system = System(SystemConfig(teacher=_LLM()))
+        reply, _ = system.answer(Query("hi"))
+        self.assertEqual(reply, "llm:hi")
+
+    def test_answer_respects_an_explicit_budget(self):
+        system = System(SystemConfig(teacher=_fake_teacher, default_budget=1))
+        _, receipt = system.answer(Query("x"), budget=5)
+        self.assertEqual(receipt["budget"], 5)
+
+
+class SystemIngestTest(unittest.TestCase):
+    def test_ingest_with_no_store_is_an_honest_noop(self):
+        system = System(SystemConfig(teacher=_fake_teacher))
+        report = system.ingest("the sky is blue", source={"model": "teacher-v1"})
+        self.assertEqual(report["status"], "no_store")
+        self.assertFalse(report["assimilated"])
+
+    def test_ingest_falls_back_to_a_retrievable_substrate_item_when_no_belief_store_exists(self):
+        store = Substrate()
+        system = System(SystemConfig(teacher=_fake_teacher, store=store))
+        report = system.ingest("the sky is blue", source={"model": "teacher-v1"})
+
+        self.assertEqual(report["status"], "ok_fallback")
+        item = store.get(report["item_id"])
+        self.assertIsNotNone(item)
+        self.assertEqual(item.text, "the sky is blue")
+        self.assertEqual(item.provenance, {"model": "teacher-v1"})
+
+
+class SystemImproveTest(unittest.TestCase):
+    def test_improve_on_an_empty_system_is_honest(self):
+        system = System(SystemConfig(teacher=_fake_teacher))
+        report = system.improve(10)
+        self.assertEqual(report["status"], "nothing_to_improve")
+        self.assertEqual(report["budget"], 10)
+
+
+class SystemConfigFromEnvTest(unittest.TestCase):
+    def test_from_env_requires_base_url_and_model(self):
+        with self.assertRaises(ValueError) as ctx:
+            SystemConfig.from_env()
+        self.assertIn("MIXLE_TEACHER_BASE_URL", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Workstream J1/J8: `mixle/system.py` adds `SystemConfig`, `Query`, and `System` -- the facade three verbs sit behind, built as a thin shell so the system boots on day 0.
- `System.answer(query, budget=...)` routes straight to the configured teacher (any `LLM` or plain callable) and returns `(reply, receipt)` with `produced_by="teacher"`, spend, and budget.
- `System.ingest(model_output, source=...)` uses the belief store (`mixle.substrate.belief`, workstream E/KNOW-a) when it's importable; degrades to writing a plain retrievable `SubstrateItem` otherwise -- the shell does not hard-depend on a card that isn't merged onto this base yet.
- `System.improve(budget)` is an honest stub: "nothing to improve yet" until an orchestrator/registry registers into it.
- `SystemConfig.from_env()` builds an `OpenAICompatLLM` teacher from `MIXLE_TEACHER_BASE_URL`/`MIXLE_TEACHER_MODEL`/`MIXLE_TEACHER_API_KEY` -- secrets come from env, never hardcoded.

Per `notes/0.6.3-execution-playbook.md` CARD SYS-a. Out of scope here (per the card): registry (REG-a, in flight on another branch), budget ledger (SPEND-a), fault modes (FAULT-a), scorecard (SCORE-a).

## Test plan
- [x] `.venv/bin/python -m pytest mixle/tests/system_test.py -q` -- 7 passed
- [x] `.venv/bin/python -m ruff check mixle/system.py mixle/tests/system_test.py` -- clean
- [x] `.venv/bin/python -m ruff format --check mixle/system.py mixle/tests/system_test.py` -- clean
- [ ] Full gate not run in this session per instructions to only run targeted tests; recommend running before merge.
