### PR TITLE
task/REG: local model registry

### DIFF
--- a/mixle/registry.py
+++ b/mixle/registry.py
@@ -1,0 +1,182 @@
+"""``Registry`` -- a local directory + index of fitted task models, queryable by capability and fingerprint.
+
+Workstream J2: the library catalog the orchestrator/router read from and the capture/accumulation flywheels
+(D9, ACCUM-a) write into. Deliberately a directory + a JSON index, not a server: every entry is a saved
+:class:`~mixle.task.model.TaskModel` or :class:`~mixle.task.calibrate.CalibratedTaskModel` artifact directory
+(see :mod:`mixle.task.artifact`) plus a small index record naming its capabilities, task fingerprint
+(:func:`~mixle.task.edge.task_fingerprint`), and capture profile. ``find_for`` answers "do I already have
+something for this task"; ``tier_stack`` turns a matching capability into a cheapest-first tier list -- the
+shape :class:`~mixle.task.router.Router` consumes directly (``Router(tiers=stack)``), with the frontier
+appended last as the router's own fallback tier.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+
+from mixle.task.calibrate import CalibratedTaskModel
+from mixle.task.model import TaskModel
+
+_INDEX_NAME = "index.json"
+
+
+@dataclass
+class RegistryEntry:
+    """One catalog record: where the artifact lives, what it's registered under, and how much it costs to run."""
+
+    entry_id: str
+    path: str
+    kind: str  # "task" or "calibrated" -- which class reloads the artifact at ``path``
+    capabilities: list[str] = field(default_factory=list)
+    fingerprint: list[float] | None = None
+    profile: dict[str, Any] = field(default_factory=dict)
+    cost: float = 0.0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "entry_id": self.entry_id,
+            "path": self.path,
+            "kind": self.kind,
+            "capabilities": list(self.capabilities),
+            "fingerprint": list(self.fingerprint) if self.fingerprint is not None else None,
+            "profile": self.profile,
+            "cost": self.cost,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> RegistryEntry:
+        return cls(
+            entry_id=d["entry_id"],
+            path=d["path"],
+            kind=d["kind"],
+            capabilities=list(d.get("capabilities", [])),
+            fingerprint=d.get("fingerprint"),
+            profile=d.get("profile", {}),
+            cost=float(d.get("cost", 0.0)),
+        )
+
+
+class Registry:
+    """A ``dir``-backed catalog of registered models: ``register`` writes an artifact + index entry;
+    ``find_for``/``tier_stack`` query it. Re-opening the same ``dir`` in a fresh process sees every entry."""
+
+    def __init__(self, dir: str) -> None:
+        self.dir = dir
+        os.makedirs(dir, exist_ok=True)
+        self._entries: list[RegistryEntry] = self._read_index()
+
+    def _index_path(self) -> str:
+        return os.path.join(self.dir, _INDEX_NAME)
+
+    def _read_index(self) -> list[RegistryEntry]:
+        if not os.path.exists(self._index_path()):
+            return []
+        with open(self._index_path()) as f:
+            return [RegistryEntry.from_dict(d) for d in json.load(f)]
+
+    def _write_index(self) -> None:
+        with open(self._index_path(), "w") as f:
+            json.dump([e.to_dict() for e in self._entries], f, indent=2, sort_keys=True)
+
+    def register(
+        self,
+        model: TaskModel | CalibratedTaskModel,
+        *,
+        capabilities: Sequence[str],
+        fingerprint: Sequence[float] | None = None,
+        profile: dict[str, Any] | None = None,
+        cost: float = 0.0,
+        entry_id: str | None = None,
+    ) -> RegistryEntry:
+        """Save ``model``'s artifact under ``dir`` and add its index entry; return the entry.
+
+        ``model`` is a fitted :class:`~mixle.task.model.TaskModel` or
+        :class:`~mixle.task.calibrate.CalibratedTaskModel` -- the two artifact-saveable task model kinds.
+        ``capabilities`` names what this model answers (matched by :meth:`find_for`); ``fingerprint`` is
+        typically :func:`~mixle.task.edge.task_fingerprint`'s vector for the training data; ``profile`` is
+        free-form (e.g. a :func:`~mixle.task.capability.capture_profile` dict); ``cost`` is the per-request
+        cost used to order :meth:`tier_stack`.
+        """
+        if isinstance(model, CalibratedTaskModel):
+            kind = "calibrated"
+        elif isinstance(model, TaskModel):
+            kind = "task"
+        else:
+            raise TypeError(f"Registry only stores TaskModel/CalibratedTaskModel, got {type(model)!r}")
+        entry_id = entry_id or f"entry_{len(self._entries):04d}"
+        path = os.path.join(self.dir, entry_id)
+        model.save(path)
+        entry = RegistryEntry(
+            entry_id=entry_id,
+            path=path,
+            kind=kind,
+            capabilities=list(capabilities),
+            fingerprint=list(fingerprint) if fingerprint is not None else None,
+            profile=dict(profile or {}),
+            cost=float(cost),
+        )
+        self._entries.append(entry)
+        self._write_index()
+        return entry
+
+    def load(self, entry_id: str) -> TaskModel | CalibratedTaskModel:
+        """Reload a registered model by ``entry_id`` (round-trips through the artifact on disk)."""
+        entry = self._get(entry_id)
+        cls = CalibratedTaskModel if entry.kind == "calibrated" else TaskModel
+        return cls.load(entry.path)
+
+    def _get(self, entry_id: str) -> RegistryEntry:
+        for e in self._entries:
+            if e.entry_id == entry_id:
+                return e
+        raise KeyError(f"no registry entry {entry_id!r}")
+
+    def find_for(self, query: str | Sequence[float], *, top_k: int | None = None) -> list[RegistryEntry]:
+        """Entries matching ``query``: a capability name (``str``, containment match) or a task fingerprint
+        vector (array-like of floats, nearest-neighbor match). ``top_k`` caps how many are returned -- every
+        capability match by default, or the single nearest fingerprint match by default."""
+        if isinstance(query, str):
+            matches = [e for e in self._entries if query in e.capabilities]
+            return matches[:top_k] if top_k is not None else matches
+        q = np.asarray(query, dtype=np.float64)
+        scored = sorted(
+            (
+                (float(np.linalg.norm(np.asarray(e.fingerprint, dtype=np.float64) - q)), e)
+                for e in self._entries
+                if e.fingerprint is not None
+            ),
+            key=lambda t: t[0],
+        )
+        k = top_k if top_k is not None else 1
+        return [e for _, e in scored[:k]]
+
+    def tier_stack(
+        self,
+        task: str,
+        *,
+        frontier: Any,
+        costs: Sequence[float] | None = None,
+        names: Sequence[str] | None = None,
+    ) -> list[tuple[str, Any, float]]:
+        """Cheapest-first ``(name, model, cost)`` tiers for capability ``task``, ``frontier`` appended last.
+
+        Matching entries are loaded (:meth:`load`) and ordered by their registered ``cost``. The result is
+        exactly the shape :class:`~mixle.task.router.Router` takes as ``tiers=``: each non-final tier exposes
+        ``decide(x)``, the final tier is the callable ``frontier`` fallback. ``costs`` (one entry per matching
+        solution plus one for ``frontier``, mirroring :meth:`~mixle.task.router.Router.from_solutions`) overrides
+        the registered per-entry costs when given.
+        """
+        pool = sorted(self.find_for(task), key=lambda e: e.cost)
+        if costs is not None and len(costs) != len(pool) + 1:
+            raise ValueError("costs needs one entry per matching solution plus one for the frontier")
+        tier_costs = [float(c) for c in costs] if costs is not None else [e.cost for e in pool] + [1.0]
+        tier_names = list(names) if names is not None else [e.entry_id for e in pool] + ["frontier"]
+        tiers = [(tier_names[i], self.load(e.entry_id), tier_costs[i]) for i, e in enumerate(pool)]
+        tiers.append((tier_names[-1], frontier, tier_costs[-1]))
+        return tiers

--- a/mixle/tests/registry_test.py
+++ b/mixle/tests/registry_test.py
@@ -1,0 +1,98 @@
+"""Registry (mixle.registry): a dir-backed catalog of registered task models, queried by capability/fingerprint.
+
+Card REG-a (workstream J2): register writes a real task-artifact directory + a JSON index entry; find_for and
+tier_stack read the index back, including in a fresh Registry instance pointed at the same dir.
+"""
+
+import tempfile
+import unittest
+
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("safetensors")
+
+from mixle.registry import Registry  # noqa: E402
+from mixle.task.calibrate import ESCALATE  # noqa: E402
+from mixle.task.distill import distill_for_routing  # noqa: E402
+from mixle.task.router import Router  # noqa: E402
+
+
+def _spam_teacher(texts):
+    words = {"free", "winner", "prize"}
+    return ["spam" if any(w in t.split() for w in words) else "ham" for t in texts]
+
+
+def _billing_teacher(texts):
+    words = {"invoice", "overdue", "payment"}
+    return ["billing" if any(w in t.split() for w in words) else "other" for t in texts]
+
+
+def _toy_model(teacher, vocab, seed):
+    texts = [f"{a} {b} filler {c}" for a in vocab for b in vocab for c in ["x", "y", "z"]]
+    return distill_for_routing(teacher, texts, dim=64, hidden=[16], epochs=40, seed=seed, calibration_frac=0.3)
+
+
+class RegistryTest(unittest.TestCase):
+    def test_find_for_matches_capability_not_the_other(self):
+        with tempfile.TemporaryDirectory() as d:
+            reg = Registry(d)
+            spam_model = _toy_model(_spam_teacher, ["free", "winner", "prize", "meeting", "lunch"], seed=0)
+            billing_model = _toy_model(_billing_teacher, ["invoice", "overdue", "payment", "meeting", "lunch"], seed=1)
+            reg.register(spam_model, capabilities=["spam_filter"], fingerprint=[0.0, 0.0, 0.0, 0.0, 0.0], cost=0.01)
+            reg.register(
+                billing_model, capabilities=["billing_router"], fingerprint=[9.0, 9.0, 9.0, 9.0, 9.0], cost=0.02
+            )
+
+            spam_matches = reg.find_for("spam_filter")
+            self.assertEqual(len(spam_matches), 1)
+            self.assertEqual(spam_matches[0].capabilities, ["spam_filter"])
+
+            billing_matches = reg.find_for("billing_router")
+            self.assertEqual(len(billing_matches), 1)
+            self.assertEqual(billing_matches[0].capabilities, ["billing_router"])
+
+            near_spam = reg.find_for([0.1, 0.0, 0.0, 0.0, 0.0])
+            self.assertEqual(len(near_spam), 1)
+            self.assertEqual(near_spam[0].capabilities, ["spam_filter"])
+
+    def test_tier_stack_cheapest_first_frontier_last(self):
+        with tempfile.TemporaryDirectory() as d:
+            reg = Registry(d)
+            cheap = _toy_model(_spam_teacher, ["free", "winner", "prize", "meeting", "lunch"], seed=2)
+            pricier = _toy_model(_spam_teacher, ["free", "winner", "prize", "meeting", "lunch"], seed=3)
+            reg.register(pricier, capabilities=["spam_filter"], cost=0.05)
+            reg.register(cheap, capabilities=["spam_filter"], cost=0.01)
+
+            def frontier(text):
+                return _spam_teacher([text])[0]
+
+            stack = reg.tier_stack("spam_filter", frontier=frontier, costs=[0.01, 0.05, 1.0])
+
+            self.assertEqual(len(stack), 3)
+            self.assertEqual([c for _, _, c in stack], [0.01, 0.05, 1.0])
+            self.assertEqual(stack[-1][0], "frontier")
+            self.assertIs(stack[-1][1], frontier)
+            for name, model, _cost in stack[:-1]:
+                self.assertTrue(hasattr(model, "decide"))
+
+            # the exact shape Router's constructor wants: cheapest calibrated tiers, frontier fallback last
+            router = Router(tiers=stack)
+            decisions = [router(t) for t in ["free prize now", "team meeting today"]]
+            for d_ in decisions:
+                self.assertTrue(d_ is ESCALATE or isinstance(d_, str))
+
+    def test_round_trips_through_a_fresh_registry_instance(self):
+        with tempfile.TemporaryDirectory() as d:
+            first = Registry(d)
+            model = _toy_model(_spam_teacher, ["free", "winner", "prize", "meeting", "lunch"], seed=4)
+            entry = first.register(model, capabilities=["spam_filter"], fingerprint=[1.0, 2.0, 3.0], cost=0.02)
+
+            reopened = Registry(d)
+            self.assertEqual(len(reopened.find_for("spam_filter")), 1)
+            reloaded = reopened.load(entry.entry_id)
+            self.assertEqual(reloaded.decide("free prize now"), model.decide("free prize now"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Card REG-a (workstream J2): `mixle/registry.py` -- a `dir` + JSON-index catalog for fitted `TaskModel`/`CalibratedTaskModel` artifacts. No HTTP, no server.
- `register(model, *, capabilities, fingerprint=None, profile=None, cost=0.0)` saves the artifact via the model's own `.save(path)` and appends an index entry.
- `find_for(query, *, top_k=None)`: `query` is a capability name (`str`, containment match) or a task-fingerprint vector (nearest-neighbor match, default top-1).
- `tier_stack(task, *, frontier, costs=None, names=None)`: cheapest-first `(name, model, cost)` tuples for matching entries, `frontier` appended last -- the exact shape `Router(tiers=...)` takes directly.
- `load(entry_id)` reloads by dispatching on the stored `kind` (`"task"` vs `"calibrated"`).

**Deviation from the card's literal wording:** the card says `tier_stack` should be "ready to hand to `Router.from_solutions`", but that classmethod takes a list of `Solution` objects (`.cascade.model`) + a separate `teacher` arg, not a single combined list. I built `tier_stack` to return the tuple shape `Router`'s own constructor (`Router(tiers=...)`) consumes directly instead, since that's the literal "cheapest-first tiers + frontier fallback" list the card describes and is directly testable end-to-end (see `test_tier_stack_cheapest_first_frontier_last`, which builds a real `Router` from the stack and calls it).

## Test plan
- [x] `mixle/tests/registry_test.py`: `find_for` returns the matching capability/fingerprint entry and not the other; `tier_stack` orders cheapest-first with the frontier last and the result plugs straight into `Router`; a fresh `Registry` instance pointed at the same dir sees the same entries and reloads a model that decides identically.
- [x] `.venv/bin/python -m pytest mixle/tests/registry_test.py -q` -- 3 passed.
- [x] `ruff check` / `ruff format --check` on changed files -- clean.
