### PR TITLE
task/H2-a: ExecutionTrace + bit-identical replay

### DIFF
--- a/mixle/task/__init__.py
+++ b/mixle/task/__init__.py
@@ -109,6 +109,7 @@ from mixle.task.quantize import (
 )
 from mixle.task.recommend import FieldChoice, ModelRecommendation, recommend_model
 from mixle.task.regress import RegressionSolution, solve_regression
+from mixle.task.replay import ExecutionTrace, TraceStep, is_bit_identical_replay, record_step, replay
 from mixle.task.router import Router, RouterStats, route_stack
 from mixle.task.scorecard import Scorecard, scorecard
 from mixle.task.sft_plan import GenerativePlanner, sample_plans, score_plan, sft_planner
@@ -136,6 +137,7 @@ __all__ = [
     "EdgeDistillResult",
     "EdgeFootprint",
     "EdgeSpace",
+    "ExecutionTrace",
     "ExtractionIO",
     "ExtractorHarness",
     "MatcherHarness",
@@ -163,6 +165,7 @@ __all__ = [
     "StructuredClassifierIO",
     "TaskManifest",
     "TaskModel",
+    "TraceStep",
     "ToolCaller",
     "ToolSpec",
     "TextClassifierIO",
@@ -198,12 +201,15 @@ __all__ = [
     "parse_conversation",
     "get_arrays_builder",
     "get_builder",
+    "is_bit_identical_replay",
     "llm_extractor",
     "llm_labeler",
     "load_harvested",
     "lns_classifier",
     "pick_label",
+    "record_step",
     "recommend_model",
+    "replay",
     "recommend_route",
     "replace_alerter",
     "replace_extractor",

--- a/mixle/task/replay.py
+++ b/mixle/task/replay.py
@@ -1,0 +1,88 @@
+"""Replayable execution traces -- record each step an executor took (tool, args, seed, result) as a
+plain JSON-able object, and re-run it later to prove the run was deterministic (workstream H2, built
+against :mod:`mixle.task.traces`' ``AgentTrace`` shape so the future orchestrator (C3-a) can emit one
+trace object that both this module and the plan model consume).
+
+A step is only trustworthy to replay if every source of randomness it used is named and captured --
+that is the whole point of recording ``seed`` per step rather than trusting global RNG state. ``replay``
+re-invokes each step's registered tool with the SAME args and seed and returns a new
+:class:`ExecutionTrace`; ``diff`` is the honest per-step comparison (bit-identical or not), never a
+silent pass.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class TraceStep:
+    """One recorded step: the tool name, the args it ran with, the seed (if any), and its result."""
+
+    tool: str
+    args: dict[str, Any] = field(default_factory=dict)
+    seed: int | None = None
+    result: Any = None
+
+    def to_json(self) -> dict[str, Any]:
+        return {"tool": self.tool, "args": self.args, "seed": self.seed, "result": self.result}
+
+    @classmethod
+    def from_json(cls, d: dict[str, Any]) -> TraceStep:
+        return cls(tool=d["tool"], args=dict(d.get("args") or {}), seed=d.get("seed"), result=d.get("result"))
+
+
+@dataclass
+class ExecutionTrace:
+    """An ordered list of :class:`TraceStep` -- JSON-serializable, so it can be stored (e.g. as a
+    ``mixle.substrate`` ``"trace"`` item) and replayed in a fresh process."""
+
+    request: str
+    steps: list[TraceStep] = field(default_factory=list)
+
+    def to_json(self) -> dict[str, Any]:
+        return {"request": self.request, "steps": [s.to_json() for s in self.steps]}
+
+    @classmethod
+    def from_json(cls, d: dict[str, Any]) -> ExecutionTrace:
+        return cls(request=d["request"], steps=[TraceStep.from_json(s) for s in d.get("steps") or []])
+
+    def dumps(self) -> str:
+        return json.dumps(self.to_json(), sort_keys=True)
+
+
+def record_step(
+    tools: dict[str, Callable[..., Any]], tool: str, args: dict[str, Any], *, seed: int | None = None
+) -> TraceStep:
+    """Run ``tools[tool]`` once with ``args`` (and ``seed``, if the tool accepts one), recording the result."""
+    fn = tools[tool]
+    call_args = dict(args)
+    if seed is not None:
+        call_args["seed"] = seed
+    result = fn(**call_args)
+    return TraceStep(tool=tool, args=dict(args), seed=seed, result=result)
+
+
+def replay(trace: ExecutionTrace, tools: dict[str, Callable[..., Any]]) -> ExecutionTrace:
+    """Re-execute every step of ``trace`` against ``tools`` with the exact same args and seed."""
+    replayed = [record_step(tools, step.tool, step.args, seed=step.seed) for step in trace.steps]
+    return ExecutionTrace(request=trace.request, steps=replayed)
+
+
+def diff(a: ExecutionTrace, b: ExecutionTrace) -> list[tuple[int, str]]:
+    """Indices + tool names where ``a`` and ``b`` disagree (JSON-serialized result comparison)."""
+    mismatches = []
+    for i, (sa, sb) in enumerate(zip(a.steps, b.steps)):
+        if sa.tool != sb.tool or json.dumps(sa.result, sort_keys=True) != json.dumps(sb.result, sort_keys=True):
+            mismatches.append((i, sa.tool))
+    if len(a.steps) != len(b.steps):
+        mismatches.append((min(len(a.steps), len(b.steps)), "length_mismatch"))
+    return mismatches
+
+
+def is_bit_identical_replay(trace: ExecutionTrace, tools: dict[str, Callable[..., Any]]) -> bool:
+    """Replay ``trace`` and assert every step reproduces exactly -- the load-bearing check for H2."""
+    return not diff(trace, replay(trace, tools))

--- a/mixle/tests/task_replay_test.py
+++ b/mixle/tests/task_replay_test.py
@@ -1,0 +1,60 @@
+"""ExecutionTrace + replay: bit-identical re-execution given the same recorded args/seed (workstream H2)."""
+
+import unittest
+
+import numpy as np
+
+from mixle.task.replay import ExecutionTrace, TraceStep, diff, is_bit_identical_replay, record_step, replay
+
+
+def _draw_normal(n: int, seed: int) -> list[float]:
+    rng = np.random.RandomState(seed)
+    return rng.normal(size=n).tolist()
+
+
+def _uppercase(text: str) -> str:
+    return text.upper()
+
+
+_TOOLS = {"draw_normal": _draw_normal, "uppercase": _uppercase}
+
+
+class ReplayTest(unittest.TestCase):
+    def _record(self) -> ExecutionTrace:
+        step1 = record_step(_TOOLS, "uppercase", {"text": "hello"})
+        step2 = record_step(_TOOLS, "draw_normal", {"n": 5}, seed=42)
+        return ExecutionTrace(request="demo", steps=[step1, step2])
+
+    def test_replay_is_bit_identical_given_the_same_seed(self):
+        trace = self._record()
+        self.assertTrue(is_bit_identical_replay(trace, _TOOLS))
+
+        replayed = replay(trace, _TOOLS)
+        self.assertEqual(trace.steps[0].result, replayed.steps[0].result)
+        self.assertEqual(trace.steps[1].result, replayed.steps[1].result)  # stochastic step, same seed
+
+    def test_diff_detects_a_changed_seed(self):
+        trace = self._record()
+        tampered = ExecutionTrace(
+            request=trace.request,
+            steps=[trace.steps[0], TraceStep(tool="draw_normal", args={"n": 5}, seed=99, result=trace.steps[1].result)],
+        )
+        replayed = replay(tampered, _TOOLS)
+        mismatches = diff(tampered, replayed)
+        self.assertEqual(mismatches, [(1, "draw_normal")])
+
+    def test_trace_round_trips_through_json(self):
+        trace = self._record()
+        restored = ExecutionTrace.from_json(trace.to_json())
+        self.assertEqual(trace.dumps(), restored.dumps())
+        self.assertTrue(is_bit_identical_replay(restored, _TOOLS))
+
+    def test_length_mismatch_is_reported(self):
+        trace = self._record()
+        shorter = ExecutionTrace(request=trace.request, steps=trace.steps[:1])
+        mismatches = diff(trace, shorter)
+        self.assertIn((1, "length_mismatch"), mismatches)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Workstream H2 (replayable traces, per `notes/0.6.3-execution-playbook.md` "Later cards"): `mixle/task/replay.py` adds `TraceStep`/`ExecutionTrace` -- a plain JSON-able record of each executor step (tool name, args, seed, result).
- `replay(trace, tools)` re-invokes every step against a tool registry with the exact same args/seed; `diff(a, b)` and `is_bit_identical_replay(trace, tools)` give an honest per-step comparison rather than a silent pass.
- Designed so the future orchestrator (C3-a) has one trace object to emit that this module (and the C1-a plan model) both consume, without depending on C3-a existing yet.

## Test plan
- [x] `.venv/bin/python -m pytest mixle/tests/task_replay_test.py -q` -- 4 passed (includes a stochastic step replayed bit-identically given the same seed, a tampered-seed mismatch detection, JSON round-trip, and length-mismatch detection)
- [x] `.venv/bin/python -m ruff check mixle/task/replay.py mixle/tests/task_replay_test.py mixle/task/__init__.py` -- clean
- [x] `.venv/bin/python -m ruff format --check` on the same files -- clean
- [ ] Full gate not run in this session per instructions to only run targeted tests; recommend running before merge.
