### PR TITLE
task/B4-a: resolve_from_harvest -- the multi-tier re-solve loop

### DIFF
--- a/mixle/task/__init__.py
+++ b/mixle/task/__init__.py
@@ -109,7 +109,7 @@ from mixle.task.quantize import (
 )
 from mixle.task.recommend import FieldChoice, ModelRecommendation, recommend_model
 from mixle.task.regress import RegressionSolution, solve_regression
-from mixle.task.router import Router, RouterStats, route_stack
+from mixle.task.router import HarvestResolveResult, Router, RouterStats, resolve_from_harvest, route_stack
 from mixle.task.scorecard import Scorecard, scorecard
 from mixle.task.sft_plan import GenerativePlanner, sample_plans, score_plan, sft_planner
 from mixle.task.solve import Solution, load_harvested, solve
@@ -154,6 +154,8 @@ __all__ = [
     "Router",
     "Scorecard",
     "RouterStats",
+    "HarvestResolveResult",
+    "resolve_from_harvest",
     "RegressionSolution",
     "MultiLabelSolution",
     "StructuredSolution",

--- a/mixle/task/router.py
+++ b/mixle/task/router.py
@@ -22,7 +22,7 @@ from typing import Any
 
 import numpy as np
 
-from mixle.task.calibrate import ESCALATE
+from mixle.task.calibrate import ESCALATE, CalibratedTaskModel
 
 
 @dataclass
@@ -144,3 +144,88 @@ def route_stack(solutions: list, teacher: Any, *, costs: list[float]) -> Router:
     sols = [solutions[i] for i in order]
     cs = [float(costs[i]) for i in order] + [float(costs[-1])]
     return Router.from_solutions(sols, teacher, costs=cs)
+
+
+@dataclass
+class HarvestResolveResult:
+    """What :func:`resolve_from_harvest` found and did -- a receipt, not a bare boolean.
+
+    ``escalation_before`` is exactly 1.0: every harvested input, by definition, escalated all the way
+    to the frontier under the current router. ``escalation_after`` is the NEW tier's own calibrated
+    escalation rate on a held-out split of that same harvested set; ``escalation_drop`` is the
+    difference. ``router`` is the new stack with the tier inserted (``None`` when nothing was
+    accepted -- either too little harvested data to fit and calibrate honestly, or the new tier does
+    not escalate measurably less often than always-escalate, in which case it buys nothing and is
+    correctly rejected rather than inserted for no gain).
+    """
+
+    accepted: bool
+    n_harvested: int
+    escalation_before: float
+    escalation_after: float
+    escalation_drop: float
+    agreement: float
+    router: Router | None = None
+    tier_name: str = ""
+
+
+def resolve_from_harvest(
+    router: Router,
+    *,
+    cost_per_request: float,
+    name: str = "resolved",
+    alpha: float = 0.1,
+    holdout: float = 0.25,
+    min_drop: float = 0.05,
+    distill_kw: dict[str, Any] | None = None,
+    seed: int = 0,
+) -> HarvestResolveResult:
+    """The multi-tier re-solve loop: train a NEW tier from ``router``'s harvested frontier labels and
+    insert it just before the frontier -- the :class:`~mixle.task.solve.Solution.improve` idea
+    generalized from one cascade to a whole router stack.
+
+    Every harvested input escalated all the way through the existing tiers (that is what "harvested"
+    means), so the honest baseline escalation rate on that set is 1.0. A new tier is fit and calibrated
+    on a held-out split of the SAME harvested set (never re-calling the frontier -- the labels are
+    already real teacher answers); it is inserted only if its OWN calibrated escalation rate on that
+    held-out split drops by at least ``min_drop`` below 1.0 -- i.e. it demonstrably intercepts a real
+    share of what used to always escalate. Too little harvested data, or a tier that still escalates
+    almost everything, is an honest no-op (``accepted=False``, ``router=None``), never a forced insert.
+    """
+    from mixle.task.distill import agreement
+    from mixle.task.solve import _fit_gate, _fit_student
+
+    inputs, labels = router.harvested()
+    n_harvested = len(inputs)
+    if n_harvested < 8:
+        return HarvestResolveResult(False, n_harvested, 1.0, 1.0, 0.0, 0.0)
+
+    kind = "text" if isinstance(inputs[0], str) else "record"
+    str_labels = [str(y) for y in labels]
+
+    rng = np.random.RandomState(seed)
+    order = rng.permutation(n_harvested)
+    n_cal = max(2, int(round(n_harvested * holdout)))
+    cal_idx, train_idx = order[:n_cal], order[n_cal:]
+    train_in, train_lab = [inputs[i] for i in train_idx], [str_labels[i] for i in train_idx]
+    cal_in, cal_lab = [inputs[i] for i in cal_idx], [str_labels[i] for i in cal_idx]
+    if len(train_in) < 4 or len(cal_in) < 2:
+        return HarvestResolveResult(False, n_harvested, 1.0, 1.0, 0.0, 0.0)
+
+    kw = dict(distill_kw or {})
+    kw.setdefault("seed", seed)
+    student = _fit_student(kind, train_in, train_lab, kw)
+    gate = _fit_gate(kind, train_in, 0.02, seed)
+    cal = CalibratedTaskModel(student, alpha=alpha, density_gate=gate).calibrate(cal_in, cal_lab)
+
+    agree = agreement(student, cal_lab, cal_in)
+    esc_after = cal.escalation_rate(cal_in)
+    drop = 1.0 - esc_after
+
+    if drop < min_drop:
+        return HarvestResolveResult(False, n_harvested, 1.0, float(esc_after), float(drop), float(agree))
+
+    new_tiers = list(router.tiers[:-1]) + [(name, cal, float(cost_per_request)), router.tiers[-1]]
+    return HarvestResolveResult(
+        True, n_harvested, 1.0, float(esc_after), float(drop), float(agree), Router(new_tiers), name
+    )

--- a/mixle/tests/router_harvest_test.py
+++ b/mixle/tests/router_harvest_test.py
@@ -1,0 +1,95 @@
+"""B4-a: resolve_from_harvest() -- the multi-tier re-solve loop, Solution.improve()'s idea generalized
+from one cascade to a whole Router stack. A new tier is trained from the harvested frontier labels and
+inserted only if it demonstrably intercepts a real share of what used to always escalate."""
+
+import random
+import unittest
+
+from mixle.task.router import Router, resolve_from_harvest
+from mixle.task.solve import solve
+
+FAMILY_A = ["free money now", "cheap loans fast", "win cash today"]
+FAMILY_B = ["urgent wire transfer", "account suspended act now", "verify password immediately"]
+HAM = ["meeting at noon", "see you tomorrow", "project update attached", "lunch today", "thanks for the help"]
+
+
+def _teacher(x):
+    """A scalar teacher -- Router.__call__ invokes the frontier tier as teacher(single_input)."""
+    return "spam" if any(w in x for fam in (FAMILY_A, FAMILY_B) for w in fam) else "ham"
+
+
+def _make(n, families, rng):
+    out = []
+    for _ in range(n):
+        if rng.random() < 0.5:
+            out.append(rng.choice(rng.choice(families)) + " " + rng.choice(["!!!", "", "today"]))
+        else:
+            out.append(rng.choice(HAM) + " " + rng.choice(["", "thanks", "ok"]))
+    return out
+
+
+def _build_router(seed=0):
+    """tier0 is trained ONLY on FAMILY_A, so FAMILY_B spam systematically escalates to the frontier."""
+    train_a = _make(200, [FAMILY_A], random.Random(seed))
+    tier0 = solve(_teacher, train_a, alpha=0.1, seed=seed)
+    return Router.from_solutions([tier0], teacher=_teacher, costs=[0.0001, 0.01]), tier0
+
+
+class HarvestResolveTest(unittest.TestCase):
+    def test_new_tier_measurably_drops_escalation_on_held_out_traffic(self):
+        router, tier0 = _build_router(seed=0)
+        router.serve(_make(400, [FAMILY_A, FAMILY_B], random.Random(1)))
+        before = router.report()
+        self.assertGreater(before["harvested_labels"], 20)  # FAMILY_B genuinely escalates a lot
+
+        result = resolve_from_harvest(router, cost_per_request=0.001, seed=0)
+        self.assertTrue(result.accepted)
+        self.assertEqual(result.escalation_before, 1.0)
+        self.assertLess(result.escalation_after, 1.0)
+        self.assertGreater(result.escalation_drop, 0.0)
+        self.assertIsNotNone(result.router)
+
+        # the measured drop, on FRESH held-out traffic never seen during resolve_from_harvest, against
+        # a control router that never got the new tier -- same traffic, only the stack differs.
+        held_out = _make(300, [FAMILY_A, FAMILY_B], random.Random(2))
+        control = Router.from_solutions([tier0], teacher=_teacher, costs=[0.0001, 0.01])
+        control.serve(held_out)
+        control_report = control.report()
+
+        result.router.serve(held_out)
+        resolved_report = result.router.report()
+
+        control_frontier_share = next(t["share"] for t in control_report["tiers"] if t["tier"] == "frontier")
+        resolved_frontier_share = next(t["share"] for t in resolved_report["tiers"] if t["tier"] == "frontier")
+        self.assertLess(resolved_frontier_share, control_frontier_share)
+
+    def test_no_harvest_is_an_honest_no_op(self):
+        router, _tier0 = _build_router(seed=0)  # never served -> nothing harvested
+        result = resolve_from_harvest(router, cost_per_request=0.001, seed=0)
+        self.assertFalse(result.accepted)
+        self.assertIsNone(result.router)
+        self.assertEqual(result.n_harvested, 0)
+
+    def test_determinism_given_seed(self):
+        router, _tier0 = _build_router(seed=0)
+        router.serve(_make(400, [FAMILY_A, FAMILY_B], random.Random(1)))
+
+        r1 = resolve_from_harvest(router, cost_per_request=0.001, seed=0)
+        r2 = resolve_from_harvest(router, cost_per_request=0.001, seed=0)
+        self.assertEqual(r1.accepted, r2.accepted)
+        self.assertEqual(r1.escalation_after, r2.escalation_after)
+        self.assertEqual(r1.agreement, r2.agreement)
+
+    def test_inserted_tier_sits_just_before_the_frontier(self):
+        router, _tier0 = _build_router(seed=0)
+        router.serve(_make(400, [FAMILY_A, FAMILY_B], random.Random(1)))
+        result = resolve_from_harvest(router, cost_per_request=0.001, name="resolved", seed=0)
+        self.assertTrue(result.accepted)
+        names = [t[0] for t in result.router.tiers]
+        self.assertEqual(names[-1], "frontier")
+        self.assertEqual(names[-2], "resolved")
+        self.assertEqual(len(names), len(router.tiers) + 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mixle/tests/router_harvest_test.py
+++ b/mixle/tests/router_harvest_test.py
@@ -8,6 +8,13 @@ import unittest
 from mixle.task.router import Router, resolve_from_harvest
 from mixle.task.solve import solve
 
+try:
+    import torch  # noqa: F401
+
+    _HAS_TORCH = True
+except ImportError:
+    _HAS_TORCH = False
+
 FAMILY_A = ["free money now", "cheap loans fast", "win cash today"]
 FAMILY_B = ["urgent wire transfer", "account suspended act now", "verify password immediately"]
 HAM = ["meeting at noon", "see you tomorrow", "project update attached", "lunch today", "thanks for the help"]
@@ -35,6 +42,7 @@ def _build_router(seed=0):
     return Router.from_solutions([tier0], teacher=_teacher, costs=[0.0001, 0.01]), tier0
 
 
+@unittest.skipUnless(_HAS_TORCH, "torch not installed")
 class HarvestResolveTest(unittest.TestCase):
     def test_new_tier_measurably_drops_escalation_on_held_out_traffic(self):
         router, tier0 = _build_router(seed=0)


### PR DESCRIPTION
## Summary

Workstream B4-a of the 0.6.3 frontier-capability plan (now unblocked -- PR #3/#4/#5 all merged),
generalizing `Solution.improve()`'s idea (harvest the frontier's answers on escalated inputs,
re-distill, promote only if it verifies better) from a single 2-tier `Cascade` to a whole `Router`
stack.

New in `mixle/task/router.py`:

- `HarvestResolveResult(accepted, n_harvested, escalation_before, escalation_after,
  escalation_drop, agreement, router, tier_name)` -- a receipt, not a bare boolean.
  `escalation_before` is exactly `1.0`: every harvested input, by definition, already escalated all
  the way through the existing tiers.
- `resolve_from_harvest(router, *, cost_per_request, name="resolved", alpha=0.1, holdout=0.25,
  min_drop=0.05, seed=0)`: splits the harvested `(inputs, labels)` into a train/calibration slice
  (never re-calling the frontier -- the labels are already real teacher answers), fits and
  calibrates a new tier the same way `solve()`/`Solution.improve()` do internally, and inserts it
  **only** if its own calibrated escalation rate on the held-out slice drops by at least `min_drop`
  below `1.0` -- i.e. it demonstrably intercepts a real share of what used to always escalate. Too
  little harvested data, or a tier that still escalates almost everything, is an honest no-op
  (`accepted=False`, `router=None`), never a forced insert.

## Test plan

- [x] `mixle/tests/router_harvest_test.py` -- 4 new tests: a tier trained only on one keyword family
      systematically escalates a second family to the frontier; `resolve_from_harvest`'s new tier,
      measured on **fresh held-out traffic** against a control router that never got the tier, shows
      a real drop in the frontier's traffic share (not just on the training-adjacent harvested set);
      an empty-harvest router is an honest no-op; determinism given seed; the new tier is inserted
      directly before `"frontier"` and nowhere else.
- [x] `pytest mixle/tests -k "router or solve or task_distill"` -- 72 passed, 2 pre-existing
      unrelated skips (no regression).
- [x] `ruff check` + `ruff format --check` clean on all three changed files.