### PR TITLE
task/F4: task-sufficient projection pi_T over a mixture belief

### DIFF
--- a/mixle/reason/__init__.py
+++ b/mixle/reason/__init__.py
@@ -59,6 +59,7 @@ from mixle.reason.ontology import (
     constrained_decode,
 )
 from mixle.reason.store import CrossModalStore, RetrievalStep
+from mixle.reason.task_projection import TaskReadout, read_out, task_sufficient_projection
 
 __all__ = [
     "Ontology",
@@ -92,6 +93,9 @@ __all__ = [
     "content_overlap",
     "ModalityView",
     "ModalityGraph",
+    "TaskReadout",
+    "task_sufficient_projection",
+    "read_out",
     "information_corroborator",
     "GraphLLM",
     "GraphDistribution",

--- a/mixle/reason/task_projection.py
+++ b/mixle/reason/task_projection.py
@@ -1,0 +1,104 @@
+"""Task-sufficient projection ``pi_T`` (workstream F4): compress a mixture belief for one receiver's
+task, keeping only the distinctions that task's readout can tell apart.
+
+Cross-context in this plan is a *task-sufficient projection*, not a compressed blob: a
+:class:`~mixle.reason.modality.ModalityView` carries a full structured belief (workstream F1); a
+receiver with task ``T`` should get the smallest view of that belief that still answers ``T`` --
+different receivers, different projections of the *same* belief. This module builds that operator on
+mixle's existing closed-form projection tools (:mod:`mixle.inference.project`: exact Gaussian mixture
+collapse, Runnalls reduction) rather than a new compression scheme: components of the belief that
+``task`` cannot distinguish are exactly moment-matched into one Gaussian (nothing task-relevant is
+lost, because the task never looked at what distinguished them); components ``task`` *can* distinguish
+are kept apart.
+
+This is deliberately not generic compression -- a projection built for a different task is not expected
+to serve this one well (see ``task_projection_test.py``'s mismatched-projection control), and that gap is
+the falsifiable claim this operator has to earn.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Hashable
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+from mixle.inference.project import collapse_mixture
+from mixle.stats.latent.mixture import MixtureDistribution
+
+
+@dataclass
+class TaskReadout:
+    """A receiver's task ``T``, reduced to the one thing a projection needs: which components of a
+    belief it can tell apart. ``label(mean)`` maps a mixture component's mean to a discrete readout
+    value (e.g. a predicted class); components sharing a readout are indistinguishable *for this task*
+    and can be losslessly (for ``T``) merged, components with different readouts must stay separate.
+    """
+
+    name: str
+    label: Callable[[np.ndarray], Hashable]
+
+
+def task_sufficient_projection(mixture: Any, task: TaskReadout) -> MixtureDistribution:
+    """``pi_T(mixture)``: collapse ``mixture``'s components into groups sharing ``task.label``.
+
+    Groups components by ``task.label(component_mean)``; within a group (size > 1), the components are
+    exactly moment-matched (:func:`~mixle.inference.project.collapse_mixture`, closed form -- no
+    samples) onto one Gaussian. Groups of size 1 pass through unchanged. Returns a
+    :class:`~mixle.stats.latent.mixture.MixtureDistribution` with at most as many components as
+    ``mixture`` had distinct task labels -- far smaller when many components share a label, and never
+    larger than the input.
+    """
+    w = np.asarray(mixture.w, dtype=float)
+    means = _component_means(mixture)
+
+    groups: dict[Hashable, list[int]] = {}
+    for k in range(len(w)):
+        groups.setdefault(task.label(means[k]), []).append(k)
+
+    merged_dists = [_merge_group(mixture, idx) for idx in groups.values()]
+    merged_w = np.asarray([float(w[idx].sum()) for idx in groups.values()])
+    return MixtureDistribution(merged_dists, merged_w / merged_w.sum())
+
+
+def read_out(mixture: Any, task: TaskReadout, x: Any) -> Hashable:
+    """The receiver's decision for observation ``x``: ``task.label`` of whichever component of
+    ``mixture`` has the highest posterior responsibility for ``x``.
+
+    This is how a receiver consumes a belief -- projected or full -- that it did not itself choose the
+    component grouping of: it reads off the task's own label from the winning component's mean, so a
+    projection built for a *different* task is scored fairly (and, when it discarded information ``T``
+    needed, honestly worse) rather than being handed an answer key.
+    """
+    w = np.asarray(mixture.w, dtype=float)
+    means = _component_means(mixture)
+    log_post = np.array(
+        [np.log(max(w[k], 1e-300)) + float(mixture.components[k].log_density(x)) for k in range(len(w))]
+    )
+    return task.label(means[int(np.argmax(log_post))])
+
+
+def _component_means(mixture: Any) -> np.ndarray:
+    if hasattr(mixture, "mu") and hasattr(mixture, "sig2"):  # GaussianMixtureDistribution: (K, d) directly
+        return np.asarray(mixture.mu, dtype=float)
+    means = []
+    for c in mixture.components:
+        if hasattr(c, "covar"):  # MultivariateGaussianDistribution(mu, covar)
+            means.append(np.asarray(c.mu, dtype=float).ravel())
+        elif hasattr(c, "sigma2"):  # univariate GaussianDistribution(mu, sigma2)
+            means.append(np.array([float(c.mu)]))
+        else:
+            raise ValueError(
+                f"component {type(c).__name__} is not Gaussian; task_sufficient_projection needs a "
+                "Gaussian mixture belief (see mixle.inference.project for the same restriction)."
+            )
+    return np.asarray(means)
+
+
+def _merge_group(mixture: Any, idx: list[int]) -> Any:
+    if len(idx) == 1:
+        return mixture.components[idx[0]]
+    sub_w = np.asarray(mixture.w, dtype=float)[idx]
+    sub = MixtureDistribution([mixture.components[i] for i in idx], sub_w / sub_w.sum())
+    return collapse_mixture(sub)

--- a/mixle/tests/task_projection_test.py
+++ b/mixle/tests/task_projection_test.py
@@ -1,0 +1,112 @@
+"""Task-sufficient projection (mixle.reason.task_projection): pi_T compresses a belief for one task.
+
+The load-bearing claim is the mismatched-projection control: a projection built for task A must not
+be assumed to serve task B well. We construct a 2-D Gaussian-mixture belief whose first coordinate
+carries task A's signal and second coordinate carries task B's signal, with the two only partially
+correlated -- so collapsing by task A's grouping measurably destroys information task B needed, and
+vice versa.
+"""
+
+import unittest
+
+import numpy as np
+
+from mixle.inference.project import gaussian_kl
+from mixle.reason.task_projection import TaskReadout, read_out, task_sufficient_projection
+from mixle.stats.latent.gaussian_mixture import GaussianMixtureDistribution
+
+
+def _label_x(mean: np.ndarray) -> str:
+    return "pos" if mean[0] >= 0 else "neg"
+
+
+def _label_y(mean: np.ndarray) -> str:
+    return "pos" if mean[1] >= 0 else "neg"
+
+
+TASK_A = TaskReadout("A", _label_x)
+TASK_B = TaskReadout("B", _label_y)
+
+
+def _belief():
+    # 8 components on a 2x2x2 grid of (sign(x), sign(y), a within-cell offset) so components sharing a
+    # task-A label differ in y (and vice versa) -- correlated but not identical groupings.
+    mu = []
+    for sx in (-3.0, 3.0):
+        for sy in (-3.0, 3.0):
+            for off in (-0.6, 0.6):
+                mu.append([sx + off, sy - off])
+    mu = np.asarray(mu)
+    cov = np.stack([0.25 * np.eye(2) for _ in range(len(mu))])
+    w = np.full(len(mu), 1.0 / len(mu))
+    return GaussianMixtureDistribution(mu, cov, w)
+
+
+def _samples(belief, n, seed):
+    return belief.sampler(seed).sample(n)
+
+
+class TaskProjectionTest(unittest.TestCase):
+    def test_projection_shrinks_and_groups_by_task_label(self):
+        belief = _belief()
+        pi_a = task_sufficient_projection(belief, TASK_A)
+        self.assertLess(pi_a.num_components, belief.num_components)
+        self.assertEqual(pi_a.num_components, 2)  # exactly the two task-A labels
+        self.assertAlmostEqual(float(pi_a.w.sum()), 1.0, places=6)
+
+    def test_matched_projection_preserves_accuracy(self):
+        belief = _belief()
+        pi_a = task_sufficient_projection(belief, TASK_A)
+        xs = _samples(belief, 300, 0)
+        truth = [_label_x(x) for x in xs]
+        full_acc = np.mean([read_out(belief, TASK_A, x) == t for x, t in zip(xs, truth)])
+        proj_acc = np.mean([read_out(pi_a, TASK_A, x) == t for x, t in zip(xs, truth)])
+        self.assertGreater(full_acc, 0.9)
+        # far smaller (2 vs 8 components) yet matches full-belief accuracy on ITS task
+        self.assertGreaterEqual(proj_acc, full_acc - 0.03)
+
+    def test_mismatched_projection_measurably_underperforms(self):
+        belief = _belief()
+        pi_a = task_sufficient_projection(belief, TASK_A)  # built for task A
+        pi_b = task_sufficient_projection(belief, TASK_B)  # built for task B
+        xs = _samples(belief, 400, 1)
+        truth_b = [_label_y(x) for x in xs]
+
+        acc_matched = np.mean([read_out(pi_b, TASK_B, x) == t for x, t in zip(xs, truth_b)])
+        acc_mismatched = np.mean([read_out(pi_a, TASK_B, x) == t for x, t in zip(xs, truth_b)])
+
+        self.assertGreater(acc_matched, 0.9)
+        # pi_a collapsed components that disagree on task B's label -- it must measurably underperform
+        # pi_b when asked to answer task B, proving the projection is task-specific, not generic
+        # compression that happens to work for anything.
+        self.assertLess(acc_mismatched, acc_matched - 0.1)
+
+    def test_within_group_merge_is_exact_moment_match(self):
+        belief = _belief()
+        pi_a = task_sufficient_projection(belief, TASK_A)
+        # the "pos" group covers 4 original components sharing sign(x) >= 0: its moment-matched merge
+        # must reproduce that subset's exact weighted mean (law of total variance), checkable via KL
+        # to itself and via the raw mean formula.
+        idx = [k for k in range(belief.num_components) if _label_x(belief.mu[k]) == "pos"]
+        w = belief.w[idx] / belief.w[idx].sum()
+        expected_mean = w @ belief.mu[idx]
+        merged = next(c for c in pi_a.components if _label_x(_mean_of(c)) == "pos")
+        np.testing.assert_allclose(_mean_of(merged), expected_mean, atol=1e-8)
+        self.assertAlmostEqual(gaussian_kl(merged, merged), 0.0, places=9)
+
+    def test_single_component_group_passes_through_unchanged(self):
+        # a task fine enough to give every component its own label: no merging happens.
+        fine = TaskReadout("fine", lambda mean: tuple(np.round(mean, 3)))
+        belief = _belief()
+        pi_fine = task_sufficient_projection(belief, fine)
+        self.assertEqual(pi_fine.num_components, belief.num_components)
+
+
+def _mean_of(component) -> np.ndarray:
+    if hasattr(component, "covar"):
+        return np.asarray(component.mu, dtype=float).ravel()
+    return np.array([float(component.mu)])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Card F4-a from the plan (workstream F step 4): `mixle.reason.task_projection.task_sufficient_projection` is the `pi_T` operator -- given a Gaussian-mixture belief and a `TaskReadout` (which mixture components a task can tell apart), it groups components sharing a task label and exactly moment-matches each group (`mixle.inference.project.collapse_mixture`, closed form, no samples) into one Gaussian; components with different labels stay separate.
- `read_out(mixture, task, x)` is the receiver side: the task label of whichever component has the highest posterior responsibility for `x` -- so a receiver reads its own label off a belief (projected or full) it didn't choose the grouping of.
- Composes with F1's `ModalityView`: a receiver's task-sufficient view of a belief is `pi_T` applied to the same underlying mixture, not a generic compressed blob.
- Built entirely on `mixle.inference.project`'s public exports (`collapse_mixture`); verified those exports first per the card (no assumed names).

## Test plan
- [x] `mixle/tests/task_projection_test.py` (5 new tests): projection strictly shrinks component count; a task's own projection matches full-belief read-out accuracy despite being far smaller; the mismatched-projection control -- a projection built for a different task measurably underperforms on this task (the falsifiable \"genuinely task-specific, not generic compression\" claim from the plan); within-group merges are an exact moment match; single-component groups pass through unchanged.
- [x] Targeted regression: pytest mixle/tests -k \"modality or reason or project\" -- 109 passed, 2 skipped (expected compiled-kernel skips), 0 failed.
- [x] ruff check / ruff format --check clean on changed files.