### PR TITLE
task/A4: torsion / twisted composition (research spike)

### DIFF
--- a/mixle/inference/__init__.py
+++ b/mixle/inference/__init__.py
@@ -281,6 +281,13 @@ from mixle.inference.target import (
     rhat_max,
     split_rhat,
 )
+from mixle.inference.torsion import (
+    CyclicGroup,
+    TwistedMixtureResult,
+    fit_independent_mixtures,
+    fit_twisted_mixture,
+    independent_log_density,
+)
 
 # epistemic / aleatoric uncertainty decomposition for any predictive (generalizes KG BALD)
 from mixle.inference.uncertainty import (
@@ -385,6 +392,12 @@ __all__ = [
     # synthesize() -- a dataset factory: sample, label, keep only what verifies
     "synthesize",
     "Dataset",
+    # torsion (A4) -- twisted composition: mixture components sharing one base density modulo a group element
+    "CyclicGroup",
+    "TwistedMixtureResult",
+    "fit_twisted_mixture",
+    "fit_independent_mixtures",
+    "independent_log_density",
     # create() -- data (+ budget/device) to a certified model artifact
     "create",
     "CreatedModel",

--- a/mixle/inference/torsion.py
+++ b/mixle/inference/torsion.py
@@ -1,0 +1,137 @@
+"""Torsion / twisted composition (workstream A4, research spike): mixture components that glue to ONE
+shared base density via a declared group action, instead of each independently learning a density from
+scratch on its own slice of data.
+
+The plan's framing: "compositions whose local statistical factors glue with a non-trivial twist -- character/
+phase twists in periodic or sequential data, mixture components sharing a base density modulo a group
+element -- so structure that factors locally does not trivialize globally." Concretely: :class:`CyclicGroup`
+acts on a periodic coordinate by rotation of its ``(cos, sin)`` embedding (an exact, Jacobian-1 change of
+variables, so a fitted embedding density scores identically whichever group element aligned a point into it);
+:func:`fit_twisted_mixture` pools every group's data into ONE shared base density after undoing each group's
+twist, so the shared density is fit on the union -- effectively ``|groups|`` times the data for the same
+parameter count as fitting one group alone.
+
+Kill criterion (stated up front, per the plan's non-goals): if the twisted (shared-base) model does not beat
+independently-fit per-group models at matched per-component capacity on held-out per-group log-likelihood in
+the small-sample regime, this is a negative result -- record it in ``notes/a4-torsion-negative.md`` and keep
+the untwisted, independent-per-group baseline as the default. This module ships either way; a negative verdict
+means "don't reach for this by default," not "delete the machinery."
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class CyclicGroup:
+    """Z_``order`` acting on a periodic real-valued coordinate of period ``period`` by rotation.
+
+    Each group element ``k`` in ``{0, ..., order - 1}`` is realized concretely as a rotation of the
+    coordinate's ``(cos, sin)`` embedding by angle ``2*pi*k/order`` -- an orthogonal (norm- and
+    Jacobian-preserving) transform, so composing group elements is exactly addition mod ``order``
+    (:meth:`compose`), and a density fit on the embedding is unaffected by which element aligned a point into
+    it (the twist is undone before scoring, not baked into the density).
+    """
+
+    order: int
+    period: float = 1.0
+
+    def embed(self, x: Sequence[float]) -> np.ndarray:
+        """The periodic coordinate's ``(cos, sin)`` embedding, shape ``(..., 2)``."""
+        theta = 2.0 * np.pi * np.asarray(x, dtype=np.float64) / self.period
+        return np.stack([np.cos(theta), np.sin(theta)], axis=-1)
+
+    def _rotation(self, k: int) -> np.ndarray:
+        angle = 2.0 * np.pi * (k % self.order) / self.order
+        c, s = np.cos(angle), np.sin(angle)
+        return np.array([[c, -s], [s, c]])
+
+    def act(self, embedded: np.ndarray, k: int) -> np.ndarray:
+        """Rotate an ``(..., 2)`` embedding by group element ``k`` (the forward twist)."""
+        return np.asarray(embedded, dtype=np.float64) @ self._rotation(k).T
+
+    def inverse_act(self, embedded: np.ndarray, k: int) -> np.ndarray:
+        """Undo group element ``k``'s twist -- ``act(inverse_act(v, k), k) == v``."""
+        return self.act(embedded, -k)
+
+    def compose(self, k1: int, k2: int) -> int:
+        """The group element equivalent to applying ``k1`` then ``k2`` -- addition mod ``order``."""
+        return (k1 + k2) % self.order
+
+
+@dataclass
+class TwistedMixtureResult:
+    """A single shared base density plus the group whose elements twist it into each group's local factor."""
+
+    base_density: Any
+    group: CyclicGroup
+
+    def log_density(self, x: Sequence[float], k: int) -> np.ndarray:
+        """``log p(x | group=k)``: undo ``k``'s twist, then score under the shared base density."""
+        aligned = self.group.inverse_act(self.group.embed(x), k)
+        enc = self.base_density.dist_to_encoder().seq_encode([row for row in aligned])
+        return np.asarray(self.base_density.seq_log_density(enc), dtype=np.float64)
+
+
+def _fit_density(rows: list[np.ndarray], *, n_components: int, seed: int, max_its: int) -> Any:
+    import mixle.stats as st
+    from mixle.inference import optimize
+
+    est = st.MixtureEstimator([st.DiagonalGaussianEstimator(dim=2)] * n_components)
+    return optimize(rows, est, max_its=max_its, rng=np.random.RandomState(seed), out=None)
+
+
+def fit_twisted_mixture(
+    group: CyclicGroup,
+    data_by_group: dict[int, Sequence[float]],
+    *,
+    n_components: int = 2,
+    seed: int = 0,
+    max_its: int = 50,
+) -> TwistedMixtureResult:
+    """Fit ONE base density on every group's data pooled together after undoing each group's twist.
+
+    ``data_by_group`` maps a group element ``k`` to that group's (small) sample of the periodic coordinate.
+    Every sample is embedded and rotated back by its own group's ``inverse_act`` before pooling -- so the
+    fitted ``n_components``-component density sees ``sum(len(v) for v in data_by_group.values())`` points,
+    not just one group's slice, for the same parameter count as :func:`fit_independent_mixtures` spends on a
+    SINGLE group.
+    """
+    rows: list[np.ndarray] = []
+    for k, xs in data_by_group.items():
+        aligned = group.inverse_act(group.embed(xs), k)
+        rows.extend(list(aligned))
+    return TwistedMixtureResult(_fit_density(rows, n_components=n_components, seed=seed, max_its=max_its), group)
+
+
+def fit_independent_mixtures(
+    group: CyclicGroup,
+    data_by_group: dict[int, Sequence[float]],
+    *,
+    n_components: int = 2,
+    seed: int = 0,
+    max_its: int = 50,
+) -> dict[int, Any]:
+    """The untwisted baseline: one independently-fit ``n_components``-component density per group.
+
+    Same per-group parameter count as the shared base density in :func:`fit_twisted_mixture`, but ``|groups|``
+    times the total parameters overall, and each fit sees only its own group's (small) sample -- the
+    comparison :func:`fit_twisted_mixture` is measured against.
+    """
+    out: dict[int, Any] = {}
+    for k, xs in data_by_group.items():
+        rows = list(group.embed(xs))
+        out[k] = _fit_density(rows, n_components=n_components, seed=seed + int(k), max_its=max_its)
+    return out
+
+
+def independent_log_density(models: dict[int, Any], group: CyclicGroup, x: Sequence[float], k: int) -> np.ndarray:
+    """Score ``x`` under group ``k``'s independently-fit density (the baseline sibling of
+    :meth:`TwistedMixtureResult.log_density`)."""
+    enc = models[k].dist_to_encoder().seq_encode([row for row in group.embed(x)])
+    return np.asarray(models[k].seq_log_density(enc), dtype=np.float64)

--- a/mixle/tests/torsion_test.py
+++ b/mixle/tests/torsion_test.py
@@ -1,0 +1,106 @@
+"""Torsion / twisted composition (mixle.inference.torsion), CARD A4-a -- research spike, sibling of A3-a.
+
+Kill criterion (stated up front, per the card): if the twisted (shared-base) model does not beat
+independently-fit per-group models on held-out per-group log-likelihood in the small-sample regime, this is a
+negative result to record in notes/a4-torsion-negative.md, not to paper over.
+"""
+
+import unittest
+
+import numpy as np
+
+from mixle.inference.torsion import (
+    CyclicGroup,
+    fit_independent_mixtures,
+    fit_twisted_mixture,
+    independent_log_density,
+)
+
+
+def _cluster_angles_deg():
+    # two fixed clusters on the period-360 circle -- the shared base pattern every group is a rotation of
+    return [40.0, 200.0]
+
+
+def _make_group_samples(group: CyclicGroup, *, n_per_group=10, noise=6.0, seed=0):
+    """Real cyclic structure: every group k's sample is a noisy draw from ONE shared base pattern (two
+    von-Mises-like clusters), rotated by k group elements -- so the groups literally differ only by a twist."""
+    rng = np.random.RandomState(seed)
+    base_angles = _cluster_angles_deg()
+    train, test = {}, {}
+    for k in range(group.order):
+        shift_deg = k * (group.period / group.order)
+
+        def draw(n, rng=rng, shift_deg=shift_deg):
+            centers = rng.choice(base_angles, size=n)
+            return (centers + shift_deg + rng.normal(0, noise, size=n)) % group.period
+
+        train[k] = draw(n_per_group)
+        test[k] = draw(50)
+    return train, test
+
+
+class CyclicGroupTest(unittest.TestCase):
+    def test_twist_survives_composition(self):
+        # the load-bearing algebraic check: composing two group elements and applying once must match
+        # applying them one after another -- the twist is a genuine homomorphism, not an ad hoc transform
+        group = CyclicGroup(order=6, period=360.0)
+        rng = np.random.RandomState(0)
+        x = rng.uniform(0, 360.0, size=20)
+        embedded = group.embed(x)
+        for k1 in range(group.order):
+            for k2 in range(group.order):
+                sequential = group.act(group.act(embedded, k1), k2)
+                combined = group.act(embedded, group.compose(k1, k2))
+                np.testing.assert_allclose(sequential, combined, atol=1e-9)
+
+    def test_inverse_act_undoes_the_twist(self):
+        group = CyclicGroup(order=5, period=360.0)
+        rng = np.random.RandomState(1)
+        x = rng.uniform(0, 360.0, size=15)
+        embedded = group.embed(x)
+        for k in range(group.order):
+            roundtrip = group.inverse_act(group.act(embedded, k), k)
+            np.testing.assert_allclose(roundtrip, embedded, atol=1e-9)
+
+    def test_embedding_is_norm_preserving(self):
+        # act() must be an orthogonal transform (exact Jacobian-1), or scoring through it would silently
+        # distort densities -- this is what makes log_density comparable across group elements at all
+        group = CyclicGroup(order=4, period=360.0)
+        embedded = group.embed(np.array([10.0, 200.0, 359.0]))
+        rotated = group.act(embedded, 3)
+        np.testing.assert_allclose(np.linalg.norm(embedded, axis=-1), np.linalg.norm(rotated, axis=-1), atol=1e-9)
+
+
+class TwistedMixtureEfficiencyTest(unittest.TestCase):
+    def test_twisted_shared_base_beats_independent_per_group_in_small_sample_regime(self):
+        group = CyclicGroup(order=6, period=360.0)
+        train, test = _make_group_samples(group, n_per_group=10, seed=2)
+
+        twisted = fit_twisted_mixture(group, train, n_components=2, seed=0, max_its=100)
+        independent = fit_independent_mixtures(group, train, n_components=2, seed=0, max_its=100)
+
+        twisted_ll = np.mean([np.mean(twisted.log_density(test[k], k)) for k in range(group.order)])
+        independent_ll = np.mean(
+            [np.mean(independent_log_density(independent, group, test[k], k)) for k in range(group.order)]
+        )
+
+        # KILL CRITERION: record a negative result if the twisted shared-base model does not win here.
+        self.assertGreater(
+            twisted_ll,
+            independent_ll,
+            f"A4 kill criterion failed: twisted={twisted_ll:.3f} <= independent={independent_ll:.3f}; "
+            "record the negative result in notes/a4-torsion-negative.md",
+        )
+
+    def test_deterministic_given_seed(self):
+        group = CyclicGroup(order=4, period=360.0)
+        train, _test = _make_group_samples(group, n_per_group=8, seed=3)
+        a = fit_twisted_mixture(group, train, n_components=2, seed=7, max_its=40)
+        b = fit_twisted_mixture(group, train, n_components=2, seed=7, max_its=40)
+        probe = [10.0, 100.0, 250.0]
+        np.testing.assert_allclose(a.log_density(probe, 0), b.log_density(probe, 0), atol=1e-9)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Card A4-a (workstream A4), a timeboxed research spike, sibling of A3-a (quotient leaf), independent of it.
- `mixle/inference/torsion.py`: `CyclicGroup` (Z_K acting on a periodic coordinate by rotation of its `(cos, sin)` embedding -- an exact, Jacobian-1 change of variables) + `fit_twisted_mixture` (pools every group's data into ONE shared base density after undoing each group's twist) vs. `fit_independent_mixtures` (the untwisted baseline: one independently-fit density per group).
- This is the plan's framing verbatim: "mixture components sharing a base density modulo a group element."

**Kill criterion (stated before starting, per the card):** the twisted shared-base model must beat independently-fit per-group models on held-out per-group log-likelihood in the small-sample regime, or this is a negative result.

**Result: POSITIVE.** On a synthetic-but-genuinely-cyclic dataset (6 groups, 10 samples each, all sharing one two-cluster base pattern related by a known rotation), the twisted shared-base density measurably beats 6 independently-fit densities on held-out log-likelihood -- pooling via the group action gives it ~6x the effective sample size at the same per-component parameter count as any single independent fit.

## Test plan
- [x] `mixle/tests/torsion_test.py`:
  - `test_twist_survives_composition` -- composing two group elements and applying once matches applying them sequentially (the twist is a genuine homomorphism), checked over every pair in Z_6.
  - `test_inverse_act_undoes_the_twist`, `test_embedding_is_norm_preserving` -- the group action is exactly invertible and orthogonal (log-densities are comparable across group elements without distortion).
  - `test_twisted_shared_base_beats_independent_per_group_in_small_sample_regime` -- the kill-criterion check itself.
  - `test_deterministic_given_seed`.
- [x] `.venv/bin/python -m pytest mixle/tests/torsion_test.py -q` -- 5 passed.
- [x] `ruff check` / `ruff format --check` on changed files -- clean.
- [x] `python -c "import mixle.inference as inf; inf.CyclicGroup, inf.fit_twisted_mixture, ..."` -- new exports load cleanly.