### PR TITLE
CARD COLLAPSE-a: shared collapse monitor for self-improvement loops

### DIFF
--- a/mixle/task/__init__.py
+++ b/mixle/task/__init__.py
@@ -30,6 +30,12 @@ from mixle.task.artifact import (
 )
 from mixle.task.calibrate import ESCALATE, CalibratedTaskModel
 from mixle.task.cascade import Cascade, CascadeStats
+from mixle.task.collapse import (
+    CollapseVerdict,
+    collapse_monitor,
+    distinct_count_diversity,
+    entropy_diversity,
+)
 from mixle.task.density import DensityGate
 from mixle.task.design import DesignedModel, design_model, spec_to_estimator
 from mixle.task.distill import (
@@ -128,6 +134,10 @@ __all__ = [
     "CallableLLM",
     "Cascade",
     "CascadeStats",
+    "CollapseVerdict",
+    "collapse_monitor",
+    "distinct_count_diversity",
+    "entropy_diversity",
     "CostModel",
     "DensityGate",
     "DesignModel",

--- a/mixle/task/collapse.py
+++ b/mixle/task/collapse.py
@@ -1,0 +1,98 @@
+"""``collapse_monitor`` -- the shared collapse-detection utility for self-improvement loops.
+
+Every self-improvement round (an amplification round in AMPLIFY-a, a probing-policy episode in
+PROBE-a, a diagnosis-directed correction in REFINE-a) claims to be getting better. This is the ONE
+check that claim must pass, built once and reused rather than reimplemented per loop: across rounds,
+the held-out VERIFIED score must be non-decreasing, and the proposal diversity must not be shrinking
+-- a loop that improves its score by collapsing onto a few candidates (mode collapse) is not a genuine
+improvement, it is overfitting to the verifier.
+
+    verdict = collapse_monitor(history)
+    verdict.ok                 # True iff both checks hold across every round
+    verdict.reason             # None, or "score_decreased" / "diversity_shrunk" (which check failed)
+
+``history`` is one entry per round: a dict with the round's held-out verified score and its pool of
+candidates (or a precomputed diversity number). Reused verbatim by AMPLIFY-a, PROBE-a, and REFINE-a --
+none of them reimplement this.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+
+def distinct_count_diversity(candidates: Sequence[Any]) -> float:
+    """Diversity proxy: the number of distinct candidates (by ``str`` identity) in the round's pool."""
+    return float(len({str(c) for c in candidates}))
+
+
+def entropy_diversity(candidates: Sequence[Any]) -> float:
+    """Diversity proxy: Shannon entropy (nats) of the candidate-frequency distribution in the round's pool."""
+    counts: dict[str, int] = {}
+    for c in candidates:
+        key = str(c)
+        counts[key] = counts.get(key, 0) + 1
+    n = sum(counts.values())
+    if n == 0:
+        return 0.0
+    return float(-sum((k / n) * math.log(k / n) for k in counts.values()))
+
+
+@dataclass
+class CollapseVerdict:
+    """The result of :func:`collapse_monitor`: ``ok`` plus which check failed, and the raw series."""
+
+    ok: bool
+    reason: str | None  # None if ok; else "score_decreased" or "diversity_shrunk"
+    scores: list[float] = field(default_factory=list)
+    diversities: list[float] = field(default_factory=list)
+    failed_round: int | None = None  # index of the first round where the failing check tripped
+
+
+def collapse_monitor(
+    history: Sequence[Mapping[str, Any]],
+    *,
+    score_key: str = "score",
+    candidates_key: str = "candidates",
+    diversity_fn: Callable[[Sequence[Any]], float] = distinct_count_diversity,
+    score_tol: float = 0.0,
+    diversity_tol: float = 0.0,
+) -> CollapseVerdict:
+    """Check a self-improvement round history for collapse: score non-decreasing AND diversity not shrinking.
+
+    Each entry of ``history`` supplies the round's held-out verified score under ``score_key`` and either
+    its candidate pool under ``candidates_key`` (diversity computed via ``diversity_fn``) or, when
+    ``candidates_key`` is absent, a precomputed diversity number directly under ``"diversity"``.
+    ``score_tol``/``diversity_tol`` allow a small, explicitly-named amount of round-to-round noise before
+    a decrease/shrink counts as a real regression (0.0 = strict non-decreasing). The first round to violate
+    either check ends the scan -- ``reason`` names which check failed, ``failed_round`` where.
+    """
+    scores: list[float] = []
+    diversities: list[float] = []
+    reason: str | None = None
+    failed_round: int | None = None
+
+    for i, round_ in enumerate(history):
+        score = float(round_[score_key])
+        if candidates_key in round_:
+            diversity = float(diversity_fn(list(round_[candidates_key])))
+        else:
+            diversity = float(round_["diversity"])
+        scores.append(score)
+        diversities.append(diversity)
+
+        if reason is None and i > 0:
+            if scores[i] < scores[i - 1] - score_tol:
+                reason, failed_round = "score_decreased", i
+            elif diversities[i] < diversities[i - 1] - diversity_tol:
+                reason, failed_round = "diversity_shrunk", i
+
+    return CollapseVerdict(
+        ok=reason is None, reason=reason, scores=scores, diversities=diversities, failed_round=failed_round
+    )
+
+
+__all__ = ["CollapseVerdict", "collapse_monitor", "distinct_count_diversity", "entropy_diversity"]

--- a/mixle/tests/collapse_monitor_test.py
+++ b/mixle/tests/collapse_monitor_test.py
@@ -1,0 +1,126 @@
+"""collapse_monitor: the shared collapse-detection utility for self-improvement loops (CARD COLLAPSE-a).
+
+A self-improvement round claims to be getting better; this is the check that claim must pass: held-out
+verified score non-decreasing AND proposal diversity not shrinking, across every round.
+"""
+
+import unittest
+
+from mixle.task.collapse import (
+    CollapseVerdict,
+    collapse_monitor,
+    distinct_count_diversity,
+    entropy_diversity,
+)
+
+
+def _round(score, candidates):
+    return {"score": score, "candidates": candidates}
+
+
+class ImprovingTrajectoryTest(unittest.TestCase):
+    """A synthetic genuinely-improving trajectory: score rises, diversity holds -- verdict is ok."""
+
+    def test_improving_and_diverse_trajectory_is_ok(self):
+        history = [
+            _round(0.50, ["a", "b", "c", "d"]),
+            _round(0.62, ["a", "e", "f", "g"]),
+            _round(0.71, ["b", "h", "i", "j"]),
+            _round(0.80, ["c", "k", "l", "m"]),
+        ]
+        verdict = collapse_monitor(history)
+        self.assertIsInstance(verdict, CollapseVerdict)
+        self.assertTrue(verdict.ok)
+        self.assertIsNone(verdict.reason)
+        self.assertIsNone(verdict.failed_round)
+        self.assertEqual(verdict.scores, [0.50, 0.62, 0.71, 0.80])
+        self.assertEqual(verdict.diversities, [4.0, 4.0, 4.0, 4.0])
+
+    def test_flat_score_within_tolerance_is_ok(self):
+        history = [_round(0.80, ["a", "b"]), _round(0.799, ["c", "d"]), _round(0.801, ["e", "f"])]
+        verdict = collapse_monitor(history, score_tol=0.01)
+        self.assertTrue(verdict.ok)
+
+
+class ModeCollapseTest(unittest.TestCase):
+    """A synthetic mode-collapsing trajectory: score rises only because the pool shrank to a few winners."""
+
+    def test_shrinking_diversity_is_flagged_even_as_score_rises(self):
+        history = [
+            _round(0.50, ["a", "b", "c", "d", "e", "f"]),
+            _round(0.65, ["a", "a", "a", "b", "c", "d"]),  # pool narrowing
+            _round(0.90, ["a", "a", "a", "a", "a", "a"]),  # fully collapsed onto one candidate
+        ]
+        verdict = collapse_monitor(history)
+        self.assertFalse(verdict.ok)
+        self.assertEqual(verdict.reason, "diversity_shrunk")
+        self.assertEqual(verdict.failed_round, 1)  # the FIRST round the shrink is visible
+
+    def test_score_decrease_is_flagged_regardless_of_diversity(self):
+        history = [
+            _round(0.80, ["a", "b", "c"]),
+            _round(0.60, ["d", "e", "f"]),  # genuine regression, diversity fine
+        ]
+        verdict = collapse_monitor(history)
+        self.assertFalse(verdict.ok)
+        self.assertEqual(verdict.reason, "score_decreased")
+        self.assertEqual(verdict.failed_round, 1)
+
+    def test_score_check_is_reported_before_diversity_check_in_the_same_round(self):
+        """When both regress in the same round, score_decreased is the named cause (checked first)."""
+        history = [
+            _round(0.80, ["a", "b", "c", "d"]),
+            _round(0.50, ["a", "a", "a", "a"]),  # both score down AND diversity down
+        ]
+        verdict = collapse_monitor(history)
+        self.assertEqual(verdict.reason, "score_decreased")
+
+
+class PrecomputedDiversityTest(unittest.TestCase):
+    def test_accepts_a_precomputed_diversity_value_without_a_candidates_key(self):
+        history = [
+            {"score": 0.5, "diversity": 5.0},
+            {"score": 0.6, "diversity": 5.0},
+            {"score": 0.7, "diversity": 2.0},  # shrinks
+        ]
+        verdict = collapse_monitor(history)
+        self.assertFalse(verdict.ok)
+        self.assertEqual(verdict.reason, "diversity_shrunk")
+
+
+class DiversityFunctionsTest(unittest.TestCase):
+    def test_distinct_count_diversity(self):
+        self.assertEqual(distinct_count_diversity(["a", "a", "b", "c"]), 3.0)
+        self.assertEqual(distinct_count_diversity([]), 0.0)
+
+    def test_entropy_diversity_is_zero_for_a_single_repeated_candidate(self):
+        self.assertEqual(entropy_diversity(["a", "a", "a"]), 0.0)
+
+    def test_entropy_diversity_is_higher_for_a_uniform_spread(self):
+        uniform = entropy_diversity(["a", "b", "c", "d"])
+        skewed = entropy_diversity(["a", "a", "a", "b"])
+        self.assertGreater(uniform, skewed)
+
+    def test_collapse_monitor_can_use_entropy_diversity(self):
+        history = [
+            _round(0.5, ["a", "b", "c", "d"]),
+            _round(0.6, ["a", "a", "a", "b"]),  # entropy drops even though count stays 2
+        ]
+        verdict = collapse_monitor(history, diversity_fn=entropy_diversity)
+        self.assertFalse(verdict.ok)
+        self.assertEqual(verdict.reason, "diversity_shrunk")
+
+
+class EdgeCasesTest(unittest.TestCase):
+    def test_single_round_history_is_trivially_ok(self):
+        verdict = collapse_monitor([_round(0.5, ["a"])])
+        self.assertTrue(verdict.ok)
+
+    def test_empty_history_is_trivially_ok(self):
+        verdict = collapse_monitor([])
+        self.assertTrue(verdict.ok)
+        self.assertEqual(verdict.scores, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
CARD COLLAPSE-a from `notes/0.6.3-execution-playbook.md`. A shared utility every self-improvement
round (AMPLIFY-a, PROBE-a, REFINE-a) reuses rather than reimplementing: across rounds, the held-out
verified score must be non-decreasing AND proposal diversity must not shrink. A loop that improves
its score by collapsing onto a few candidates is overfitting to the verifier, not genuinely
improving.

- **New** `collapse_monitor(history) -> CollapseVerdict`: `ok`/`reason` (`"score_decreased"` or
  `"diversity_shrunk"`) plus which round first violated it.
- **New** `distinct_count_diversity`/`entropy_diversity`: two pluggable diversity proxies.
- Exported from `mixle.task`.

## Test plan
- [x] 12 tests in `collapse_monitor_test.py`: improving+diverse trajectory is ok; mode-collapse
      (score rises only as the pool narrows) is flagged `diversity_shrunk` at the first round it's
      visible; a genuine regression is flagged `score_decreased`; precomputed-diversity input path;
      both diversity functions.
- [x] Narrow sweep: `collapse_monitor_test`, `task_cascade_test`, `task_calibrate_test` = 19 passed.
- [x] `ruff check` / `ruff format --check` clean.