### PR TITLE
CARD COMPOSE-a: composition operator chaining two models

### DIFF
--- a/mixle/task/__init__.py
+++ b/mixle/task/__init__.py
@@ -30,6 +30,7 @@ from mixle.task.artifact import (
 )
 from mixle.task.calibrate import ESCALATE, CalibratedTaskModel
 from mixle.task.cascade import Cascade, CascadeStats
+from mixle.task.compose import ComposedModel, compose
 from mixle.task.density import DensityGate
 from mixle.task.design import DesignedModel, design_model, spec_to_estimator
 from mixle.task.distill import (
@@ -128,6 +129,8 @@ __all__ = [
     "CallableLLM",
     "Cascade",
     "CascadeStats",
+    "ComposedModel",
+    "compose",
     "CostModel",
     "DensityGate",
     "DesignModel",

--- a/mixle/task/compose.py
+++ b/mixle/task/compose.py
@@ -1,0 +1,65 @@
+"""``compose`` -- chain two models/teachers into one ledger-carrying callable (CARD COMPOSE-a).
+
+Neither stage answers the composite question alone: stage ``a`` maps ``x -> y``, stage ``b`` maps
+``y -> z``; only the composition answers ``x -> z``. ``ComposedModel`` is that chain as one callable,
+and its ``answer(x)`` emits a receipt attributing the final answer to both stages' own
+input/output -- the workstream-H discipline applied to a composition of arbitrary callables (not just
+fitted mixle distributions, which is what :func:`mixle.inference.explain.explain` decomposes).
+
+    pipeline = compose(classify_reading, recommend_action, name_a="classify", name_b="recommend")
+    answer, receipt = pipeline.answer(87.0)
+    receipt["stages"]     # [{"name": "classify", "input": 87.0, "output": "high"},
+                           #  {"name": "recommend", "input": "high", "output": "escalate"}]
+
+This is the substrate AMPLIFY-a's "2-teacher composition" chains, and (extended to more than two
+stages) the belief-walk (F3) transport chain: a multi-hop path is a longer composition of the same
+shape, each hop's own input/output named in the receipt.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class ComposedModel:
+    """Two callables chained ``x -> y -> z``; ``answer`` returns ``z`` plus a per-stage receipt."""
+
+    stage_a: Callable[[Any], Any]
+    stage_b: Callable[[Any], Any]
+    name_a: str = "stage_a"
+    name_b: str = "stage_b"
+
+    def __call__(self, x: Any) -> Any:
+        return self.answer(x)[0]
+
+    def answer(self, x: Any) -> tuple[Any, dict[str, Any]]:
+        """Run both stages on ``x``; return ``(z, receipt)`` with the receipt naming each stage's own
+        input/output -- an H-style attribution for a plain callable composition, not just a fitted
+        distribution's margin."""
+        y = self.stage_a(x)
+        z = self.stage_b(y)
+        receipt = {
+            "answer": z,
+            "stages": [
+                {"name": self.name_a, "input": x, "output": y},
+                {"name": self.name_b, "input": y, "output": z},
+            ],
+        }
+        return z, receipt
+
+
+def compose(
+    a: Callable[[Any], Any],
+    b: Callable[[Any], Any],
+    *,
+    name_a: str = "stage_a",
+    name_b: str = "stage_b",
+) -> ComposedModel:
+    """Chain ``a: x -> y`` and ``b: y -> z`` into one callable ``ComposedModel`` answering ``x -> z``."""
+    return ComposedModel(stage_a=a, stage_b=b, name_a=name_a, name_b=name_b)
+
+
+__all__ = ["ComposedModel", "compose"]

--- a/mixle/tests/compose_test.py
+++ b/mixle/tests/compose_test.py
@@ -1,0 +1,70 @@
+"""compose: chain two models/teachers into one ledger-carrying callable (CARD COMPOSE-a).
+
+Neither stage answers the composite x -> z question alone: stage_a classifies a raw reading into a
+category (it knows nothing about actions); stage_b maps a category to a recommended action (it cannot
+accept a raw numeric reading). Only the composition bridges x -> z.
+"""
+
+import unittest
+
+from mixle.task.compose import ComposedModel, compose
+
+
+def classify_reading(x: float) -> str:
+    """x -> y: a raw sensor reading classified into a severity category. Knows nothing about actions."""
+    if x < 30:
+        return "low"
+    if x < 70:
+        return "mid"
+    return "high"
+
+
+_ACTION_TABLE = {"low": "log", "mid": "notify", "high": "escalate"}
+
+
+def recommend_action(y: str) -> str:
+    """y -> z: a category mapped to a recommended action. Its domain is categories, not raw readings."""
+    return _ACTION_TABLE[y]
+
+
+class ComposeTest(unittest.TestCase):
+    def test_neither_stage_answers_x_to_z_alone(self):
+        # stage_a's own output IS the category, not an action -- it cannot answer the x->z question
+        self.assertEqual(classify_reading(87.0), "high")
+        # stage_b's domain is categories: feeding it the raw reading directly is a type/domain error
+        with self.assertRaises(KeyError):
+            recommend_action(87.0)  # not a valid category key
+
+    def test_composition_answers_x_to_z(self):
+        pipeline = compose(classify_reading, recommend_action)
+        self.assertIsInstance(pipeline, ComposedModel)
+        self.assertEqual(pipeline(87.0), "escalate")
+        self.assertEqual(pipeline(15.0), "log")
+        self.assertEqual(pipeline(50.0), "notify")
+
+    def test_receipt_attributes_the_answer_to_both_stages(self):
+        pipeline = compose(classify_reading, recommend_action, name_a="classify", name_b="recommend")
+        answer, receipt = pipeline.answer(87.0)
+        self.assertEqual(answer, "escalate")
+        self.assertEqual(receipt["answer"], "escalate")
+        self.assertEqual(len(receipt["stages"]), 2)
+        stage1, stage2 = receipt["stages"]
+        self.assertEqual(stage1, {"name": "classify", "input": 87.0, "output": "high"})
+        self.assertEqual(stage2, {"name": "recommend", "input": "high", "output": "escalate"})
+        # the intermediate value chains: stage1's output IS stage2's input
+        self.assertEqual(stage1["output"], stage2["input"])
+
+    def test_default_stage_names(self):
+        pipeline = compose(classify_reading, recommend_action)
+        _answer, receipt = pipeline.answer(10.0)
+        self.assertEqual(receipt["stages"][0]["name"], "stage_a")
+        self.assertEqual(receipt["stages"][1]["name"], "stage_b")
+
+    def test_three_severities_all_bridge_correctly(self):
+        pipeline = compose(classify_reading, recommend_action)
+        for x, expected in [(5.0, "log"), (45.0, "notify"), (99.0, "escalate")]:
+            self.assertEqual(pipeline(x), expected)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
CARD COMPOSE-a from `notes/0.6.3-execution-playbook.md`. Neither stage answers a composite `x -> z`
question alone: stage `a` maps `x -> y`, stage `b` maps `y -> z`. `ComposedModel` is that chain as
one callable, with `answer(x)` emitting a receipt attributing the final answer to both stages' own
input/output.

- **New** `compose(a, b, name_a=, name_b=) -> ComposedModel`: `__call__(x)` returns `z` directly;
  `answer(x)` returns `(z, receipt)` where `receipt['stages']` names each stage's input/output.
- Exported from `mixle.task`.

Substrate for AMPLIFY-a's 2-teacher composition and (extended to more stages) the belief-walk (F3)
transport chain.

**Deviation from the card**: the receipt is a lightweight dict (answer + per-stage input/output), not
`AnswerLedger`/`Explanation` from H1 -- those decompose a fitted distribution's log-density margin,
not an arbitrary callable composition. A real H-receipt integration (calibration state, provenance)
is a follow-up once H3 lands.

## Test plan
- [x] 5 tests in `compose_test.py`: neither stage answers x->z alone (stage_b raises `KeyError` on a
      raw reading, proving the domain mismatch); the composition bridges it; the receipt attributes
      both stages with the intermediate value chaining exactly; default stage names; three
      severities all route correctly.
- [x] Narrow sweep: `compose_test`, `task_cascade_test` = 8 passed.
- [x] `ruff check` / `ruff format --check` clean.