### PR TITLE
task/F6: information-gain retrieval over the substrate

### DIFF
--- a/mixle/substrate/__init__.py
+++ b/mixle/substrate/__init__.py
@@ -32,6 +32,7 @@ from mixle.substrate.context import (
     compress_text,
 )
 from mixle.substrate.core import MODALITIES, Substrate, SubstrateItem
+from mixle.substrate.eig_retrieve import eig_retrieve
 from mixle.substrate.factuality import ClaimVerdict, FactualityReceipt, check_factuality
 from mixle.substrate.freshness import Freshness, check_freshness, content_hash, freshness_report
 from mixle.substrate.governance import Governance, approve, pending, propose, reject
@@ -84,6 +85,7 @@ __all__ = [
     "compress_text",
     "retrieve",
     "Retrieval",
+    "eig_retrieve",
     "multihop",
     "HopChain",
     "HopStep",

--- a/mixle/substrate/eig_retrieve.py
+++ b/mixle/substrate/eig_retrieve.py
@@ -1,0 +1,68 @@
+"""Information-gain retrieval (workstream F6): score substrate items by how much they would actually move a
+belief, not by how textually similar they are to the query.
+
+:func:`~mixle.substrate.retrieve.retrieve` ranks by cosine/lexical similarity -- a sound default, but many
+similar-looking items can carry the *same* evidence (redundant), while a single differently-worded item can
+be decisive. :func:`eig_retrieve` instead scores each candidate by the entropy it would actually remove from a
+given :class:`~mixle.inference.belief.BeliefState` if assimilated, and greedily picks the highest-gain item
+each round, updating the running belief before scoring what remains -- so a second item redundant with the
+first correctly scores near zero the next round. The same greedy EIG scorer is the one workstream C5
+(experiment-design-as-planning) reuses; it is written once, here.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import numpy as np
+
+from mixle.inference.belief import BeliefState
+from mixle.substrate.core import Substrate, SubstrateItem
+from mixle.substrate.retrieve import Retrieval
+
+
+def eig_retrieve(
+    substrate: Substrate,
+    belief: BeliefState,
+    evidence_fn: Callable[[SubstrateItem], Any],
+    *,
+    k: int = 8,
+    kind: str | None = None,
+    scope: str | None = None,
+) -> Retrieval:
+    """Greedily pick up to ``k`` substrate items by expected posterior-entropy reduction against ``belief``.
+
+    ``evidence_fn(item)`` turns a candidate item into whatever ``belief.update(...)`` expects (e.g. a
+    per-hypothesis log-likelihood vector for a :class:`~mixle.inference.belief.CategoricalBelief`). Each
+    round, every remaining candidate is scored by ``current_belief.entropy() - updated_belief.entropy()``;
+    the best-scoring item is taken, the running belief moves to its post-update state, and scoring repeats
+    against the shrunk pool -- so an item whose evidence is redundant with an already-picked item scores
+    near zero on its next look, the direct fix for similarity retrieval pulling in near-duplicates. Items
+    whose ``evidence_fn`` raises (no usable evidence) are skipped, not fatal. Returned as a
+    :class:`~mixle.substrate.retrieve.Retrieval` (``query`` is a fixed marker, not a text query) so it
+    composes with the same ``to_context``/``by_kind`` surface as cosine retrieval.
+    """
+    pool = [it for it in substrate.all(scope=scope) if kind is None or it.kind == kind]
+    chosen: list[SubstrateItem] = []
+    scores: list[float] = []
+    current = belief
+    remaining = list(pool)
+    while remaining and len(chosen) < k:
+        best_idx: int | None = None
+        best_gain = -np.inf
+        best_next: BeliefState | None = None
+        for idx, item in enumerate(remaining):
+            try:
+                nxt = current.update(evidence_fn(item))
+            except Exception:  # noqa: BLE001 -- an item with no usable evidence is skipped, not fatal
+                continue
+            gain = float(current.entropy() - nxt.entropy())
+            if gain > best_gain:
+                best_idx, best_gain, best_next = idx, gain, nxt
+        if best_idx is None:
+            break
+        chosen.append(remaining.pop(best_idx))
+        scores.append(best_gain)
+        current = best_next
+    return Retrieval(query="<information-gain>", items=chosen, scores=scores)

--- a/mixle/tests/eig_retrieve_test.py
+++ b/mixle/tests/eig_retrieve_test.py
@@ -1,0 +1,93 @@
+"""Information-gain retrieval (mixle.substrate.eig_retrieve), CARD F6-a.
+
+Acceptance (per the card): fewer items than cosine/lexical retrieval to reach a target accuracy. The scenario
+below has several textually redundant filler items (near-duplicate wording of the query, carrying almost no
+evidence) and one differently-worded item that is decisive -- so a similarity-ranked retrieval spends its
+budget on the redundant filler while information-gain retrieval goes straight for the decisive item.
+"""
+
+import unittest
+
+from mixle.inference.belief import CategoricalBelief
+from mixle.substrate.core import Substrate, SubstrateItem
+from mixle.substrate.eig_retrieve import eig_retrieve
+from mixle.substrate.retrieve import retrieve
+
+LABELS = ["alpha", "beta", "gamma"]
+
+
+def _evidence_fn(item):
+    return item.payload["log_lik"]
+
+
+def _build_substrate():
+    substrate = Substrate()
+    query = "status update about the project rollout timeline"
+    # six near-duplicate filler items: high textual overlap with the query, almost no evidence
+    filler_texts = [
+        "status update about the project rollout timeline for stakeholders",
+        "another status update about the project rollout timeline this week",
+        "weekly status update covering the project rollout timeline",
+        "project rollout timeline status update from the team",
+        "status update: project rollout timeline unchanged since last week",
+        "brief status update about the rollout timeline for the project",
+    ]
+    for text in filler_texts:
+        substrate.put(SubstrateItem(kind="text", text=text, payload={"log_lik": [0.01, -0.01, 0.0]}))
+    # one decisive item: different wording (low textual overlap with the query), strong evidence for "beta"
+    substrate.put(
+        SubstrateItem(
+            kind="text",
+            text="engineering confirms beta migration finished successfully",
+            payload={"log_lik": [-8.0, 0.0, -8.0]},
+        )
+    )
+    return substrate, query
+
+
+class EigRetrieveTest(unittest.TestCase):
+    def test_stays_on_the_lexical_path_for_this_small_corpus(self):
+        # load-bearing precondition: with < 8 text items, Substrate.search is the deterministic lexical
+        # fallback (no learned-embedder noise), so the comparison below isn't an embedding-fit accident
+        substrate, _query = _build_substrate()
+        self.assertLess(len(substrate.all()), 8)
+
+    def test_eig_retrieve_reaches_correct_map_with_fewer_items_than_cosine(self):
+        substrate, query = _build_substrate()
+
+        eig_result = eig_retrieve(substrate, CategoricalBelief.uniform(LABELS), _evidence_fn, k=1)
+        eig_belief = CategoricalBelief.uniform(LABELS)
+        for item in eig_result.items:
+            eig_belief = eig_belief.update(_evidence_fn(item))
+        self.assertEqual(eig_belief.map(), "beta")
+        self.assertLess(eig_belief.entropy(), 0.2)
+
+        cosine_result = retrieve(substrate, query, k=1, diversify=False)
+        cosine_belief = CategoricalBelief.uniform(LABELS)
+        for item in cosine_result.items:
+            cosine_belief = cosine_belief.update(_evidence_fn(item))
+        # the top cosine hit is one of the redundant filler items (near-duplicate wording of the query);
+        # its near-zero evidence leaves the belief essentially unmoved from uniform
+        self.assertNotEqual(cosine_belief.map(), "beta")
+        self.assertGreater(cosine_belief.entropy(), eig_belief.entropy())
+
+    def test_second_pick_scores_low_once_its_evidence_is_redundant_with_the_first(self):
+        # greedy re-scoring against the shrunk pool: once the decisive item is taken, every remaining
+        # filler item (near-zero evidence) should score near zero on the next round
+        substrate, _query = _build_substrate()
+        result = eig_retrieve(substrate, CategoricalBelief.uniform(LABELS), _evidence_fn, k=2)
+        self.assertEqual(len(result.items), 2)
+        self.assertGreater(result.scores[0], result.scores[1])
+        self.assertLess(result.scores[1], 0.05)
+
+    def test_items_with_unusable_evidence_are_skipped_not_fatal(self):
+        substrate, _query = _build_substrate()
+        substrate.put(SubstrateItem(kind="text", text="unrelated item with no evidence", payload={}))
+        result = eig_retrieve(substrate, CategoricalBelief.uniform(LABELS), _evidence_fn, k=7)
+        # every returned item actually had usable evidence; the malformed one was skipped, not raised
+        for item in result.items:
+            self.assertIn("log_lik", item.payload)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Card F6-a (workstream F6), unblocked now that F1-a (ModalityView) merged. The card was a one-paragraph spec ("score substrate items by expected posterior update against the current belief; test = fewer items than cosine retrieval to reach target accuracy"), so I wrote the full acceptance test myself.
- `mixle/substrate/eig_retrieve.py`: `eig_retrieve(substrate, belief, evidence_fn, *, k=8, kind=None, scope=None)` -- greedily picks up to `k` items by the entropy drop `belief.entropy() - belief.update(evidence_fn(item)).entropy()`, re-scoring the shrunk remaining pool against the *updated* belief each round (so an item redundant with one already picked scores near zero next time). Skips items whose `evidence_fn` raises rather than failing the whole retrieval.
- Uses the existing `mixle.inference.belief.BeliefState` (`CategoricalBelief`/`GaussianBelief`) interface -- no new belief abstraction. Exported from `mixle.substrate`.

## Test plan
- [x] `mixle/tests/eig_retrieve_test.py`: a corpus of six textually-redundant filler items (near-duplicate wording of the query, near-zero per-hypothesis evidence) plus one differently-worded decisive item (strong evidence for one hypothesis). Cosine/lexical `retrieve()` spends its `k=1` budget on a filler item and leaves the belief near-uniform; `eig_retrieve` reaches the correct MAP hypothesis with low posterior entropy at the same `k=1` budget. Also checks the second-pick-scores-low-once-redundant property and that unusable-evidence items are skipped, not fatal.
- [x] `.venv/bin/python -m pytest mixle/tests/eig_retrieve_test.py -q` -- 4 passed.
- [x] `ruff check` / `ruff format --check` on changed files -- clean.
- [x] `python -c "import mixle.substrate as s; s.eig_retrieve"` -- new export loads cleanly.