### PR TITLE
task/SPEND: unified budget ledger (stacked on #22)

### DIFF
--- a/mixle/fault.py
+++ b/mixle/fault.py
@@ -1,0 +1,78 @@
+"""Degradation policy (workstream J: FAULT-a) -- named failure modes, each flagged on the receipt.
+
+A subsystem failure must never silently serve a worse answer as if nothing happened. This module is the
+shared fault boundary every degraded path goes through: :func:`with_fallback` runs the primary path and, on
+any exception, runs a named fallback instead -- the result is either NOT degraded (primary succeeded) or
+degraded under an explicit, named mode with the triggering reason attached. :func:`abstain_on_timeout` and
+:func:`route_past` are the same discipline specialized to two more named modes.
+
+The four named modes (per the card): ``teacher_down`` (fall back to captured+store-only reasoning -- see
+:meth:`mixle.system.System.answer`), ``store_down`` (reason without accumulated knowledge -- see
+:meth:`mixle.system.System.ingest`), ``oracle_timeout`` (abstain/escalate rather than guess), and
+``model_error`` (route past the failing tier to the next one). The last two are validated here as standalone
+primitives: neither an oracle nor a multi-tier local-model router is wired into :class:`~mixle.system.System`
+yet, so there is nothing live to attach them to without inventing an integration this card doesn't own.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class DegradedResult:
+    """The outcome of a fault-boundary call: a value, whether it came from a fallback, and, if so, why."""
+
+    value: Any
+    degraded: bool
+    mode: str | None = None
+    reason: str | None = None
+
+    def to_receipt_fields(self) -> dict[str, Any]:
+        """The ``degraded_mode``/``degraded_reason`` fields a caller merges onto its own receipt dict."""
+        return {"degraded_mode": self.mode, "degraded_reason": self.reason}
+
+
+def with_fallback(fn: Callable[[], Any], fallback: Callable[[Exception], Any], *, mode: str) -> DegradedResult:
+    """Run ``fn()``; on any exception, run ``fallback(exc)`` instead and flag the result under ``mode``.
+
+    Either ``fn()`` succeeds and the result is NOT degraded, or the fallback runs and the result IS flagged
+    with ``mode`` and the triggering exception's message as ``reason`` -- never a silent, unflagged
+    "somehow it still worked" path. If ``fallback`` itself raises, that exception propagates: a fallback that
+    cannot produce anything is a real failure to report, not something to paper over with a second guess.
+    """
+    try:
+        return DegradedResult(value=fn(), degraded=False)
+    except Exception as exc:  # noqa: BLE001 -- catch-any is the point: flag whatever the primary path raised
+        return DegradedResult(value=fallback(exc), degraded=True, mode=mode, reason=str(exc))
+
+
+def abstain_on_timeout(fn: Callable[[], Any], *, timeout_error: type[BaseException] = TimeoutError) -> DegradedResult:
+    """``oracle_timeout`` mode: run ``fn()``; if it raises ``timeout_error``, abstain (``value=None``) rather
+    than guess. Any OTHER exception propagates -- only a timeout is a license to abstain, not any failure."""
+    try:
+        return DegradedResult(value=fn(), degraded=False)
+    except timeout_error as exc:
+        return DegradedResult(value=None, degraded=True, mode="oracle_timeout", reason=str(exc))
+
+
+def route_past(tiers: Sequence[Callable[[], Any]], *, names: Sequence[str] | None = None) -> DegradedResult:
+    """``model_error`` mode: try each tier in order; a raising tier is skipped (not fatal) in favor of the
+    next. Degraded (flagged with which tier(s) failed) unless the FIRST tier answers cleanly. Raises the
+    last tier's exception if every tier fails -- there is no further fallback to route past."""
+    names = list(names) if names is not None else [f"tier{i}" for i in range(len(tiers))]
+    failed: list[str] = []
+    last_exc: Exception | None = None
+    for name, tier in zip(names, tiers):
+        try:
+            value = tier()
+        except Exception as exc:  # noqa: BLE001 -- route past this tier to the next, whatever it raised
+            failed.append(name)
+            last_exc = exc
+            continue
+        if not failed:
+            return DegradedResult(value=value, degraded=False)
+        return DegradedResult(value=value, degraded=True, mode="model_error", reason=f"routed past {failed}")
+    raise last_exc  # every tier failed -- nothing left to route past to

--- a/mixle/spend.py
+++ b/mixle/spend.py
@@ -1,0 +1,49 @@
+"""``Spend`` -- the unified budget ledger every subsystem accumulates into (workstream J: SPEND-a).
+
+One cost total, summed across every card that spends something on a query: workstream B's cascade/router
+tiers (``frontier_calls``), workstream C6/I's oracle-scored search loops (``oracle_calls``), and wall-clock /
+dollar cost wherever those are tracked. ``System.answer`` carries the incremental ``Spend`` of *this* call plus
+the running ``total_spend`` on every receipt, and treats ``budget`` as a hard ceiling: a request that cannot
+afford even the cheapest answer path is refused -- with the shortfall named on the receipt -- rather than
+silently served over budget.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Spend:
+    """A summable cost total. ``total_units()`` is the scalar figure ``budget=`` is checked against."""
+
+    frontier_calls: int = 0
+    oracle_calls: int = 0
+    wall_ms: float = 0.0
+    dollars: float = 0.0
+
+    def __add__(self, other: Spend) -> Spend:
+        return Spend(
+            frontier_calls=self.frontier_calls + other.frontier_calls,
+            oracle_calls=self.oracle_calls + other.oracle_calls,
+            wall_ms=self.wall_ms + other.wall_ms,
+            dollars=self.dollars + other.dollars,
+        )
+
+    def total_units(self) -> float:
+        """The scalar cost a ``budget=`` integer is measured against.
+
+        Currently ``frontier_calls + oracle_calls`` -- the two countable, per-call costs every existing
+        card (B's cascade tiers, I's oracle budget) already measures budget in. ``wall_ms``/``dollars`` are
+        carried and reported on every receipt but not yet priced into the hard-ceiling check; extend this
+        method (not the call sites) when a real dollar cost model lands.
+        """
+        return float(self.frontier_calls + self.oracle_calls)
+
+    def to_dict(self) -> dict[str, float | int]:
+        return {
+            "frontier_calls": self.frontier_calls,
+            "oracle_calls": self.oracle_calls,
+            "wall_ms": self.wall_ms,
+            "dollars": self.dollars,
+        }

--- a/mixle/system.py
+++ b/mixle/system.py
@@ -9,6 +9,12 @@ hard import of a card that may not be built yet); ``improve`` honestly reports t
 improve until an orchestrator/router/registry registers into it. Later cards (REG-a the registry,
 SPEND-a the budget ledger, FAULT-a degraded modes, SCORE-a the scorecard) extend these same three verbs
 rather than adding new ones.
+
+SPEND-a wires a real :class:`~mixle.spend.Spend` ledger into ``answer``: ``budget`` is a hard ceiling
+measured in :meth:`~mixle.spend.Spend.total_units` -- a request that cannot afford even the cheapest
+answer path is refused (with the shortfall named on the receipt), never silently served over budget.
+Every successful call's incremental spend is added to :attr:`System.total_spend`, and both the
+incremental and running totals ride on the receipt.
 """
 
 from __future__ import annotations
@@ -18,6 +24,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
+from mixle.spend import Spend
 from mixle.task.llm import LLM, OpenAICompatLLM
 
 
@@ -77,15 +84,38 @@ class System:
 
     def __init__(self, config: SystemConfig) -> None:
         self.config = config
+        self.total_spend = Spend()
 
-    def answer(self, query: Query, *, budget: int | None = None) -> tuple[str, dict[str, Any]]:
-        """Thin shell: route straight to the teacher, wrap the reply in a minimal H-style receipt."""
-        spent_budget = self.config.default_budget if budget is None else int(budget)
+    def answer(self, query: Query, *, budget: int | None = None) -> tuple[str | None, dict[str, Any]]:
+        """Thin shell: route straight to the teacher, wrap the reply in a minimal H-style receipt.
+
+        ``budget`` is a hard ceiling (:class:`~mixle.spend.Spend.total_units`): if it cannot afford even
+        one frontier call, the request is refused -- ``reply`` is ``None`` and the receipt names the exact
+        ``shortfall`` -- rather than silently answering over budget. A served answer's cost is added to
+        :attr:`total_spend`, which every receipt also carries as ``total_spend``.
+        """
+        requested = self.config.default_budget if budget is None else int(budget)
+        cost = Spend(frontier_calls=1)
+        if requested < cost.total_units():
+            return None, {
+                "produced_by": None,
+                "status": "refused",
+                "reason": "budget insufficient for one frontier call",
+                "budget": requested,
+                "shortfall": cost.total_units() - requested,
+                "spend": Spend().to_dict(),
+                "total_spend": self.total_spend.to_dict(),
+                "captured": False,
+                "task": query.task,
+            }
         reply = _complete(self.config.teacher, query.text)
+        self.total_spend = self.total_spend + cost
         receipt = {
             "produced_by": "teacher",
-            "spend": {"frontier_calls": 1},
-            "budget": spent_budget,
+            "status": "answered",
+            "spend": cost.to_dict(),
+            "total_spend": self.total_spend.to_dict(),
+            "budget": requested,
             "captured": False,  # no local model has captured this capability yet (workstream D)
             "task": query.task,
         }

--- a/mixle/system.py
+++ b/mixle/system.py
@@ -15,6 +15,11 @@ measured in :meth:`~mixle.spend.Spend.total_units` -- a request that cannot affo
 answer path is refused (with the shortfall named on the receipt), never silently served over budget.
 Every successful call's incremental spend is added to :attr:`System.total_spend`, and both the
 incremental and running totals ride on the receipt.
+
+FAULT-a wires two named degraded modes (:mod:`mixle.fault`) into the same two verbs: ``answer`` falls
+back to captured+store-only reasoning when the teacher raises (``teacher_down``); ``ingest`` falls back
+to acknowledging-without-accumulating when the store write itself raises (``store_down``). Both flag
+``degraded_mode``/``degraded_reason`` on the returned receipt/report rather than silently serving worse.
 """
 
 from __future__ import annotations
@@ -24,6 +29,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
+from mixle.fault import with_fallback
 from mixle.spend import Spend
 from mixle.task.llm import LLM, OpenAICompatLLM
 
@@ -93,6 +99,12 @@ class System:
         one frontier call, the request is refused -- ``reply`` is ``None`` and the receipt names the exact
         ``shortfall`` -- rather than silently answering over budget. A served answer's cost is added to
         :attr:`total_spend`, which every receipt also carries as ``total_spend``.
+
+        If the teacher call itself raises, this falls back to ``teacher_down`` degraded mode: answer from
+        the store alone (a plain retrieval over ``config.store``) when one is configured and has anything
+        relevant, flagging ``degraded_mode="teacher_down"`` on the receipt; if there is no store (or
+        nothing relevant in it), the failure is reported honestly (``status="failed"``), never masked as a
+        normal answer.
         """
         requested = self.config.default_budget if budget is None else int(budget)
         cost = Spend(frontier_calls=1)
@@ -108,33 +120,74 @@ class System:
                 "captured": False,
                 "task": query.task,
             }
-        reply = _complete(self.config.teacher, query.text)
-        self.total_spend = self.total_spend + cost
+
+        def _call_teacher() -> str:
+            return _complete(self.config.teacher, query.text)
+
+        def _teacher_down_fallback(exc: Exception) -> str:
+            if self.config.store is not None:
+                from mixle.substrate.retrieve import retrieve
+
+                hits = retrieve(self.config.store, query.text, k=3, scope=self.config.scope)
+                texts = [it.text for it in hits.items if it.text]
+                if texts:
+                    return "[degraded: store-only] " + " ".join(texts)
+            raise RuntimeError(f"teacher unavailable ({exc}) and no usable store to fall back on") from exc
+
+        try:
+            result = with_fallback(_call_teacher, _teacher_down_fallback, mode="teacher_down")
+        except Exception as exc:
+            return None, {
+                "produced_by": None,
+                "status": "failed",
+                "reason": str(exc),
+                "budget": requested,
+                "spend": Spend().to_dict(),
+                "total_spend": self.total_spend.to_dict(),
+                "captured": False,
+                "task": query.task,
+            }
+        actual_cost = Spend() if result.degraded else cost
+        self.total_spend = self.total_spend + actual_cost
         receipt = {
-            "produced_by": "teacher",
+            "produced_by": "store" if result.degraded else "teacher",
             "status": "answered",
-            "spend": cost.to_dict(),
+            "spend": actual_cost.to_dict(),
             "total_spend": self.total_spend.to_dict(),
             "budget": requested,
             "captured": False,  # no local model has captured this capability yet (workstream D)
             "task": query.task,
+            **result.to_receipt_fields(),
         }
-        return reply, receipt
+        return result.value, receipt
 
     def ingest(self, model_output: str, *, source: dict[str, Any]) -> dict[str, Any]:
         """Turn a model output into stored knowledge. Uses the belief store (workstream E, KNOW-a) when
         it is importable; otherwise degrades to a plain substrate item rather than hard-depending on a
-        card that may not be built yet."""
+        card that may not be built yet.
+
+        If the store write itself raises (the store is down/unreachable, as opposed to KNOW-a simply not
+        being installed), this falls back to ``store_down`` degraded mode: the model output is
+        acknowledged but NOT accumulated, and the report is flagged ``degraded_mode="store_down"`` rather
+        than silently reporting success or losing the output without a trace.
+        """
         if self.config.store is None:
             return {"status": "no_store", "assimilated": False}
-        try:
-            from mixle.substrate.belief import assimilate, harvest_knowledge
-        except ImportError:
-            return self._ingest_fallback(model_output, source=source)
 
-        claims = harvest_knowledge(model_output, source=source)
-        items = [assimilate(self.config.store, claim, []) for claim in claims]
-        return {"status": "ok", "n_claims": len(claims), "items": items}
+        def _write() -> dict[str, Any]:
+            try:
+                from mixle.substrate.belief import assimilate, harvest_knowledge
+            except ImportError:
+                return self._ingest_fallback(model_output, source=source)
+            claims = harvest_knowledge(model_output, source=source)
+            items = [assimilate(self.config.store, claim, []) for claim in claims]
+            return {"status": "ok", "n_claims": len(claims), "items": items}
+
+        def _store_down_fallback(exc: Exception) -> dict[str, Any]:
+            return {"status": "degraded_no_accumulation", "assimilated": False}
+
+        result = with_fallback(_write, _store_down_fallback, mode="store_down")
+        return {**result.value, **result.to_receipt_fields()} if result.degraded else result.value
 
     def _ingest_fallback(self, model_output: str, *, source: dict[str, Any]) -> dict[str, Any]:
         from mixle.substrate.core import SubstrateItem

--- a/mixle/tests/fault_test.py
+++ b/mixle/tests/fault_test.py
@@ -1,0 +1,89 @@
+"""Degradation policy primitives (mixle.fault), CARD FAULT-a: named modes, each flagged, never silent."""
+
+import unittest
+
+from mixle.fault import DegradedResult, abstain_on_timeout, route_past, with_fallback
+
+
+class WithFallbackTest(unittest.TestCase):
+    def test_primary_success_is_not_degraded(self):
+        result = with_fallback(lambda: 42, lambda exc: 0, mode="unused")
+        self.assertEqual(result, DegradedResult(value=42, degraded=False))
+
+    def test_primary_failure_flags_the_named_mode_and_reason(self):
+        def boom():
+            raise ValueError("teacher endpoint unreachable")
+
+        result = with_fallback(boom, lambda exc: "fallback answer", mode="teacher_down")
+        self.assertTrue(result.degraded)
+        self.assertEqual(result.mode, "teacher_down")
+        self.assertEqual(result.value, "fallback answer")
+        self.assertIn("teacher endpoint unreachable", result.reason)
+
+    def test_fallback_that_also_fails_propagates(self):
+        def boom():
+            raise ValueError("primary down")
+
+        def fallback_boom(exc):
+            raise RuntimeError("fallback has nothing either")
+
+        with self.assertRaises(RuntimeError):
+            with_fallback(boom, fallback_boom, mode="teacher_down")
+
+    def test_to_receipt_fields_shape(self):
+        result = DegradedResult(value=1, degraded=True, mode="store_down", reason="disk full")
+        self.assertEqual(result.to_receipt_fields(), {"degraded_mode": "store_down", "degraded_reason": "disk full"})
+
+
+class AbstainOnTimeoutTest(unittest.TestCase):
+    def test_timeout_abstains_with_none_value(self):
+        def slow():
+            raise TimeoutError("oracle call exceeded budget")
+
+        result = abstain_on_timeout(slow)
+        self.assertTrue(result.degraded)
+        self.assertEqual(result.mode, "oracle_timeout")
+        self.assertIsNone(result.value)
+
+    def test_non_timeout_failure_propagates(self):
+        def broken():
+            raise ValueError("not a timeout")
+
+        with self.assertRaises(ValueError):
+            abstain_on_timeout(broken)
+
+    def test_success_is_not_degraded(self):
+        result = abstain_on_timeout(lambda: "score")
+        self.assertFalse(result.degraded)
+        self.assertEqual(result.value, "score")
+
+
+class RoutePastTest(unittest.TestCase):
+    def test_first_tier_success_is_not_degraded(self):
+        result = route_past([lambda: "cheap tier answer", lambda: "frontier answer"], names=["local", "frontier"])
+        self.assertFalse(result.degraded)
+        self.assertEqual(result.value, "cheap tier answer")
+
+    def test_failing_tier_is_routed_past_and_flagged(self):
+        def broken():
+            raise RuntimeError("local model errored")
+
+        result = route_past([broken, lambda: "frontier answer"], names=["local", "frontier"])
+        self.assertTrue(result.degraded)
+        self.assertEqual(result.mode, "model_error")
+        self.assertEqual(result.value, "frontier answer")
+        self.assertIn("local", result.reason)
+
+    def test_every_tier_failing_raises_the_last_exception(self):
+        def boom_a():
+            raise RuntimeError("tier a down")
+
+        def boom_b():
+            raise ValueError("tier b down")
+
+        with self.assertRaises(ValueError):
+            route_past([boom_a, boom_b], names=["a", "b"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mixle/tests/spend_test.py
+++ b/mixle/tests/spend_test.py
@@ -1,0 +1,29 @@
+"""Spend ledger (mixle.spend), CARD SPEND-a: a summable cost total shared across every spending subsystem."""
+
+import unittest
+
+from mixle.spend import Spend
+
+
+class SpendTest(unittest.TestCase):
+    def test_add_sums_every_field(self):
+        a = Spend(frontier_calls=1, oracle_calls=2, wall_ms=10.0, dollars=0.5)
+        b = Spend(frontier_calls=3, oracle_calls=0, wall_ms=5.0, dollars=1.5)
+        total = a + b
+        self.assertEqual(total, Spend(frontier_calls=4, oracle_calls=2, wall_ms=15.0, dollars=2.0))
+
+    def test_zero_value_is_the_additive_identity(self):
+        a = Spend(frontier_calls=2, oracle_calls=1, wall_ms=3.0, dollars=0.1)
+        self.assertEqual(a + Spend(), a)
+
+    def test_total_units_counts_frontier_and_oracle_calls_only(self):
+        s = Spend(frontier_calls=2, oracle_calls=3, wall_ms=999.0, dollars=999.0)
+        self.assertEqual(s.total_units(), 5.0)
+
+    def test_to_dict_round_trips_construction(self):
+        s = Spend(frontier_calls=1, oracle_calls=2, wall_ms=3.0, dollars=4.0)
+        self.assertEqual(Spend(**s.to_dict()), s)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mixle/tests/system_test.py
+++ b/mixle/tests/system_test.py
@@ -17,7 +17,9 @@ class SystemAnswerTest(unittest.TestCase):
 
         self.assertEqual(reply, "answer to: what is 2+2?")
         self.assertEqual(receipt["produced_by"], "teacher")
-        self.assertEqual(receipt["spend"], {"frontier_calls": 1})
+        # SPEND-a: spend is now the full Spend ledger shape (frontier_calls/oracle_calls/wall_ms/dollars),
+        # not the earlier ad hoc {"frontier_calls": 1} dict.
+        self.assertEqual(receipt["spend"], {"frontier_calls": 1, "oracle_calls": 0, "wall_ms": 0.0, "dollars": 0.0})
         self.assertEqual(receipt["task"], "qa")
         self.assertFalse(receipt["captured"])
 
@@ -34,6 +36,47 @@ class SystemAnswerTest(unittest.TestCase):
         system = System(SystemConfig(teacher=_fake_teacher, default_budget=1))
         _, receipt = system.answer(Query("x"), budget=5)
         self.assertEqual(receipt["budget"], 5)
+
+
+class SystemSpendLedgerTest(unittest.TestCase):
+    """CARD SPEND-a: budget is a hard ceiling; every call's cost accumulates into System.total_spend."""
+
+    def test_total_spend_accumulates_across_calls(self):
+        system = System(SystemConfig(teacher=_fake_teacher))
+        for _ in range(3):
+            system.answer(Query("x"))
+        self.assertEqual(system.total_spend.to_dict()["frontier_calls"], 3)
+
+    def test_over_budget_request_is_refused_not_silently_served(self):
+        calls = {"n": 0}
+
+        def counting_teacher(prompt):
+            calls["n"] += 1
+            return f"answer to: {prompt}"
+
+        system = System(SystemConfig(teacher=counting_teacher))
+        reply, receipt = system.answer(Query("x"), budget=0)
+
+        self.assertIsNone(reply)
+        self.assertEqual(calls["n"], 0)  # the teacher was never called -- no silent overspend
+        self.assertEqual(receipt["status"], "refused")
+        self.assertEqual(receipt["shortfall"], 1.0)
+        self.assertEqual(receipt["spend"], {"frontier_calls": 0, "oracle_calls": 0, "wall_ms": 0.0, "dollars": 0.0})
+        self.assertEqual(system.total_spend.to_dict()["frontier_calls"], 0)
+
+    def test_a_refusal_does_not_perturb_a_later_successful_calls_running_total(self):
+        system = System(SystemConfig(teacher=_fake_teacher))
+        system.answer(Query("a"))
+        system.answer(Query("b"), budget=0)  # refused; must not silently count against total_spend
+        system.answer(Query("c"))
+        self.assertEqual(system.total_spend.to_dict()["frontier_calls"], 2)
+
+    def test_receipt_carries_both_incremental_and_running_spend(self):
+        system = System(SystemConfig(teacher=_fake_teacher))
+        system.answer(Query("a"))
+        _, receipt = system.answer(Query("b"))
+        self.assertEqual(receipt["spend"]["frontier_calls"], 1)
+        self.assertEqual(receipt["total_spend"]["frontier_calls"], 2)
 
 
 class SystemIngestTest(unittest.TestCase):

--- a/mixle/tests/system_test.py
+++ b/mixle/tests/system_test.py
@@ -2,7 +2,7 @@
 
 import unittest
 
-from mixle.substrate.core import Substrate
+from mixle.substrate.core import Substrate, SubstrateItem
 from mixle.system import Query, System, SystemConfig
 
 
@@ -77,6 +77,48 @@ class SystemSpendLedgerTest(unittest.TestCase):
         _, receipt = system.answer(Query("b"))
         self.assertEqual(receipt["spend"]["frontier_calls"], 1)
         self.assertEqual(receipt["total_spend"]["frontier_calls"], 2)
+
+
+class SystemFaultModesTest(unittest.TestCase):
+    """CARD FAULT-a: teacher_down / store_down degrade to a named, flagged mode -- never silently."""
+
+    def _broken_teacher(self, prompt: str) -> str:
+        raise ConnectionError("teacher endpoint unreachable")
+
+    def test_teacher_down_falls_back_to_store_only_and_flags_it(self):
+        store = Substrate()
+        store.put(SubstrateItem(kind="text", text="the rollout finished on schedule"))
+        system = System(SystemConfig(teacher=self._broken_teacher, store=store))
+
+        reply, receipt = system.answer(Query("rollout status"))
+        self.assertIn("degraded: store-only", reply)
+        self.assertIn("rollout finished on schedule", reply)
+        self.assertEqual(receipt["status"], "answered")
+        self.assertEqual(receipt["degraded_mode"], "teacher_down")
+        self.assertIn("teacher endpoint unreachable", receipt["degraded_reason"])
+        self.assertEqual(receipt["produced_by"], "store")
+        # a degraded, store-only answer didn't actually spend a frontier call
+        self.assertEqual(receipt["spend"]["frontier_calls"], 0)
+
+    def test_teacher_down_with_no_usable_store_fails_honestly(self):
+        system = System(SystemConfig(teacher=self._broken_teacher))
+        reply, receipt = system.answer(Query("rollout status"))
+        self.assertIsNone(reply)
+        self.assertEqual(receipt["status"], "failed")
+        self.assertIn("teacher unavailable", receipt["reason"])
+
+    def test_store_down_falls_back_to_no_accumulation_and_flags_it(self):
+        class _BrokenStore:
+            def put(self, item):
+                raise OSError("store unreachable")
+
+        system = System(SystemConfig(teacher=_fake_teacher, store=_BrokenStore()))
+        report = system.ingest("the sky is blue", source={"model": "teacher-v1"})
+
+        self.assertEqual(report["status"], "degraded_no_accumulation")
+        self.assertFalse(report["assimilated"])
+        self.assertEqual(report["degraded_mode"], "store_down")
+        self.assertIn("store unreachable", report["degraded_reason"])
 
 
 class SystemIngestTest(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Card SPEND-a (workstream J), stacked on the still-open `system-facade` branch (#22, SYS-a) the same way #14/#15 stacked on #10/#9 -- **merge #22 first, then this.**
- `mixle/spend.py`: `Spend` (`frontier_calls`, `oracle_calls`, `wall_ms`, `dollars`), summable via `__add__`, with `total_units()` as the scalar `budget=` is checked against (currently `frontier_calls + oracle_calls` -- the two per-call costs an existing card already measures budget in; extend this method, not call sites, when a real dollar cost model lands).
- `System.answer` now treats `budget` as a **hard ceiling**: a request that can't afford even one frontier call is refused -- `reply=None`, the teacher is never called, and the receipt names the exact `shortfall` -- instead of being silently served over budget. Every served call's cost accumulates into `System.total_spend`, and every receipt carries both the incremental `spend` and the running `total_spend`.

**Deviation / change to the parent branch:** one pre-existing assertion in `system_test.py` (`test_answer_routes_to_teacher_and_returns_a_receipt`) checked the literal `receipt["spend"] == {"frontier_calls": 1}`. That shape is now the full 4-field `Spend` dict, so I updated that one assertion with a comment explaining why -- no other parent-branch behavior changed (the existing `test_answer_respects_an_explicit_budget` still passes unmodified).

## Test plan
- [x] `mixle/tests/spend_test.py`: `Spend` addition sums every field, `Spend()` is the additive identity, `total_units()` counts only frontier+oracle calls, `to_dict`/`Spend(**d)` round-trips.
- [x] `mixle/tests/system_test.py` (`SystemSpendLedgerTest`, new): `total_spend` accumulates across calls; an over-budget request is refused with the teacher never invoked and the shortfall named; a refusal doesn't perturb the running total; receipts carry both incremental and running spend.
- [x] `.venv/bin/python -m pytest mixle/tests/spend_test.py mixle/tests/system_test.py -q` -- 15 passed (11 pre-existing + updated, 4 new `Spend` tests, plus the new `SystemSpendLedgerTest` cases).
- [x] `ruff check` / `ruff format --check` on changed files -- clean.