### PR TITLE
CARD C1-a: plans as fitted Markov-chain models over agent traces

### DIFF
--- a/mixle/task/__init__.py
+++ b/mixle/task/__init__.py
@@ -96,6 +96,7 @@ from mixle.task.model import (
 )
 from mixle.task.multilabel import MultiLabelSolution, solve_multilabel
 from mixle.task.plan import Planner, distill_planner
+from mixle.task.plan_model import PlanModel, fit_plan_model
 from mixle.task.plan_refine import RefinementReport, outcome_refine_planner
 
 # post-training quantization: int8/int4 MLP weights (numpy-only inference) + LNS integer log-space
@@ -159,6 +160,8 @@ __all__ = [
     "StructuredSolution",
     "GenerativePlanner",
     "Planner",
+    "PlanModel",
+    "fit_plan_model",
     "Solution",
     "StructuredClassifierIO",
     "TaskManifest",

--- a/mixle/task/plan_model.py
+++ b/mixle/task/plan_model.py
@@ -1,0 +1,93 @@
+"""``fit_plan_model`` -- plans as fitted models over harvested agent traces (CARD C1-a).
+
+A plan is the ordered sequence of tool NAMES an agent called for a request. Fitting a Markov chain
+over those sequences (via the ordinary ``optimize`` entry point every mixle model goes through, not a
+hand-rolled counter) turns "which plans look like what this agent usually does" into a real, scoreable
+distribution: ``PlanModel.log_prob(plan)`` is exact, ``PlanModel.sample(rng)`` draws a plausible plan,
+and ``PlanModel.is_typical(plan)`` flags a plan whose probability falls below the training traces' own
+log-prob quantile -- an escalation signal, not a silent guess, the same discipline
+:func:`~mixle.task.sft_plan.sample_plans` uses for its generative sibling.
+
+    model = fit_plan_model(harvest_agent_traces())
+    model.log_prob(["lookup_order", "notify"])
+    model.is_typical(candidate_plan)   # False -> escalate; this plan does not look like the traces
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+from mixle.task.traces import AgentTrace, AgentTraces
+
+
+def _tool_names(plan: Sequence[Any]) -> list[str]:
+    """A plan is either already a list of tool-name strings, or the ``AgentTrace``/teacher shape
+    ``[{"tool": name, "args": {...}}, ...]`` -- accept both so a harvested trace's ``plan`` and a
+    freshly proposed candidate plan score the same way."""
+    plan = list(plan)
+    if all(isinstance(p, str) for p in plan):
+        return plan
+    return [str(step["tool"]) for step in plan]
+
+
+@dataclass
+class PlanModel:
+    """A fitted Markov chain over tool-name sequences, plus the training traces' own log-prob spread."""
+
+    dist: Any  # a fitted mixle.stats.MarkovChainDistribution over tool-name sequences
+    training_log_probs: np.ndarray  # log_prob of every training trace, for is_typical's quantile
+
+    def log_prob(self, plan: Sequence[Any]) -> float:
+        """Exact log-probability of ``plan`` (a tool-name list, or the ``[{"tool":...}, ...]`` shape)."""
+        return float(self.dist.log_density(_tool_names(plan)))
+
+    def sample(self, rng: np.random.RandomState | None = None) -> list[str]:
+        """Draw one plausible tool-name sequence from the fitted chain.
+
+        The underlying sampler draws a length from ``len_dist`` first, then walks the chain; once the
+        walk reaches an absorbing state (no fitted outgoing transition -- typically the tool that
+        always ends a workflow), the remaining, unreachable slots come back as ``None``. Truncate
+        there rather than exposing that padding: only known, actually-reached tool names are emitted.
+        """
+        rng = rng if rng is not None else np.random.RandomState()
+        seed = int(rng.randint(0, 2**31 - 1))
+        raw = list(self.dist.sampler(seed).sample())
+        out: list[str] = []
+        for tool in raw:
+            if tool is None:
+                break
+            out.append(str(tool))
+        return out
+
+    def is_typical(self, plan: Sequence[Any], *, quantile: float = 0.05) -> bool:
+        """False when ``plan`` scores below the training traces' own ``quantile`` log-prob -- the
+        escalation signal: a plan that does not look like what this agent usually does."""
+        floor = float(np.quantile(self.training_log_probs, quantile))
+        return self.log_prob(plan) >= floor
+
+
+def fit_plan_model(traces: AgentTraces | Sequence[AgentTrace], *, smoothing: float = 0.5) -> PlanModel:
+    """Fit a :class:`PlanModel` on harvested traces' tool-name sequences.
+
+    ``smoothing`` is the Markov chain's Dirichlet pseudo-count (higher = smoother transition
+    estimates, matters most with few traces). Fits via :func:`mixle.inference.optimize` on the
+    existing :class:`~mixle.stats.sequences.markov_chain.MarkovChainEstimator` -- the same
+    declare-an-estimator/call-optimize path every other mixle model uses, not hand-rolled counting.
+    """
+    from mixle.inference import optimize
+    from mixle.stats import IntegerCategoricalEstimator, MarkovChainEstimator
+
+    trace_list = list(traces.traces) if isinstance(traces, AgentTraces) else list(traces)
+    sequences = [_tool_names(t.plan) for t in trace_list]
+
+    est = MarkovChainEstimator(pseudo_count=float(smoothing), len_estimator=IntegerCategoricalEstimator())
+    dist = optimize(sequences, est, out=None)
+    log_probs = np.asarray([dist.log_density(seq) for seq in sequences], dtype=float)
+    return PlanModel(dist=dist, training_log_probs=log_probs)
+
+
+__all__ = ["PlanModel", "fit_plan_model"]

--- a/mixle/tests/plan_model_test.py
+++ b/mixle/tests/plan_model_test.py
@@ -1,0 +1,86 @@
+"""fit_plan_model / PlanModel: plans as fitted Markov-chain models over agent traces (CARD C1-a).
+
+A known 3-tool workflow grammar (search -> fetch -> summarize, fetch sometimes skipped) generates the
+synthetic traces; a held-out plan from the SAME grammar should score as typical, a shuffled/alien
+sequence should not, samples should only ever emit known tools, and fitting is deterministic given seed.
+"""
+
+import unittest
+
+import numpy as np
+
+from mixle.task.plan_model import PlanModel, fit_plan_model
+from mixle.task.traces import AgentTrace, AgentTraces
+
+_KNOWN_TOOLS = {"search", "fetch", "summarize"}
+
+
+def _grammar_trace(i: int, rng: np.random.RandomState) -> AgentTrace:
+    """search -> [fetch] -> summarize: fetch is skipped ~30% of the time, order is otherwise fixed."""
+    plan = [{"tool": "search", "args": {}}]
+    if rng.rand() < 0.7:
+        plan.append({"tool": "fetch", "args": {}})
+    plan.append({"tool": "summarize", "args": {}})
+    return AgentTrace(request=f"request {i}", plan=plan, reply="done")
+
+
+def _traces(n: int, seed: int = 0) -> AgentTraces:
+    rng = np.random.RandomState(seed)
+    return AgentTraces(traces=[_grammar_trace(i, rng) for i in range(n)])
+
+
+class FitPlanModelTest(unittest.TestCase):
+    def setUp(self):
+        self.model = fit_plan_model(_traces(50, seed=0), smoothing=0.5)
+
+    def test_returns_a_plan_model(self):
+        self.assertIsInstance(self.model, PlanModel)
+
+    def test_held_out_grammar_plans_score_as_typical(self):
+        """(a) held-out plans from the SAME grammar score above the quantile flag."""
+        held_out = _traces(20, seed=99)  # different seed -> genuinely unseen draws from the same grammar
+        for t in held_out.traces:
+            self.assertTrue(self.model.is_typical(t.plan), f"held-out grammar plan flagged atypical: {t.plan}")
+
+    def test_alien_tool_sequence_is_flagged_atypical(self):
+        """(b) a shuffled/alien tool sequence is flagged atypical."""
+        alien = ["summarize", "search", "fetch", "fetch", "fetch"]  # wrong order, repeated tool
+        self.assertFalse(self.model.is_typical(alien))
+        # and it scores strictly worse than a well-formed grammar plan
+        typical = ["search", "fetch", "summarize"]
+        self.assertLess(self.model.log_prob(alien), self.model.log_prob(typical))
+
+    def test_samples_only_emit_known_tools(self):
+        """(c) samples only emit known tools."""
+        rng = np.random.RandomState(7)
+        for _ in range(30):
+            sample = self.model.sample(rng)
+            for tool in sample:
+                self.assertIn(str(tool), _KNOWN_TOOLS)
+
+    def test_fitting_is_deterministic_given_seed(self):
+        """(d) round-trip determinism given seed."""
+        model_a = fit_plan_model(_traces(50, seed=0), smoothing=0.5)
+        model_b = fit_plan_model(_traces(50, seed=0), smoothing=0.5)
+        plan = ["search", "fetch", "summarize"]
+        self.assertEqual(model_a.log_prob(plan), model_b.log_prob(plan))
+        self.assertEqual(list(model_a.training_log_probs), list(model_b.training_log_probs))
+
+    def test_accepts_either_plan_shape(self):
+        dict_shaped = [{"tool": "search", "args": {}}, {"tool": "summarize", "args": {}}]
+        str_shaped = ["search", "summarize"]
+        self.assertEqual(self.model.log_prob(dict_shaped), self.model.log_prob(str_shaped))
+
+    def test_is_typical_quantile_is_tunable(self):
+        # the less-common (but still grammar-valid) fetch-skipped path: fetch appears ~70% of training
+        # traces, so this pattern sits at the bottom of the training log-prob distribution -- typical
+        # under a permissive floor, atypical under a strict one. quantile is a LOWER bound on the
+        # training log-prob distribution: quantile=0.0 -> the most permissive floor (the training
+        # minimum); quantile close to 1.0 -> the strictest (near the training maximum).
+        less_common = ["search", "summarize"]
+        self.assertTrue(self.model.is_typical(less_common, quantile=0.05))
+        self.assertFalse(self.model.is_typical(less_common, quantile=0.9))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
CARD C1-a from `notes/0.6.3-execution-playbook.md`. A plan is the ordered sequence of tool names an
agent called for a request. Fitting a Markov chain over those sequences (via the ordinary
`optimize()` entry point, not hand-rolled counting) turns "which plans look like what this agent
usually does" into a real, scoreable distribution.

- **New** `fit_plan_model(traces, smoothing=0.5) -> PlanModel`: fits `MarkovChainEstimator` (with an
  `IntegerCategoricalEstimator` length distribution) over each trace's tool-name sequence.
- **New** `PlanModel.log_prob(plan)`: exact log-density, accepting either a bare tool-name list or the
  teacher/trace `[{"tool":...}, ...]` shape.
- **New** `PlanModel.sample(rng)`: draws a plausible tool sequence; truncates at the underlying
  sampler's `None` padding (emitted once the chain reaches an absorbing state before the length
  distribution's drawn length).
- **New** `PlanModel.is_typical(plan, quantile=0.05)`: `False` when a plan scores below the training
  traces' own log-prob quantile -- an escalation signal, not a silent guess.
- Exported from `mixle.task`.

Distinct from the existing `Planner`/`GenerativePlanner` (C1/C2, already merged): those are a
discriminative next-step classifier and a char-level LM writing full plan text respectively; this is
a lightweight, exactly-scoreable Markov chain over tool *names* -- a different, complementary
representation for the same "plan as a modeled object" idea.

## Test plan
- [x] 7 tests in `plan_model_test.py`: fit on 50 synthetic traces from a known 3-tool grammar
      (search -> [fetch] -> summarize); held-out plans from the same grammar score typical; a
      shuffled/alien sequence is flagged atypical; samples emit only known tools; fitting is
      deterministic given seed; both plan shapes score identically; quantile is a tunable lower
      bound.
- [x] Narrow sweep: `plan_model_test`, `task_traces_test` = 11 passed.
- [x] `ruff check` / `ruff format --check` clean.