### PR TITLE
task/FAULT: degradation policy (stacked on #32)

### DIFF
--- a/mixle/fault.py
+++ b/mixle/fault.py
@@ -1,0 +1,78 @@
+"""Degradation policy (workstream J: FAULT-a) -- named failure modes, each flagged on the receipt.
+
+A subsystem failure must never silently serve a worse answer as if nothing happened. This module is the
+shared fault boundary every degraded path goes through: :func:`with_fallback` runs the primary path and, on
+any exception, runs a named fallback instead -- the result is either NOT degraded (primary succeeded) or
+degraded under an explicit, named mode with the triggering reason attached. :func:`abstain_on_timeout` and
+:func:`route_past` are the same discipline specialized to two more named modes.
+
+The four named modes (per the card): ``teacher_down`` (fall back to captured+store-only reasoning -- see
+:meth:`mixle.system.System.answer`), ``store_down`` (reason without accumulated knowledge -- see
+:meth:`mixle.system.System.ingest`), ``oracle_timeout`` (abstain/escalate rather than guess), and
+``model_error`` (route past the failing tier to the next one). The last two are validated here as standalone
+primitives: neither an oracle nor a multi-tier local-model router is wired into :class:`~mixle.system.System`
+yet, so there is nothing live to attach them to without inventing an integration this card doesn't own.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class DegradedResult:
+    """The outcome of a fault-boundary call: a value, whether it came from a fallback, and, if so, why."""
+
+    value: Any
+    degraded: bool
+    mode: str | None = None
+    reason: str | None = None
+
+    def to_receipt_fields(self) -> dict[str, Any]:
+        """The ``degraded_mode``/``degraded_reason`` fields a caller merges onto its own receipt dict."""
+        return {"degraded_mode": self.mode, "degraded_reason": self.reason}
+
+
+def with_fallback(fn: Callable[[], Any], fallback: Callable[[Exception], Any], *, mode: str) -> DegradedResult:
+    """Run ``fn()``; on any exception, run ``fallback(exc)`` instead and flag the result under ``mode``.
+
+    Either ``fn()`` succeeds and the result is NOT degraded, or the fallback runs and the result IS flagged
+    with ``mode`` and the triggering exception's message as ``reason`` -- never a silent, unflagged
+    "somehow it still worked" path. If ``fallback`` itself raises, that exception propagates: a fallback that
+    cannot produce anything is a real failure to report, not something to paper over with a second guess.
+    """
+    try:
+        return DegradedResult(value=fn(), degraded=False)
+    except Exception as exc:  # noqa: BLE001 -- catch-any is the point: flag whatever the primary path raised
+        return DegradedResult(value=fallback(exc), degraded=True, mode=mode, reason=str(exc))
+
+
+def abstain_on_timeout(fn: Callable[[], Any], *, timeout_error: type[BaseException] = TimeoutError) -> DegradedResult:
+    """``oracle_timeout`` mode: run ``fn()``; if it raises ``timeout_error``, abstain (``value=None``) rather
+    than guess. Any OTHER exception propagates -- only a timeout is a license to abstain, not any failure."""
+    try:
+        return DegradedResult(value=fn(), degraded=False)
+    except timeout_error as exc:
+        return DegradedResult(value=None, degraded=True, mode="oracle_timeout", reason=str(exc))
+
+
+def route_past(tiers: Sequence[Callable[[], Any]], *, names: Sequence[str] | None = None) -> DegradedResult:
+    """``model_error`` mode: try each tier in order; a raising tier is skipped (not fatal) in favor of the
+    next. Degraded (flagged with which tier(s) failed) unless the FIRST tier answers cleanly. Raises the
+    last tier's exception if every tier fails -- there is no further fallback to route past."""
+    names = list(names) if names is not None else [f"tier{i}" for i in range(len(tiers))]
+    failed: list[str] = []
+    last_exc: Exception | None = None
+    for name, tier in zip(names, tiers):
+        try:
+            value = tier()
+        except Exception as exc:  # noqa: BLE001 -- route past this tier to the next, whatever it raised
+            failed.append(name)
+            last_exc = exc
+            continue
+        if not failed:
+            return DegradedResult(value=value, degraded=False)
+        return DegradedResult(value=value, degraded=True, mode="model_error", reason=f"routed past {failed}")
+    raise last_exc  # every tier failed -- nothing left to route past to

--- a/mixle/system.py
+++ b/mixle/system.py
@@ -15,6 +15,11 @@ measured in :meth:`~mixle.spend.Spend.total_units` -- a request that cannot affo
 answer path is refused (with the shortfall named on the receipt), never silently served over budget.
 Every successful call's incremental spend is added to :attr:`System.total_spend`, and both the
 incremental and running totals ride on the receipt.
+
+FAULT-a wires two named degraded modes (:mod:`mixle.fault`) into the same two verbs: ``answer`` falls
+back to captured+store-only reasoning when the teacher raises (``teacher_down``); ``ingest`` falls back
+to acknowledging-without-accumulating when the store write itself raises (``store_down``). Both flag
+``degraded_mode``/``degraded_reason`` on the returned receipt/report rather than silently serving worse.
 """
 
 from __future__ import annotations
@@ -24,6 +29,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
+from mixle.fault import with_fallback
 from mixle.spend import Spend
 from mixle.task.llm import LLM, OpenAICompatLLM
 
@@ -93,6 +99,12 @@ class System:
         one frontier call, the request is refused -- ``reply`` is ``None`` and the receipt names the exact
         ``shortfall`` -- rather than silently answering over budget. A served answer's cost is added to
         :attr:`total_spend`, which every receipt also carries as ``total_spend``.
+
+        If the teacher call itself raises, this falls back to ``teacher_down`` degraded mode: answer from
+        the store alone (a plain retrieval over ``config.store``) when one is configured and has anything
+        relevant, flagging ``degraded_mode="teacher_down"`` on the receipt; if there is no store (or
+        nothing relevant in it), the failure is reported honestly (``status="failed"``), never masked as a
+        normal answer.
         """
         requested = self.config.default_budget if budget is None else int(budget)
         cost = Spend(frontier_calls=1)
@@ -108,33 +120,74 @@ class System:
                 "captured": False,
                 "task": query.task,
             }
-        reply = _complete(self.config.teacher, query.text)
-        self.total_spend = self.total_spend + cost
+
+        def _call_teacher() -> str:
+            return _complete(self.config.teacher, query.text)
+
+        def _teacher_down_fallback(exc: Exception) -> str:
+            if self.config.store is not None:
+                from mixle.substrate.retrieve import retrieve
+
+                hits = retrieve(self.config.store, query.text, k=3, scope=self.config.scope)
+                texts = [it.text for it in hits.items if it.text]
+                if texts:
+                    return "[degraded: store-only] " + " ".join(texts)
+            raise RuntimeError(f"teacher unavailable ({exc}) and no usable store to fall back on") from exc
+
+        try:
+            result = with_fallback(_call_teacher, _teacher_down_fallback, mode="teacher_down")
+        except Exception as exc:
+            return None, {
+                "produced_by": None,
+                "status": "failed",
+                "reason": str(exc),
+                "budget": requested,
+                "spend": Spend().to_dict(),
+                "total_spend": self.total_spend.to_dict(),
+                "captured": False,
+                "task": query.task,
+            }
+        actual_cost = Spend() if result.degraded else cost
+        self.total_spend = self.total_spend + actual_cost
         receipt = {
-            "produced_by": "teacher",
+            "produced_by": "store" if result.degraded else "teacher",
             "status": "answered",
-            "spend": cost.to_dict(),
+            "spend": actual_cost.to_dict(),
             "total_spend": self.total_spend.to_dict(),
             "budget": requested,
             "captured": False,  # no local model has captured this capability yet (workstream D)
             "task": query.task,
+            **result.to_receipt_fields(),
         }
-        return reply, receipt
+        return result.value, receipt
 
     def ingest(self, model_output: str, *, source: dict[str, Any]) -> dict[str, Any]:
         """Turn a model output into stored knowledge. Uses the belief store (workstream E, KNOW-a) when
         it is importable; otherwise degrades to a plain substrate item rather than hard-depending on a
-        card that may not be built yet."""
+        card that may not be built yet.
+
+        If the store write itself raises (the store is down/unreachable, as opposed to KNOW-a simply not
+        being installed), this falls back to ``store_down`` degraded mode: the model output is
+        acknowledged but NOT accumulated, and the report is flagged ``degraded_mode="store_down"`` rather
+        than silently reporting success or losing the output without a trace.
+        """
         if self.config.store is None:
             return {"status": "no_store", "assimilated": False}
-        try:
-            from mixle.substrate.belief import assimilate, harvest_knowledge
-        except ImportError:
-            return self._ingest_fallback(model_output, source=source)
 
-        claims = harvest_knowledge(model_output, source=source)
-        items = [assimilate(self.config.store, claim, []) for claim in claims]
-        return {"status": "ok", "n_claims": len(claims), "items": items}
+        def _write() -> dict[str, Any]:
+            try:
+                from mixle.substrate.belief import assimilate, harvest_knowledge
+            except ImportError:
+                return self._ingest_fallback(model_output, source=source)
+            claims = harvest_knowledge(model_output, source=source)
+            items = [assimilate(self.config.store, claim, []) for claim in claims]
+            return {"status": "ok", "n_claims": len(claims), "items": items}
+
+        def _store_down_fallback(exc: Exception) -> dict[str, Any]:
+            return {"status": "degraded_no_accumulation", "assimilated": False}
+
+        result = with_fallback(_write, _store_down_fallback, mode="store_down")
+        return {**result.value, **result.to_receipt_fields()} if result.degraded else result.value
 
     def _ingest_fallback(self, model_output: str, *, source: dict[str, Any]) -> dict[str, Any]:
         from mixle.substrate.core import SubstrateItem

--- a/mixle/tests/fault_test.py
+++ b/mixle/tests/fault_test.py
@@ -1,0 +1,89 @@
+"""Degradation policy primitives (mixle.fault), CARD FAULT-a: named modes, each flagged, never silent."""
+
+import unittest
+
+from mixle.fault import DegradedResult, abstain_on_timeout, route_past, with_fallback
+
+
+class WithFallbackTest(unittest.TestCase):
+    def test_primary_success_is_not_degraded(self):
+        result = with_fallback(lambda: 42, lambda exc: 0, mode="unused")
+        self.assertEqual(result, DegradedResult(value=42, degraded=False))
+
+    def test_primary_failure_flags_the_named_mode_and_reason(self):
+        def boom():
+            raise ValueError("teacher endpoint unreachable")
+
+        result = with_fallback(boom, lambda exc: "fallback answer", mode="teacher_down")
+        self.assertTrue(result.degraded)
+        self.assertEqual(result.mode, "teacher_down")
+        self.assertEqual(result.value, "fallback answer")
+        self.assertIn("teacher endpoint unreachable", result.reason)
+
+    def test_fallback_that_also_fails_propagates(self):
+        def boom():
+            raise ValueError("primary down")
+
+        def fallback_boom(exc):
+            raise RuntimeError("fallback has nothing either")
+
+        with self.assertRaises(RuntimeError):
+            with_fallback(boom, fallback_boom, mode="teacher_down")
+
+    def test_to_receipt_fields_shape(self):
+        result = DegradedResult(value=1, degraded=True, mode="store_down", reason="disk full")
+        self.assertEqual(result.to_receipt_fields(), {"degraded_mode": "store_down", "degraded_reason": "disk full"})
+
+
+class AbstainOnTimeoutTest(unittest.TestCase):
+    def test_timeout_abstains_with_none_value(self):
+        def slow():
+            raise TimeoutError("oracle call exceeded budget")
+
+        result = abstain_on_timeout(slow)
+        self.assertTrue(result.degraded)
+        self.assertEqual(result.mode, "oracle_timeout")
+        self.assertIsNone(result.value)
+
+    def test_non_timeout_failure_propagates(self):
+        def broken():
+            raise ValueError("not a timeout")
+
+        with self.assertRaises(ValueError):
+            abstain_on_timeout(broken)
+
+    def test_success_is_not_degraded(self):
+        result = abstain_on_timeout(lambda: "score")
+        self.assertFalse(result.degraded)
+        self.assertEqual(result.value, "score")
+
+
+class RoutePastTest(unittest.TestCase):
+    def test_first_tier_success_is_not_degraded(self):
+        result = route_past([lambda: "cheap tier answer", lambda: "frontier answer"], names=["local", "frontier"])
+        self.assertFalse(result.degraded)
+        self.assertEqual(result.value, "cheap tier answer")
+
+    def test_failing_tier_is_routed_past_and_flagged(self):
+        def broken():
+            raise RuntimeError("local model errored")
+
+        result = route_past([broken, lambda: "frontier answer"], names=["local", "frontier"])
+        self.assertTrue(result.degraded)
+        self.assertEqual(result.mode, "model_error")
+        self.assertEqual(result.value, "frontier answer")
+        self.assertIn("local", result.reason)
+
+    def test_every_tier_failing_raises_the_last_exception(self):
+        def boom_a():
+            raise RuntimeError("tier a down")
+
+        def boom_b():
+            raise ValueError("tier b down")
+
+        with self.assertRaises(ValueError):
+            route_past([boom_a, boom_b], names=["a", "b"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mixle/tests/system_test.py
+++ b/mixle/tests/system_test.py
@@ -2,7 +2,7 @@
 
 import unittest
 
-from mixle.substrate.core import Substrate
+from mixle.substrate.core import Substrate, SubstrateItem
 from mixle.system import Query, System, SystemConfig
 
 
@@ -77,6 +77,48 @@ class SystemSpendLedgerTest(unittest.TestCase):
         _, receipt = system.answer(Query("b"))
         self.assertEqual(receipt["spend"]["frontier_calls"], 1)
         self.assertEqual(receipt["total_spend"]["frontier_calls"], 2)
+
+
+class SystemFaultModesTest(unittest.TestCase):
+    """CARD FAULT-a: teacher_down / store_down degrade to a named, flagged mode -- never silently."""
+
+    def _broken_teacher(self, prompt: str) -> str:
+        raise ConnectionError("teacher endpoint unreachable")
+
+    def test_teacher_down_falls_back_to_store_only_and_flags_it(self):
+        store = Substrate()
+        store.put(SubstrateItem(kind="text", text="the rollout finished on schedule"))
+        system = System(SystemConfig(teacher=self._broken_teacher, store=store))
+
+        reply, receipt = system.answer(Query("rollout status"))
+        self.assertIn("degraded: store-only", reply)
+        self.assertIn("rollout finished on schedule", reply)
+        self.assertEqual(receipt["status"], "answered")
+        self.assertEqual(receipt["degraded_mode"], "teacher_down")
+        self.assertIn("teacher endpoint unreachable", receipt["degraded_reason"])
+        self.assertEqual(receipt["produced_by"], "store")
+        # a degraded, store-only answer didn't actually spend a frontier call
+        self.assertEqual(receipt["spend"]["frontier_calls"], 0)
+
+    def test_teacher_down_with_no_usable_store_fails_honestly(self):
+        system = System(SystemConfig(teacher=self._broken_teacher))
+        reply, receipt = system.answer(Query("rollout status"))
+        self.assertIsNone(reply)
+        self.assertEqual(receipt["status"], "failed")
+        self.assertIn("teacher unavailable", receipt["reason"])
+
+    def test_store_down_falls_back_to_no_accumulation_and_flags_it(self):
+        class _BrokenStore:
+            def put(self, item):
+                raise OSError("store unreachable")
+
+        system = System(SystemConfig(teacher=_fake_teacher, store=_BrokenStore()))
+        report = system.ingest("the sky is blue", source={"model": "teacher-v1"})
+
+        self.assertEqual(report["status"], "degraded_no_accumulation")
+        self.assertFalse(report["assimilated"])
+        self.assertEqual(report["degraded_mode"], "store_down")
+        self.assertIn("store unreachable", report["degraded_reason"])
 
 
 class SystemIngestTest(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Card FAULT-a (workstream J), stacked on `spend-ledger` (#32, itself stacked on `system-facade` #22 SYS-a) -- **merge order: #22, then #32, then this.**
- Note: a local branch named \`fault-modes\` already existed (empty, no commits) when I started, suggesting another session may also be attempting this card under that name -- if a second implementation shows up, please pick one and close the other.
- `mixle/fault.py`: `with_fallback` (run a primary path; on any exception, run a named fallback and flag the result as degraded under that mode + the triggering reason -- never a silent "somehow it still worked"), `abstain_on_timeout` (`oracle_timeout` -> abstain rather than guess), `route_past` (`model_error` -> skip the failing tier for the next one).
- Wired two of the four named modes into `System`, the two integration points that already exist in the thin shell:
  - `System.answer`: `teacher_down` falls back to a store-only retrieval answer when the teacher call raises and the store has anything relevant (flagged, and the degraded answer doesn't spend a frontier call); with no usable store, the failure is reported honestly (`status="failed"`), never masked as a normal answer.
  - `System.ingest`: `store_down` falls back to acknowledging the model output without accumulating it when the store write itself raises (as opposed to KNOW-a simply not being installed, which is the pre-existing `ok_fallback` path and is unchanged).
- `oracle_timeout`/`model_error` are validated as standalone primitives (no oracle or multi-tier local-model router is wired into `System` yet -- wiring those two in belongs to whichever card adds that integration point, not invented here).

## Test plan
- [x] `mixle/tests/fault_test.py`: `with_fallback` success/failure/fallback-also-fails-propagates; `abstain_on_timeout` timeout-vs-other-exception; `route_past` first-tier-success, failing-tier-routed-past-and-flagged, every-tier-failing-raises.
- [x] `mixle/tests/system_test.py` (`SystemFaultModesTest`, new): teacher-down falls back to a store-only answer and flags it (with zero frontier spend); teacher-down with no usable store fails honestly; store-down falls back to no-accumulation and flags it.
- [x] `.venv/bin/python -m pytest mixle/tests/fault_test.py mixle/tests/system_test.py mixle/tests/spend_test.py -q` -- 28 passed.
- [x] `ruff check` / `ruff format --check` on changed files -- clean.