### PR TITLE
task/SEED: cold-start-from-frontier capture (stacked on #36)

### DIFF
--- a/mixle/scorecard.py
+++ b/mixle/scorecard.py
@@ -1,0 +1,100 @@
+"""System scorecard (workstream J: SCORE-a) -- one fixed held-out question set, evaluated every
+improve-round, a worsening round caught and reported rather than silently accepted.
+
+Named ``SystemScorecard`` (not ``Scorecard``) to avoid colliding with
+:class:`mixle.task.scorecard.Scorecard` -- a different, narrower comparison (one student solution vs its
+teacher on a task); this one evaluates a whole :class:`~mixle.system.System` (teacher, captured cache,
+degraded modes, budget, all of it) end to end.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+from mixle.system import Query, System
+
+
+def _default_scorer(reply: str | None, expected: str) -> bool:
+    return reply is not None and expected.strip().lower() in reply.strip().lower()
+
+
+@dataclass
+class SystemScorecard:
+    """One evaluation of a :class:`~mixle.system.System` against a fixed held-out question set."""
+
+    quality: float
+    calibration: float
+    realized_cost: float
+    grounded_fraction: float
+    n: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return dict(self.__dict__)
+
+
+def evaluate(
+    system: System,
+    question_set: Sequence[tuple[Query, str]],
+    *,
+    scorer: Callable[[str | None, str], bool] | None = None,
+) -> SystemScorecard:
+    """Evaluate ``system`` over a fixed ``[(query, expected_answer), ...]`` set.
+
+    * ``quality`` -- fraction of questions ``scorer`` judges correct (default: case-insensitive
+      substring match of ``expected`` in the reply).
+    * ``grounded_fraction`` -- fraction answered WITHOUT a degraded mode (teacher or captured, not a
+      store-only fallback / refusal / failure): the fraction of answers you can actually trust came
+      from a real answer path, not a fault-boundary guess.
+    * ``realized_cost`` -- total spend units (:meth:`~mixle.spend.Spend.total_units`) across the set.
+    * ``calibration`` -- a coarse proxy (currently equal to ``quality``) until ``answer`` carries a real
+      per-answer confidence to calibrate against; extend THIS function, not call sites, once that lands.
+    """
+    n = len(question_set)
+    if n == 0:
+        return SystemScorecard(quality=0.0, calibration=0.0, realized_cost=0.0, grounded_fraction=0.0, n=0)
+    scorer = scorer or _default_scorer
+    correct = 0
+    grounded = 0
+    cost = 0.0
+    for query, expected in question_set:
+        reply, receipt = system.answer(query)
+        if scorer(reply, expected):
+            correct += 1
+        if receipt.get("status") == "answered" and receipt.get("degraded_mode") is None:
+            grounded += 1
+        spend = receipt.get("spend") or {}
+        cost += float(spend.get("frontier_calls", 0)) + float(spend.get("oracle_calls", 0))
+    quality = correct / n
+    return SystemScorecard(
+        quality=quality, calibration=quality, realized_cost=cost, grounded_fraction=grounded / n, n=n
+    )
+
+
+@dataclass
+class RegressionReport:
+    """Whether ``current`` is worse than ``baseline`` on any tracked axis, and exactly why."""
+
+    regressed: bool
+    reasons: list[str] = field(default_factory=list)
+
+
+def detect_regression(
+    baseline: SystemScorecard, current: SystemScorecard, *, tolerance: float = 1e-9
+) -> RegressionReport:
+    """Compare two scorecards from the SAME held-out set across improve-rounds.
+
+    Never silently accepts a round that answers worse, less groundedly, or for more cost than the round
+    before it -- each tracked axis that got worse (beyond ``tolerance``) is named in ``reasons``.
+    """
+    reasons: list[str] = []
+    if current.quality < baseline.quality - tolerance:
+        reasons.append(f"quality regressed: {baseline.quality:.3f} -> {current.quality:.3f}")
+    if current.grounded_fraction < baseline.grounded_fraction - tolerance:
+        reasons.append(
+            f"grounded_fraction regressed: {baseline.grounded_fraction:.3f} -> {current.grounded_fraction:.3f}"
+        )
+    if current.realized_cost > baseline.realized_cost + tolerance:
+        reasons.append(f"realized_cost increased: {baseline.realized_cost:.3f} -> {current.realized_cost:.3f}")
+    return RegressionReport(regressed=bool(reasons), reasons=reasons)

--- a/mixle/system.py
+++ b/mixle/system.py
@@ -99,14 +99,16 @@ class System:
     def __init__(self, config: SystemConfig) -> None:
         self.config = config
         self.total_spend = Spend()
-        self._harvest: dict[str, str] = {}
-        self._captured: dict[str, str] = {}
+        self._harvest: dict[tuple[str, str, str], str] = {}
+        self._captured: dict[tuple[str, str, str], str] = {}
 
     def answer(self, query: Query, *, budget: int | None = None) -> tuple[str | None, dict[str, Any]]:
         """Thin shell: route straight to the teacher, wrap the reply in a minimal H-style receipt.
 
-        Checks the captured cache first (see :meth:`improve`): an exact repeat of a query already
-        promoted by a prior ``improve()`` call is served free, no budget spent, ``captured=True``.
+        Checks the captured cache first (see :meth:`improve`): an exact repeat of a query (same text,
+        task, AND scope -- two queries that merely share text but differ in task/scope are different
+        questions and must not share a cache entry) already promoted by a prior ``improve()`` call is
+        served free, no budget spent, ``captured=True``.
 
         ``budget`` is a hard ceiling (:class:`~mixle.spend.Spend.total_units`): if it cannot afford even
         one frontier call, the request is refused -- ``reply`` is ``None`` and the receipt names the exact
@@ -119,8 +121,9 @@ class System:
         nothing relevant in it), the failure is reported honestly (``status="failed"``), never masked as a
         normal answer.
         """
-        if query.text in self._captured:
-            return self._captured[query.text], {
+        cache_key = (query.text, query.task, query.scope)
+        if cache_key in self._captured:
+            return self._captured[cache_key], {
                 "produced_by": "captured",
                 "status": "answered",
                 "spend": Spend().to_dict(),
@@ -176,7 +179,7 @@ class System:
         actual_cost = Spend() if result.degraded else cost
         self.total_spend = self.total_spend + actual_cost
         if not result.degraded:
-            self._harvest[query.text] = result.value
+            self._harvest[cache_key] = result.value
         receipt = {
             "produced_by": "store" if result.degraded else "teacher",
             "status": "answered",

--- a/mixle/system.py
+++ b/mixle/system.py
@@ -20,6 +20,14 @@ FAULT-a wires two named degraded modes (:mod:`mixle.fault`) into the same two ve
 back to captured+store-only reasoning when the teacher raises (``teacher_down``); ``ingest`` falls back
 to acknowledging-without-accumulating when the store write itself raises (``store_down``). Both flag
 ``degraded_mode``/``degraded_reason`` on the returned receipt/report rather than silently serving worse.
+
+SEED-a closes the cold-start loop: every teacher-produced answer is harvested (query text -> reply);
+``improve`` promotes whatever has been harvested into a captured cache (nothing fancier -- this thin
+shell's "capture" is a verbatim lookup, not a trained model); ``answer`` checks the captured cache
+FIRST, before spending anything, so a repeat of the exact same query after an ``improve`` call is
+served free (``captured=True``, zero frontier calls) instead of re-querying the teacher. Capture only
+promotes after an explicit ``improve()`` -- a repeat query *before* ``improve`` still pays for a fresh
+teacher call, so the measured saving is attributable to ``improve``, not an implicit cache.
 """
 
 from __future__ import annotations
@@ -91,9 +99,14 @@ class System:
     def __init__(self, config: SystemConfig) -> None:
         self.config = config
         self.total_spend = Spend()
+        self._harvest: dict[str, str] = {}
+        self._captured: dict[str, str] = {}
 
     def answer(self, query: Query, *, budget: int | None = None) -> tuple[str | None, dict[str, Any]]:
         """Thin shell: route straight to the teacher, wrap the reply in a minimal H-style receipt.
+
+        Checks the captured cache first (see :meth:`improve`): an exact repeat of a query already
+        promoted by a prior ``improve()`` call is served free, no budget spent, ``captured=True``.
 
         ``budget`` is a hard ceiling (:class:`~mixle.spend.Spend.total_units`): if it cannot afford even
         one frontier call, the request is refused -- ``reply`` is ``None`` and the receipt names the exact
@@ -106,6 +119,19 @@ class System:
         nothing relevant in it), the failure is reported honestly (``status="failed"``), never masked as a
         normal answer.
         """
+        if query.text in self._captured:
+            return self._captured[query.text], {
+                "produced_by": "captured",
+                "status": "answered",
+                "spend": Spend().to_dict(),
+                "total_spend": self.total_spend.to_dict(),
+                "budget": self.config.default_budget if budget is None else int(budget),
+                "captured": True,
+                "task": query.task,
+                "degraded_mode": None,
+                "degraded_reason": None,
+            }
+
         requested = self.config.default_budget if budget is None else int(budget)
         cost = Spend(frontier_calls=1)
         if requested < cost.total_units():
@@ -149,6 +175,8 @@ class System:
             }
         actual_cost = Spend() if result.degraded else cost
         self.total_spend = self.total_spend + actual_cost
+        if not result.degraded:
+            self._harvest[query.text] = result.value
         receipt = {
             "produced_by": "store" if result.degraded else "teacher",
             "status": "answered",
@@ -203,9 +231,25 @@ class System:
         return {"status": "ok_fallback", "assimilated": False, "item_id": item.id}
 
     def improve(self, budget: int) -> dict[str, Any]:
-        """Stub until an orchestrator/router/registry registers into the system: nothing to improve yet."""
+        """Promote every harvested (query, reply) pair from :meth:`answer` into the captured cache.
+
+        Honestly reports there is nothing to improve when nothing has been harvested yet (an orchestrator/
+        router/registry with a real training step is future work); otherwise this is the cold-start
+        capture step SEED-a measures: after this call, a repeat of any just-captured query is answered
+        for free (see :meth:`answer`).
+        """
+        if not self._harvest:
+            return {
+                "status": "nothing_to_improve",
+                "reason": "no improvement subsystem registered yet",
+                "budget": int(budget),
+            }
+        n_captured = len(self._harvest)
+        self._captured.update(self._harvest)
+        self._harvest.clear()
         return {
-            "status": "nothing_to_improve",
-            "reason": "no improvement subsystem registered yet",
+            "status": "captured",
+            "reason": f"promoted {n_captured} harvested (query, reply) pair(s) into the captured cache",
             "budget": int(budget),
+            "n_captured": n_captured,
         }

--- a/mixle/tests/scorecard_test.py
+++ b/mixle/tests/scorecard_test.py
@@ -1,0 +1,94 @@
+"""System scorecard (mixle.scorecard), CARD SCORE-a: evaluate() over a fixed set; catch a worsening round."""
+
+import unittest
+
+from mixle.scorecard import detect_regression, evaluate
+from mixle.substrate.core import Substrate, SubstrateItem
+from mixle.system import Query, System, SystemConfig
+
+
+class EvaluateTest(unittest.TestCase):
+    def test_quality_and_grounded_fraction_on_a_perfect_system(self):
+        system = System(SystemConfig(teacher=lambda p: "yes, absolutely"))
+        question_set = [(Query("q1"), "yes"), (Query("q2"), "yes")]
+        card = evaluate(system, question_set)
+        self.assertEqual(card.quality, 1.0)
+        self.assertEqual(card.grounded_fraction, 1.0)
+        self.assertEqual(card.realized_cost, 2.0)
+        self.assertEqual(card.n, 2)
+
+    def test_quality_reflects_wrong_answers(self):
+        system = System(SystemConfig(teacher=lambda p: "no idea"))
+        question_set = [(Query("q1"), "yes"), (Query("q2"), "yes")]
+        card = evaluate(system, question_set)
+        self.assertEqual(card.quality, 0.0)
+
+    def test_empty_question_set_is_honest_not_a_div_by_zero_crash(self):
+        system = System(SystemConfig(teacher=lambda p: "x"))
+        card = evaluate(system, [])
+        self.assertEqual(card.n, 0)
+        self.assertEqual(card.quality, 0.0)
+
+    def test_teacher_down_answers_are_not_counted_grounded(self):
+        def broken_teacher(prompt):
+            raise ConnectionError("down")
+
+        store = Substrate()
+        store.put(SubstrateItem(kind="text", text="yes it is confirmed"))
+        system = System(SystemConfig(teacher=broken_teacher, store=store))
+        card = evaluate(system, [(Query("q1"), "yes")])
+        self.assertEqual(card.grounded_fraction, 0.0)
+
+
+class RegressionDetectionTest(unittest.TestCase):
+    def test_a_deliberately_worsening_round_is_caught(self):
+        question_set = [(Query("q1"), "yes"), (Query("q2"), "yes")]
+
+        good_system = System(SystemConfig(teacher=lambda p: "yes, absolutely"))
+        baseline = evaluate(good_system, question_set)
+
+        bad_system = System(SystemConfig(teacher=lambda p: "no idea"))
+        worse = evaluate(bad_system, question_set)
+
+        report = detect_regression(baseline, worse)
+        self.assertTrue(report.regressed)
+        self.assertTrue(any("quality regressed" in r for r in report.reasons))
+
+    def test_a_grounded_fraction_drop_is_caught(self):
+        question_set = [(Query("q1"), "yes")]
+        good_system = System(SystemConfig(teacher=lambda p: "yes"))
+        baseline = evaluate(good_system, question_set)
+
+        def broken_teacher(prompt):
+            raise ConnectionError("down")
+
+        store = Substrate()
+        store.put(SubstrateItem(kind="text", text="yes indeed"))
+        degraded_system = System(SystemConfig(teacher=broken_teacher, store=store))
+        current = evaluate(degraded_system, question_set)
+
+        report = detect_regression(baseline, current)
+        self.assertTrue(report.regressed)
+        self.assertTrue(any("grounded_fraction regressed" in r for r in report.reasons))
+
+    def test_a_non_regressing_round_is_not_flagged(self):
+        question_set = [(Query("q1"), "yes")]
+        system = System(SystemConfig(teacher=lambda p: "yes, absolutely"))
+        baseline = evaluate(system, question_set)
+        current = evaluate(system, question_set)
+        report = detect_regression(baseline, current)
+        self.assertFalse(report.regressed)
+        self.assertEqual(report.reasons, [])
+
+    def test_an_improving_round_is_not_flagged(self):
+        question_set = [(Query("q1"), "yes")]
+        bad_system = System(SystemConfig(teacher=lambda p: "no idea"))
+        baseline = evaluate(bad_system, question_set)
+        good_system = System(SystemConfig(teacher=lambda p: "yes, absolutely"))
+        improved = evaluate(good_system, question_set)
+        report = detect_regression(baseline, improved)
+        self.assertFalse(report.regressed)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mixle/tests/system_test.py
+++ b/mixle/tests/system_test.py
@@ -148,6 +148,60 @@ class SystemImproveTest(unittest.TestCase):
         self.assertEqual(report["budget"], 10)
 
 
+class SystemColdStartCaptureTest(unittest.TestCase):
+    """CARD SEED-a: from an empty system, answer then improve, and the second identical answer is free."""
+
+    def _counting_teacher(self):
+        calls = {"n": 0}
+
+        def teacher(prompt):
+            calls["n"] += 1
+            return f"answer to: {prompt}"
+
+        return teacher, calls
+
+    def test_second_identical_query_after_improve_costs_no_frontier_calls(self):
+        teacher, calls = self._counting_teacher()
+        system = System(SystemConfig(teacher=teacher))
+        query = Query("what is the capital of Freedonia?")
+
+        reply1, receipt1 = system.answer(query)
+        self.assertEqual(calls["n"], 1)
+        self.assertFalse(receipt1["captured"])
+
+        report = system.improve(10)
+        self.assertEqual(report["status"], "captured")
+        self.assertEqual(report["n_captured"], 1)
+
+        reply2, receipt2 = system.answer(query)
+        self.assertEqual(calls["n"], 1)  # no new frontier call -- served from the captured cache
+        self.assertEqual(reply2, reply1)
+        self.assertTrue(receipt2["captured"])
+        self.assertEqual(receipt2["produced_by"], "captured")
+        self.assertEqual(receipt2["spend"], {"frontier_calls": 0, "oracle_calls": 0, "wall_ms": 0.0, "dollars": 0.0})
+
+    def test_repeat_query_before_improve_still_pays_for_a_fresh_teacher_call(self):
+        teacher, calls = self._counting_teacher()
+        system = System(SystemConfig(teacher=teacher))
+        query = Query("what is the capital of Freedonia?")
+        system.answer(query)
+        system.answer(query)
+        self.assertEqual(calls["n"], 2)
+
+    def test_capture_is_specific_to_the_captured_query_text(self):
+        teacher, calls = self._counting_teacher()
+        system = System(SystemConfig(teacher=teacher))
+        system.answer(Query("query one"))
+        system.improve(10)
+        system.answer(Query("query two"))  # a different query -- still a real teacher call
+        self.assertEqual(calls["n"], 2)
+
+    def test_improve_with_nothing_harvested_yet_is_still_honest(self):
+        system = System(SystemConfig(teacher=_fake_teacher))
+        report = system.improve(10)
+        self.assertEqual(report["status"], "nothing_to_improve")
+
+
 class SystemConfigFromEnvTest(unittest.TestCase):
     def test_from_env_requires_base_url_and_model(self):
         with self.assertRaises(ValueError) as ctx:

--- a/mixle/tests/system_test.py
+++ b/mixle/tests/system_test.py
@@ -201,6 +201,24 @@ class SystemColdStartCaptureTest(unittest.TestCase):
         report = system.improve(10)
         self.assertEqual(report["status"], "nothing_to_improve")
 
+    def test_same_text_different_task_does_not_share_a_captured_cache_entry(self):
+        # regression: two queries with identical text but a different task (or scope) are different
+        # questions and must not silently answer one from the other's captured cache
+        teacher, calls = self._counting_teacher()
+        system = System(SystemConfig(teacher=teacher))
+        system.answer(Query("classify this", task="sentiment"))
+        system.improve(10)
+        system.answer(Query("classify this", task="topic"))
+        self.assertEqual(calls["n"], 2)
+
+    def test_same_text_different_scope_does_not_share_a_captured_cache_entry(self):
+        teacher, calls = self._counting_teacher()
+        system = System(SystemConfig(teacher=teacher))
+        system.answer(Query("classify this", scope="team-a"))
+        system.improve(10)
+        system.answer(Query("classify this", scope="team-b"))
+        self.assertEqual(calls["n"], 2)
+
 
 class SystemConfigFromEnvTest(unittest.TestCase):
     def test_from_env_requires_base_url_and_model(self):


### PR DESCRIPTION
## Summary
- Card SEED-a (workstream J), stacked on `fault-degraded-modes` (#36, itself stacked on #32 SPEND-a, itself stacked on #22 SYS-a) -- **merge order: #22, #32, #36, then this.**
- Closes the cold-start loop on `System`: every teacher-produced (non-degraded) answer from `answer()` is harvested as a `(query text -> reply)` pair; `improve(budget)` promotes whatever has been harvested into a captured cache; `answer()` checks that cache FIRST, before spending anything.
- Deliberately the simplest honest "capture" for a thin shell: a verbatim exact-match lookup, not a trained model (real distillation belongs to workstream D once there's enough harvested volume and a task shape that fits a classifier/regressor -- free-form QA replies don't fit `TaskModel`'s classification contract as-is).
- Capture only takes effect after an explicit `improve()` call -- a repeat query *before* `improve()` still pays for a fresh teacher call, so the measured saving in the acceptance test is attributable to `improve()`, not an implicit cache.

## Test plan
- [x] `mixle/tests/system_test.py` (`SystemColdStartCaptureTest`, new): the card's literal acceptance -- from empty, `answer()` then `improve()`, and the second identical `answer()` costs zero frontier calls (verified via a call-counting fake teacher, not just receipt bookkeeping) and returns the identical reply, flagged `captured=True`/`produced_by="captured"`; a repeat query *before* `improve()` still calls the teacher; capture is specific to the captured query text (a different query still calls the teacher); `improve()` with nothing harvested yet is still honest.
- [x] `.venv/bin/python -m pytest mixle/tests/system_test.py mixle/tests/fault_test.py mixle/tests/spend_test.py -q` -- 32 passed.
- [x] `ruff check` / `ruff format --check` on changed files -- clean.