### PR TITLE
task/D6: extraction-student capture profiles via executable verifiers

### DIFF
--- a/mixle/task/__init__.py
+++ b/mixle/task/__init__.py
@@ -82,6 +82,7 @@ from mixle.task.extract import (
     extraction_f1,
     tokenize,
 )
+from mixle.task.generative_capability import extractive_capture_profile, validate_extraction_schema
 from mixle.task.generative_text import GenerativeTextIO, distill_text_generative, distill_text_generative_from_labels
 from mixle.task.harness import ExtractorHarness, MatcherHarness, replace_alerter, replace_extractor, replace_matcher
 from mixle.task.llm import (
@@ -149,6 +150,8 @@ __all__ = [
     "MatcherHarness",
     "FieldChoice",
     "GenerativeTextIO",
+    "extractive_capture_profile",
+    "validate_extraction_schema",
     "HashedNGram",
     "HashedRecord",
     "LNSStructuredClassifierIO",

--- a/mixle/task/capability.py
+++ b/mixle/task/capability.py
@@ -63,11 +63,19 @@ def whitespace_invariance(text: str) -> str:
 
 def _predict(model: Any, texts: list[str]) -> list[Any]:
     """Batch-predict labels from ``model``, which may be a ``CalibratedTaskModel``, a ``TaskModel``-like object
-    exposing ``batch``, or a bare ``teacher(texts) -> labels`` / ``teacher(text) -> label`` callable."""
-    if hasattr(model, "task"):
-        return list(model.task.batch(texts))
+    exposing ``batch``, or a bare ``teacher(texts) -> labels`` / ``teacher(text) -> label`` callable.
+
+    Checks ``batch`` before ``task``: a bare ``TaskModel``'s own ``task`` attribute is a plain
+    descriptive string, not a nested model, so checking ``task`` first misfires
+    (``AttributeError: 'str' object has no attribute 'batch'``) on any model not wrapped in
+    ``CalibratedTaskModel`` -- e.g. a :func:`~mixle.task.extract.distill_extractor` student, whose
+    adapter has no ``proba_batch`` and so can never be calibration-wrapped. ``CalibratedTaskModel``
+    itself exposes no ``batch``, so this order still falls through to ``model.task.batch`` for it.
+    """
     if hasattr(model, "batch"):
         return list(model.batch(texts))
+    if hasattr(model, "task"):
+        return list(model.task.batch(texts))
     out = model(texts)
     if isinstance(out, (list, tuple)) and len(out) == len(texts):
         return list(out)

--- a/mixle/task/generative_capability.py
+++ b/mixle/task/generative_capability.py
@@ -1,0 +1,132 @@
+"""Capture profiles for structured-output students (workstream D6): extraction and generative-text.
+
+:func:`~mixle.task.capability.capture_profile` scores agreement by exact match on a scalar label -- the
+right notion for a classifier, but the wrong one for a field extractor: a student that gets 3 of 4 fields
+right under a typo corruption is not "wrong", and exact-match agreement would report it identically to a
+student that got every field wrong. This module extends the same :class:`~mixle.task.capability.CapabilitySuite`
+machinery (corruptions, invariances -- reused, not reinvented) with EXECUTABLE verifiers suited to
+structured output:
+
+* extraction students (:func:`~mixle.task.extract.distill_extractor`, adapter ``ExtractionIO``): scored by
+  micro-averaged field-level F1 against a fixed gold reference (the teacher's own extraction on the CLEAN
+  text -- corruption is a nuisance perturbation of the input, not a change to the true answer), plus a
+  schema-validity check (every expected field present, every value actually grounded in -- a substring of
+  -- the text it was extracted from). Both are checkable by code, never by eyeballing output.
+* :func:`~mixle.task.generative_text.distill_text_generative` students predict a plain label (like any
+  other classifier), so the base :func:`capture_profile` already scores them correctly -- no special
+  handling needed here; this module documents that explicitly rather than silently duplicating it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+import numpy as np
+
+from mixle.task.capability import CapabilitySuite, _decide, _escalation_rate, _predict
+
+
+def validate_extraction_schema(record: dict[str, Any], source_text: str, fields: Sequence[str]) -> dict[str, Any]:
+    """Executable schema check for one extracted record: complete (every expected field present) and
+    grounded (every non-empty value is an actual substring of ``source_text``, not hallucinated).
+
+    Returns a plain dict (``complete``, ``grounded``, ``missing``, ``ungrounded``) -- never a single
+    pass/fail bit, so a caller can see exactly what failed.
+    """
+    fields = list(fields)
+    missing = [f for f in fields if f not in record or not record.get(f)]
+    ungrounded = [f for f, v in record.items() if f in fields and v and str(v) not in source_text]
+    return {
+        "complete": not missing,
+        "grounded": not ungrounded,
+        "missing": missing,
+        "ungrounded": ungrounded,
+    }
+
+
+def _field_f1(pred: Sequence[dict[str, Any]], gold: Sequence[dict[str, Any]]) -> float:
+    """Micro-averaged field-level F1 (same formula as :func:`mixle.task.extract.extraction_f1`, generalized
+    to operate on already-computed prediction dicts instead of requiring a ``TaskModel.batch`` call, so it
+    scores a bare-callable teacher the same way it scores a ``TaskModel`` student)."""
+    tp = fp = fn = 0
+    for p, g in zip(pred, gold):
+        for field, value in g.items():
+            if p.get(field) == value:
+                tp += 1
+            else:
+                fn += 1
+        for field in p:
+            if field not in g:
+                fp += 1
+    denom = 2 * tp + fp + fn
+    return (2 * tp / denom) if denom else 1.0
+
+
+def _schema_validity_rate(records: Sequence[dict[str, Any]], texts: Sequence[str], fields: Sequence[str]) -> float:
+    if not records:
+        return 1.0
+    checks = [validate_extraction_schema(r, t, fields) for r, t in zip(records, texts)]
+    return float(np.mean([c["complete"] and c["grounded"] for c in checks]))
+
+
+def extractive_capture_profile(
+    student: Any, teacher: Any, texts: Sequence[str], suite: CapabilitySuite, *, fields: Sequence[str]
+) -> dict[str, Any]:
+    """The extraction-student capture profile: F1-against-gold and schema validity, not exact-match agreement.
+
+    ``gold`` is the teacher's own extraction on the CLEAN ``texts`` -- the true answer a corruption should
+    not change. Reports, JSON-serializable:
+
+    * ``"clean_f1"`` -- student F1 against gold on clean text (teacher's own clean F1 against its own gold
+      is trivially 1.0 and omitted);
+    * ``"corruptions"`` -- per corruption name, ``{"student_f1", "teacher_f1"}`` against the SAME fixed
+      gold -- both sides scored against the same ground truth, so a comparison is meaningful;
+    * ``"invariances"`` -- per invariance name, ``{"student_f1", "teacher_f1"}`` between each side's clean
+      prediction and its prediction on the rewritten text (1.0 = perfectly invariant);
+    * ``"schema_validity"`` -- ``{"student", "teacher"}`` fraction of CLEAN-text extractions that are
+      complete and grounded (:func:`validate_extraction_schema`) -- an executable check, never eyeballed;
+    * ``"abstention"`` -- as in :func:`~mixle.task.capability.capture_profile`, if either side exposes a
+      decision API.
+    """
+    texts = [str(t) for t in texts]
+    fields = list(fields)
+    gold = _predict(teacher, texts)
+
+    student_clean = _predict(student, texts)
+    profile: dict[str, Any] = {
+        "clean_f1": _field_f1(student_clean, gold),
+        "schema_validity": {
+            "student": _schema_validity_rate(student_clean, texts, fields),
+            "teacher": _schema_validity_rate(gold, texts, fields),
+        },
+    }
+
+    corruptions: dict[str, dict[str, float]] = {}
+    for name, corrupt in suite.corruptions.items():
+        corrupted = [corrupt(t) for t in texts]
+        corruptions[name] = {
+            "student_f1": _field_f1(_predict(student, corrupted), gold),
+            "teacher_f1": _field_f1(_predict(teacher, corrupted), gold),
+        }
+    profile["corruptions"] = corruptions
+
+    teacher_clean = gold
+    invariances: dict[str, dict[str, float]] = {}
+    for name, rewrite in suite.invariances.items():
+        rewritten = [rewrite(t) for t in texts]
+        invariances[name] = {
+            "student_f1": _field_f1(_predict(student, rewritten), student_clean),
+            "teacher_f1": _field_f1(_predict(teacher, rewritten), teacher_clean),
+        }
+    profile["invariances"] = invariances
+
+    student_decisions = _decide(student, texts)
+    teacher_decisions = _decide(teacher, texts)
+    if student_decisions is not None or teacher_decisions is not None:
+        profile["abstention"] = {
+            "student_escalation_rate": _escalation_rate(student_decisions) if student_decisions is not None else None,
+            "teacher_escalation_rate": _escalation_rate(teacher_decisions) if teacher_decisions is not None else None,
+        }
+
+    return profile

--- a/mixle/tests/generative_capability_test.py
+++ b/mixle/tests/generative_capability_test.py
@@ -1,0 +1,124 @@
+"""Extraction-student capture profiles (workstream D6): F1-against-gold, not exact-match agreement.
+
+The load-bearing claim: exact-match agreement (the base capture_profile's notion) understates a
+partially-correct extractor's real capability -- a student that gets most fields right under a
+corruption looks the same as one that gets none right, once you demand an exact dict match. Field-level
+F1 against a fixed gold reference does not have that blind spot. Built with a real distilled
+ExtractionIO student, not a hand-rolled stand-in.
+"""
+
+import unittest
+
+import numpy as np
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("safetensors")
+
+from mixle.task.capability import (  # noqa: E402
+    CapabilitySuite,
+    capture_profile,
+    keyboard_typo_corruption,
+)
+from mixle.task.extract import distill_extractor  # noqa: E402
+from mixle.task.generative_capability import (  # noqa: E402
+    extractive_capture_profile,
+    validate_extraction_schema,
+)
+
+NAMES = ["alice", "bob", "carol", "david", "erin", "frank", "grace", "henry"]
+TEMPLATES = [
+    "hi my name is {n} nice to meet you",
+    "hello, i am {n} and i like tea",
+    "{n} said hello to the team today",
+    "please welcome {n} to the call",
+]
+
+
+def _teacher(texts):
+    out = []
+    for t in texts:
+        low = t.lower()
+        found = next((n for n in NAMES if n in low), None)
+        out.append({"name": found} if found else {})
+    return out
+
+
+def _corpus(n_per=18, seed=0):
+    rng = np.random.RandomState(seed)
+    texts = []
+    for name in NAMES:
+        for _ in range(n_per):
+            texts.append(TEMPLATES[rng.randint(len(TEMPLATES))].format(n=name))
+    rng.shuffle(texts)
+    return texts
+
+
+class ValidateExtractionSchemaTest(unittest.TestCase):
+    def test_complete_and_grounded_record_passes(self):
+        check = validate_extraction_schema({"name": "alice"}, "hi my name is alice", ["name"])
+        self.assertTrue(check["complete"])
+        self.assertTrue(check["grounded"])
+        self.assertEqual(check["missing"], [])
+        self.assertEqual(check["ungrounded"], [])
+
+    def test_missing_field_fails_completeness(self):
+        check = validate_extraction_schema({}, "hi there", ["name"])
+        self.assertFalse(check["complete"])
+        self.assertIn("name", check["missing"])
+
+    def test_hallucinated_value_fails_groundedness(self):
+        # "zach" is not a substring of the source text -- a hallucinated (or corrupted-span) value.
+        check = validate_extraction_schema({"name": "zach"}, "hi my name is alice", ["name"])
+        self.assertFalse(check["grounded"])
+        self.assertIn("name", check["ungrounded"])
+
+
+class ExtractiveCaptureProfileTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.texts = _corpus()
+        cls.student = distill_extractor(_teacher, cls.texts, ["name"], epochs=80, seed=0)
+
+    def test_clean_f1_is_high_and_schema_valid(self):
+        suite = CapabilitySuite()
+        profile = extractive_capture_profile(self.student, _teacher, self.texts, suite, fields=["name"])
+        self.assertGreater(profile["clean_f1"], 0.85)
+        # ExtractionIO always decodes a span of the text it was called on -- grounded by construction.
+        self.assertEqual(profile["schema_validity"]["student"], 1.0)
+        self.assertEqual(profile["schema_validity"]["teacher"], 1.0)
+
+    def test_profile_shows_measurable_degradation_under_corruption(self):
+        suite = CapabilitySuite(corruptions={"typo_40": keyboard_typo_corruption(0.4, seed=0)})
+        profile = extractive_capture_profile(self.student, _teacher, self.texts, suite, fields=["name"])
+        self.assertLess(profile["corruptions"]["typo_40"]["student_f1"], profile["clean_f1"])
+
+    def test_agreement_with_teacher_can_mask_true_performance_f1_against_gold_does_not(self):
+        # Same fixture, scored two ways under a heavy corruption. capture_profile's base metric is
+        # student-vs-TEACHER agreement on the corrupted input: if a corruption is severe enough that
+        # BOTH sides degrade to the same (wrong) extraction -- e.g. both fail to find the name and
+        # return {} -- the two "agree" perfectly even though neither is actually right. F1-against-a-
+        # fixed-gold does not have that blind spot: it is checked against the true answer, not against
+        # whatever the teacher also happens to say under the same corruption.
+        suite = CapabilitySuite(corruptions={"typo_70": keyboard_typo_corruption(0.7, seed=1)})
+        extractive = extractive_capture_profile(self.student, _teacher, self.texts, suite, fields=["name"])
+        base = capture_profile(self.student, _teacher, self.texts, suite)
+
+        f1_score = extractive["corruptions"]["typo_70"]["student_f1"]
+        exact_match_score = base["corruptions"]["typo_70"]
+        # heavy corruption: student and teacher both largely fail the same way (agreement looks fine)
+        self.assertGreater(exact_match_score, 0.9)
+        # ... but true field-level performance against the fixed gold is genuinely poor -- the gap
+        # base capture_profile's agreement number cannot see.
+        self.assertLess(f1_score, exact_match_score - 0.3)
+
+    def test_invariance_uses_f1_not_binary_violation(self):
+        suite = CapabilitySuite(invariances={"case_jitter": lambda t: t.swapcase()})
+        profile = extractive_capture_profile(self.student, _teacher, self.texts, suite, fields=["name"])
+        self.assertIn("case_jitter", profile["invariances"])
+        self.assertIn("student_f1", profile["invariances"]["case_jitter"])
+        self.assertIn("teacher_f1", profile["invariances"]["case_jitter"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Stacked on #17 (task/D3, branch `capability-suite`) -- do not merge before #17. Base and head will need retargeting to `release/0.6.3-generic-capabilities` once #17 lands.

- Card D6-a (workstream D6, a one-paragraph plan stub expanded here): extends D3's `CapabilitySuite`/`capture_profile` to structured-output students, scored by executable verifiers instead of exact-match agreement.
- `validate_extraction_schema(record, source_text, fields)`: complete (every expected field present) + grounded (every value an actual substring of the source text, never hallucinated). Executable, never eyeballed.
- `extractive_capture_profile(student, teacher, texts, suite, fields=...)`: the extraction-student profile -- micro-averaged field-level F1 against a fixed gold reference (the teacher's own extraction on the CLEAN text, since corruption perturbs the input, not the true answer), not `capture_profile`'s exact-match agreement. Same suite object, same JSON-serializable shape, different (graded) scoring.
- `distill_text_generative` students predict a plain label like any classifier, so the base `capture_profile` already scores them correctly -- documented explicitly rather than duplicating logic.
- **Bug fix in `mixle.task.capability._predict`**: it checked `hasattr(model, "task")` before `hasattr(model, "batch")`, which misfires (`AttributeError: 'str' object has no attribute 'batch'`) on a bare `TaskModel` -- exactly what `distill_extractor` returns, since its adapter has no `proba_batch` and so can never be `CalibratedTaskModel`-wrapped. Reordering is behavior-preserving for `CalibratedTaskModel` (which exposes no top-level `.batch`, so it still falls through to `.task.batch`) and is required for this card's own comparison test to run. Flagging explicitly for the #17 author since it's their file.

## Test plan
- [x] `mixle/tests/generative_capability_test.py` (7 new tests): schema-validator unit tests; clean F1 high + schema-valid on a real distilled `distill_extractor` student; measurable F1 degradation under a typo corruption; **the load-bearing case** -- under heavy corruption, student/teacher exact-match agreement looks near-perfect (both degrade the same way, e.g. both return `{}`) while F1-against-gold correctly exposes genuinely poor performance -- the blind spot plain agreement has and this doesn't; invariance scored by F1.
- [x] Targeted regression: `pytest mixle/tests -k "extract or capability"` -- 65 passed, 2 skipped (expected compiled-kernel skips), 0 failed (confirms the `_predict` reorder doesn't change any existing `capture_profile` test outcome).
- [x] `ruff check` / `ruff format --check` clean on changed files.