### PR TITLE
task/SCORE: system scorecard + regression detection (stacked on #37)

### DIFF
--- a/mixle/scorecard.py
+++ b/mixle/scorecard.py
@@ -1,0 +1,100 @@
+"""System scorecard (workstream J: SCORE-a) -- one fixed held-out question set, evaluated every
+improve-round, a worsening round caught and reported rather than silently accepted.
+
+Named ``SystemScorecard`` (not ``Scorecard``) to avoid colliding with
+:class:`mixle.task.scorecard.Scorecard` -- a different, narrower comparison (one student solution vs its
+teacher on a task); this one evaluates a whole :class:`~mixle.system.System` (teacher, captured cache,
+degraded modes, budget, all of it) end to end.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+from mixle.system import Query, System
+
+
+def _default_scorer(reply: str | None, expected: str) -> bool:
+    return reply is not None and expected.strip().lower() in reply.strip().lower()
+
+
+@dataclass
+class SystemScorecard:
+    """One evaluation of a :class:`~mixle.system.System` against a fixed held-out question set."""
+
+    quality: float
+    calibration: float
+    realized_cost: float
+    grounded_fraction: float
+    n: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return dict(self.__dict__)
+
+
+def evaluate(
+    system: System,
+    question_set: Sequence[tuple[Query, str]],
+    *,
+    scorer: Callable[[str | None, str], bool] | None = None,
+) -> SystemScorecard:
+    """Evaluate ``system`` over a fixed ``[(query, expected_answer), ...]`` set.
+
+    * ``quality`` -- fraction of questions ``scorer`` judges correct (default: case-insensitive
+      substring match of ``expected`` in the reply).
+    * ``grounded_fraction`` -- fraction answered WITHOUT a degraded mode (teacher or captured, not a
+      store-only fallback / refusal / failure): the fraction of answers you can actually trust came
+      from a real answer path, not a fault-boundary guess.
+    * ``realized_cost`` -- total spend units (:meth:`~mixle.spend.Spend.total_units`) across the set.
+    * ``calibration`` -- a coarse proxy (currently equal to ``quality``) until ``answer`` carries a real
+      per-answer confidence to calibrate against; extend THIS function, not call sites, once that lands.
+    """
+    n = len(question_set)
+    if n == 0:
+        return SystemScorecard(quality=0.0, calibration=0.0, realized_cost=0.0, grounded_fraction=0.0, n=0)
+    scorer = scorer or _default_scorer
+    correct = 0
+    grounded = 0
+    cost = 0.0
+    for query, expected in question_set:
+        reply, receipt = system.answer(query)
+        if scorer(reply, expected):
+            correct += 1
+        if receipt.get("status") == "answered" and receipt.get("degraded_mode") is None:
+            grounded += 1
+        spend = receipt.get("spend") or {}
+        cost += float(spend.get("frontier_calls", 0)) + float(spend.get("oracle_calls", 0))
+    quality = correct / n
+    return SystemScorecard(
+        quality=quality, calibration=quality, realized_cost=cost, grounded_fraction=grounded / n, n=n
+    )
+
+
+@dataclass
+class RegressionReport:
+    """Whether ``current`` is worse than ``baseline`` on any tracked axis, and exactly why."""
+
+    regressed: bool
+    reasons: list[str] = field(default_factory=list)
+
+
+def detect_regression(
+    baseline: SystemScorecard, current: SystemScorecard, *, tolerance: float = 1e-9
+) -> RegressionReport:
+    """Compare two scorecards from the SAME held-out set across improve-rounds.
+
+    Never silently accepts a round that answers worse, less groundedly, or for more cost than the round
+    before it -- each tracked axis that got worse (beyond ``tolerance``) is named in ``reasons``.
+    """
+    reasons: list[str] = []
+    if current.quality < baseline.quality - tolerance:
+        reasons.append(f"quality regressed: {baseline.quality:.3f} -> {current.quality:.3f}")
+    if current.grounded_fraction < baseline.grounded_fraction - tolerance:
+        reasons.append(
+            f"grounded_fraction regressed: {baseline.grounded_fraction:.3f} -> {current.grounded_fraction:.3f}"
+        )
+    if current.realized_cost > baseline.realized_cost + tolerance:
+        reasons.append(f"realized_cost increased: {baseline.realized_cost:.3f} -> {current.realized_cost:.3f}")
+    return RegressionReport(regressed=bool(reasons), reasons=reasons)

--- a/mixle/tests/scorecard_test.py
+++ b/mixle/tests/scorecard_test.py
@@ -1,0 +1,94 @@
+"""System scorecard (mixle.scorecard), CARD SCORE-a: evaluate() over a fixed set; catch a worsening round."""
+
+import unittest
+
+from mixle.scorecard import detect_regression, evaluate
+from mixle.substrate.core import Substrate, SubstrateItem
+from mixle.system import Query, System, SystemConfig
+
+
+class EvaluateTest(unittest.TestCase):
+    def test_quality_and_grounded_fraction_on_a_perfect_system(self):
+        system = System(SystemConfig(teacher=lambda p: "yes, absolutely"))
+        question_set = [(Query("q1"), "yes"), (Query("q2"), "yes")]
+        card = evaluate(system, question_set)
+        self.assertEqual(card.quality, 1.0)
+        self.assertEqual(card.grounded_fraction, 1.0)
+        self.assertEqual(card.realized_cost, 2.0)
+        self.assertEqual(card.n, 2)
+
+    def test_quality_reflects_wrong_answers(self):
+        system = System(SystemConfig(teacher=lambda p: "no idea"))
+        question_set = [(Query("q1"), "yes"), (Query("q2"), "yes")]
+        card = evaluate(system, question_set)
+        self.assertEqual(card.quality, 0.0)
+
+    def test_empty_question_set_is_honest_not_a_div_by_zero_crash(self):
+        system = System(SystemConfig(teacher=lambda p: "x"))
+        card = evaluate(system, [])
+        self.assertEqual(card.n, 0)
+        self.assertEqual(card.quality, 0.0)
+
+    def test_teacher_down_answers_are_not_counted_grounded(self):
+        def broken_teacher(prompt):
+            raise ConnectionError("down")
+
+        store = Substrate()
+        store.put(SubstrateItem(kind="text", text="yes it is confirmed"))
+        system = System(SystemConfig(teacher=broken_teacher, store=store))
+        card = evaluate(system, [(Query("q1"), "yes")])
+        self.assertEqual(card.grounded_fraction, 0.0)
+
+
+class RegressionDetectionTest(unittest.TestCase):
+    def test_a_deliberately_worsening_round_is_caught(self):
+        question_set = [(Query("q1"), "yes"), (Query("q2"), "yes")]
+
+        good_system = System(SystemConfig(teacher=lambda p: "yes, absolutely"))
+        baseline = evaluate(good_system, question_set)
+
+        bad_system = System(SystemConfig(teacher=lambda p: "no idea"))
+        worse = evaluate(bad_system, question_set)
+
+        report = detect_regression(baseline, worse)
+        self.assertTrue(report.regressed)
+        self.assertTrue(any("quality regressed" in r for r in report.reasons))
+
+    def test_a_grounded_fraction_drop_is_caught(self):
+        question_set = [(Query("q1"), "yes")]
+        good_system = System(SystemConfig(teacher=lambda p: "yes"))
+        baseline = evaluate(good_system, question_set)
+
+        def broken_teacher(prompt):
+            raise ConnectionError("down")
+
+        store = Substrate()
+        store.put(SubstrateItem(kind="text", text="yes indeed"))
+        degraded_system = System(SystemConfig(teacher=broken_teacher, store=store))
+        current = evaluate(degraded_system, question_set)
+
+        report = detect_regression(baseline, current)
+        self.assertTrue(report.regressed)
+        self.assertTrue(any("grounded_fraction regressed" in r for r in report.reasons))
+
+    def test_a_non_regressing_round_is_not_flagged(self):
+        question_set = [(Query("q1"), "yes")]
+        system = System(SystemConfig(teacher=lambda p: "yes, absolutely"))
+        baseline = evaluate(system, question_set)
+        current = evaluate(system, question_set)
+        report = detect_regression(baseline, current)
+        self.assertFalse(report.regressed)
+        self.assertEqual(report.reasons, [])
+
+    def test_an_improving_round_is_not_flagged(self):
+        question_set = [(Query("q1"), "yes")]
+        bad_system = System(SystemConfig(teacher=lambda p: "no idea"))
+        baseline = evaluate(bad_system, question_set)
+        good_system = System(SystemConfig(teacher=lambda p: "yes, absolutely"))
+        improved = evaluate(good_system, question_set)
+        report = detect_regression(baseline, improved)
+        self.assertFalse(report.regressed)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Card SCORE-a (workstream J), stacked on `seed-cold-start` (#37, itself stacked on #36 FAULT, #32 SPEND, #22 SYS-a) -- **merge order: #22, #32, #36, #37, then this.**
- `mixle/scorecard.py`: named `SystemScorecard` (not `Scorecard`) to avoid colliding with the existing `mixle.task.scorecard.Scorecard`, which is a different, narrower thing (one student `Solution` vs its teacher on a task) -- this evaluates a whole `System` end to end.
  - `evaluate(system, question_set) -> SystemScorecard`: `quality` (scorer match rate over a fixed `[(Query, expected_answer), ...]` set), `grounded_fraction` (fraction answered without a degraded mode -- teacher/captured, not a store-only fallback or refusal/failure), `realized_cost` (total spend units), `calibration` (a coarse quality-equal proxy until `answer()` carries a real per-answer confidence to calibrate against -- noted as a placeholder to extend, not faked as something it isn't).
  - `detect_regression(baseline, current) -> RegressionReport`: compares two scorecards from the same held-out set across improve-rounds and names exactly which tracked axis got worse, rather than silently accepting a worsening round.

## Test plan
- [x] `mixle/tests/scorecard_test.py`: `evaluate()` quality/grounded_fraction/realized_cost on a perfect system, quality reflecting wrong answers, an empty question set handled honestly (no div-by-zero), teacher-down answers correctly excluded from `grounded_fraction`; `detect_regression()` catches a deliberately-worsening round (quality drop) -- the card's literal acceptance test -- plus a grounded-fraction drop, confirms a non-regressing round isn't flagged, and confirms an *improving* round isn't flagged either.
- [x] `.venv/bin/python -m pytest mixle/tests/scorecard_test.py mixle/tests/system_test.py mixle/tests/fault_test.py mixle/tests/spend_test.py -q` -- 40 passed.
- [x] `ruff check` / `ruff format --check` on changed files -- clean.