### PR TITLE
task/design_prior: what-works prior over structural design families (CARD DESIGN-a)

### DIFF
--- a/mixle/task/__init__.py
+++ b/mixle/task/__init__.py
@@ -32,6 +32,7 @@ from mixle.task.calibrate import ESCALATE, CalibratedTaskModel
 from mixle.task.cascade import Cascade, CascadeStats
 from mixle.task.density import DensityGate
 from mixle.task.design import DesignedModel, design_model, spec_to_estimator
+from mixle.task.design_prior import best_family, rank_design_families, record_accepted_recipe
 from mixle.task.distill import (
     agreement,
     distill,
@@ -132,6 +133,9 @@ __all__ = [
     "DensityGate",
     "DesignModel",
     "DesignedModel",
+    "best_family",
+    "rank_design_families",
+    "record_accepted_recipe",
     "DeviceSpec",
     "EdgeDistillResult",
     "EdgeFootprint",

--- a/mixle/task/design_prior.py
+++ b/mixle/task/design_prior.py
@@ -1,0 +1,76 @@
+"""``rank_design_families`` -- the persistent what-works prior over structural design families (CARD DESIGN-a).
+
+:class:`~mixle.task.edge.DesignModel` already ledgers every evaluated design point with an arbitrary
+tag dict, so a caller can tag each accepted structural recipe with which FAMILY it belongs to (a
+quotient leaf vs a plain head, a richer factorization vs a simpler one -- workstream A5/REFINE-a/
+IMAGINE-a's structural choices, and D8's capability-conditioned recipes). This module is the thin
+query layered on that existing ledger: rank the families seen so far by their mean recorded quality,
+so the NEXT round's structural-search proposal starts from a sharper prior instead of from scratch --
+"what has actually worked" persisted across rounds and design searches, not re-derived each time.
+
+    record_accepted_recipe(design, point, quality, violations, family="quotient_leaf")
+    rank_design_families(design)                    # [("quotient_leaf", 0.91), ("plain_head", 0.62)]
+    best_family(design)                              # "quotient_leaf"
+
+An untried candidate family (never recorded) has no evidence and ranks below every family that has
+been recorded, via an explicit, named ``default_score`` -- never silently tied with a proven winner.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Sequence
+from typing import Any
+
+import numpy as np
+
+from mixle.task.edge import DesignModel
+
+
+def record_accepted_recipe(
+    design: DesignModel,
+    point: Any,
+    quality: float,
+    violations: Sequence[float],
+    *,
+    family: str,
+    fingerprint: Sequence[float] | None = None,
+    **tag: Any,
+) -> None:
+    """Record an accepted structural recipe under its ``family`` tag -- the training signal for
+    :func:`rank_design_families`. A thin, named wrapper over ``DesignModel.add`` so callers do not
+    have to remember which tag key the prior reads."""
+    design.add(point, quality, violations, fingerprint=fingerprint, family=family, **tag)
+
+
+def rank_design_families(
+    design: DesignModel,
+    *,
+    tag_key: str = "family",
+    candidates: Sequence[str] | None = None,
+    default_score: float = float("-inf"),
+) -> list[tuple[str, float]]:
+    """Rank every family tag recorded in ``design`` by its mean quality, best first.
+
+    ``candidates``, if given, are ALSO included in the ranking even if never recorded -- an untried
+    family gets ``default_score`` (``-inf`` by default: no evidence ranks strictly below any recorded
+    family, however weak, rather than being silently omitted or tied with a proven winner).
+    """
+    buckets: dict[str, list[float]] = defaultdict(list)
+    for tag, q in zip(design.tags, design.quality):
+        fam = tag.get(tag_key)
+        if fam is not None:
+            buckets[str(fam)].append(float(q))
+
+    families = set(buckets) | (set(str(c) for c in candidates) if candidates else set())
+    scored = [(fam, float(np.mean(buckets[fam])) if fam in buckets else default_score) for fam in families]
+    return sorted(scored, key=lambda kv: kv[1], reverse=True)
+
+
+def best_family(design: DesignModel, *, tag_key: str = "family") -> str | None:
+    """The single top-ranked recorded family, or ``None`` if nothing has been recorded yet."""
+    ranked = rank_design_families(design, tag_key=tag_key)
+    return ranked[0][0] if ranked else None
+
+
+__all__ = ["best_family", "rank_design_families", "record_accepted_recipe"]

--- a/mixle/tests/design_prior_test.py
+++ b/mixle/tests/design_prior_test.py
@@ -1,0 +1,72 @@
+"""rank_design_families: the persistent what-works prior over structural design families (CARD DESIGN-a).
+
+After feeding N accepted recipes, the prior must rank the accepted (higher-quality) family above an
+un-tried one -- so the next round's structural-search proposal starts from a sharper prior.
+"""
+
+import unittest
+
+from mixle.task.design_prior import best_family, rank_design_families, record_accepted_recipe
+from mixle.task.edge import DesignModel
+
+
+def _design_with_two_families():
+    design = DesignModel(signature="test-design", n_constraints=1)
+    for point, quality in [([1.0, 2.0], 0.92), ([1.1, 2.1], 0.88), ([0.9, 1.9], 0.90)]:
+        record_accepted_recipe(design, point, quality, [0.0], family="quotient_leaf")
+    for point, quality in [([0.5, 1.0], 0.60), ([0.6, 1.1], 0.65)]:
+        record_accepted_recipe(design, point, quality, [0.0], family="plain_head")
+    return design
+
+
+class RankDesignFamiliesTest(unittest.TestCase):
+    def test_accepted_family_ranks_above_an_untried_one(self):
+        """The card's own acceptance: after N accepted recipes, the prior ranks the accepted family
+        above an un-tried one."""
+        design = _design_with_two_families()
+        ranked = rank_design_families(design, candidates=["never_tried_family"])
+        names = [name for name, _score in ranked]
+        self.assertEqual(names, ["quotient_leaf", "plain_head", "never_tried_family"])
+
+    def test_untried_family_gets_the_named_default_score(self):
+        design = _design_with_two_families()
+        ranked = dict(rank_design_families(design, candidates=["never_tried_family"]))
+        self.assertEqual(ranked["never_tried_family"], float("-inf"))
+
+    def test_ranking_is_by_mean_recorded_quality(self):
+        design = _design_with_two_families()
+        ranked = dict(rank_design_families(design))
+        self.assertAlmostEqual(ranked["quotient_leaf"], (0.92 + 0.88 + 0.90) / 3, places=9)
+        self.assertAlmostEqual(ranked["plain_head"], (0.60 + 0.65) / 2, places=9)
+
+    def test_best_family_returns_the_top_ranked_family(self):
+        design = _design_with_two_families()
+        self.assertEqual(best_family(design), "quotient_leaf")
+
+    def test_empty_design_has_no_ranking_and_no_best_family(self):
+        empty = DesignModel(signature="empty", n_constraints=1)
+        self.assertEqual(rank_design_families(empty), [])
+        self.assertIsNone(best_family(empty))
+
+    def test_untried_candidate_alone_with_no_history_still_reports(self):
+        empty = DesignModel(signature="empty", n_constraints=1)
+        ranked = rank_design_families(empty, candidates=["some_family"])
+        self.assertEqual(ranked, [("some_family", float("-inf"))])
+
+    def test_custom_tag_key(self):
+        design = DesignModel(signature="custom", n_constraints=1)
+        design.add([1.0], 0.8, [0.0], structure="conv_pool")
+        design.add([2.0], 0.5, [0.0], structure="linear")
+        ranked = rank_design_families(design, tag_key="structure")
+        self.assertEqual([name for name, _ in ranked], ["conv_pool", "linear"])
+
+    def test_rows_without_the_tag_key_are_ignored(self):
+        design = DesignModel(signature="mixed", n_constraints=1)
+        design.add([1.0], 0.9, [0.0], family="tracked")
+        design.add([2.0], 0.1, [0.0])  # no family tag: not a candidate for the prior
+        ranked = rank_design_families(design)
+        self.assertEqual(ranked, [("tracked", 0.9)])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- `DesignModel` (mixle/task/edge.py) already ledgers every evaluated design point with an arbitrary tag dict. This adds a thin query layer on top: rank the structural families seen so far by mean recorded quality, so the next round's structural-search proposal starts from a sharper prior instead of from scratch.
- `record_accepted_recipe(design, point, quality, violations, family=, **tag)`: named wrapper over `DesignModel.add`.
- `rank_design_families(design, tag_key="family", candidates=None, default_score=-inf)`: ranks recorded families by mean quality, best first. Untried candidates get `default_score` (`-inf`) — no evidence ranks strictly below any recorded family, never silently omitted or tied with a proven winner.
- `best_family(design)`: single top-ranked family, or `None`.
- Exported from `mixle.task`.
- Does not depend on D2-a's (still unmerged) capacity-ladder code — `DesignModel` already exists on this release branch, so the card is unblocked rather than stacked.

## Test plan
- [x] `mixle/tests/design_prior_test.py` — 8 tests, all passing (accepted family ranks above untried; untried gets named default score; ranking is exact mean quality; best_family on populated/empty designs; custom tag_key; rows missing the tag key ignored).
- [x] `ruff check` + `ruff format --check` clean on all 3 changed files.