### PR TITLE
task/ACCUM-a: knowledge-accumulation flywheel measurement (stacked on #16, #30)

### DIFF
--- a/mixle/substrate/__init__.py
+++ b/mixle/substrate/__init__.py
@@ -8,6 +8,7 @@ scope, tags, links, and a retrievable text surface.
 
 from __future__ import annotations
 
+from mixle.substrate.accum import FlywheelMeasurement, FlywheelReport, QAItem, measure_flywheel
 from mixle.substrate.act import (
     Action,
     Investigation,
@@ -103,6 +104,10 @@ __all__ = [
     "HopStep",
     "answer_from_substrate",
     "Answer",
+    "measure_flywheel",
+    "FlywheelReport",
+    "FlywheelMeasurement",
+    "QAItem",
     "investigate",
     "Investigation",
     "Action",

--- a/mixle/substrate/__init__.py
+++ b/mixle/substrate/__init__.py
@@ -32,6 +32,7 @@ from mixle.substrate.context import (
     compress_text,
 )
 from mixle.substrate.core import MODALITIES, Substrate, SubstrateItem
+from mixle.substrate.eig_retrieve import eig_retrieve
 from mixle.substrate.factuality import ClaimVerdict, FactualityReceipt, check_factuality
 from mixle.substrate.freshness import Freshness, check_freshness, content_hash, freshness_report
 from mixle.substrate.governance import Governance, approve, pending, propose, reject
@@ -84,6 +85,7 @@ __all__ = [
     "compress_text",
     "retrieve",
     "Retrieval",
+    "eig_retrieve",
     "multihop",
     "HopChain",
     "HopStep",

--- a/mixle/substrate/__init__.py
+++ b/mixle/substrate/__init__.py
@@ -23,6 +23,18 @@ from mixle.substrate.act import (
     simulate_action,
 )
 from mixle.substrate.answer import Answer, answer_from_substrate
+from mixle.substrate.belief import (
+    MODEL_ASSERTION,
+    MODEL_ASSERTION_CAP,
+    BeliefItem,
+    Claim,
+    EvidenceEntry,
+    assimilate,
+    credence_from_history,
+    harvest_knowledge,
+    retract,
+    retrieve_beliefs,
+)
 from mixle.substrate.context import (
     ContextBudget,
     ContextPacket,
@@ -143,4 +155,14 @@ __all__ = [
     "monitoring_harness",
     "register_harness",
     "find_harnesses",
+    "harvest_knowledge",
+    "assimilate",
+    "retract",
+    "retrieve_beliefs",
+    "credence_from_history",
+    "BeliefItem",
+    "Claim",
+    "EvidenceEntry",
+    "MODEL_ASSERTION",
+    "MODEL_ASSERTION_CAP",
 ]

--- a/mixle/substrate/accum.py
+++ b/mixle/substrate/accum.py
@@ -1,0 +1,93 @@
+"""The knowledge-accumulation flywheel (workstream ACCUM-a): measure whether adding calibrated
+knowledge to the belief store (:mod:`mixle.substrate.belief`, workstream E/KNOW-a) improves answers on
+a held-out question set, WITH NO MODEL RETRAINING -- the third self-improvement mode (distillation
+improves the student, accumulation improves what the student/teacher can retrieve).
+
+Two guards keep the measurement honest:
+
+  * **attribution** -- the improvement must disappear when the newly-assimilated items are withheld
+    from retrieval, proving the gain came from the store growing rather than anything else (timing,
+    caching, a lucky ``answer_fn``).
+  * **credence weighting** -- retrieval goes through
+    :func:`mixle.substrate.belief.retrieve_beliefs`, which ranks by ``relevance * credence`` and can be
+    hard-thresholded with ``min_credence``; a batch of low-credence (e.g. pure ``MODEL_ASSERTION``)
+    knowledge must NOT inflate the measured improvement -- it is down-weighted, never treated as
+    ground truth.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+
+from mixle.substrate.belief import retrieve_beliefs
+from mixle.substrate.core import Substrate
+
+
+@dataclass
+class QAItem:
+    """One held-out question: ``answer_fn`` is judged correct on it if it produces ``answer`` from the
+    retrieved context alone."""
+
+    question: str
+    answer: str
+
+
+@dataclass
+class FlywheelMeasurement:
+    solve_rate: float
+    grounded_fraction: float  # fraction of questions where retrieval returned at least one belief
+
+
+@dataclass
+class FlywheelReport:
+    before: FlywheelMeasurement
+    after: FlywheelMeasurement
+    withheld: FlywheelMeasurement  # measured after assimilation, but with the new items excluded from retrieval
+    attribution_confirmed: bool
+
+
+def _measure(
+    sub: Substrate,
+    questions: Sequence[QAItem],
+    answer_fn: Callable[[str, list[str]], str],
+    *,
+    k: int,
+    min_credence: float | None,
+    exclude_ids: set[str],
+) -> FlywheelMeasurement:
+    n_correct = 0
+    n_grounded = 0
+    for qa in questions:
+        beliefs = retrieve_beliefs(sub, qa.question, k=k + len(exclude_ids), min_credence=min_credence)
+        beliefs = [b for b in beliefs if b.id not in exclude_ids][:k]
+        if beliefs:
+            n_grounded += 1
+        context = [b.claim.text for b in beliefs]
+        if answer_fn(qa.question, context) == qa.answer:
+            n_correct += 1
+    n = len(questions) or 1
+    return FlywheelMeasurement(solve_rate=n_correct / n, grounded_fraction=n_grounded / n)
+
+
+def measure_flywheel(
+    sub: Substrate,
+    questions: Sequence[QAItem],
+    answer_fn: Callable[[str, list[str]], str],
+    assimilate_batch: Callable[[Substrate], list[str]],
+    *,
+    k: int = 5,
+    min_credence: float | None = None,
+) -> FlywheelReport:
+    """Measure ``answer_fn`` against ``questions`` before and after ``assimilate_batch(sub)`` adds a
+    batch of calibrated beliefs (returning the ids it touched), with a THIRD measurement that excludes
+    exactly those ids from retrieval -- the attribution control. ``answer_fn`` and every other piece of
+    the system stay fixed throughout: only the store's content (and what it makes retrievable) changes.
+    """
+    before = _measure(sub, questions, answer_fn, k=k, min_credence=min_credence, exclude_ids=set())
+    added_ids = set(assimilate_batch(sub))
+    after = _measure(sub, questions, answer_fn, k=k, min_credence=min_credence, exclude_ids=set())
+    withheld = _measure(sub, questions, answer_fn, k=k, min_credence=min_credence, exclude_ids=added_ids)
+
+    attribution_confirmed = after.solve_rate > before.solve_rate and withheld.solve_rate <= before.solve_rate + 1e-9
+    return FlywheelReport(before=before, after=after, withheld=withheld, attribution_confirmed=attribution_confirmed)

--- a/mixle/substrate/belief.py
+++ b/mixle/substrate/belief.py
@@ -1,0 +1,292 @@
+"""Calibrated belief store: harvest claims from model output and assimilate them as CREDENCES.
+
+A model's output is a paragraph of assertions -- some grounded, some not. This module turns each
+assertion into a tracked belief with a probability (not a binary "fact" flag) that moves with the
+STRENGTH of its evidence: a verifiable source (a document, an executable check, a held-out truth, a
+real measurement) moves it strongly; the model's own say-so moves it weakly and is capped low. Every
+belief carries its full ``evidence_history`` so the current credence is always reproducible by
+replaying it, and evidence can be revised or :func:`retract`-ed, cascading to whatever depended on it.
+
+Anti-laundering is the load-bearing property: evidence that resolves back to the claim itself, or to
+another belief that has no independent (non-model-assertion) support of its own, contributes ZERO --
+a claim cannot bootstrap high credence by citing itself or an equally ungrounded peer.
+
+This is the write side of workstream E (harvest / credence assimilation / traceable history); the read
+side is :mod:`mixle.substrate.retrieve`. See ``notes/0.6.3-execution-playbook.md`` CARD KNOW-a.
+"""
+
+from __future__ import annotations
+
+import math
+import time
+import uuid
+from collections.abc import Callable, Sequence
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+from mixle.substrate.core import Substrate, SubstrateItem
+
+# The weakest evidence tier: a model asserting something about itself, with no external check. Kept
+# outside mixle.doe.oracle.VERIFIABILITY_TIERS because "a model graded itself" is exactly the tier that
+# workstream I rejects for de novo optimization -- here it is not rejected, only capped low.
+MODEL_ASSERTION = "model_assertion"
+
+# Evidence-tier strength, weakest to strongest: a model's own assertion moves credence the least; a
+# real measurement moves it the most. Reuses mixle.doe.oracle's verifiability vocabulary (a verified
+# oracle result is strong evidence) plus MODEL_ASSERTION as the floor tier.
+_TIER_STRENGTH: dict[str, float] = {
+    MODEL_ASSERTION: 0.05,
+    "executable": 0.3,
+    "simulation": 0.5,
+    "held_out_truth": 0.8,
+    "real_measurement": 1.0,
+}
+
+# A belief supported ONLY by model-assertion-tier evidence can never rise above this credence -- the
+# cap that keeps a model from bootstrapping high confidence in something it merely asserted.
+MODEL_ASSERTION_CAP = 0.5
+
+# Log-odds scale per unit of tier strength. Not fit to data -- a qualitative calibration knob so that
+# one real_measurement entry lands "high" and one model_assertion entry lands at the cap.
+_K = 3.0
+
+_BELIEF_TAG = "belief"
+
+
+@dataclass
+class Claim:
+    """One atomic proposition (or typed quantity) pulled from a model's output."""
+
+    text: str
+    produced_by: dict[str, Any] = field(default_factory=dict)
+    quantity: float | None = None
+
+
+@dataclass
+class EvidenceEntry:
+    """One piece of evidence that moved a belief's credence, in the order it was applied."""
+
+    source_id: str
+    tier: str
+    direction: str = "+"  # "+" supports the claim, "-" contradicts it
+    weight: float = 1.0
+    time: float = field(default_factory=time.time)
+
+
+@dataclass
+class BeliefItem:
+    """A claim's current credence plus the full evidence trail that produced it."""
+
+    id: str
+    claim: Claim
+    credence: float
+    evidence_history: list[EvidenceEntry] = field(default_factory=list)
+    scope: str = "local"
+
+
+def harvest_knowledge(
+    model_output: str,
+    *,
+    source: dict[str, Any],
+    extract: Callable[[str], list[str]] | None = None,
+) -> list[Claim]:
+    """Split ``model_output`` into atomic claims, each stamped with ``source`` (which model produced it,
+    its confidence, etc). Default extraction is sentence-level (:func:`mixle.reason.llm.sentence_claims`);
+    pass ``extract`` for a different atomic-proposition splitter."""
+    from mixle.reason.llm import sentence_claims
+
+    extract = extract or sentence_claims
+    return [Claim(text=c, produced_by=dict(source)) for c in extract(model_output)]
+
+
+def credence_from_history(evidence_history: Sequence[EvidenceEntry]) -> float:
+    """The credence implied by an evidence history alone -- a pure function, so replaying a belief's
+    stored ``evidence_history`` through this always reproduces its current ``credence`` exactly."""
+    if not evidence_history:
+        return 0.5  # neutral: no evidence yet
+    logit = 0.0
+    has_real_support = False
+    for e in evidence_history:
+        if e.weight <= 0:
+            continue
+        strength = _tier_strength(e.tier) * e.weight
+        sign = 1.0 if e.direction == "+" else -1.0
+        logit += sign * strength * _K
+        if e.tier != MODEL_ASSERTION:
+            has_real_support = True
+    credence = 1.0 / (1.0 + math.exp(-logit))
+    if not has_real_support:
+        credence = min(credence, MODEL_ASSERTION_CAP)
+    return credence
+
+
+def assimilate(
+    sub: Substrate,
+    claim: Claim,
+    evidence: dict[str, Any] | Sequence[dict[str, Any]],
+    *,
+    scope: str = "local",
+) -> BeliefItem:
+    """Bayesian-ish update of the belief in ``claim`` from ``evidence`` -- never a binary write.
+
+    Finds or creates the belief item (keyed on normalized claim text) and appends each evidence entry
+    (``{"source_id", "tier", "direction": "+"/"-", "weight"}``); ``tier`` must be one of
+    :data:`_TIER_STRENGTH` (``"model_assertion"`` plus :data:`mixle.doe.oracle.VERIFIABILITY_TIERS`).
+
+    Anti-laundering: an entry whose ``source_id`` resolves back to THIS belief (a cycle) or to another
+    belief item with no independent (non-model-assertion) support of its own is stored with an
+    effective weight of zero -- it cannot move the credence, though it stays in the trail for audit.
+    """
+    entries = [evidence] if isinstance(evidence, dict) else list(evidence)
+    key = _claim_key(claim.text)
+    existing = _find(sub, key, scope)
+    belief = (
+        _from_item(existing)
+        if existing is not None
+        else BeliefItem(id=uuid.uuid4().hex[:16], claim=claim, credence=0.5, evidence_history=[], scope=scope)
+    )
+
+    for raw in entries:
+        tier = raw["tier"]
+        _tier_strength(tier)  # validates; raises on an unrecognized tier rather than silently accepting one
+        source_id = str(raw.get("source_id", ""))
+        weight = float(raw.get("weight", 1.0))
+        if _launders(sub, source_id, belief.id, scope):
+            weight = 0.0
+        belief.evidence_history.append(
+            EvidenceEntry(
+                source_id=source_id,
+                tier=tier,
+                direction=raw.get("direction", "+"),
+                weight=weight,
+                time=float(raw["time"]) if "time" in raw else time.time(),
+            )
+        )
+
+    belief.credence = credence_from_history(belief.evidence_history)
+    sub.put(_to_item(belief))
+    return belief
+
+
+def retract(sub: Substrate, source_id: str, *, scope: str | None = None) -> list[BeliefItem]:
+    """Remove every evidence entry citing ``source_id``, recomputing credence, and CASCADE: if that
+    removal causes a belief to lose its only independent support, also strip citations of THAT belief
+    from whatever cited it, recursively. Returns every belief item touched by the cascade."""
+    changed: list[BeliefItem] = []
+    frontier = {source_id}
+    visited: set[str] = set()
+    while frontier:
+        cur = frontier.pop()
+        if cur in visited:
+            continue
+        visited.add(cur)
+        for item in sub.all(kind="record", scope=scope):
+            if _BELIEF_TAG not in item.tags:
+                continue
+            belief = _from_item(item)
+            new_history = [e for e in belief.evidence_history if e.source_id != cur]
+            if len(new_history) == len(belief.evidence_history):
+                continue
+            before_grounded = _has_real_support(belief)
+            belief.evidence_history = new_history
+            belief.credence = credence_from_history(new_history)
+            sub.put(_to_item(belief))
+            changed.append(belief)
+            if before_grounded and not _has_real_support(belief):
+                frontier.add(belief.id)  # this belief lost its grounding -- re-check its own citers
+    return changed
+
+
+def retrieve_beliefs(
+    sub: Substrate, query: str, *, k: int = 8, min_credence: float | None = None, scope: str | None = None
+) -> list[BeliefItem]:
+    """Beliefs relevant to ``query``, optionally thresholded on ``min_credence`` and re-ranked by
+    ``relevance * credence`` -- so a caller can weight by, or hard-filter on, how much the store
+    actually believes each item (never a "fact" vs "non-fact" partition, only credence)."""
+    hits = sub.search(query, k=max(int(k) * 3, int(k)), kind="record", scope=scope)
+    scored: list[tuple[BeliefItem, float]] = []
+    for item, sc in hits:
+        if _BELIEF_TAG not in item.tags:
+            continue
+        belief = _from_item(item)
+        if min_credence is not None and belief.credence < min_credence:
+            continue
+        scored.append((belief, sc * belief.credence))
+    scored.sort(key=lambda t: -t[1])
+    return [b for b, _ in scored[: int(k)]]
+
+
+# --- internals --------------------------------------------------------------------------------------
+
+
+def _tier_strength(tier: str) -> float:
+    if tier not in _TIER_STRENGTH:
+        raise ValueError(f"unknown evidence tier {tier!r}; expected one of {sorted(_TIER_STRENGTH)}")
+    return _TIER_STRENGTH[tier]
+
+
+def _has_real_support(belief: BeliefItem) -> bool:
+    return any(e.tier != MODEL_ASSERTION and e.weight > 0 for e in belief.evidence_history)
+
+
+def _claim_key(text: str) -> str:
+    return " ".join(text.lower().split())
+
+
+def _find(sub: Substrate, key: str, scope: str) -> SubstrateItem | None:
+    for item in sub.all(kind="record", scope=scope):
+        if _BELIEF_TAG in item.tags and item.payload.get("key") == key:
+            return item
+    return None
+
+
+def _launders(sub: Substrate, source_id: str, belief_id: str, scope: str, _seen: set[str] | None = None) -> bool:
+    """True iff citing ``source_id`` as evidence for ``belief_id`` would launder unearned credence:
+    a direct or indirect cycle back to ``belief_id``, or a reference to another belief item that has
+    no independent support of its own. A ``source_id`` that is not itself a belief item in the
+    substrate (a document, an oracle receipt, any genuine external reference) is never laundering."""
+    if source_id == belief_id:
+        return True
+    seen = _seen or set()
+    if source_id in seen:
+        return True  # a cycle among referenced claims that never reaches belief_id directly
+    ref_item = sub.get(source_id)
+    if ref_item is None or _BELIEF_TAG not in ref_item.tags:
+        return False
+    ref = _from_item(ref_item)
+    if not _has_real_support(ref):
+        return True
+    return False
+
+
+def _to_item(belief: BeliefItem) -> SubstrateItem:
+    return SubstrateItem(
+        id=belief.id,
+        kind="record",
+        text=belief.claim.text,
+        payload={
+            "key": _claim_key(belief.claim.text),
+            "claim": {
+                "text": belief.claim.text,
+                "produced_by": belief.claim.produced_by,
+                "quantity": belief.claim.quantity,
+            },
+            "credence": belief.credence,
+            "evidence_history": [asdict(e) for e in belief.evidence_history],
+        },
+        tags=[_BELIEF_TAG],
+        scope=belief.scope,
+        provenance={"kind": _BELIEF_TAG},
+    )
+
+
+def _from_item(item: SubstrateItem) -> BeliefItem:
+    p = item.payload
+    c = p["claim"]
+    return BeliefItem(
+        id=item.id,
+        claim=Claim(text=c["text"], produced_by=dict(c.get("produced_by", {})), quantity=c.get("quantity")),
+        credence=p["credence"],
+        evidence_history=[EvidenceEntry(**e) for e in p.get("evidence_history", [])],
+        scope=item.scope,
+    )

--- a/mixle/substrate/eig_retrieve.py
+++ b/mixle/substrate/eig_retrieve.py
@@ -1,0 +1,68 @@
+"""Information-gain retrieval (workstream F6): score substrate items by how much they would actually move a
+belief, not by how textually similar they are to the query.
+
+:func:`~mixle.substrate.retrieve.retrieve` ranks by cosine/lexical similarity -- a sound default, but many
+similar-looking items can carry the *same* evidence (redundant), while a single differently-worded item can
+be decisive. :func:`eig_retrieve` instead scores each candidate by the entropy it would actually remove from a
+given :class:`~mixle.inference.belief.BeliefState` if assimilated, and greedily picks the highest-gain item
+each round, updating the running belief before scoring what remains -- so a second item redundant with the
+first correctly scores near zero the next round. The same greedy EIG scorer is the one workstream C5
+(experiment-design-as-planning) reuses; it is written once, here.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import numpy as np
+
+from mixle.inference.belief import BeliefState
+from mixle.substrate.core import Substrate, SubstrateItem
+from mixle.substrate.retrieve import Retrieval
+
+
+def eig_retrieve(
+    substrate: Substrate,
+    belief: BeliefState,
+    evidence_fn: Callable[[SubstrateItem], Any],
+    *,
+    k: int = 8,
+    kind: str | None = None,
+    scope: str | None = None,
+) -> Retrieval:
+    """Greedily pick up to ``k`` substrate items by expected posterior-entropy reduction against ``belief``.
+
+    ``evidence_fn(item)`` turns a candidate item into whatever ``belief.update(...)`` expects (e.g. a
+    per-hypothesis log-likelihood vector for a :class:`~mixle.inference.belief.CategoricalBelief`). Each
+    round, every remaining candidate is scored by ``current_belief.entropy() - updated_belief.entropy()``;
+    the best-scoring item is taken, the running belief moves to its post-update state, and scoring repeats
+    against the shrunk pool -- so an item whose evidence is redundant with an already-picked item scores
+    near zero on its next look, the direct fix for similarity retrieval pulling in near-duplicates. Items
+    whose ``evidence_fn`` raises (no usable evidence) are skipped, not fatal. Returned as a
+    :class:`~mixle.substrate.retrieve.Retrieval` (``query`` is a fixed marker, not a text query) so it
+    composes with the same ``to_context``/``by_kind`` surface as cosine retrieval.
+    """
+    pool = [it for it in substrate.all(scope=scope) if kind is None or it.kind == kind]
+    chosen: list[SubstrateItem] = []
+    scores: list[float] = []
+    current = belief
+    remaining = list(pool)
+    while remaining and len(chosen) < k:
+        best_idx: int | None = None
+        best_gain = -np.inf
+        best_next: BeliefState | None = None
+        for idx, item in enumerate(remaining):
+            try:
+                nxt = current.update(evidence_fn(item))
+            except Exception:  # noqa: BLE001 -- an item with no usable evidence is skipped, not fatal
+                continue
+            gain = float(current.entropy() - nxt.entropy())
+            if gain > best_gain:
+                best_idx, best_gain, best_next = idx, gain, nxt
+        if best_idx is None:
+            break
+        chosen.append(remaining.pop(best_idx))
+        scores.append(best_gain)
+        current = best_next
+    return Retrieval(query="<information-gain>", items=chosen, scores=scores)

--- a/mixle/tests/eig_retrieve_test.py
+++ b/mixle/tests/eig_retrieve_test.py
@@ -1,0 +1,93 @@
+"""Information-gain retrieval (mixle.substrate.eig_retrieve), CARD F6-a.
+
+Acceptance (per the card): fewer items than cosine/lexical retrieval to reach a target accuracy. The scenario
+below has several textually redundant filler items (near-duplicate wording of the query, carrying almost no
+evidence) and one differently-worded item that is decisive -- so a similarity-ranked retrieval spends its
+budget on the redundant filler while information-gain retrieval goes straight for the decisive item.
+"""
+
+import unittest
+
+from mixle.inference.belief import CategoricalBelief
+from mixle.substrate.core import Substrate, SubstrateItem
+from mixle.substrate.eig_retrieve import eig_retrieve
+from mixle.substrate.retrieve import retrieve
+
+LABELS = ["alpha", "beta", "gamma"]
+
+
+def _evidence_fn(item):
+    return item.payload["log_lik"]
+
+
+def _build_substrate():
+    substrate = Substrate()
+    query = "status update about the project rollout timeline"
+    # six near-duplicate filler items: high textual overlap with the query, almost no evidence
+    filler_texts = [
+        "status update about the project rollout timeline for stakeholders",
+        "another status update about the project rollout timeline this week",
+        "weekly status update covering the project rollout timeline",
+        "project rollout timeline status update from the team",
+        "status update: project rollout timeline unchanged since last week",
+        "brief status update about the rollout timeline for the project",
+    ]
+    for text in filler_texts:
+        substrate.put(SubstrateItem(kind="text", text=text, payload={"log_lik": [0.01, -0.01, 0.0]}))
+    # one decisive item: different wording (low textual overlap with the query), strong evidence for "beta"
+    substrate.put(
+        SubstrateItem(
+            kind="text",
+            text="engineering confirms beta migration finished successfully",
+            payload={"log_lik": [-8.0, 0.0, -8.0]},
+        )
+    )
+    return substrate, query
+
+
+class EigRetrieveTest(unittest.TestCase):
+    def test_stays_on_the_lexical_path_for_this_small_corpus(self):
+        # load-bearing precondition: with < 8 text items, Substrate.search is the deterministic lexical
+        # fallback (no learned-embedder noise), so the comparison below isn't an embedding-fit accident
+        substrate, _query = _build_substrate()
+        self.assertLess(len(substrate.all()), 8)
+
+    def test_eig_retrieve_reaches_correct_map_with_fewer_items_than_cosine(self):
+        substrate, query = _build_substrate()
+
+        eig_result = eig_retrieve(substrate, CategoricalBelief.uniform(LABELS), _evidence_fn, k=1)
+        eig_belief = CategoricalBelief.uniform(LABELS)
+        for item in eig_result.items:
+            eig_belief = eig_belief.update(_evidence_fn(item))
+        self.assertEqual(eig_belief.map(), "beta")
+        self.assertLess(eig_belief.entropy(), 0.2)
+
+        cosine_result = retrieve(substrate, query, k=1, diversify=False)
+        cosine_belief = CategoricalBelief.uniform(LABELS)
+        for item in cosine_result.items:
+            cosine_belief = cosine_belief.update(_evidence_fn(item))
+        # the top cosine hit is one of the redundant filler items (near-duplicate wording of the query);
+        # its near-zero evidence leaves the belief essentially unmoved from uniform
+        self.assertNotEqual(cosine_belief.map(), "beta")
+        self.assertGreater(cosine_belief.entropy(), eig_belief.entropy())
+
+    def test_second_pick_scores_low_once_its_evidence_is_redundant_with_the_first(self):
+        # greedy re-scoring against the shrunk pool: once the decisive item is taken, every remaining
+        # filler item (near-zero evidence) should score near zero on the next round
+        substrate, _query = _build_substrate()
+        result = eig_retrieve(substrate, CategoricalBelief.uniform(LABELS), _evidence_fn, k=2)
+        self.assertEqual(len(result.items), 2)
+        self.assertGreater(result.scores[0], result.scores[1])
+        self.assertLess(result.scores[1], 0.05)
+
+    def test_items_with_unusable_evidence_are_skipped_not_fatal(self):
+        substrate, _query = _build_substrate()
+        substrate.put(SubstrateItem(kind="text", text="unrelated item with no evidence", payload={}))
+        result = eig_retrieve(substrate, CategoricalBelief.uniform(LABELS), _evidence_fn, k=7)
+        # every returned item actually had usable evidence; the malformed one was skipped, not raised
+        for item in result.items:
+            self.assertIn("log_lik", item.payload)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mixle/tests/substrate_accum_test.py
+++ b/mixle/tests/substrate_accum_test.py
@@ -1,0 +1,89 @@
+"""The knowledge-accumulation flywheel (workstream ACCUM-a): assimilating calibrated knowledge should
+raise solve-rate on a held-out set, WITH NO MODEL RETRAINING -- and the gain must be attributable to
+the store growing, and immune to being inflated by low-credence assertions."""
+
+import unittest
+
+from mixle.substrate.accum import QAItem, measure_flywheel
+from mixle.substrate.belief import MODEL_ASSERTION, Claim, assimilate
+from mixle.substrate.core import Substrate
+
+_QUESTIONS = [
+    QAItem(question="capital of Fooland", answer="Foo City"),
+    QAItem(question="capital of Barland", answer="Bar Town"),
+]
+
+_FACTS = {
+    "capital of Fooland": ("Fooland's capital is Foo City", "Foo City"),
+    "capital of Barland": ("Barland's capital is Bar Town", "Bar Town"),
+}
+
+
+def _answer_from_context(question: str, context: list[str]) -> str:
+    """A fixed, never-retrained 'model': answers only what appears verbatim in retrieved context."""
+    fact = _FACTS.get(question)
+    if fact is None:
+        return "unknown"
+    claim_text, answer = fact
+    return answer if claim_text in context else "unknown"
+
+
+def _assimilate_strong_batch(sub: Substrate) -> list[str]:
+    ids = []
+    for claim_text, _answer in _FACTS.values():
+        belief = assimilate(
+            sub, Claim(text=claim_text), {"source_id": "gazetteer-2026", "tier": "held_out_truth", "weight": 1.0}
+        )
+        ids.append(belief.id)
+    return ids
+
+
+def _assimilate_weak_batch(sub: Substrate) -> list[str]:
+    ids = []
+    for claim_text, _answer in _FACTS.values():
+        belief = assimilate(
+            sub, Claim(text=claim_text), {"source_id": "self-assertion", "tier": MODEL_ASSERTION, "weight": 1.0}
+        )
+        ids.append(belief.id)
+    return ids
+
+
+class FlywheelTest(unittest.TestCase):
+    def test_assimilating_calibrated_knowledge_raises_solve_rate_with_no_retraining(self):
+        sub = Substrate()
+        report = measure_flywheel(sub, _QUESTIONS, _answer_from_context, _assimilate_strong_batch, min_credence=0.6)
+
+        self.assertEqual(report.before.solve_rate, 0.0)
+        self.assertEqual(report.before.grounded_fraction, 0.0)
+        self.assertEqual(report.after.solve_rate, 1.0)
+        self.assertEqual(report.after.grounded_fraction, 1.0)
+
+    def test_the_improvement_is_attributed_to_the_new_knowledge_not_something_else(self):
+        sub = Substrate()
+        report = measure_flywheel(sub, _QUESTIONS, _answer_from_context, _assimilate_strong_batch, min_credence=0.6)
+
+        self.assertTrue(report.attribution_confirmed)
+        # withholding exactly the newly-assimilated beliefs from retrieval erases the gain
+        self.assertEqual(report.withheld.solve_rate, report.before.solve_rate)
+
+    def test_low_credence_assertions_do_not_inflate_the_measured_improvement(self):
+        sub = Substrate()
+        report = measure_flywheel(sub, _QUESTIONS, _answer_from_context, _assimilate_weak_batch, min_credence=0.6)
+
+        # MODEL_ASSERTION-only evidence is capped at 0.5 credence -- below the 0.6 retrieval threshold,
+        # so these claims are never retrieved and the measured solve-rate does not move at all.
+        self.assertEqual(report.before.solve_rate, report.after.solve_rate)
+        self.assertEqual(report.after.solve_rate, 0.0)
+        self.assertFalse(report.attribution_confirmed)  # no real improvement to attribute
+
+    def test_a_lower_credence_threshold_lets_weak_assertions_through_but_still_capped(self):
+        sub = Substrate()
+        report = measure_flywheel(sub, _QUESTIONS, _answer_from_context, _assimilate_weak_batch, min_credence=0.3)
+
+        # with the threshold below the model-assertion cap (0.5), the weak claims ARE retrievable
+        self.assertEqual(report.after.solve_rate, 1.0)
+        self.assertTrue(report.attribution_confirmed)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mixle/tests/substrate_belief_test.py
+++ b/mixle/tests/substrate_belief_test.py
@@ -1,0 +1,192 @@
+"""KNOW-a: harvest -> assimilate calibrated belief, anti-laundering, revision/retract, replay."""
+
+import random
+import unittest
+
+from mixle.substrate import Substrate
+from mixle.substrate.belief import (
+    MODEL_ASSERTION_CAP,
+    Claim,
+    EvidenceEntry,
+    assimilate,
+    credence_from_history,
+    harvest_knowledge,
+    retract,
+)
+
+
+class HarvestKnowledgeTest(unittest.TestCase):
+    def test_splits_atomic_claims_with_provenance(self):
+        text = "The rate is 5%. It rose from 3% last year."
+        claims = harvest_knowledge(text, source={"model": "teacher-v1", "confidence": 0.9})
+        self.assertEqual(len(claims), 2)
+        for c in claims:
+            self.assertIsInstance(c, Claim)
+            self.assertEqual(c.produced_by, {"model": "teacher-v1", "confidence": 0.9})
+        self.assertIn("5%", claims[0].text)
+
+
+class CredenceTierTest(unittest.TestCase):
+    def test_strong_source_beats_model_assertion_and_cap_holds(self):
+        strong_sub = Substrate()
+        strong = assimilate(
+            strong_sub,
+            Claim(text="The Eiffel Tower is in Paris.", produced_by={"model": "m"}),
+            {"source_id": "doc-1", "tier": "real_measurement", "direction": "+", "weight": 1.0},
+        )
+        self.assertGreater(strong.credence, 0.9)
+
+        weak_sub = Substrate()
+        weak = assimilate(
+            weak_sub,
+            Claim(text="The Eiffel Tower is in Paris.", produced_by={"model": "m"}),
+            {"source_id": "self-assert", "tier": "model_assertion", "direction": "+", "weight": 1.0},
+        )
+        self.assertLessEqual(weak.credence, MODEL_ASSERTION_CAP)
+        self.assertGreater(strong.credence, weak.credence)
+
+
+class AntiLaunderingTest(unittest.TestCase):
+    def test_self_reference_contributes_zero(self):
+        sub = Substrate()
+        claim = Claim(text="X causes Y.", produced_by={"model": "m"})
+        b1 = assimilate(
+            sub, claim, {"source_id": "self-assert", "tier": "model_assertion", "direction": "+", "weight": 1.0}
+        )
+        before = b1.credence
+
+        # cite the belief's own id as "evidence" for itself, at a strong declared tier
+        b2 = assimilate(sub, claim, {"source_id": b1.id, "tier": "held_out_truth", "direction": "+", "weight": 1.0})
+        self.assertEqual(b2.credence, before)
+        self.assertLessEqual(b2.credence, MODEL_ASSERTION_CAP)
+
+    def test_ungrounded_peer_in_same_batch_contributes_zero(self):
+        sub = Substrate()
+        claim = Claim(text="X causes Y.", produced_by={"model": "m"})
+        b1 = assimilate(
+            sub, claim, {"source_id": "self-assert", "tier": "model_assertion", "direction": "+", "weight": 1.0}
+        )
+        before = b1.credence
+
+        # a second claim whose ONLY support is also a bare model assertion (not independently grounded)
+        peer = assimilate(
+            sub,
+            Claim(text="Z is true because X causes Y.", produced_by={"model": "m"}),
+            {"source_id": "self-assert-2", "tier": "model_assertion", "direction": "+", "weight": 1.0},
+        )
+        self.assertLessEqual(peer.credence, MODEL_ASSERTION_CAP)
+
+        # laundering attempt: cite the ungrounded peer as if it were solid evidence
+        laundered = assimilate(
+            sub, claim, {"source_id": peer.id, "tier": "real_measurement", "direction": "+", "weight": 1.0}
+        )
+        self.assertEqual(laundered.credence, before)
+        self.assertLessEqual(laundered.credence, MODEL_ASSERTION_CAP)
+
+    def test_citing_an_independently_grounded_belief_is_not_laundering(self):
+        sub = Substrate()
+        grounded = assimilate(
+            sub,
+            Claim(text="The rate is 5%.", produced_by={"model": "m"}),
+            {"source_id": "doc-1", "tier": "held_out_truth", "direction": "+", "weight": 1.0},
+        )
+        self.assertGreater(grounded.credence, 0.5)
+
+        downstream = assimilate(
+            sub,
+            Claim(text="Therefore the estimate holds.", produced_by={"model": "m"}),
+            {"source_id": grounded.id, "tier": "held_out_truth", "direction": "+", "weight": 1.0},
+        )
+        self.assertGreater(downstream.credence, 0.5)
+
+
+class RevisionAndRetractTest(unittest.TestCase):
+    def test_contradicting_evidence_lowers_credence(self):
+        sub = Substrate()
+        claim = Claim(text="The rate is 5%.", produced_by={"model": "m"})
+        supported = assimilate(
+            sub, claim, {"source_id": "doc-1", "tier": "held_out_truth", "direction": "+", "weight": 1.0}
+        )
+        high = supported.credence
+
+        revised = assimilate(
+            sub, claim, {"source_id": "doc-2", "tier": "held_out_truth", "direction": "-", "weight": 1.0}
+        )
+        self.assertLess(revised.credence, high)
+
+    def test_retract_lowers_dependents_and_cascades(self):
+        sub = Substrate()
+        base = assimilate(
+            sub,
+            Claim(text="The rate is 5%.", produced_by={"model": "m"}),
+            {"source_id": "doc-1", "tier": "held_out_truth", "direction": "+", "weight": 1.0},
+        )
+        self.assertGreater(base.credence, 0.9)
+
+        downstream = assimilate(
+            sub,
+            Claim(text="Therefore the estimate holds.", produced_by={"model": "m"}),
+            {"source_id": base.id, "tier": "held_out_truth", "direction": "+", "weight": 1.0},
+        )
+        self.assertGreater(downstream.credence, 0.9)
+
+        changed = retract(sub, "doc-1")
+        changed_ids = {c.id for c in changed}
+
+        # base lost its only support -> back to neutral, no longer independently grounded
+        self.assertIn(base.id, changed_ids)
+        rebased = next(c for c in changed if c.id == base.id)
+        self.assertAlmostEqual(rebased.credence, 0.5, places=6)
+
+        # cascade: downstream cited base, which is no longer grounded, so its citation is now zeroed too
+        self.assertIn(downstream.id, changed_ids)
+        redown = next(c for c in changed if c.id == downstream.id)
+        self.assertAlmostEqual(redown.credence, 0.5, places=6)
+
+
+class TraceableHistoryTest(unittest.TestCase):
+    def test_replay_reproduces_stored_credence(self):
+        sub = Substrate()
+        b = assimilate(
+            sub,
+            Claim(text="Revenue grew 12% year over year.", produced_by={"model": "m"}),
+            [
+                {"source_id": "doc-1", "tier": "held_out_truth", "direction": "+", "weight": 1.0},
+                {"source_id": "doc-2", "tier": "simulation", "direction": "+", "weight": 0.6},
+                {"source_id": "assistant-1", "tier": "model_assertion", "direction": "+", "weight": 1.0},
+            ],
+        )
+        replayed = credence_from_history(b.evidence_history)
+        self.assertAlmostEqual(replayed, b.credence, places=9)
+
+
+class CalibrationTest(unittest.TestCase):
+    def test_coarse_reliability_across_evidence_profiles(self):
+        rng = random.Random(0)
+        sub = Substrate()
+        profiles = {
+            "strong": [{"source_id": "s", "tier": "real_measurement", "direction": "+", "weight": 1.0}],
+            "medium": [{"source_id": "s", "tier": "held_out_truth", "direction": "+", "weight": 1.0}],
+            "weak": [{"source_id": "s", "tier": "simulation", "direction": "+", "weight": 0.6}],
+        }
+        n_per_profile = 60
+        results: dict[str, list[bool]] = {name: [] for name in profiles}
+        target: dict[str, float] = {}
+
+        for name, evidence in profiles.items():
+            target[name] = credence_from_history([EvidenceEntry(**e) for e in evidence])
+            for i in range(n_per_profile):
+                truth = rng.random() < target[name]
+                claim = Claim(text=f"{name}-claim-{i}", produced_by={"model": "m"})
+                evidence_i = [dict(e, source_id=f"{e['source_id']}-{name}-{i}") for e in evidence]
+                b = assimilate(sub, claim, evidence_i)
+                self.assertAlmostEqual(b.credence, target[name], places=9)
+                results[name].append(truth)
+
+        for name, truths in results.items():
+            rate = sum(truths) / len(truths)
+            self.assertLess(abs(rate - target[name]), 0.15, msg=f"{name}: rate={rate} target={target[name]}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Workstream ACCUM-a (per notes/0.6.3-execution-playbook.md "Later cards"): mixle/substrate/accum.py adds measure_flywheel(sub, questions, answer_fn, assimilate_batch, min_credence=...) -- measures solve-rate and grounded-fraction on a held-out question set BEFORE vs AFTER a batch of calibrated beliefs is assimilated, with answer_fn (and everything else) held fixed -- no model retraining, the third self-improvement mode.
- Attribution control: a third "withheld" measurement excludes exactly the newly-assimilated belief ids from retrieval; attribution_confirmed is only true when the gain actually disappears under that ablation, proving the improvement came from the store growing and not something else.
- Guard: retrieval goes through the existing mixle.substrate.belief.retrieve_beliefs (ranks by relevance*credence, supports min_credence), so a batch of low-credence (pure MODEL_ASSERTION-tier) knowledge is down-weighted/thresholded out rather than inflating the measured improvement.
- Stacked on #16 (KNOW-a belief store) and #30 (F6-a eig-retrieval) since accum.py imports mixle.substrate.belief -- merge order: #16, then #30, then this.

## Test plan
- [x] `.venv/bin/python -m pytest mixle/tests/substrate_accum_test.py -q` -- 4 passed (strong-evidence batch raises solve-rate with no retraining; the gain is attributable and disappears when withheld; a low-credence-only batch does not inflate the measurement at a threshold above the model-assertion cap; a lower threshold lets the same weak batch through and the gain is then attributable)
- [x] `.venv/bin/python -m ruff check mixle/substrate/accum.py mixle/tests/substrate_accum_test.py mixle/substrate/__init__.py` -- clean
- [x] `.venv/bin/python -m ruff format --check` on the same files -- clean
- [ ] Full gate not run in this session per instructions to only run targeted tests; recommend running before merge.