### PR TITLE
task/D4: disagreement map wired to escalation (stacked on #17)

### DIFF
--- a/mixle/task/__init__.py
+++ b/mixle/task/__init__.py
@@ -39,6 +39,7 @@ from mixle.task.capability import (
 from mixle.task.cascade import Cascade, CascadeStats
 from mixle.task.density import DensityGate
 from mixle.task.design import DesignedModel, design_model, spec_to_estimator
+from mixle.task.disagreement import DisagreementGate, UnionGate, fit_disagreement_gate, measure_disagreement_mass
 from mixle.task.distill import (
     agreement,
     distill,
@@ -140,6 +141,8 @@ __all__ = [
     "DensityGate",
     "DesignModel",
     "DesignedModel",
+    "DisagreementGate",
+    "UnionGate",
     "DeviceSpec",
     "EdgeDistillResult",
     "EdgeFootprint",
@@ -184,6 +187,8 @@ __all__ = [
     "cascade_cost_per_request",
     "case_jitter_invariance",
     "design_model",
+    "fit_disagreement_gate",
+    "measure_disagreement_mass",
     "distill",
     "distill_designer",
     "distill_extractor",

--- a/mixle/task/disagreement.py
+++ b/mixle/task/disagreement.py
@@ -1,0 +1,109 @@
+"""Disagreement gate (workstream D5, CARD D4-a): escalate where the student has historically diverged
+from the teacher -- not just where inputs look statistically atypical
+(:class:`~mixle.task.density.DensityGate`) or where the conformal set itself is ambiguous
+(:class:`~mixle.task.calibrate.CalibratedTaskModel`).
+
+:func:`fit_disagreement_gate` turns a set of ``(text, student_label, teacher_label)`` triples into a small
+binary ``agree``/``disagree`` classifier over the student's OWN feature space (reusing
+:func:`~mixle.task.distill.distill_from_labels` -- the disagreement gate is itself a tiny distilled student,
+just of a different target). The resulting :class:`DisagreementGate` exposes ``ood_mask`` with the exact
+same duck-typed shape as :class:`~mixle.task.density.DensityGate`, so it plugs into
+``CalibratedTaskModel(..., density_gate=...)`` directly -- or unions with a real density gate via
+:func:`union_gate` -- with no changes needed to :mod:`mixle.task.calibrate`'s extension point.
+
+:func:`measure_disagreement_mass` is the plain fraction-of-examples-where-student-differs-from-teacher
+metric the active-labeling loop (:func:`~mixle.task.active.active_distill`) is measured against: label the
+gate-flagged region with the teacher, re-distill including those labels, and confirm the region's mass
+shrinks.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+from mixle.task.distill import distill_from_labels
+from mixle.task.model import TaskModel
+
+
+def measure_disagreement_mass(student: TaskModel, texts: Sequence[str], teacher_labels: Sequence[Any]) -> float:
+    """Fraction of ``texts`` where the student's label differs from the teacher's."""
+    if not texts:
+        return 0.0
+    pred = student.batch(list(texts))
+    tl = [str(t) for t in teacher_labels]
+    return float(np.mean([p != t for p, t in zip(pred, tl)]))
+
+
+@dataclass
+class DisagreementGate:
+    """A fitted agree/disagree classifier over the student's feature space, plus an escalation threshold."""
+
+    classifier: TaskModel
+    threshold: float = 0.5
+
+    def disagreement_proba(self, texts: Sequence[str]) -> np.ndarray:
+        """``P(disagree | x)`` under the fitted classifier."""
+        prob = self.classifier.adapter.proba_batch(self.classifier.model, list(texts))
+        idx = self.classifier.adapter.labels.index("disagree")
+        return prob[:, idx]
+
+    def is_ood(self, text: str) -> bool:
+        return bool(self.disagreement_proba([text])[0] > self.threshold)
+
+    def ood_mask(self, texts: Sequence[str]) -> np.ndarray:
+        """Same duck-typed shape as :meth:`mixle.task.density.DensityGate.ood_mask` -- drops straight into
+        ``CalibratedTaskModel(..., density_gate=this)``."""
+        return self.disagreement_proba(texts) > self.threshold
+
+
+def fit_disagreement_gate(
+    student: TaskModel,
+    texts: Sequence[str],
+    teacher_labels: Sequence[Any],
+    *,
+    dim: int = 256,
+    hidden: Sequence[int] = (32,),
+    epochs: int = 150,
+    lr: float = 1e-2,
+    seed: int = 0,
+    threshold: float = 0.5,
+) -> DisagreementGate:
+    """Fit a :class:`DisagreementGate` from a labeled sample: run ``student`` on ``texts``, label each
+    example ``"disagree"`` where it differs from ``teacher_labels`` and ``"agree"`` otherwise, and distill a
+    tiny binary classifier of that target over the SAME hashed n-gram feature family the student itself
+    uses (a different, wider/deeper recipe is fine -- what matters is the classifier learns a decision
+    surface over the input text, not that it matches the student's exact recipe).
+    """
+    texts = [str(t) for t in texts]
+    student_labels = student.batch(texts)
+    tl = [str(t) for t in teacher_labels]
+    disagreement_labels = ["disagree" if s != t else "agree" for s, t in zip(student_labels, tl)]
+    classifier = distill_from_labels(
+        texts,
+        disagreement_labels,
+        labels=["agree", "disagree"],
+        dim=dim,
+        hidden=hidden,
+        epochs=epochs,
+        lr=lr,
+        seed=seed,
+        task="disagreement gate",
+    )
+    return DisagreementGate(classifier, threshold=threshold)
+
+
+class UnionGate:
+    """Escalate if ANY constituent gate flags an input -- composes a :class:`DisagreementGate` with a real
+    :class:`~mixle.task.density.DensityGate` (or any other ``ood_mask``-exposing gate) with no changes to
+    either gate's own code."""
+
+    def __init__(self, *gates: Any) -> None:
+        self.gates = gates
+
+    def ood_mask(self, texts: Sequence[str]) -> np.ndarray:
+        masks = [np.asarray(g.ood_mask(texts), dtype=bool) for g in self.gates]
+        return np.logical_or.reduce(masks) if masks else np.zeros(len(texts), dtype=bool)

--- a/mixle/tests/disagreement_test.py
+++ b/mixle/tests/disagreement_test.py
@@ -1,0 +1,168 @@
+"""Disagreement gate + active-labeling shrink (mixle.task.disagreement), CARD D4-a.
+
+The corpus is built so the student provably can't follow the teacher on one sub-region: it trains only on
+a SEEN set of sentiment synonyms and is evaluated (region B) on a disjoint HELD-OUT set of synonyms never
+seen in training -- a hashed bag-of-words student has no representation for genuinely novel tokens, so it
+is near-chance there, while region A (the SEEN vocabulary, held out only as fresh examples of the same
+words) is easy.
+"""
+
+import unittest
+
+import numpy as np
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("safetensors")
+
+from mixle.task.calibrate import CalibratedTaskModel  # noqa: E402
+from mixle.task.disagreement import (  # noqa: E402
+    UnionGate,
+    fit_disagreement_gate,
+    measure_disagreement_mass,
+)
+from mixle.task.distill import agreement, distill_from_labels  # noqa: E402
+
+POS_SEEN = ["fantastic", "wonderful", "excellent", "superb", "stellar"]
+POS_HELD = ["marvelous", "terrific", "outstanding", "exceptional", "phenomenal"]
+NEG_SEEN = ["terrible", "awful", "dreadful", "atrocious", "abysmal"]
+NEG_HELD = ["horrendous", "appalling", "lousy", "subpar", "deficient"]
+FILLER = ["the", "movie", "was", "really", "quite", "so", "this", "book", "show", "honestly"]
+
+
+def _teacher(texts):
+    out = []
+    for t in texts:
+        toks = set(t.split())
+        if toks & set(POS_SEEN + POS_HELD):
+            out.append("positive")
+        elif toks & set(NEG_SEEN + NEG_HELD):
+            out.append("negative")
+        else:
+            out.append("negative")
+    return out
+
+
+def _make_texts(vocab_pos, vocab_neg, n_per_class=60, seed=0):
+    rng = np.random.RandomState(seed)
+    texts = []
+    for vocab in (vocab_pos, vocab_neg):
+        for _ in range(n_per_class):
+            k = rng.randint(3, 6)
+            toks = [rng.choice(vocab)] + list(rng.choice(FILLER, size=k))
+            rng.shuffle(toks)
+            texts.append(" ".join(toks))
+    rng.shuffle(texts)
+    return texts
+
+
+class DisagreementMassTest(unittest.TestCase):
+    def test_student_disagrees_far_more_on_held_out_synonyms_than_seen_ones(self):
+        train = _make_texts(POS_SEEN, NEG_SEEN, n_per_class=80, seed=1)
+        student = distill_from_labels(
+            train, _teacher(train), labels=["positive", "negative"], n=2, dim=64, hidden=[16], epochs=60, seed=0
+        )
+
+        region_a = _make_texts(POS_SEEN, NEG_SEEN, n_per_class=40, seed=2)  # same vocab, fresh examples
+        region_b = _make_texts(POS_HELD, NEG_HELD, n_per_class=40, seed=3)  # never-seen synonyms
+
+        mass_a = measure_disagreement_mass(student, region_a, _teacher(region_a))
+        mass_b = measure_disagreement_mass(student, region_b, _teacher(region_b))
+
+        self.assertLess(mass_a, 0.15)
+        self.assertGreater(mass_b, 0.3)
+        self.assertGreater(mass_b, mass_a)
+
+
+class DisagreementGateTest(unittest.TestCase):
+    def _fit_student_and_gate(self, seed=0):
+        train = _make_texts(POS_SEEN, NEG_SEEN, n_per_class=80, seed=seed)
+        student = distill_from_labels(
+            train, _teacher(train), labels=["positive", "negative"], n=2, dim=64, hidden=[16], epochs=60, seed=0
+        )
+        # fit the gate on a MIXED sample from both regions so it has examples of true agreement AND
+        # disagreement to learn from
+        gate_fit_texts = _make_texts(POS_SEEN, NEG_SEEN, n_per_class=30, seed=seed + 10) + _make_texts(
+            POS_HELD, NEG_HELD, n_per_class=30, seed=seed + 20
+        )
+        gate = fit_disagreement_gate(
+            student, gate_fit_texts, _teacher(gate_fit_texts), dim=64, hidden=[16], epochs=100, seed=0
+        )
+        return student, gate
+
+    def test_gate_flags_the_held_out_region_far_more_than_the_seen_region(self):
+        student, gate = self._fit_student_and_gate(seed=1)
+        region_a = _make_texts(POS_SEEN, NEG_SEEN, n_per_class=40, seed=42)
+        region_b = _make_texts(POS_HELD, NEG_HELD, n_per_class=40, seed=43)
+
+        flag_rate_a = float(np.mean(gate.ood_mask(region_a)))
+        flag_rate_b = float(np.mean(gate.ood_mask(region_b)))
+        self.assertGreater(flag_rate_b, flag_rate_a)
+
+    def test_cascade_with_the_gate_recovers_near_teacher_level_agreement(self):
+        student, gate = self._fit_student_and_gate(seed=2)
+        calibrated = CalibratedTaskModel(student, alpha=0.2, density_gate=gate).calibrate(
+            _make_texts(POS_SEEN, NEG_SEEN, n_per_class=30, seed=77),
+            _teacher(_make_texts(POS_SEEN, NEG_SEEN, n_per_class=30, seed=77)),
+        )
+        test = _make_texts(POS_SEEN, NEG_SEEN, n_per_class=20, seed=88) + _make_texts(
+            POS_HELD, NEG_HELD, n_per_class=20, seed=89
+        )
+        truth = _teacher(test)
+        served = []
+        for t, y in zip(test, truth):
+            decision = calibrated.decide(t)
+            served.append(y if decision is None else decision)  # ESCALATE -> teacher answers correctly
+        realized_agreement = float(np.mean([s == y for s, y in zip(served, truth)]))
+        unaided_agreement = agreement(student, truth, test)
+        self.assertGreater(realized_agreement, unaided_agreement)
+        self.assertGreater(realized_agreement, 0.85)
+
+    def test_union_gate_ors_two_gates(self):
+        class _AlwaysFlag:
+            def ood_mask(self, texts):
+                return np.ones(len(texts), dtype=bool)
+
+        class _NeverFlag:
+            def ood_mask(self, texts):
+                return np.zeros(len(texts), dtype=bool)
+
+        union = UnionGate(_NeverFlag(), _AlwaysFlag())
+        self.assertTrue(np.all(union.ood_mask(["a", "b", "c"])))
+        union_none = UnionGate(_NeverFlag(), _NeverFlag())
+        self.assertFalse(np.any(union_none.ood_mask(["a", "b"])))
+
+
+class ActiveLabelingShrinksTheRegionTest(unittest.TestCase):
+    def test_labeling_the_flagged_region_and_redistilling_shrinks_its_disagreement_mass(self):
+        train = _make_texts(POS_SEEN, NEG_SEEN, n_per_class=80, seed=5)
+        student = distill_from_labels(
+            train, _teacher(train), labels=["positive", "negative"], n=2, dim=64, hidden=[16], epochs=60, seed=0
+        )
+        flagged_region = _make_texts(POS_HELD, NEG_HELD, n_per_class=40, seed=6)
+        region_labels = _teacher(flagged_region)
+
+        mass_before = measure_disagreement_mass(student, flagged_region, region_labels)
+        self.assertGreater(mass_before, 0.3)
+
+        # sample the disagreement region, label it with the teacher, re-distill including those labels
+        augmented_texts = train + flagged_region
+        augmented_labels = _teacher(train) + region_labels
+        restudent = distill_from_labels(
+            augmented_texts,
+            augmented_labels,
+            labels=["positive", "negative"],
+            n=2,
+            dim=64,
+            hidden=[16],
+            epochs=60,
+            seed=0,
+        )
+        mass_after = measure_disagreement_mass(restudent, flagged_region, region_labels)
+
+        self.assertLess(mass_after, mass_before)
+        self.assertLess(mass_after, 0.1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Card D4-a (workstream D5), stacked on my own `capability-suite` (#17, D3-a) -- **merge #17 first, then this.**
- Note: an empty local branch named `disagreement-map` (the card's suggested branch name) already existed at the same base commit when I started, suggesting another session may also be attempting this card -- if a second implementation shows up, please pick one and close the other.
- `mixle/task/disagreement.py`: `fit_disagreement_gate` distills a tiny `agree`/`disagree` classifier over the student's own hashed n-gram feature family from `(text, student_label, teacher_label)` triples -- itself just a distilled student of a different target, reusing `distill_from_labels` rather than inventing a new fitting path. The resulting `DisagreementGate` exposes `ood_mask` with the exact same duck-typed shape as `mixle.task.density.DensityGate`, so it plugs into `CalibratedTaskModel(..., density_gate=...)` directly -- **no changes to `mixle/task/calibrate.py`** were needed or made. `UnionGate` composes it with a real density gate (or any other `ood_mask`-exposing gate) via logical OR. `measure_disagreement_mass` is the plain student-vs-teacher divergence fraction the active-labeling loop is measured against.
- Corpus construction (the "provably can't follow" part of the card): the student trains only on a SEEN set of sentiment synonyms and is evaluated on a disjoint HELD-OUT set of synonyms never seen in training. A hashed bag-of-words student has no representation for genuinely novel tokens, so it disagrees with the teacher far more on the held-out region than the seen one -- a provable capability gap, not a statistical coin-flip.

## Test plan
- [x] `mixle/tests/disagreement_test.py`:
  - `DisagreementMassTest` -- disagreement mass on the held-out synonym region is both higher in absolute terms (>0.3) and higher than the seen region (<0.15).
  - `DisagreementGateTest` -- the gate flags the held-out region at a higher rate than the seen region; a `CalibratedTaskModel` cascade using the gate (`density_gate=gate`) recovers realized agreement above the student's unaided agreement and above 0.85 (~teacher level, since escalated cases are answered correctly by construction); `UnionGate` ORs two gates correctly.
  - `ActiveLabelingShrinksTheRegionTest` -- the card's closing-the-loop acceptance: sampling the flagged region, labeling it with the teacher, and re-distilling with those labels included shrinks that exact region's measured disagreement mass from >0.3 to <0.1.
- [x] `.venv/bin/python -m pytest mixle/tests/disagreement_test.py -q` -- 5 passed.
- [x] `python -c "import mixle.task as t; t.DisagreementGate, t.UnionGate, t.fit_disagreement_gate, t.measure_disagreement_mass"` -- new exports load cleanly.
- [x] `ruff check` / `ruff format --check` on changed files -- clean.