### PR TITLE
task/REFINE-a: diagnosis-directed correction beats blind structure search (stacked on #18)

### DIFF
--- a/mixle/inference/__init__.py
+++ b/mixle/inference/__init__.py
@@ -94,7 +94,7 @@ from mixle.inference.event_study import (
     poisson_lograte_effect,
     tipping_drift,
 )
-from mixle.inference.explain import Explanation, explain, explain_margin, explain_margin_mixture
+from mixle.inference.explain import Explanation, FaultReport, diagnose, explain, explain_margin, explain_margin_mixture
 from mixle.inference.fisher import FisherView, FixedFisherView, to_fisher
 from mixle.inference.forecast import Forecast, forecast
 
@@ -313,6 +313,8 @@ __all__ = [
     "explain",
     "explain_margin",
     "explain_margin_mixture",
+    "FaultReport",
+    "diagnose",
     "InterventionalNetwork",
     "average_causal_effect",
     "counterfactual",

--- a/mixle/inference/explain.py
+++ b/mixle/inference/explain.py
@@ -39,6 +39,7 @@ decision margin between two named hypotheses -- into the same kind of per-factor
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -187,3 +188,86 @@ def explain_margin_mixture(model: Any, x: Any, answer: int, runner_up: int) -> E
     total = (wa + float(ca.log_density(x))) - (wr + float(cr.log_density(x)))
     correction = total - float(sum(v for _, v in parts))
     return Explanation(total, sorted(parts, key=lambda p: p[1]), correction=correction)
+
+
+# --- diagnose: ledger -> FaultReport (workstream H5, the refinement loop's critic role) ------------
+
+_FIX_VOCAB = frozenset({"add_edge", "upgrade_leaf", "split_region", "add_factor"})
+
+
+@dataclass
+class FaultReport:
+    """A structural diagnosis built ONLY from :func:`explain` ledgers over failing cases -- no model
+    opinion. ``dominant`` names the structural element(s) most responsible (empty when nothing rises
+    above ordinary case-to-case variability); ``suggested_fix`` is one of :data:`_FIX_VOCAB` (empty
+    when nothing is dominant); ``evidence`` is every element ranked by its adverse contribution."""
+
+    dominant: str
+    evidence: list[tuple[str, float]] = field(default_factory=list)
+    suggested_fix: str = ""
+    receipt: dict[str, Any] = field(default_factory=dict)
+
+
+def diagnose(
+    model: Any,
+    cases: Sequence[Any],
+    *,
+    background: Sequence[Any] | None = None,
+    min_z: float = 1.0,
+    co_occurrence_threshold: float = 0.5,
+) -> FaultReport:
+    """Aggregate :func:`explain` ledgers over ``cases`` (failing / low-margin / miscalibrated examples)
+    into a :class:`FaultReport` naming the structural element most responsible.
+
+    Each case's per-part contributions are compared to ``background`` (a reference sample of typical
+    cases; defaults to ``cases`` themselves, though a real, separately-supplied background is needed to
+    detect a fault that is systematic across every case, since self-baselining against the failing set
+    cancels a shift common to all of it) via a robust z-score (median/MAD per part name), so "adverse"
+    is relative to that part's own normal variability, not a raw log-density magnitude.
+
+    A single part scoring far from baseline is NOT, by itself, evidence of a structural defect --
+    ordinary tail draws look surprising even under a well-specified model. The one closed-vocabulary
+    fault this function actively detects is a missing dependency: two parts that are BOTH adverse on
+    (almost) exactly the same cases far more than chance predicts -- the signature of an unmodeled edge
+    between them, ranked by exact ledger numbers, never guessed. When no such co-anomalous pair is
+    found, the honest report is empty/low-severity, not a forced guess at ``upgrade_leaf`` (that
+    single-part detector, and ``split_region``/``add_factor``, are real, separate follow-up work --
+    see the module's diagnose_test.py and the KNOW-a/DIAGNOSE-a cards).
+    """
+    bg = list(background) if background is not None else list(cases)
+    if not bg or not cases:
+        return FaultReport("", [], "", {"n_cases": len(cases), "n_background": len(bg)})
+
+    bg_explanations = [explain(model, x) for x in bg]
+    names = sorted({name for ex in bg_explanations for name, _ in ex.parts})
+    baseline: dict[str, float] = {}
+    scale: dict[str, float] = {}
+    for name in names:
+        vals = np.asarray([v for ex in bg_explanations for n, v in ex.parts if n == name], dtype=np.float64)
+        med = float(np.median(vals))
+        mad = float(np.median(np.abs(vals - med))) * 1.4826  # normal-consistent MAD -> std-equivalent
+        baseline[name], scale[name] = med, max(mad, 1e-9)
+
+    rows: list[dict[str, float]] = []
+    for x in cases:
+        ex = explain(model, x)
+        rows.append({name: max(0.0, (baseline[name] - v) / scale[name]) for name, v in ex.parts if name in baseline})
+
+    mean_adverse = {name: float(np.mean([r.get(name, 0.0) for r in rows])) for name in names}
+    ranked = sorted(mean_adverse.items(), key=lambda kv: -kv[1])
+
+    dominant, fix, severity = "", "", 0.0
+    if len(ranked) > 1:
+        top_name, second_name = ranked[0][0], ranked[1][0]
+        both = sum(1 for r in rows if r.get(top_name, 0.0) > min_z and r.get(second_name, 0.0) > min_z)
+        either = sum(1 for r in rows if r.get(top_name, 0.0) > min_z or r.get(second_name, 0.0) > min_z)
+        co_occurrence = (both / either) if either else 0.0
+        if either > 0 and co_occurrence >= co_occurrence_threshold:
+            dominant, fix, severity = f"{top_name}+{second_name}", "add_edge", co_occurrence
+
+    return FaultReport(
+        dominant=dominant,
+        evidence=ranked,
+        suggested_fix=fix,
+        receipt={"n_cases": len(cases), "n_background": len(bg), "severity": round(severity, 4)},
+    )

--- a/mixle/task/__init__.py
+++ b/mixle/task/__init__.py
@@ -108,6 +108,14 @@ from mixle.task.quantize import (
     quantize_mlp,
 )
 from mixle.task.recommend import FieldChoice, ModelRecommendation, recommend_model
+from mixle.task.refine import (
+    EditTrial,
+    SearchOutcome,
+    apply_edge,
+    blind_structure_search,
+    diagnosis_directed_correction,
+    fit_independent_baseline,
+)
 from mixle.task.regress import RegressionSolution, solve_regression
 from mixle.task.router import Router, RouterStats, route_stack
 from mixle.task.scorecard import Scorecard, scorecard
@@ -148,6 +156,12 @@ __all__ = [
     "OpenAICompatLLM",
     "QuantizedClassifierIO",
     "QuantizedMLP",
+    "EditTrial",
+    "SearchOutcome",
+    "apply_edge",
+    "blind_structure_search",
+    "diagnosis_directed_correction",
+    "fit_independent_baseline",
     "RecipeSpace",
     "RecordClassifierIO",
     "RoutePlan",

--- a/mixle/task/refine.py
+++ b/mixle/task/refine.py
@@ -1,0 +1,154 @@
+"""Diagnosis-directed correction vs blind structure search on a planted-fault benchmark (workstream
+A5 + the refinement loop's REFINE-a spike).
+
+``diagnose`` (H5, workstream H) turns failing cases into a :class:`~mixle.inference.explain.FaultReport`
+naming a structural element and a suggested fix; the open question this module answers is whether
+ACTING on that diagnosis reaches a held-out target in fewer trials than blind structure search over the
+same edit space. Every candidate edge -- diagnosed or blindly tried -- is refit from the SAME training
+data and VERIFIED against held-out data before being accepted; a candidate that does not clear the
+held-out bar is a recorded failed trial, never silently kept.
+
+Kill criterion, stated before any comparison is run (per the plan): if diagnosis-directed correction
+does not reach the held-out target in fewer trials than blind search on the planted-fault benchmark,
+that is the honest, recorded negative result, and blind search is kept -- the critic (``diagnose``) has
+not earned its place. See ``notes/refine-directed-negative.md`` for the recording convention if this
+kill criterion is ever hit on a different benchmark than the one exercised by this module's tests.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+
+from mixle.inference.bayesian_network import HeterogeneousBayesianNetwork, _LinearGaussianFactor, _MarginalFactor
+from mixle.inference.explain import diagnose
+from mixle.stats import GaussianDistribution
+
+
+def _columns(data: Sequence[tuple]) -> list[list[Any]]:
+    return [list(col) for col in zip(*data)]
+
+
+def _mean_log_density(model: HeterogeneousBayesianNetwork, data: Sequence[tuple]) -> float:
+    return float(np.mean([model.log_density(x) for x in data]))
+
+
+def fit_independent_baseline(train_data: Sequence[tuple]) -> HeterogeneousBayesianNetwork:
+    """Fit a fully independent (no-edge) network -- the planted fault when two fields are actually
+    correlated: one marginal Gaussian per field, MLE-fit from ``train_data``."""
+    cols = _columns(train_data)
+    factors = []
+    for i, col in enumerate(cols):
+        arr = np.asarray(col, dtype=np.float64)
+        factors.append(_MarginalFactor(i, GaussianDistribution(float(arr.mean()), float(max(arr.var(), 1e-9)))))
+    return HeterogeneousBayesianNetwork(factors)
+
+
+def apply_edge(
+    model: HeterogeneousBayesianNetwork, edge: tuple[int, int], train_data: Sequence[tuple]
+) -> HeterogeneousBayesianNetwork:
+    """Refit ONLY the named edge's child factor as a linear-Gaussian conditional on the named parent,
+    from the SAME training data, leaving every other factor untouched -- "apply ONLY the suggested
+    fix," literally: no other structural change rides along."""
+    parent, child = edge
+    cols = _columns(train_data)
+    new_factor = _LinearGaussianFactor.fit(child, [parent], cols, discrete={})
+    factors = [f if f.child != child else new_factor for f in model.factors]
+    return HeterogeneousBayesianNetwork(factors)
+
+
+@dataclass
+class EditTrial:
+    edge: tuple[int, int]
+    held_out_score: float
+    verified: bool  # cleared the held-out target, not just "improved a bit"
+
+
+@dataclass
+class SearchOutcome:
+    trials: int
+    found_edge: tuple[int, int] | None
+    final_model: HeterogeneousBayesianNetwork
+    history: list[EditTrial] = field(default_factory=list)
+
+
+def _try_edge(
+    model: HeterogeneousBayesianNetwork,
+    edge: tuple[int, int],
+    train_data: Sequence[tuple],
+    held_out: Sequence[tuple],
+    *,
+    target: float,
+) -> EditTrial:
+    candidate = apply_edge(model, edge, train_data)
+    score = _mean_log_density(candidate, held_out)
+    return EditTrial(edge=edge, held_out_score=score, verified=score >= target)
+
+
+def _dominant_pair(dominant: str) -> tuple[int, int] | None:
+    """Parse the two field indices out of a ``diagnose`` dominant string like
+    ``"field[1]|parents()+field[2]|parents()"``; ``None`` if it does not name a two-field pair."""
+    parts = dominant.split("+")
+    if len(parts) != 2:
+        return None
+    try:
+        return tuple(int(p.split("[", 1)[1].split("]", 1)[0]) for p in parts)  # type: ignore[return-value]
+    except (IndexError, ValueError):
+        return None
+
+
+def diagnosis_directed_correction(
+    model: HeterogeneousBayesianNetwork,
+    train_data: Sequence[tuple],
+    failing_cases: Sequence[tuple],
+    held_out: Sequence[tuple],
+    *,
+    background: Sequence[tuple] | None = None,
+    target: float,
+) -> SearchOutcome:
+    """Diagnose the fault from ``failing_cases``, apply ONLY its suggested edge (trying both parent-child
+    orientations of the named pair, since ``diagnose`` reports an undirected co-anomaly), and verify held-out
+    improvement before accepting -- one trial if the diagnosis names the right pair and orientation,
+    honestly more (or a refusal) if it does not."""
+    report = diagnose(model, failing_cases, background=background)
+    history: list[EditTrial] = []
+    if report.suggested_fix != "add_edge":
+        return SearchOutcome(trials=0, found_edge=None, final_model=model, history=history)
+
+    pair = _dominant_pair(report.dominant)
+    if pair is None:
+        return SearchOutcome(trials=0, found_edge=None, final_model=model, history=history)
+
+    for edge in (pair, (pair[1], pair[0])):
+        trial = _try_edge(model, edge, train_data, held_out, target=target)
+        history.append(trial)
+        if trial.verified:
+            return SearchOutcome(
+                trials=len(history), found_edge=edge, final_model=apply_edge(model, edge, train_data), history=history
+            )
+    return SearchOutcome(trials=len(history), found_edge=None, final_model=model, history=history)
+
+
+def blind_structure_search(
+    model: HeterogeneousBayesianNetwork,
+    train_data: Sequence[tuple],
+    held_out: Sequence[tuple],
+    edit_space: Sequence[tuple[int, int]],
+    *,
+    target: float,
+) -> SearchOutcome:
+    """Try each candidate edge in ``edit_space``'s given order, verifying held-out improvement before
+    accepting -- the same verification discipline as :func:`diagnosis_directed_correction`, just without
+    a diagnosis telling it where to look first."""
+    history: list[EditTrial] = []
+    for edge in edit_space:
+        trial = _try_edge(model, edge, train_data, held_out, target=target)
+        history.append(trial)
+        if trial.verified:
+            return SearchOutcome(
+                trials=len(history), found_edge=edge, final_model=apply_edge(model, edge, train_data), history=history
+            )
+    return SearchOutcome(trials=len(history), found_edge=None, final_model=model, history=history)

--- a/mixle/tests/diagnose_test.py
+++ b/mixle/tests/diagnose_test.py
@@ -1,0 +1,105 @@
+"""DIAGNOSE-a: diagnose() aggregates explain() ledgers over failing cases into a FaultReport --
+planted-fault recovery for a missing dependency, and a well-specified model showing nothing dominant.
+
+The merged H1-a `explain`/`explain_margin` do NOT take the (models, priors) dict-of-classifiers shape
+the original card sketched before H1-a landed; the real API is `explain(model, x) -> Explanation`
+(see mixle/inference/explain.py). `diagnose` composes with THAT real signature, calling `explain` once
+per case and aggregating -- same spirit (H1's ledger feeds H5's critic), adapted to the shipped API.
+"""
+
+import unittest
+
+import numpy as np
+
+from mixle.inference import diagnose
+from mixle.inference.bayesian_network import HeterogeneousBayesianNetwork, _LinearGaussianFactor, _MarginalFactor
+from mixle.stats import GaussianDistribution
+
+
+def _split_cases():
+    """A grid of (a, b) pairs where b = a + 0.05 -- a genuine, tight correlation between the two
+    fields. 'background' is the interior (typical) range; 'failing' is the tail, where a model that
+    does not know about the correlation is most surprised."""
+    a_grid = np.linspace(-3.0, 3.0, 41)
+    pairs = [(float(a), float(a) + 0.05) for a in a_grid]
+    background = [p for p in pairs if abs(p[0]) <= 1.5]
+    failing = [p for p in pairs if abs(p[0]) > 2.2]
+    return background, failing
+
+
+def _buggy_net():
+    """The planted fault: b is truly b = a + noise, but modeled as fully independent of a."""
+    return HeterogeneousBayesianNetwork(
+        [
+            _MarginalFactor(0, GaussianDistribution(0.0, 1.0)),
+            _MarginalFactor(1, GaussianDistribution(0.0, 1.0)),
+        ]
+    )
+
+
+def _well_specified_net():
+    """The SAME data, correctly modeled: b's factor is conditioned on a."""
+    return HeterogeneousBayesianNetwork(
+        [
+            _MarginalFactor(0, GaussianDistribution(0.0, 1.0)),
+            _LinearGaussianFactor(1, [0], {}, np.array([1.0, 0.0]), 0.1),
+        ]
+    )
+
+
+class PlantedFaultRecoveryTest(unittest.TestCase):
+    def test_missing_edge_is_named_dominant_with_add_edge(self):
+        background, failing = _split_cases()
+        report = diagnose(_buggy_net(), failing, background=background)
+
+        self.assertEqual(report.suggested_fix, "add_edge")
+        self.assertIn("field[0]", report.dominant)
+        self.assertIn("field[1]", report.dominant)
+        self.assertGreater(report.receipt["severity"], 0.9)  # both fields adverse on (almost) every case
+
+    def test_well_specified_model_on_same_data_reports_nothing_dominant(self):
+        background, failing = _split_cases()
+        report = diagnose(_well_specified_net(), failing, background=background)
+
+        self.assertEqual(report.dominant, "")
+        self.assertEqual(report.suggested_fix, "")
+        self.assertEqual(report.receipt["severity"], 0.0)
+
+    def test_evidence_is_ranked_and_exact_field_names_present(self):
+        background, failing = _split_cases()
+        report = diagnose(_buggy_net(), failing, background=background)
+        names = [n for n, _ in report.evidence]
+        self.assertEqual(names, sorted(names, key=lambda n: -dict(report.evidence)[n]))
+        self.assertEqual({n.split("|")[0] for n in names}, {"field[0]", "field[1]"})
+
+
+class DeterminismTest(unittest.TestCase):
+    def test_same_seeded_cases_give_bit_identical_reports(self):
+        rng1 = np.random.default_rng(0)
+        rng2 = np.random.default_rng(0)
+
+        def make_cases(rng):
+            a = rng.uniform(-3.0, 3.0, size=30)
+            return [(float(x), float(x) + 0.05) for x in a]
+
+        cases1, cases2 = make_cases(rng1), make_cases(rng2)
+        background, _ = _split_cases()
+
+        r1 = diagnose(_buggy_net(), cases1, background=background)
+        r2 = diagnose(_buggy_net(), cases2, background=background)
+
+        self.assertEqual(r1.dominant, r2.dominant)
+        self.assertEqual(r1.suggested_fix, r2.suggested_fix)
+        self.assertEqual(r1.evidence, r2.evidence)
+        self.assertEqual(r1.receipt, r2.receipt)
+
+
+class EmptyInputTest(unittest.TestCase):
+    def test_no_cases_returns_empty_report_not_a_crash(self):
+        report = diagnose(_buggy_net(), [])
+        self.assertEqual(report.dominant, "")
+        self.assertEqual(report.evidence, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mixle/tests/task_refine_test.py
+++ b/mixle/tests/task_refine_test.py
@@ -1,0 +1,119 @@
+"""Diagnosis-directed correction vs blind structure search on a planted-fault benchmark (REFINE-a).
+
+Kill criterion (stated before the comparison, per the card): diagnosis-directed correction must reach
+the held-out target in FEWER trials than blind search over the same edit space, or the negative result
+is what these tests would need to record instead."""
+
+import itertools
+import unittest
+
+import numpy as np
+
+from mixle.inference.explain import diagnose
+from mixle.task.refine import blind_structure_search, diagnosis_directed_correction, fit_independent_baseline
+
+# 4 fields: 0 and 3 are independent noise; 1 (a) and 2 (b) carry a genuine, tight linear correlation
+# (b = a + 0.05 + small noise) -- the planted fault is modeling 1 and 2 as independent.
+_N = 300
+
+
+def _generate(seed: int, n: int = _N) -> list[tuple]:
+    rng = np.random.default_rng(seed)
+    a = rng.uniform(-3.0, 3.0, size=n)
+    b = a + 0.05 + rng.normal(0.0, 0.15, size=n)
+    f0 = rng.normal(0.0, 1.0, size=n)
+    f3 = rng.normal(0.0, 1.0, size=n)
+    return list(zip(f0.tolist(), a.tolist(), b.tolist(), f3.tolist()))
+
+
+def _split_cases(train_data: list[tuple]) -> tuple[list[tuple], list[tuple]]:
+    background = [x for x in train_data if abs(x[1]) <= 1.5]
+    failing = [x for x in train_data if abs(x[1]) > 2.2]
+    return background, failing
+
+
+_EDIT_SPACE = list(itertools.combinations(range(4), 2))  # canonical enumeration order, not cherry-picked
+
+
+class PlantedFaultSetupTest(unittest.TestCase):
+    def test_diagnose_names_the_planted_pair_on_the_fitted_baseline(self):
+        train_data = _generate(seed=0)
+        baseline = fit_independent_baseline(train_data)
+        background, failing = _split_cases(train_data)
+
+        report = diagnose(baseline, failing, background=background)
+        self.assertEqual(report.suggested_fix, "add_edge")
+        self.assertIn("field[1]", report.dominant)
+        self.assertIn("field[2]", report.dominant)
+
+
+class DiagnosisVsBlindSearchTest(unittest.TestCase):
+    def setUp(self):
+        self.train_data = _generate(seed=0)
+        self.held_out = _generate(seed=1)
+        self.baseline = fit_independent_baseline(self.train_data)
+        self.background, self.failing = _split_cases(self.train_data)
+        baseline_score = float(np.mean([self.baseline.log_density(x) for x in self.held_out]))
+        self.target = baseline_score + 1.0  # only the true edge (~+2.4 nats) clears this bar
+
+    def test_diagnosis_directed_correction_finds_the_true_edge_in_one_or_two_trials(self):
+        outcome = diagnosis_directed_correction(
+            self.baseline, self.train_data, self.failing, self.held_out, background=self.background, target=self.target
+        )
+        self.assertIsNotNone(outcome.found_edge)
+        self.assertEqual(set(outcome.found_edge), {1, 2})
+        self.assertLessEqual(outcome.trials, 2)
+        self.assertTrue(outcome.history[-1].verified)
+
+    def test_blind_search_needs_more_trials_over_the_same_edit_space(self):
+        outcome = blind_structure_search(self.baseline, self.train_data, self.held_out, _EDIT_SPACE, target=self.target)
+        self.assertIsNotNone(outcome.found_edge)
+        self.assertEqual(set(outcome.found_edge), {1, 2})
+        self.assertGreater(outcome.trials, 2)  # the canonical order tries several wrong edges first
+
+    def test_diagnosis_beats_blind_search_on_trials_to_target(self):
+        directed = diagnosis_directed_correction(
+            self.baseline, self.train_data, self.failing, self.held_out, background=self.background, target=self.target
+        )
+        blind = blind_structure_search(self.baseline, self.train_data, self.held_out, _EDIT_SPACE, target=self.target)
+
+        # the card's literal acceptance test: fewer trials than blind search, or record the negative result.
+        self.assertLess(directed.trials, blind.trials)
+
+    def test_wrong_edges_do_not_clear_the_target_only_the_true_pair_does(self):
+        outcome = blind_structure_search(self.baseline, self.train_data, self.held_out, _EDIT_SPACE, target=self.target)
+        for trial in outcome.history:
+            if set(trial.edge) != {1, 2}:
+                self.assertFalse(trial.verified)
+
+
+class NoFaultFoundTest(unittest.TestCase):
+    def test_a_well_specified_model_yields_no_diagnosis_and_zero_trials(self):
+        # correct from the start: fields modeled with the true edge already in place
+        train_data = _generate(seed=0)
+        from mixle.inference.bayesian_network import (
+            HeterogeneousBayesianNetwork,
+            _LinearGaussianFactor,
+            _MarginalFactor,
+        )
+        from mixle.stats import GaussianDistribution
+
+        cols = [list(col) for col in zip(*train_data)]
+        factors = [
+            _MarginalFactor(0, GaussianDistribution(float(np.mean(cols[0])), float(np.var(cols[0])))),
+            _MarginalFactor(1, GaussianDistribution(float(np.mean(cols[1])), float(np.var(cols[1])))),
+            _LinearGaussianFactor.fit(2, [1], cols, discrete={}),
+            _MarginalFactor(3, GaussianDistribution(float(np.mean(cols[3])), float(np.var(cols[3])))),
+        ]
+        well_specified = HeterogeneousBayesianNetwork(factors)
+        background, failing = _split_cases(train_data)
+
+        outcome = diagnosis_directed_correction(
+            well_specified, train_data, failing, train_data, background=background, target=0.0
+        )
+        self.assertEqual(outcome.trials, 0)
+        self.assertIsNone(outcome.found_edge)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Workstream A5 research spike, stacked on `task/diagnose-a-fault-diagnose` (#18 DIAGNOSE-a) -- **merge order: #18, then this.**
- `mixle/task/refine.py`: on a planted-fault benchmark (a 4-field Bayesian network where fields 1 and 2 carry a genuine linear correlation but are modeled as independent), `diagnose()` names the missing edge; `diagnosis_directed_correction` applies ONLY that suggested fix -- refit the named child factor as linear-Gaussian on the named parent, from the same training data, verified against held-out data before being accepted.
- `blind_structure_search` tries every candidate edge in a fixed canonical enumeration order (not cherry-picked to favor either side) over the same 6-edge edit space, with the identical verification discipline.
- Result on this benchmark: diagnosis reaches the held-out target in **1 trial**; blind search needs **4**. Kill criterion is recorded in the module docstring (a future benchmark reversing this result goes in `notes/refine-directed-negative.md` and blind search is kept) -- not hit here.
- Note: I noticed a second local branch (`refine-diagnosis-directed`) with the same `mixle/task/refine.py` filename mid-session, suggesting another concurrent session may also be attempting this card -- if a duplicate PR shows up, please pick one and close the other.

## Test plan
- [x] `.venv/bin/python -m pytest mixle/tests/task_refine_test.py -q` -- 6 passed (diagnose names the planted pair on the fitted baseline; diagnosis-directed correction finds the true edge in <=2 trials; blind search needs more trials over the same edit space; diagnosis beats blind search on trials-to-target -- the card's literal acceptance test; wrong edges never clear the target; a well-specified model yields no diagnosis and zero trials)
- [x] `.venv/bin/python -m ruff check mixle/task/refine.py mixle/tests/task_refine_test.py mixle/task/__init__.py` -- clean
- [x] `.venv/bin/python -m ruff format --check` on the same files -- clean
- [ ] Full gate not run in this session per instructions to only run targeted tests; recommend running before merge.