### PR TITLE
fix: capacity.py embedding_head rung -- _fit_mlp 3-tuple unpack mismatch

### DIFF
--- a/mixle/task/capacity.py
+++ b/mixle/task/capacity.py
@@ -256,7 +256,9 @@ def _fit_rung(
         label_index = {y: i for i, y in enumerate(label_list)}
         y = np.asarray([label_index[str(t)] for t in train_labels], dtype=np.int64)
         featurizer = WordEmbeddingFeaturizer(word_vectors, dim=vec_dim, seed=seed)
-        module, cfg = _fit_mlp(featurizer.transform(train_texts), y, len(label_list), hidden, epochs, lr, seed, device)
+        module, cfg, _steps_run = _fit_mlp(
+            featurizer.transform(train_texts), y, len(label_list), hidden, epochs, lr, seed, device
+        )
         student = TaskModel(
             module,
             EmbeddingHeadIO(featurizer, label_list),


### PR DESCRIPTION
## Summary
- Bug fix, found incidentally while running a broader regression check for an unrelated PR (#46, REFINE-a) -- confirmed broken on \`origin/release/0.6.3-generic-capabilities\` itself (not something my own branches caused).
- \`mixle/task/distill.py\`'s \`_fit_mlp\` started returning \`(module, cfg, steps_run)\` when early-stopping landed (PR #5, \`distill-fast-adaptive\`); its own two call sites were updated to match at the time. \`mixle/task/capacity.py\`'s \`embedding_head\` rung (added later in PR #21, \`capacity-ladder\`) still unpacked only \`(module, cfg)\`, raising \`ValueError: too many values to unpack (expected 2)\` on every call.
- One-line fix: unpack the third value (\`_steps_run\`, unused here) too.

## Test plan
- [x] Reproduced on \`origin/release/0.6.3-generic-capabilities\` directly (detached-HEAD worktree, no other changes): \`mixle/tests/capacity_ladder_test.py\` -- 2 failed, 7 passed.
- [x] After the fix: \`.venv/bin/python -m pytest mixle/tests/capacity_ladder_test.py -q\` -- 9 passed.
- [x] Grepped for other call sites of \`_fit_mlp\` -- only these three exist total; the other two (in \`distill.py\`) already unpack correctly.
- [x] \`ruff check\` / \`ruff format --check\` on the changed file -- clean.