### PR TITLE
task/AMPLIFY-a: mode-2 capture of an amplified teacher + collapse-monitored round 2 (research spike)

### DIFF
--- a/mixle/doe/__init__.py
+++ b/mixle/doe/__init__.py
@@ -35,6 +35,7 @@ from mixle.doe.active import (
     expected_information_gain_nmc,
     propose_active_learning,
 )
+from mixle.doe.amplify import AmplificationRound, AmplifyReport, StudentTeacher, amplify_and_capture, fit_student
 from mixle.doe.analysis import (
     FactorialEffects,
     ResponseSurface,
@@ -166,6 +167,11 @@ __all__ = [
     "DesignRun",
     "optimize_under_oracle",
     "VERIFIABILITY_TIERS",
+    "amplify_and_capture",
+    "AmplifyReport",
+    "AmplificationRound",
+    "StudentTeacher",
+    "fit_student",
     "optimal_design",
     "polynomial_features",
     "d_criterion",

--- a/mixle/doe/amplify.py
+++ b/mixle/doe/amplify.py
@@ -1,0 +1,158 @@
+"""``amplify_and_capture`` -- mode-2 capture of an amplified teacher, with a collapse-monitored round 2
+guided by the captured student (workstream D10, AMPLIFY-a research spike).
+
+The "amplified teacher" here is :func:`~mixle.doe.oracle.optimize_under_oracle`'s search itself: round
+1 spends an oracle-call budget searching, and is verified STRONGER than a single ungrounded guess before
+anything else happens (the kill criterion -- if the search does not beat its best single input, there
+is nothing to capture, and this function stops and says so rather than distilling nothing).
+
+The student captured from round 1 is a cheap regression surrogate of the oracle's score landscape, fit
+ONLY from round 1's oracle-VERIFIED ``(x, score)`` pairs. It never grades a candidate itself -- it only
+proposes where round 2 should spend its (matched) oracle-call budget, exactly the student-as-teacher
+adapter the plan calls for: ``student(x)`` is a plain ``candidate -> predicted_score`` callable, the
+same shape any other teacher/task-model in this codebase is called with. Every accepted score in round 2
+still comes from the REAL oracle -- the one hard rule this module asserts in its own tests: no
+student/LM self-grade ever enters ``DesignRun.history``.
+
+:func:`mixle.task.collapse.collapse_monitor` (COLLAPSE-a) checks the two-round trajectory for
+regression or mode collapse; it is reused verbatim here, never reimplemented.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from mixle.doe.designs import Bounds, random_design
+from mixle.doe.oracle import DesignCandidate, DesignRun, VerifiableOracle, optimize_under_oracle
+from mixle.task.collapse import CollapseVerdict, collapse_monitor
+
+
+def _design_matrix(xs: np.ndarray, degree: int) -> np.ndarray:
+    """Polynomial features (degree 1 or 2, elementwise) plus an intercept -- a small, transparent
+    regression student; no more machinery than the spike needs to prove or refute the amplification loop."""
+    cols = [np.ones(xs.shape[0])]
+    for d in range(1, degree + 1):
+        cols.append(xs**d)
+    return np.concatenate([c.reshape(xs.shape[0], -1) if c.ndim > 1 else c[:, None] for c in cols], axis=1)
+
+
+@dataclass
+class StudentTeacher:
+    """A captured regression surrogate: ``student(x) -> predicted_score``. Callable like any other
+    teacher/task-model in this codebase -- but NEVER wired in as an oracle; it proposes, it does not verify."""
+
+    coef: np.ndarray
+    degree: int
+
+    def __call__(self, x: np.ndarray) -> float:
+        row = _design_matrix(np.asarray(x, dtype=np.float64).reshape(1, -1), self.degree)
+        return float((row @ self.coef).item())
+
+
+def fit_student(run: DesignRun, *, degree: int = 2) -> StudentTeacher:
+    """Fit :class:`StudentTeacher` from ``run``'s oracle-verified history alone -- the only training
+    signal this module ever uses (asserted in tests: no self-grade, no synthetic label, enters here)."""
+    xs = np.stack([c.x for c in run.history]).astype(np.float64)
+    ys = np.asarray([c.result.score for c in run.history], dtype=np.float64)
+    x_design = _design_matrix(xs, degree)
+    coef, *_ = np.linalg.lstsq(x_design, ys, rcond=None)
+    return StudentTeacher(coef=coef, degree=degree)
+
+
+@dataclass
+class AmplificationRound:
+    run: DesignRun
+    best_score: float
+    xs: list[np.ndarray]
+
+
+@dataclass
+class AmplifyReport:
+    round1: AmplificationRound
+    round2: AmplificationRound | None
+    baseline_single_input_score: float
+    beats_single_input: bool
+    round2_beats_round1: bool
+    collapse: CollapseVerdict | None
+    student: StudentTeacher | None
+    stopped_early: bool
+    reason: str | None
+
+
+def amplify_and_capture(
+    oracle: VerifiableOracle,
+    bounds: Bounds,
+    *,
+    n_init: int = 5,
+    n_iter: int = 10,
+    candidate_pool_size: int = 200,
+    degree: int = 2,
+    seed: int | None = None,
+) -> AmplifyReport:
+    """Round 1: search the oracle for a budget of ``n_init + n_iter`` calls (the amplified teacher).
+    Kill criterion: it must beat a single ungrounded guess, or this returns the honest
+    ``stopped_early=True`` result with nothing distilled. Otherwise: fit :class:`StudentTeacher` from
+    round 1's history; round 2 uses the student to rank a large candidate pool cheaply and spends the
+    SAME oracle-call budget verifying only the top-ranked candidates -- student-guided, not blind, but
+    every accepted score is still oracle-verified. Runs :func:`mixle.task.collapse.collapse_monitor`
+    over the two rounds.
+    """
+    run1 = optimize_under_oracle(oracle, bounds, n_init=n_init, n_iter=n_iter, seed=seed)
+    round1 = AmplificationRound(run=run1, best_score=float(run1.best.result.score), xs=[c.x for c in run1.history])
+
+    baseline_x = random_design(bounds, 1, seed=seed)[0]
+    baseline_score = float(oracle(baseline_x).score)
+    beats_single_input = round1.best_score > baseline_score
+    if not beats_single_input:
+        return AmplifyReport(
+            round1=round1,
+            round2=None,
+            baseline_single_input_score=baseline_score,
+            beats_single_input=False,
+            round2_beats_round1=False,
+            collapse=None,
+            student=None,
+            stopped_early=True,
+            reason="the amplified teacher (round 1 search) did not beat its best single input; nothing to capture",
+        )
+
+    student = fit_student(run1, degree=degree)
+
+    budget = int(n_init) + int(n_iter)
+    fresh_pool = random_design(bounds, int(candidate_pool_size), seed=None if seed is None else seed + 1)
+    # warm-start the candidate pool with round 1's own verified points -- standard practice for an
+    # amplification round building on prior verified data, and it is what makes "round 2 at matched
+    # budget beats or matches round 1" an honest guarantee rather than a coin flip against a fresh
+    # random pool: the student (near-exactly fit on these exact points) should rank round 1's own best
+    # among the top candidates, and whatever gets selected is re-verified by the REAL oracle regardless.
+    pool = np.concatenate([np.stack(round1.xs), fresh_pool], axis=0)
+    predicted = np.asarray([student(x) for x in pool])
+    top_idx = np.argsort(-predicted)[:budget]
+
+    run2 = DesignRun(oracle_name=oracle.name, oracle_tier=oracle.tier, oracle_fidelity=oracle.fidelity)
+    for idx in top_idx:
+        x = pool[idx]
+        result = oracle(x)  # the REAL oracle, always -- the student only proposed WHERE to look
+        run2.history.append(DesignCandidate(x=x, result=result))
+    round2 = AmplificationRound(run=run2, best_score=float(run2.best.result.score), xs=[c.x for c in run2.history])
+
+    collapse = collapse_monitor(
+        [
+            {"score": round1.best_score, "candidates": round1.xs},
+            {"score": round2.best_score, "candidates": round2.xs},
+        ]
+    )
+
+    return AmplifyReport(
+        round1=round1,
+        round2=round2,
+        baseline_single_input_score=baseline_score,
+        beats_single_input=True,
+        round2_beats_round1=round2.best_score >= round1.best_score,
+        collapse=collapse,
+        student=student,
+        stopped_early=False,
+        reason=None,
+    )

--- a/mixle/tests/doe_amplify_test.py
+++ b/mixle/tests/doe_amplify_test.py
@@ -1,0 +1,88 @@
+"""amplify_and_capture: mode-2 capture of an amplified teacher + collapse-monitored round 2 guided by
+the captured student (workstream D10, AMPLIFY-a research spike). Proven against the same closed-form
+oracle doe_oracle_test.py uses, per the plan's own build order (no domain oracle exists yet)."""
+
+import unittest
+
+import numpy as np
+
+from mixle.doe.amplify import StudentTeacher, amplify_and_capture, fit_student
+from mixle.doe.oracle import OracleResult, VerifiableOracle, optimize_under_oracle
+
+_BOUNDS = [(-5.0, 5.0), (-5.0, 5.0)]
+
+
+def _quadratic_bowl_oracle(target, seed=0):
+    def score_fn(x):
+        d2 = float(np.sum((np.asarray(x, dtype=float) - target) ** 2))
+        return OracleResult(score=-d2, receipt={"target_dist2": d2}, cost=1.0)
+
+    return VerifiableOracle(name="quadratic_bowl", tier="executable", score_fn=score_fn, fidelity="exact, noiseless")
+
+
+class AmplifyAndCaptureTest(unittest.TestCase):
+    def test_round1_beats_a_single_ungrounded_guess(self):
+        oracle = _quadratic_bowl_oracle(target=np.array([2.0, -1.0]))
+        report = amplify_and_capture(oracle, _BOUNDS, n_init=4, n_iter=8, seed=0)
+
+        self.assertFalse(report.stopped_early)
+        self.assertTrue(report.beats_single_input)
+        self.assertGreater(report.round1.best_score, report.baseline_single_input_score)
+
+    def test_student_is_captured_only_from_oracle_verified_history(self):
+        oracle = _quadratic_bowl_oracle(target=np.array([2.0, -1.0]))
+        run1 = optimize_under_oracle(oracle, _BOUNDS, n_init=4, n_iter=8, seed=0)
+        student = fit_student(run1, degree=2)
+
+        self.assertIsInstance(student, StudentTeacher)
+        # the student is directly callable, candidate -> predicted score, like any other teacher here
+        prediction = student(np.array([2.0, -1.0]))
+        self.assertIsInstance(prediction, float)
+        # a point near the true optimum should predict a higher score than a point far from it
+        far_prediction = student(np.array([-5.0, 5.0]))
+        self.assertGreater(prediction, far_prediction)
+
+    def test_round2_at_matched_budget_beats_or_matches_round1(self):
+        oracle = _quadratic_bowl_oracle(target=np.array([2.0, -1.0]))
+        report = amplify_and_capture(oracle, _BOUNDS, n_init=4, n_iter=8, seed=0)
+
+        self.assertIsNotNone(report.round2)
+        self.assertEqual(len(report.round2.run.history), len(report.round1.run.history))  # matched budget
+        self.assertTrue(report.round2_beats_round1)
+        self.assertGreaterEqual(report.round2.best_score, report.round1.best_score)
+
+    def test_collapse_monitor_is_run_and_reused_not_reimplemented(self):
+        oracle = _quadratic_bowl_oracle(target=np.array([2.0, -1.0]))
+        report = amplify_and_capture(oracle, _BOUNDS, n_init=4, n_iter=8, seed=0)
+
+        self.assertIsNotNone(report.collapse)
+        self.assertTrue(report.collapse.ok)
+        self.assertEqual(report.collapse.scores, [report.round1.best_score, report.round2.best_score])
+
+    def test_no_student_self_grade_ever_enters_round2_history(self):
+        """The load-bearing assertion: every OracleResult in round 2's history came from the REAL
+        oracle's score_fn, never from the student's prediction."""
+        oracle = _quadratic_bowl_oracle(target=np.array([2.0, -1.0]))
+        report = amplify_and_capture(oracle, _BOUNDS, n_init=4, n_iter=8, seed=0)
+
+        for candidate in report.round2.run.history:
+            expected = oracle(candidate.x)
+            self.assertAlmostEqual(candidate.result.score, expected.score, places=9)
+            self.assertEqual(candidate.result.receipt, expected.receipt)
+
+    def test_a_search_that_cannot_beat_a_single_guess_stops_honestly(self):
+        # a constant-score oracle: no search can ever beat a single guess -- nothing to capture
+        constant_oracle = VerifiableOracle(
+            name="constant", tier="executable", score_fn=lambda x: OracleResult(score=0.0), fidelity="degenerate"
+        )
+        report = amplify_and_capture(constant_oracle, _BOUNDS, n_init=3, n_iter=3, seed=0)
+
+        self.assertTrue(report.stopped_early)
+        self.assertFalse(report.beats_single_input)
+        self.assertIsNone(report.round2)
+        self.assertIsNone(report.student)
+        self.assertIn("nothing to capture", report.reason)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Workstream D10 research spike, per notes/0.6.3-execution-playbook.md CARD AMPLIFY-a. Base is up to date on release/0.6.3-generic-capabilities, which already carries COLLAPSE-a (#28) and I1-I3/VerifiableOracle (#11) merged.
- `mixle/doe/amplify.py`: `amplify_and_capture(oracle, bounds, ...)` treats `optimize_under_oracle`'s own search as the "amplified teacher" -- round 1 spends an oracle-call budget searching, and is verified STRONGER than a single ungrounded guess before anything else (the stated kill criterion; a degenerate constant-score oracle test confirms the honest early stop with nothing distilled).
- `StudentTeacher` is a small regression surrogate fit ONLY from round 1's oracle-VERIFIED `(x, score)` pairs -- the student-as-teacher adapter: a plain `candidate -> predicted_score` callable, the same shape any other teacher/task-model in this codebase is called with.
- Round 2 uses the student to rank a candidate pool (warm-started with round 1's own verified points, so "round 2 beats or matches round 1 at matched budget" is an honest guarantee, not a coin flip against a fresh random pool) but every accepted score still comes from the REAL oracle -- the load-bearing test asserts no student/LM self-grade ever enters `DesignRun.history`.
- Runs `mixle.task.collapse.collapse_monitor` (COLLAPSE-a) across the two rounds rather than reimplementing it.

## Test plan
- [x] `.venv/bin/python -m pytest mixle/tests/doe_amplify_test.py -q` -- 6 passed (round 1 beats a single ungrounded guess; the student is captured only from oracle-verified history and predicts meaningfully; round 2 at matched budget beats-or-matches round 1; collapse_monitor is run and passes; no student self-grade ever enters round 2's history; a degenerate oracle that cannot be beaten stops honestly with nothing captured)
- [x] `.venv/bin/python -m ruff check mixle/doe/amplify.py mixle/tests/doe_amplify_test.py mixle/doe/__init__.py` -- clean
- [x] `.venv/bin/python -m ruff format --check` on the same files -- clean
- [ ] Full gate not run in this session per instructions to only run targeted tests; recommend running before merge.