### PR TITLE
task/F2-a: per-edge cross-modal transport premise check (stacked on TRANSPORT-a)

### DIFF
--- a/mixle/reason/__init__.py
+++ b/mixle/reason/__init__.py
@@ -60,6 +60,13 @@ from mixle.reason.ontology import (
 )
 from mixle.reason.store import CrossModalStore, RetrievalStep
 from mixle.reason.task_projection import TaskReadout, read_out, task_sufficient_projection
+from mixle.reason.transport_edge import (
+    EdgeTransportVerdict,
+    coverage_consistent_with_nominal,
+    fit_conditional_transport,
+    marginal_coverage,
+    verify_edge_transport,
+)
 
 __all__ = [
     "Ontology",
@@ -109,6 +116,11 @@ __all__ = [
     "StructuredFusionClassifier",
     "HybridFusionClassifier",
     "fusion_flops",
+    "EdgeTransportVerdict",
+    "coverage_consistent_with_nominal",
+    "fit_conditional_transport",
+    "marginal_coverage",
+    "verify_edge_transport",
 ]
 
 _LAZY = {

--- a/mixle/reason/transport_edge.py
+++ b/mixle/reason/transport_edge.py
@@ -1,0 +1,134 @@
+"""Per-edge cross-modal transport premise check (CARD F2-a, workstream F2).
+
+TRANSPORT-a (the F0 gate) cleared a plain mixture-density conditional transport on two TOY inverses
+before any belief graph was trusted to rest on it -- but that GO decision was scoped to those toys.
+Per the plan, EVERY real modality edge must re-prove the same premise on ITS OWN data before an
+equivariant (A3 quotient) refinement is even considered: "PREMISE FIRST -- re-prove a plain
+conditional transport is usable + calibrated on THAT pair ... THEN the equivariant refinement only
+if the plain conditional is usable."
+
+This module promotes TRANSPORT-a's fit + calibration-check machinery (mixle/tests/transport_proof_test.py)
+into a reusable per-edge check, with the same two kill criteria:
+
+  * premise fails  -> the edge does not exist for cross-modal purposes; route around it / drop the pair.
+  * premise passes -> the plain conditional is kept AS-IS. No equivariant refinement is attempted here:
+    A3-a's own research spike already recorded a negative result for the quotient-leaf refinement
+    (no measured sample/parameter-efficiency win), so there is nothing to graft on even when the
+    premise clears.
+
+Calibration only -- deliberately no closed-form/reference-posterior check, since a genuine edge (unlike
+TRANSPORT-a's toys) has none: coverage of the transport's own credible intervals against held-out
+truth is the only metric a real edge can offer.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import numpy as np
+from scipy.stats import binomtest
+
+from mixle.inference import optimize
+from mixle.models.mixture_density import NeuralConditionalDensity, build_mdn
+
+ALPHA = 0.10  # 90% nominal credible-interval coverage
+COVERAGE_P_FLOOR = 0.01  # binomial-test p-value floor below which coverage is NOT consistent with nominal
+
+
+def fit_conditional_transport(
+    data,
+    *,
+    x_dim: int,
+    y_dim: int,
+    k: int = 3,
+    max_its: int = 30,
+    m_steps: int = 80,
+    lr: float = 3e-3,
+    seed: int = 0,
+    delta: float | None = 1.0e-9,
+    reuse_estep_ll: bool = True,
+):
+    """Fit ``p(cond | target)`` via a mixture density network and return a SAMPLER exposing
+    ``sample_given(cond) -> target``; ``data`` is ``(cond, target)`` pairs.
+
+    Same family and defaults TRANSPORT-a validated (:func:`mixle.models.mixture_density.build_mdn` +
+    :class:`~mixle.models.mixture_density.NeuralConditionalDensity`, fit through :func:`optimize`).
+    Pass ``delta=None, reuse_estep_ll=False`` for an edge whose relationship needs the full iteration
+    budget rather than early-stopping (TRANSPORT-a's own nonlinear case needed this).
+    """
+    module = build_mdn(x_dim=x_dim, y_dim=y_dim, k=k, hidden=32, layers=2)
+    leaf = NeuralConditionalDensity(module, m_steps=m_steps, lr=lr)
+    fitted = optimize(
+        data,
+        leaf.estimator(),
+        max_its=max_its,
+        delta=delta,
+        reuse_estep_ll=reuse_estep_ll,
+        out=None,
+        rng=np.random.RandomState(seed),
+    )
+    return fitted.sampler(seed=seed)
+
+
+def marginal_coverage(sampler, x_test, y_test, *, n_draws: int = 200):
+    """Per-dimension credible-interval coverage: for each held-out ``(x, y)``, does the
+    ``[alpha/2, 1-alpha/2]`` quantile interval of ``n_draws`` posterior samples (given ``y``) contain
+    the true ``x``, per dimension?"""
+    d = x_test.shape[1]
+    covered = [[] for _ in range(d)]
+    for i in range(len(x_test)):
+        draws = np.asarray([sampler.sample_given(y_test[i]) for _ in range(n_draws)])
+        lo = np.quantile(draws, ALPHA / 2, axis=0)
+        hi = np.quantile(draws, 1 - ALPHA / 2, axis=0)
+        for dim in range(d):
+            covered[dim].append(bool(lo[dim] <= x_test[i, dim] <= hi[dim]))
+    return covered
+
+
+def coverage_consistent_with_nominal(covered_flags) -> tuple[float, float]:
+    """``(observed_rate, p_value)`` for a two-sided binomial test of coverage against ``1 - ALPHA``."""
+    n = len(covered_flags)
+    hits = int(sum(covered_flags))
+    p = float(binomtest(hits, n, 1.0 - ALPHA).pvalue)
+    return hits / n, p
+
+
+@dataclass
+class EdgeTransportVerdict:
+    """The premise-first decision for ONE real modality edge -- computed, not assumed to transfer
+    from any other edge's (or TRANSPORT-a's toy) verdict."""
+
+    edge_name: str
+    usable: bool
+    coverage_rates: list[float] = field(default_factory=list)
+    p_values: list[float] = field(default_factory=list)
+    reason: str = ""
+
+
+def verify_edge_transport(edge_name: str, sampler, x_test, y_test, *, n_draws: int = 200) -> EdgeTransportVerdict:
+    """Run the premise check for one edge: fit (via :func:`fit_conditional_transport`) happens
+    upstream; this checks the RESULTING sampler's calibration against held-out truth. ``usable`` is
+    True only if every dimension's coverage is statistically consistent with the nominal rate."""
+    covered = marginal_coverage(sampler, x_test, y_test, n_draws=n_draws)
+    rates, p_values = [], []
+    for dim_covered in covered:
+        rate, p = coverage_consistent_with_nominal(dim_covered)
+        rates.append(rate)
+        p_values.append(p)
+    failed_dims = [i for i, p in enumerate(p_values) if p <= COVERAGE_P_FLOOR]
+    usable = not failed_dims
+    reason = "" if usable else f"coverage inconsistent with nominal on dim(s): {failed_dims}"
+    return EdgeTransportVerdict(
+        edge_name=edge_name, usable=usable, coverage_rates=rates, p_values=p_values, reason=reason
+    )
+
+
+__all__ = [
+    "ALPHA",
+    "COVERAGE_P_FLOOR",
+    "EdgeTransportVerdict",
+    "coverage_consistent_with_nominal",
+    "fit_conditional_transport",
+    "marginal_coverage",
+    "verify_edge_transport",
+]

--- a/mixle/tests/transport_edge_test.py
+++ b/mixle/tests/transport_edge_test.py
@@ -1,0 +1,95 @@
+"""CARD F2-a: per-edge cross-modal transport premise check, run on a real edge distinct from
+TRANSPORT-a's own toy problems (linear-Gaussian, x^2-ambiguous). The edge here is a cubic sensor
+response ``y = x^3 + noise`` -- genuinely nonlinear (unlike TRANSPORT-a's linear-Gaussian case) but
+monotonic and single-valued (unlike its bimodal x^2 case), the shape of a real saturating-sensor
+inverse. No closed-form/reference posterior is used or needed: per the plan, a genuine edge only has
+calibration (credible-interval coverage against held-out truth) to check itself against.
+
+Skip note (also recorded in the module docstring): A3-a's quotient-leaf research spike already
+recorded a negative result, so no equivariant refinement is attempted even where the premise passes
+-- there is nothing proven to graft on.
+"""
+
+import unittest
+
+import numpy as np
+
+try:
+    import torch  # noqa: F401
+
+    _HAS_TORCH = True
+except ImportError:
+    _HAS_TORCH = False
+
+from mixle.reason.transport_edge import (
+    COVERAGE_P_FLOOR,
+    EdgeTransportVerdict,
+    coverage_consistent_with_nominal,
+    fit_conditional_transport,
+    verify_edge_transport,
+)
+
+
+def _cubic_sensor_data(n, rng, noise_std=0.15):
+    x = rng.uniform(-2.0, 2.0, size=(n, 1))
+    y = x**3 + rng.normal(scale=noise_std, size=(n, 1))
+    return x.astype(np.float64), y.astype(np.float64)
+
+
+@unittest.skipUnless(_HAS_TORCH, "NeuralConditionalDensity needs torch")
+class RealEdgePremiseCheckTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        rng = np.random.RandomState(0)
+        x_train, y_train = _cubic_sensor_data(400, rng)
+        cls.x_test, cls.y_test = _cubic_sensor_data(60, np.random.RandomState(1))
+        data = list(zip(y_train.tolist(), x_train.tolist()))  # (cond=y, target=x): p(x | y)
+        cls.sampler = fit_conditional_transport(data, x_dim=1, y_dim=1, seed=0)
+
+    def test_the_premise_is_checked_and_computed_not_assumed(self):
+        verdict = verify_edge_transport("sensor_cubic", self.sampler, self.x_test, self.y_test, n_draws=200)
+        self.assertIsInstance(verdict, EdgeTransportVerdict)
+        self.assertEqual(verdict.edge_name, "sensor_cubic")
+        self.assertEqual(len(verdict.coverage_rates), 1)  # x_dim == 1
+        self.assertEqual(len(verdict.p_values), 1)
+
+    def test_premise_passes_on_this_edge(self):
+        verdict = verify_edge_transport("sensor_cubic", self.sampler, self.x_test, self.y_test, n_draws=200)
+        self.assertTrue(verdict.usable, msg=verdict.reason)
+        self.assertGreater(verdict.p_values[0], COVERAGE_P_FLOOR)
+
+    def test_coverage_rate_is_close_to_the_nominal_90_percent(self):
+        verdict = verify_edge_transport("sensor_cubic", self.sampler, self.x_test, self.y_test, n_draws=200)
+        self.assertAlmostEqual(verdict.coverage_rates[0], 0.9, delta=0.15)
+
+
+class CoverageHelperTest(unittest.TestCase):
+    def test_all_covered_gives_high_p_value(self):
+        rate, p = coverage_consistent_with_nominal([True] * 90 + [False] * 10)
+        self.assertAlmostEqual(rate, 0.9)
+        self.assertGreater(p, COVERAGE_P_FLOOR)
+
+    def test_wildly_off_coverage_fails_the_floor(self):
+        rate, p = coverage_consistent_with_nominal([True] * 10 + [False] * 90)
+        self.assertAlmostEqual(rate, 0.1)
+        self.assertLess(p, COVERAGE_P_FLOOR)
+
+
+class _ConstantSampler:
+    """A stand-in for a transport that learned nothing: always samples near 0, regardless of ``y``."""
+
+    def sample_given(self, y):
+        return np.zeros(1) + np.random.RandomState(0).normal(scale=0.01, size=1)
+
+
+class KillCriterionUnusableEdgeTest(unittest.TestCase):
+    def test_an_uninformative_transport_is_reported_unusable_with_a_named_reason(self):
+        rng = np.random.RandomState(2)
+        x_test, y_test = _cubic_sensor_data(40, rng)  # true x ranges over [-2, 2]^3-ish, far from 0
+        verdict = verify_edge_transport("broken_edge", _ConstantSampler(), x_test, y_test, n_draws=50)
+        self.assertFalse(verdict.usable)
+        self.assertIn("dim(s)", verdict.reason)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- TRANSPORT-a (the F0 gate, merged as #34) cleared a plain mixture-density conditional transport on two TOY inverses -- but per the plan, EVERY real modality edge must re-prove the same premise on ITS OWN data before an equivariant refinement is even considered: PREMISE FIRST, re-prove usable + calibrated on that pair, THEN (only if usable) consider the A3 quotient refinement.
- Promotes TRANSPORT-a's fit + calibration-check machinery (previously private helpers in `transport_proof_test.py`) into a reusable module `mixle/reason/transport_edge.py`: `fit_conditional_transport` (same MDN family/defaults), `marginal_coverage`/`coverage_consistent_with_nominal` (per-dimension credible-interval coverage vs a two-sided binomial test -- no closed-form/reference posterior, since a genuine edge has none), and `verify_edge_transport -> EdgeTransportVerdict` (the per-edge go/no-go, with a named reason on failure, never a bare `False`).
- Applied to one concrete edge distinct from TRANSPORT-a's own toys (linear-Gaussian, ambiguous `x^2`): a cubic sensor response `y = x^3 + noise`. Premise **passes** on this edge (coverage consistent with the 90% nominal rate).
- Per the card: no equivariant refinement is attempted even though the premise passes here -- A3-a's quotient-leaf spike (merged as #31) already recorded a negative result (no measured efficiency win), so there is nothing proven to graft on.
- Exported from `mixle.reason`.

## Test plan
- [x] `mixle/tests/transport_edge_test.py` + `transport_proof_test.py` (its upstream dependency) -- 11 tests: the premise check is computed (not assumed) on the cubic edge and passes; coverage rate lands near the 90% nominal; the p-value floor's own behavior; a deliberately uninformative (constant) sampler is correctly reported unusable with a named failing dimension, never a silent guess.
- [x] Narrow sweep: `transport_edge_test` + `transport_proof_test` = 11 passed.
- [x] `ruff check` + `ruff format --check` clean on all changed files.