### PR TITLE
task/explore_world + outcome_decomposer: sequential-exploration world + outcome-trained decomposer (CARDs EXPLORE-a core-side, C2-a)

### DIFF
--- a/mixle/task/__init__.py
+++ b/mixle/task/__init__.py
@@ -95,6 +95,15 @@ from mixle.task.edge import (
     measure_ops_per_second,
     task_fingerprint,
 )
+from mixle.task.explore_world import (
+    DRILL_COST,
+    SURVEY_COST,
+    EpisodeResult,
+    ExplorationWorld,
+    greedy_prospectivity_policy,
+    random_policy,
+    run_episode,
+)
 from mixle.task.extract import (
     ExtractionIO,
     distill_extractor,
@@ -123,6 +132,15 @@ from mixle.task.model import (
 )
 from mixle.task.multilabel import MultiLabelSolution, solve_multilabel
 from mixle.task.orchestrate import OrchestrationResult, World, orchestrate
+from mixle.task.outcome_decomposer import (
+    OutcomeTrainedDecomposer,
+    RoundStats,
+    evaluate_greedy_heuristic,
+    evaluate_plan_model,
+    execute_plan,
+    imitation_traces,
+    train_outcome_decomposer,
+)
 from mixle.task.plan import Planner, distill_planner
 from mixle.task.plan_model import PlanModel, fit_plan_model
 from mixle.task.plan_refine import RefinementReport, outcome_refine_planner
@@ -182,6 +200,13 @@ __all__ = [
     "ExecutionTrace",
     "EmbeddingHeadIO",
     "ExtractionIO",
+    "DRILL_COST",
+    "SURVEY_COST",
+    "EpisodeResult",
+    "ExplorationWorld",
+    "greedy_prospectivity_policy",
+    "random_policy",
+    "run_episode",
     "ExtractorHarness",
     "MatcherHarness",
     "FieldChoice",
@@ -210,6 +235,13 @@ __all__ = [
     "MultiLabelSolution",
     "OrchestrationResult",
     "World",
+    "OutcomeTrainedDecomposer",
+    "RoundStats",
+    "evaluate_greedy_heuristic",
+    "evaluate_plan_model",
+    "execute_plan",
+    "imitation_traces",
+    "train_outcome_decomposer",
     "StructuredSolution",
     "GenerativePlanner",
     "Planner",

--- a/mixle/task/explore_world.py
+++ b/mixle/task/explore_world.py
@@ -1,0 +1,169 @@
+"""A sequential-exploration world with synthetic ground truth (workstream C's acceptance anchor,
+CARD EXPLORE-a's functional substance, and the substrate C2-a's outcome-trained decomposer and
+PROBE-a's probing-policy spike both build on).
+
+The canonical EXPLORE-a card names a richer, geology-flavored world in the sibling ``mixle-demos``
+repo (``mixle_demos/exploration_world.py``, over the Red-Ridge synthetic generator). That repo had a
+concurrent, uncommitted, in-progress session's own work mid-edit in its shared checkout (no worktree
+isolation there) when this was written, so touching it risked clobbering that work. This module is a
+self-contained, dependency-free re-implementation of the SAME functional contract, inside mixle core,
+so C2-a and PROBE-a are not blocked waiting on that repo: hidden true targets, a menu of typed actions
+with costs, ``step(action) -> observation`` revealing noisy evidence, budget-exhaustion episode end,
+and ``score()`` = targets correctly identified. Seeded/deterministic, whole episode well under 1s.
+
+    world = ExplorationWorld(n_cells=30, n_targets=4, budget=40, seed=0)
+    obs = world.step({"type": "survey", "cell": 3})   # cheap: sharpens that cell's prospectivity read
+    obs = world.step({"type": "drill", "cell": 3})     # costly: reveals ground truth, scores if correct
+    world.score()                                       # targets correctly identified so far
+    world.done                                          # budget exhausted
+
+Two baseline policies are included (random, greedy-by-prospectivity) as the sanity check that the
+world has learnable signal at all -- a policy that reads the evidence should beat one that doesn't.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+
+SURVEY_COST = 1
+DRILL_COST = 5
+
+
+@dataclass
+class ExplorationWorld:
+    """One episode over a synthetic mineral-style exploration world: ``n_cells`` candidate sites,
+    ``n_targets`` of them hidden true targets, each cell's TRUE target status correlated with a
+    latent "geology" feature that a survey partially reveals as a noisy prospectivity reading."""
+
+    n_cells: int
+    n_targets: int
+    budget: int
+    seed: int = 0
+
+    def __post_init__(self) -> None:
+        rng = np.random.RandomState(self.seed)
+        self._geology = rng.normal(size=self.n_cells)
+        target_idx = rng.choice(self.n_cells, size=self.n_targets, replace=False)
+        self._is_target = np.zeros(self.n_cells, dtype=bool)
+        self._is_target[target_idx] = True
+        # a target's geology reads systematically higher, but with enough noise that a raw look is
+        # only weak evidence -- surveying a cell narrows that noise, giving a real reason to explore.
+        self._geology = self._geology + self._is_target * 2.0
+        self._survey_noise = np.full(self.n_cells, 1.5)  # per-cell prospectivity read noise, shrinks on survey
+        self._drilled = np.zeros(self.n_cells, dtype=bool)
+        self._rng = rng
+        self.remaining_budget = self.budget
+        self.done = False
+        self.history: list[dict[str, Any]] = []
+        self._correct_drills = 0
+
+    def prospectivity(self, cell: int) -> float:
+        """The world's own current noisy read of ``cell`` -- what a policy actually gets to see."""
+        return float(self._geology[cell] + self._rng.normal(scale=self._survey_noise[cell]))
+
+    def step(self, action: dict[str, Any]) -> dict[str, Any]:
+        """Apply one typed action (plain dict, so a fitted plan model can score/sample over the same
+        action vocabulary): ``{"type": "survey", "cell": i}`` or ``{"type": "drill", "cell": i}``.
+        Returns a plain-dict observation. Raises nothing on an over-budget action -- it is simply
+        refused (recorded, zero effect) once ``done``, so a policy that keeps acting past budget
+        exhaustion degrades gracefully rather than crashing."""
+        cell = int(action["cell"])
+        kind = action["type"]
+        if self.done or not (0 <= cell < self.n_cells):
+            obs = {"type": kind, "cell": cell, "accepted": False, "reason": "done_or_invalid_cell"}
+            self.history.append(obs)
+            return obs
+
+        cost = SURVEY_COST if kind == "survey" else DRILL_COST if kind == "drill" else None
+        if cost is None or cost > self.remaining_budget:
+            obs = {"type": kind, "cell": cell, "accepted": False, "reason": "unknown_action_or_over_budget"}
+            self.history.append(obs)
+            self.done = self.remaining_budget < min(SURVEY_COST, DRILL_COST)
+            return obs
+
+        self.remaining_budget -= cost
+        if kind == "survey":
+            self._survey_noise[cell] = max(0.2, self._survey_noise[cell] * 0.4)
+            obs = {"type": "survey", "cell": cell, "accepted": True, "prospectivity": self.prospectivity(cell)}
+        else:
+            is_target = bool(self._is_target[cell])
+            if is_target and not self._drilled[cell]:
+                self._correct_drills += 1
+            self._drilled[cell] = True
+            obs = {"type": "drill", "cell": cell, "accepted": True, "is_target": is_target}
+
+        self.done = self.remaining_budget < min(SURVEY_COST, DRILL_COST)
+        self.history.append(obs)
+        return obs
+
+    def score(self) -> int:
+        """Targets correctly identified so far: distinct true-target cells actually drilled."""
+        return self._correct_drills
+
+    def action_menu(self) -> list[dict[str, Any]]:
+        """Every action a policy could take right now (undrilled cells only, for drills)."""
+        return [{"type": "survey", "cell": c} for c in range(self.n_cells)] + [
+            {"type": "drill", "cell": c} for c in range(self.n_cells) if not self._drilled[c]
+        ]
+
+
+@dataclass
+class EpisodeResult:
+    score: int
+    n_actions: int
+    trace: list[dict[str, Any]] = field(default_factory=list)
+
+
+def run_episode(policy, *, n_cells: int, n_targets: int, budget: int, seed: int) -> EpisodeResult:
+    """Drive ``policy(world) -> action`` (a plain dict, or ``None`` to end early) until the world's
+    budget is exhausted or the policy stops itself."""
+    world = ExplorationWorld(n_cells=n_cells, n_targets=n_targets, budget=budget, seed=seed)
+    n_actions = 0
+    while not world.done:
+        action = policy(world)
+        if action is None:
+            break
+        world.step(action)
+        n_actions += 1
+    return EpisodeResult(score=world.score(), n_actions=n_actions, trace=world.history)
+
+
+def random_policy(world: ExplorationWorld) -> dict[str, Any] | None:
+    menu = world.action_menu()
+    if not menu:
+        return None
+    idx = world._rng.randint(0, len(menu))
+    return menu[idx]
+
+
+_SURVEYED_ENOUGH_THRESHOLD = 0.65  # comfortably above one survey's exact result (1.5 * 0.4 == 0.6000...1
+# in float64) so the boundary check never flips on rounding -- and comfortably below the post-survey
+# result (0.24), so it never falsely treats an unsurveyed cell as surveyed.
+
+
+def greedy_prospectivity_policy(world: ExplorationWorld) -> dict[str, Any] | None:
+    """Survey every undrilled cell once (cheap information), then drill highest-read-prospectivity
+    cells first -- the fixed heuristic baseline REFINE-a/PROBE-a-style spikes compare against."""
+    undrilled = [c for c in range(world.n_cells) if not world._drilled[c]]
+    if not undrilled:
+        return None
+    surveyed_enough = all(world._survey_noise[c] <= _SURVEYED_ENOUGH_THRESHOLD for c in undrilled)
+    if not surveyed_enough:
+        target = next(c for c in undrilled if world._survey_noise[c] > _SURVEYED_ENOUGH_THRESHOLD)
+        return {"type": "survey", "cell": target}
+    best = max(undrilled, key=world.prospectivity)
+    return {"type": "drill", "cell": best}
+
+
+__all__ = [
+    "DRILL_COST",
+    "SURVEY_COST",
+    "EpisodeResult",
+    "ExplorationWorld",
+    "greedy_prospectivity_policy",
+    "random_policy",
+    "run_episode",
+]

--- a/mixle/task/outcome_decomposer.py
+++ b/mixle/task/outcome_decomposer.py
@@ -1,0 +1,141 @@
+"""Outcome-trained decomposer (CARD C2-a, workstream C2): propose candidate plans by sampling C1-a's
+fitted :class:`~mixle.task.plan_model.PlanModel`, execute them in the :mod:`~mixle.task.explore_world`
+world, keep verifiably-successful traces (score above a quantile of that round's own scores), refit
+the plan model on successes, iterate a few rounds. Training signal is world score ONLY -- verifiable
+by construction, never a proxy or a teacher's opinion.
+
+    decomposer = train_outcome_decomposer(seed_worlds=40, n_cells=20, n_targets=3, budget=30)
+    decomposer.plan_model.sample(rng)          # a plan shaped by what actually worked, not just imitation
+    evaluate_decomposer(decomposer, ...)       # mean score on held-out seeds, for the acceptance check
+
+Acceptance (per the card): beats both the imitation-only model (round 0, before any outcome
+refitting) and the greedy heuristic on HELD-OUT world seeds at matched budget.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import numpy as np
+
+from mixle.task.explore_world import ExplorationWorld, greedy_prospectivity_policy, run_episode
+from mixle.task.plan_model import PlanModel, fit_plan_model
+from mixle.task.traces import AgentTrace
+
+
+def _as_traces(type_sequences: list[list[str]]) -> list[AgentTrace]:
+    return [AgentTrace(request="", plan=[{"tool": t} for t in seq]) for seq in type_sequences]
+
+
+def imitation_traces(policy, *, n_worlds: int, n_cells: int, n_targets: int, budget: int, seed_offset: int = 0):
+    """Run ``policy`` over ``n_worlds`` seeded episodes and return each episode's ACCEPTED action-type
+    sequence -- the round-0 imitation corpus C1-a's plan model fits on."""
+    out = []
+    for i in range(n_worlds):
+        result = run_episode(policy, n_cells=n_cells, n_targets=n_targets, budget=budget, seed=seed_offset + i)
+        out.append([step["type"] for step in result.trace if step.get("accepted")])
+    return out
+
+
+def execute_plan(plan_types: list[str], *, n_cells: int, n_targets: int, budget: int, seed: int) -> int:
+    """Execute a plan (a sequence of action TYPES, e.g. ``["survey", "survey", "drill", ...]``) in a
+    fresh seeded world: at each step, "survey" targets the undrilled cell with the noisiest current
+    read (most to gain), "drill" targets the undrilled cell with the highest current prospectivity
+    read -- the plan model decides the ORDER/MIX of action types, this fixed rule decides WHICH cell,
+    the same division of labor the plan/tool-name abstraction uses everywhere else in this plan.
+    Returns the world's final score."""
+    world = ExplorationWorld(n_cells=n_cells, n_targets=n_targets, budget=budget, seed=seed)
+    for kind in plan_types:
+        if world.done:
+            break
+        undrilled = [c for c in range(world.n_cells) if not world._drilled[c]]
+        if not undrilled:
+            break
+        if kind == "survey":
+            cell = max(undrilled, key=lambda c: world._survey_noise[c])
+        elif kind == "drill":
+            cell = max(undrilled, key=world.prospectivity)
+        else:
+            continue
+        world.step({"type": kind, "cell": cell})
+    return world.score()
+
+
+@dataclass
+class RoundStats:
+    round: int
+    mean_score: float
+    n_candidates: int
+    n_kept: int
+
+
+@dataclass
+class OutcomeTrainedDecomposer:
+    plan_model: PlanModel
+    imitation_model: PlanModel  # round-0, kept for the acceptance comparison
+    rounds: list[RoundStats] = field(default_factory=list)
+
+
+def train_outcome_decomposer(
+    *,
+    seed_worlds: int,
+    n_cells: int,
+    n_targets: int,
+    budget: int,
+    k_candidates: int = 30,
+    success_quantile: float = 0.6,
+    rounds: int = 3,
+    seed: int = 0,
+) -> OutcomeTrainedDecomposer:
+    rng = np.random.RandomState(seed)
+    imitation = imitation_traces(
+        greedy_prospectivity_policy, n_worlds=seed_worlds, n_cells=n_cells, n_targets=n_targets, budget=budget
+    )
+    imitation_model = fit_plan_model(_as_traces(imitation))
+    model = imitation_model
+    history = []
+    for r in range(rounds):
+        candidates = [model.sample(rng) for _ in range(k_candidates)]
+        scores = [
+            execute_plan(c, n_cells=n_cells, n_targets=n_targets, budget=budget, seed=int(rng.randint(0, 2**31 - 1)))
+            for c in candidates
+        ]
+        threshold = float(np.quantile(scores, success_quantile)) if scores else 0.0
+        kept = [c for c, s in zip(candidates, scores) if s >= threshold and s > 0 and c]
+        history.append(
+            RoundStats(round=r, mean_score=float(np.mean(scores)), n_candidates=len(candidates), n_kept=len(kept))
+        )
+        if kept:
+            model = fit_plan_model(_as_traces(kept))
+    return OutcomeTrainedDecomposer(plan_model=model, imitation_model=imitation_model, rounds=history)
+
+
+def evaluate_plan_model(
+    model: PlanModel, *, seeds, n_cells: int, n_targets: int, budget: int, rng_seed: int = 0
+) -> float:
+    """Mean world score of ``model``'s sampled plan, executed once per held-out seed."""
+    rng = np.random.RandomState(rng_seed)
+    scores = []
+    for s in seeds:
+        plan = model.sample(rng)
+        scores.append(execute_plan(plan, n_cells=n_cells, n_targets=n_targets, budget=budget, seed=s))
+    return float(np.mean(scores)) if scores else 0.0
+
+
+def evaluate_greedy_heuristic(*, seeds, n_cells: int, n_targets: int, budget: int) -> float:
+    scores = [
+        run_episode(greedy_prospectivity_policy, n_cells=n_cells, n_targets=n_targets, budget=budget, seed=s).score
+        for s in seeds
+    ]
+    return float(np.mean(scores)) if scores else 0.0
+
+
+__all__ = [
+    "OutcomeTrainedDecomposer",
+    "RoundStats",
+    "evaluate_greedy_heuristic",
+    "evaluate_plan_model",
+    "execute_plan",
+    "imitation_traces",
+    "train_outcome_decomposer",
+]

--- a/mixle/task/plan_model.py
+++ b/mixle/task/plan_model.py
@@ -70,13 +70,23 @@ class PlanModel:
         return self.log_prob(plan) >= floor
 
 
-def fit_plan_model(traces: AgentTraces | Sequence[AgentTrace], *, smoothing: float = 0.5) -> PlanModel:
+def fit_plan_model(
+    traces: AgentTraces | Sequence[AgentTrace], *, smoothing: float = 0.5, init_p: float = 1.0
+) -> PlanModel:
     """Fit a :class:`PlanModel` on harvested traces' tool-name sequences.
 
     ``smoothing`` is the Markov chain's Dirichlet pseudo-count (higher = smoother transition
     estimates, matters most with few traces). Fits via :func:`mixle.inference.optimize` on the
     existing :class:`~mixle.stats.sequences.markov_chain.MarkovChainEstimator` -- the same
     declare-an-estimator/call-optimize path every other mixle model uses, not hand-rolled counting.
+
+    ``init_p`` defaults to ``1.0`` (use every trace for the init pass), not ``optimize``'s own
+    ``init_p=0.1`` default: that Bernoulli-subsamples observations for a cheap init estimate, sized
+    for large corpora, but a trace corpus here is typically tens to a few hundred sequences -- with
+    that few, a 10% subsample has a real chance of drawing ZERO sequences, which crashes
+    ``MarkovChainEstimator.estimate1`` (``all_keys`` ends up empty, dividing by zero). Using the full
+    corpus for this small an init pass is cheap and simply correct; override down only for corpora
+    large enough that subsampling actually matters.
     """
     from mixle.inference import optimize
     from mixle.stats import IntegerCategoricalEstimator, MarkovChainEstimator
@@ -85,7 +95,7 @@ def fit_plan_model(traces: AgentTraces | Sequence[AgentTrace], *, smoothing: flo
     sequences = [_tool_names(t.plan) for t in trace_list]
 
     est = MarkovChainEstimator(pseudo_count=float(smoothing), len_estimator=IntegerCategoricalEstimator())
-    dist = optimize(sequences, est, out=None)
+    dist = optimize(sequences, est, out=None, init_p=float(init_p))
     log_probs = np.asarray([dist.log_density(seq) for seq in sequences], dtype=float)
     return PlanModel(dist=dist, training_log_probs=log_probs)
 

--- a/mixle/tests/explore_world_test.py
+++ b/mixle/tests/explore_world_test.py
@@ -1,0 +1,82 @@
+"""ExplorationWorld: the sequential-exploration world with synthetic ground truth (EXPLORE-a's
+functional substance, built in mixle core -- see the module docstring for why). Per the card's own
+acceptance: determinism given seed, exact budget accounting, and the greedy baseline beats random on
+average over 20 seeds (the sanity check that the world has learnable signal at all)."""
+
+import unittest
+
+from mixle.task.explore_world import (
+    DRILL_COST,
+    SURVEY_COST,
+    ExplorationWorld,
+    greedy_prospectivity_policy,
+    random_policy,
+    run_episode,
+)
+
+
+class DeterminismTest(unittest.TestCase):
+    def test_same_seed_gives_bit_identical_episodes(self):
+        r1 = run_episode(greedy_prospectivity_policy, n_cells=20, n_targets=3, budget=30, seed=7)
+        r2 = run_episode(greedy_prospectivity_policy, n_cells=20, n_targets=3, budget=30, seed=7)
+        self.assertEqual(r1.score, r2.score)
+        self.assertEqual(r1.trace, r2.trace)
+
+    def test_different_seeds_can_differ(self):
+        scores = {run_episode(random_policy, n_cells=20, n_targets=3, budget=20, seed=s).score for s in range(5)}
+        self.assertGreater(len(scores), 1)
+
+
+class BudgetAccountingTest(unittest.TestCase):
+    def test_survey_and_drill_costs_are_exact(self):
+        world = ExplorationWorld(n_cells=10, n_targets=2, budget=10, seed=0)
+        world.step({"type": "survey", "cell": 0})
+        self.assertEqual(world.remaining_budget, 10 - SURVEY_COST)
+        world.step({"type": "drill", "cell": 1})
+        self.assertEqual(world.remaining_budget, 10 - SURVEY_COST - DRILL_COST)
+
+    def test_episode_ends_exactly_when_budget_cannot_afford_the_cheapest_action(self):
+        world = ExplorationWorld(n_cells=10, n_targets=2, budget=SURVEY_COST, seed=0)
+        self.assertFalse(world.done)
+        world.step({"type": "survey", "cell": 0})
+        self.assertEqual(world.remaining_budget, 0)
+        self.assertTrue(world.done)
+
+    def test_actions_past_done_are_refused_not_crashing(self):
+        world = ExplorationWorld(n_cells=10, n_targets=2, budget=0, seed=0)
+        obs = world.step({"type": "drill", "cell": 0})
+        self.assertFalse(obs["accepted"])
+        self.assertEqual(world.remaining_budget, 0)
+
+
+class LearnableSignalTest(unittest.TestCase):
+    def test_greedy_beats_random_on_average_over_20_seeds(self):
+        greedy_scores = [
+            run_episode(greedy_prospectivity_policy, n_cells=30, n_targets=4, budget=60, seed=s).score
+            for s in range(20)
+        ]
+        random_scores = [
+            run_episode(random_policy, n_cells=30, n_targets=4, budget=60, seed=s).score for s in range(20)
+        ]
+        self.assertGreater(sum(greedy_scores) / len(greedy_scores), sum(random_scores) / len(random_scores))
+
+
+class ActionMenuAndPlainDictTest(unittest.TestCase):
+    def test_actions_and_observations_are_plain_dicts(self):
+        world = ExplorationWorld(n_cells=5, n_targets=1, budget=20, seed=0)
+        menu = world.action_menu()
+        self.assertTrue(all(isinstance(a, dict) for a in menu))
+        obs = world.step(menu[0])
+        self.assertIsInstance(obs, dict)
+
+    def test_score_counts_only_true_targets_correctly_drilled(self):
+        world = ExplorationWorld(n_cells=5, n_targets=5, budget=100, seed=0)  # every cell IS a target
+        self.assertEqual(world.score(), 0)
+        world.step({"type": "drill", "cell": 0})
+        self.assertEqual(world.score(), 1)
+        world.step({"type": "drill", "cell": 0})  # re-drilling the same cell is not double-counted
+        self.assertEqual(world.score(), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mixle/tests/outcome_decomposer_test.py
+++ b/mixle/tests/outcome_decomposer_test.py
@@ -1,0 +1,53 @@
+"""CARD C2-a: outcome-trained decomposer -- propose plans by sampling the fitted plan model, execute
+in the exploration world, keep verifiably-successful traces, refit, iterate. Acceptance test (per the
+card, computed on HELD-OUT seeds never used during training): the outcome-refit model beats both the
+imitation-only model (round 0) and the greedy heuristic at matched budget.
+"""
+
+import unittest
+
+from mixle.task.outcome_decomposer import (
+    evaluate_greedy_heuristic,
+    evaluate_plan_model,
+    train_outcome_decomposer,
+)
+
+N_CELLS, N_TARGETS, BUDGET = 20, 3, 30
+HELD_OUT_SEEDS = list(range(10_000, 10_030))  # disjoint from any training seed range
+
+
+class OutcomeTrainingBeatsImitationAndGreedyTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.decomposer = train_outcome_decomposer(
+            seed_worlds=40, n_cells=N_CELLS, n_targets=N_TARGETS, budget=BUDGET, rounds=3, seed=0
+        )
+        cls.outcome_score = evaluate_plan_model(
+            cls.decomposer.plan_model, seeds=HELD_OUT_SEEDS, n_cells=N_CELLS, n_targets=N_TARGETS, budget=BUDGET
+        )
+        cls.imitation_score = evaluate_plan_model(
+            cls.decomposer.imitation_model, seeds=HELD_OUT_SEEDS, n_cells=N_CELLS, n_targets=N_TARGETS, budget=BUDGET
+        )
+        cls.greedy_score = evaluate_greedy_heuristic(
+            seeds=HELD_OUT_SEEDS, n_cells=N_CELLS, n_targets=N_TARGETS, budget=BUDGET
+        )
+
+    def test_outcome_refit_beats_imitation_only_on_held_out_seeds(self):
+        self.assertGreater(self.outcome_score, self.imitation_score)
+
+    def test_outcome_refit_beats_the_greedy_heuristic_on_held_out_seeds(self):
+        self.assertGreater(self.outcome_score, self.greedy_score)
+
+    def test_training_rounds_are_recorded_not_silently_discarded(self):
+        self.assertEqual(len(self.decomposer.rounds), 3)
+        for r in self.decomposer.rounds:
+            self.assertGreaterEqual(r.n_candidates, r.n_kept)
+
+    def test_held_out_seeds_never_overlap_training_seed_range(self):
+        # training uses seed_worlds=40 (seeds 0..39) for imitation, plus rng-drawn seeds during
+        # outcome rounds -- held-out starts at 10000, far outside any plausible training draw.
+        self.assertTrue(min(HELD_OUT_SEEDS) >= 10_000)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- The canonical EXPLORE-a card names a world in the sibling `mixle-demos` repo. That repo had a concurrent, uncommitted session's own work mid-edit in its shared checkout (no worktree isolation there) when this was written -- touching it risked clobbering that work. This ships EXPLORE-a's exact functional contract as a self-contained, dependency-free module inside mixle core instead, so C2-a (and PROBE-a after it) are not blocked waiting on that repo.
- **`mixle/task/explore_world.py`**: `ExplorationWorld` -- hidden true targets over `n_cells` sites; two typed actions (`survey`: cheap, sharpens a cell's noisy prospectivity read; `drill`: costly, reveals ground truth and scores if correct); `step(action) -> plain-dict observation`; episode ends at budget exhaustion; `score()` = targets correctly identified. Seeded/deterministic, an episode runs well under 1s. Two baseline policies: `random_policy`, `greedy_prospectivity_policy`.
- **Bug fix hit along the way**: the greedy policy's "surveyed enough" check compared post-survey noise to `0.6` with `<=`, but `1.5 * 0.4 == 0.6000000000000001` in float64 -- every cell needed two surveys instead of one, draining the whole budget on surveys and never drilling (score 0, worse than random). Fixed with a threshold (`0.65`) comfortably clear of the rounding boundary.
- **`mixle/task/outcome_decomposer.py`** (CARD C2-a, workstream C2): propose K candidate plans by sampling C1-a's fitted `PlanModel`, execute each in the world, keep verifiably-successful traces (score at or above that round's own quantile), refit the plan model on successes only, iterate. Training signal is world score ONLY. `train_outcome_decomposer`/`execute_plan`/`evaluate_plan_model`/`evaluate_greedy_heuristic`, exported from `mixle.task`.
- **Second bug fix, in shared `mixle/task/plan_model.py`**: `fit_plan_model` called `optimize()` without overriding `init_p`, inheriting `optimize`'s own `init_p=0.1` (a Bernoulli subsample of the data for a cheap init pass, sized for large corpora). A plan-model trace corpus is typically tens to a few hundred sequences; with that few, a 10% subsample has a real chance of selecting ZERO sequences, crashing `MarkovChainEstimator.estimate1` (`all_keys` ends up empty, `ZeroDivisionError`) -- reproduced directly, not guessed at. Fixed by giving `fit_plan_model` its own `init_p=1.0` default (still overridable). Verified the existing `plan_model_test.py`/`task_traces_test.py` suites still pass unchanged.

## Test plan
- [x] `explore_world_test.py`: determinism given seed; exact budget accounting; actions refused (not crashing) past budget exhaustion; greedy beats random over 20 seeds; score counts distinct correct drills only.
- [x] `outcome_decomposer_test.py`: the card's own acceptance -- outcome-refit beats both imitation-only and the greedy heuristic on held-out seeds never used in training; training rounds recorded.
- [x] Regression: `plan_model_test.py` + `task_traces_test.py` unchanged by the `init_p` fix.
- [x] Narrow sweep: all 23 tests passed.
- [x] `ruff check` + `ruff format --check` clean on all changed files.