### PR TITLE
task/I3: budgeted propose-verify-retrain loop over a discrete structured design space

### DIFF
--- a/mixle/task/__init__.py
+++ b/mixle/task/__init__.py
@@ -97,6 +97,7 @@ from mixle.task.model import (
 from mixle.task.multilabel import MultiLabelSolution, solve_multilabel
 from mixle.task.plan import Planner, distill_planner
 from mixle.task.plan_refine import RefinementReport, outcome_refine_planner
+from mixle.task.propose import ProposeVerifyResult, RoundLog, SequenceProposal, propose_verify_retrain
 
 # post-training quantization: int8/int4 MLP weights (numpy-only inference) + LNS integer log-space
 # execution for structured students (transcendental-free above the leaf boundary)
@@ -211,6 +212,10 @@ __all__ = [
     "route_stack",
     "RefinementReport",
     "outcome_refine_planner",
+    "ProposeVerifyResult",
+    "RoundLog",
+    "SequenceProposal",
+    "propose_verify_retrain",
     "sample_plans",
     "score_plan",
     "scorecard",

--- a/mixle/task/propose.py
+++ b/mixle/task/propose.py
@@ -1,0 +1,162 @@
+"""Budgeted propose-verify-retrain loop over a discrete structured design space (workstream I2/I3).
+
+:mod:`mixle.doe.oracle` narrowed workstream I's design-test-learn loop to continuous/low-dimensional
+candidate spaces (:func:`~mixle.doe.oracle.optimize_under_oracle`, a Bayesian-optimization proposal
+model) and explicitly deferred structured/discrete spaces (a protein sequence, a program) as follow-up.
+This module is that deferred slice: a proposal DISTRIBUTION over short fixed-length symbol sequences --
+one :class:`~mixle.stats.univariate.discrete.categorical.CategoricalDistribution` per position -- that
+samples K candidates per round, verifies every one against a
+:class:`~mixle.doe.oracle.VerifiableOracle`, keeps the verifiably-better ones, and refits the proposal
+on the winners (reweighted MLE through the shared :func:`mixle.inference.optimize` EM driver -- no
+hand-rolled counting) for a fixed number of rounds under a hard oracle-call budget
+(``k_per_round * rounds``). Every candidate tried is retained in the round log, dead ends included;
+only ``keep_frac`` of each round feeds the refit.
+
+Same "no verifiable objective, no optimization" precondition as ``optimize_under_oracle``:
+``oracle=None`` refuses immediately rather than fabricating a candidate.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+
+from mixle.doe.oracle import OracleResult, VerifiableOracle
+from mixle.inference import optimize
+from mixle.stats.univariate.discrete.categorical import CategoricalDistribution
+
+
+@dataclass
+class SequenceProposal:
+    """A position-independent categorical proposal over fixed-length sequences from ``alphabet``."""
+
+    alphabet: tuple[Any, ...]
+    length: int
+    pseudo_count: float = 1.0
+    position_models: list[CategoricalDistribution] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if self.length <= 0:
+            raise ValueError("length must be positive.")
+        if not self.position_models:
+            uniform = {sym: 1.0 / len(self.alphabet) for sym in self.alphabet}
+            self.position_models = [CategoricalDistribution(pmap=dict(uniform)) for _ in range(self.length)]
+        elif len(self.position_models) != self.length:
+            raise ValueError("position_models must have exactly one entry per sequence position.")
+
+    def sample(self, k: int, rng: np.random.Generator) -> list[tuple]:
+        """Draw ``k`` i.i.d. sequences (each ``length`` symbols) from the current proposal."""
+        sequences = []
+        for _ in range(k):
+            symbols = [model.sampler(seed=int(rng.integers(0, 2**31 - 1))).sample() for model in self.position_models]
+            sequences.append(tuple(symbols))
+        return sequences
+
+    def refit(self, sequences: list[tuple], weights: np.ndarray) -> SequenceProposal:
+        """Reweighted MLE: refit each position's categorical on ``sequences``, replicated in that
+        position's training multiset proportional to ``weights``, through the shared ``optimize`` EM
+        driver -- never a hand-rolled frequency count."""
+        w = np.asarray(weights, dtype=float)
+        if w.shape != (len(sequences),):
+            raise ValueError("weights must have one entry per sequence.")
+        w = np.clip(w, 0.0, None)
+        if not np.any(w > 0.0):
+            raise ValueError("refit requires at least one strictly positive weight.")
+        counts = np.maximum(np.round(w / w.max() * 100.0), 1).astype(int)
+
+        new_models = []
+        for i in range(self.length):
+            data: list[Any] = []
+            for seq, count in zip(sequences, counts):
+                data.extend([seq[i]] * int(count))
+            uniform = {sym: 1.0 / len(self.alphabet) for sym in self.alphabet}
+            estimator = CategoricalDistribution(pmap=dict(uniform)).estimator(pseudo_count=self.pseudo_count)
+            fitted = optimize(data, estimator, max_its=1, out=None)
+            # Canonicalize pmap key order to `self.alphabet`: the accumulator's internal dict order
+            # is not guaranteed stable across interpreter processes (Python's per-process string hash
+            # randomization), which would otherwise change which sampled index maps to which symbol.
+            new_models.append(CategoricalDistribution(pmap={sym: fitted.pmap[sym] for sym in self.alphabet}))
+        return SequenceProposal(
+            alphabet=self.alphabet, length=self.length, pseudo_count=self.pseudo_count, position_models=new_models
+        )
+
+
+@dataclass
+class RoundLog:
+    """One round's full record: every candidate tried and its oracle result, plus which were kept."""
+
+    round_index: int
+    candidates: list[tuple]
+    results: list[OracleResult]
+    kept_indices: list[int]
+
+
+@dataclass
+class ProposeVerifyResult:
+    """The full receipted history of a propose-verify-retrain run."""
+
+    proposal: SequenceProposal
+    rounds: list[RoundLog] = field(default_factory=list)
+    best_candidate: tuple | None = None
+    best_result: OracleResult | None = None
+
+    @property
+    def oracle_calls(self) -> int:
+        return sum(len(r.candidates) for r in self.rounds)
+
+    def all_candidates(self) -> list[tuple[tuple, OracleResult]]:
+        """Every candidate tried across every round, in order -- dead ends included, none dropped."""
+        out: list[tuple[tuple, OracleResult]] = []
+        for r in self.rounds:
+            out.extend(zip(r.candidates, r.results))
+        return out
+
+
+def propose_verify_retrain(
+    proposal: SequenceProposal,
+    oracle: VerifiableOracle | None,
+    *,
+    k_per_round: int,
+    rounds: int,
+    keep_frac: float = 0.25,
+    seed: int | None = None,
+) -> ProposeVerifyResult:
+    """The I2/I3 loop: sample ``k_per_round`` candidates from ``proposal``, verify every one with
+    ``oracle``, keep the top ``keep_frac`` by oracle score, refit ``proposal`` on the kept winners
+    (weighted by score), repeat for ``rounds`` rounds -- an oracle-call budget of exactly
+    ``k_per_round * rounds``. ``oracle=None`` raises immediately (the one hard precondition this
+    workstream enforces at every entry point, never a fabricated candidate)."""
+    if oracle is None:
+        raise ValueError(
+            "no verifiable objective; cannot optimize. propose_verify_retrain requires a "
+            "VerifiableOracle -- this is the workstream's one hard precondition, not a missing default."
+        )
+    if not 0.0 < keep_frac <= 1.0:
+        raise ValueError("keep_frac must be in (0, 1].")
+    if k_per_round <= 0 or rounds <= 0:
+        raise ValueError("k_per_round and rounds must be positive.")
+
+    rng = np.random.default_rng(seed)
+    result = ProposeVerifyResult(proposal=proposal)
+    current = proposal
+    for round_index in range(rounds):
+        candidates = current.sample(k_per_round, rng)
+        results = [oracle(c) for c in candidates]
+        scores = np.asarray([r.score for r in results], dtype=float)
+
+        n_keep = max(1, int(np.ceil(keep_frac * len(candidates))))
+        kept_indices = [int(i) for i in np.argsort(-scores)[:n_keep]]
+        result.rounds.append(RoundLog(round_index, candidates, results, kept_indices))
+
+        for candidate, oracle_result in zip(candidates, results):
+            if result.best_result is None or oracle_result.score > result.best_result.score:
+                result.best_candidate, result.best_result = candidate, oracle_result
+
+        winners = [candidates[i] for i in kept_indices]
+        winner_scores = scores[kept_indices]
+        current = current.refit(winners, winner_scores)
+
+    result.proposal = current
+    return result

--- a/mixle/tests/task_propose_test.py
+++ b/mixle/tests/task_propose_test.py
@@ -1,0 +1,173 @@
+"""CARD I3-a: propose_verify_retrain vs random search and a fixed greedy heuristic, matched budget.
+
+A synthetic sequence-scoring oracle whose optimum is known by construction (a fixed target
+sequence; score = clean position-match count + noise) lets us check that the reweighted-MLE
+population loop in :mod:`mixle.task.propose` recovers more of the true optimum than random search
+or single-candidate greedy coordinate ascent, at an EXACTLY matched oracle-call budget -- the noise
+makes any one candidate's score unreliable, which is exactly the regime a population-based refit
+should be more robust in than picking one noisy "best so far" sample.
+"""
+
+import unittest
+
+import numpy as np
+
+from mixle.doe.oracle import OracleResult, VerifiableOracle
+from mixle.task.propose import ProposeVerifyResult, RoundLog, SequenceProposal, propose_verify_retrain
+
+ALPHABET = ("A", "B", "C", "D")
+LENGTH = 6
+TARGET = ("A", "B", "C", "D", "A", "B")
+
+
+def _matches(seq) -> int:
+    return sum(1 for a, b in zip(seq, TARGET) if a == b)
+
+
+def _noisy_oracle(seed: int, sigma: float = 1.0) -> VerifiableOracle:
+    noise_rng = np.random.default_rng(seed)
+
+    def score_fn(seq):
+        return OracleResult(score=_matches(seq) + noise_rng.normal(0.0, sigma), receipt={"matches": _matches(seq)})
+
+    return VerifiableOracle(name="toy-sequence", tier="simulation", score_fn=score_fn)
+
+
+def _random_search_best_matches(oracle: VerifiableOracle, budget: int, seed: int) -> int:
+    rng = np.random.default_rng(seed)
+    best_score, best_matches = -np.inf, 0
+    for _ in range(budget):
+        seq = tuple(str(rng.choice(ALPHABET)) for _ in range(LENGTH))
+        result = oracle(seq)
+        if result.score > best_score:
+            best_score, best_matches = result.score, _matches(seq)
+    return best_matches
+
+
+def _greedy_coordinate_ascent_best_matches(oracle: VerifiableOracle, budget: int, seed: int) -> int:
+    """Fixed heuristic: single-candidate coordinate ascent, one position at a time, restarted with
+    fresh random starts until the same oracle-call budget is spent."""
+    rng = np.random.default_rng(seed)
+
+    def one_pass():
+        seq = [str(rng.choice(ALPHABET)) for _ in range(LENGTH)]
+        calls = 0
+        for i in range(LENGTH):
+            best_sym, best_score = seq[i], oracle(tuple(seq)).score
+            calls += 1
+            for sym in ALPHABET:
+                if sym == seq[i]:
+                    continue
+                trial = list(seq)
+                trial[i] = sym
+                score = oracle(tuple(trial)).score
+                calls += 1
+                if score > best_score:
+                    best_score, best_sym = score, sym
+            seq[i] = best_sym
+        return tuple(seq), calls
+
+    best_score, best_matches, calls_used = -np.inf, 0, 0
+    while calls_used < budget:
+        seq, calls = one_pass()
+        calls_used += calls
+        result = oracle(seq)
+        if result.score > best_score:
+            best_score, best_matches = result.score, _matches(seq)
+    return best_matches
+
+
+class SequenceProposalTestCase(unittest.TestCase):
+    def test_sample_shape_and_alphabet(self):
+        proposal = SequenceProposal(alphabet=ALPHABET, length=LENGTH)
+        rng = np.random.default_rng(0)
+        sequences = proposal.sample(25, rng)
+        self.assertEqual(len(sequences), 25)
+        for seq in sequences:
+            self.assertEqual(len(seq), LENGTH)
+            self.assertTrue(all(sym in ALPHABET for sym in seq))
+
+    def test_refit_concentrates_toward_winners(self):
+        proposal = SequenceProposal(alphabet=ALPHABET, length=3)
+        winners = [("A", "A", "A")] * 5 + [("B", "B", "B")]
+        weights = np.array([5.0, 5.0, 5.0, 5.0, 5.0, 1.0])
+        refit = proposal.refit(winners, weights)
+        for model in refit.position_models:
+            self.assertGreater(model.pmap["A"], model.pmap["B"])
+            self.assertGreater(model.pmap["A"], 0.5)
+
+    def test_refit_rejects_mismatched_weights(self):
+        proposal = SequenceProposal(alphabet=ALPHABET, length=3)
+        with self.assertRaises(ValueError):
+            proposal.refit([("A", "A", "A")], np.array([1.0, 2.0]))
+
+    def test_refit_rejects_all_nonpositive_weights(self):
+        proposal = SequenceProposal(alphabet=ALPHABET, length=3)
+        with self.assertRaises(ValueError):
+            proposal.refit([("A", "A", "A")], np.array([0.0]))
+
+
+class ProposeVerifyRetrainTestCase(unittest.TestCase):
+    def test_no_oracle_refuses(self):
+        proposal = SequenceProposal(alphabet=ALPHABET, length=LENGTH)
+        with self.assertRaises(ValueError):
+            propose_verify_retrain(proposal, None, k_per_round=4, rounds=1)
+
+    def test_bad_keep_frac_raises(self):
+        proposal = SequenceProposal(alphabet=ALPHABET, length=LENGTH)
+        oracle = _noisy_oracle(seed=0)
+        with self.assertRaises(ValueError):
+            propose_verify_retrain(proposal, oracle, k_per_round=4, rounds=1, keep_frac=0.0)
+
+    def test_budget_and_logging_accounting(self):
+        proposal = SequenceProposal(alphabet=ALPHABET, length=LENGTH)
+        oracle = _noisy_oracle(seed=0)
+        k_per_round, rounds = 10, 3
+        result = propose_verify_retrain(proposal, oracle, k_per_round=k_per_round, rounds=rounds, seed=0)
+        self.assertIsInstance(result, ProposeVerifyResult)
+        self.assertEqual(result.oracle_calls, k_per_round * rounds)
+        self.assertEqual(len(result.rounds), rounds)
+        for round_log in result.rounds:
+            self.assertIsInstance(round_log, RoundLog)
+            self.assertEqual(len(round_log.candidates), k_per_round)
+            self.assertEqual(len(round_log.results), k_per_round)
+            self.assertGreaterEqual(len(round_log.kept_indices), 1)
+        # dead ends retained: every candidate tried appears in all_candidates(), not just winners
+        self.assertEqual(len(result.all_candidates()), k_per_round * rounds)
+
+    def test_deterministic_given_seed(self):
+        proposal = SequenceProposal(alphabet=ALPHABET, length=LENGTH)
+        oracle_a = _noisy_oracle(seed=7)
+        oracle_b = _noisy_oracle(seed=7)
+        result_a = propose_verify_retrain(proposal, oracle_a, k_per_round=8, rounds=2, seed=42)
+        result_b = propose_verify_retrain(proposal, oracle_b, k_per_round=8, rounds=2, seed=42)
+        for round_a, round_b in zip(result_a.rounds, result_b.rounds):
+            self.assertEqual(round_a.candidates, round_b.candidates)
+
+    def test_beats_random_search_and_fixed_heuristic_at_matched_budget(self):
+        # A noisy oracle score makes any single observed candidate's score unreliable -- exactly the
+        # regime a population-based refit should be more robust in than one noisy "best so far"
+        # sample. Average over several independent seeds so the comparison is not one noisy draw.
+        k_per_round, rounds = 40, 6
+        budget = k_per_round * rounds
+        propose_matches, random_matches, heuristic_matches = [], [], []
+        for seed in range(8):
+            proposal = SequenceProposal(alphabet=ALPHABET, length=LENGTH)
+            result = propose_verify_retrain(
+                proposal, _noisy_oracle(seed=seed), k_per_round=k_per_round, rounds=rounds, keep_frac=0.25, seed=seed
+            )
+            self.assertEqual(result.oracle_calls, budget)
+            propose_matches.append(_matches(result.best_candidate))
+            random_matches.append(
+                _random_search_best_matches(_noisy_oracle(seed=seed), budget=budget, seed=seed + 1000)
+            )
+            heuristic_matches.append(
+                _greedy_coordinate_ascent_best_matches(_noisy_oracle(seed=seed), budget=budget, seed=seed + 2000)
+            )
+
+        self.assertGreater(np.mean(propose_matches), np.mean(random_matches))
+        self.assertGreater(np.mean(propose_matches), np.mean(heuristic_matches))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- `mixle.doe.oracle`'s design-test-learn loop (#11) narrowed workstream I to continuous/low-dimensional
  candidate spaces and explicitly deferred structured/discrete spaces as follow-up. This is that slice.
- `mixle/task/propose.py`: `SequenceProposal` (one `CategoricalDistribution` per position, fit through
  the shared `mixle.inference.optimize` EM driver -- no hand-rolled counting) and
  `propose_verify_retrain(proposal, oracle, k_per_round, rounds, keep_frac, seed)`: sample K candidates
  per round, verify every one against a `VerifiableOracle`, keep the top `keep_frac` by score, refit
  the proposal on the winners (reweighted MLE), repeat under an exact `k_per_round * rounds` oracle-call
  budget. Every candidate tried is retained in the round log (`RoundLog`/`ProposeVerifyResult`), dead
  ends included. `oracle=None` refuses immediately, matching `optimize_under_oracle`'s precondition.
- Exported `ProposeVerifyResult`, `RoundLog`, `SequenceProposal`, `propose_verify_retrain` from
  `mixle.task`.
- Found and fixed a real determinism bug along the way: `CategoricalDistribution.pmap`'s key order is
  not stable across interpreter processes (Python's per-process string hash randomization inside the
  shared categorical accumulator), which silently changed which symbol a sampler index mapped to across
  runs. `refit()` now canonicalizes each fitted position model's key order back to the fixed alphabet
  order before use.

## Test plan
- `mixle/tests/task_propose_test.py`: sampling shape/alphabet, refit concentrates toward winners,
  input-validation errors, budget/round-logging accounting (dead ends retained), determinism given
  seed (verified stable across repeated fresh-process reruns after the canonicalization fix), and
  `propose_verify_retrain` beating both random search and a fixed greedy-coordinate-ascent heuristic at
  an exactly matched oracle-call budget on a synthetic sequence-scoring oracle with a known optimum
  (averaged over 8 seeds to avoid a single noisy draw).
- `python -m pytest mixle/tests/task_propose_test.py -q`: 9 passed (rerun 4x in fresh processes for
  stability after the determinism fix).
- `python -m pytest -q -m "not optional and not benchmark"` (full gate): 4692 passed, 6 skipped.
- `ruff check` / `ruff format --check`: clean.