### PR TITLE
hotfix: fix circular import that broke mixle.inference entirely

### DIFF
--- a/mixle/inference/receipt.py
+++ b/mixle/inference/receipt.py
@@ -23,10 +23,12 @@ pass for a claim the receipt does not make.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from mixle.inference.explain import Explanation
-from mixle.task.replay import ExecutionTrace, is_bit_identical_replay
+
+if TYPE_CHECKING:
+    from mixle.task.replay import ExecutionTrace
 
 
 @dataclass
@@ -72,6 +74,8 @@ def verify_receipt(receipt: Receipt, *, tools: dict[str, Any] | None = None, tol
     """Re-check every claim the receipt actually makes, using only the receipt's own bound data (plus
     the ``tools`` registry needed to re-execute a trace -- the one piece that cannot be inlined into the
     receipt itself, since a tool is a function, not data)."""
+    from mixle.task.replay import is_bit_identical_replay
+
     checks: dict[str, str] = {}
 
     if receipt.ledger is not None:


### PR DESCRIPTION
## Summary

**Urgent** -- `import mixle.inference` currently raises on a clean checkout of
`release/0.6.3-generic-capabilities`:

```
ImportError: cannot import name 'seq_estimate' from partially initialized module 'mixle.inference'
(most likely due to a circular import)
```

Root cause: `mixle/inference/receipt.py` (H3-a) does a top-level `from mixle.task.replay import
ExecutionTrace, is_bit_identical_replay`. Importing `mixle.task.replay` initializes the whole
`mixle.task` package, which (via `mixle/task/propose.py`, added by #54/I3-a) needs
`mixle.doe` -> `mixle.models` -> `from mixle.inference import seq_estimate, seq_initialize` --
while `mixle.inference.__init__` is still mid-import (it imports `receipt.py` before reaching those
names further down the file). This breaks every test file that transitively imports
`mixle.inference` -- which is most of the test suite -- not just receipt's own tests.

Fix: `ExecutionTrace` is only used as a type annotation (safe to move into a `TYPE_CHECKING` block
under `from __future__ import annotations`); `is_bit_identical_replay` is only called inside
`verify_receipt`, so its import moves inside that function. No behavior change -- just breaks the
import cycle.

## Test plan

- [x] `import mixle` / `mixle.inference` / `mixle.task` / `mixle.doe` / `mixle.models` /
      `mixle.substrate` / `mixle.stats` / `mixle.reason` / `mixle.utils` all clean (verified against
      a fresh detached-HEAD checkout of the release tip, confirming the bug is real and this fixes it).
- [x] `mixle/tests/create_test.py` (17 passed -- this file was failing entirely on the current
      release tip due to the import error) + `receipt_test.py` + `task_replay_test.py` all green.
- [x] `ruff check` + `ruff format --check` clean.