### PR TITLE
task/PROBE-a: myopic EIG vs outcome-trained decomposer -- negative result (replaces #55)

### DIFF
--- a/mixle/task/__init__.py
+++ b/mixle/task/__init__.py
@@ -152,6 +152,7 @@ from mixle.task.outcome_decomposer import (
 from mixle.task.plan import Planner, distill_planner
 from mixle.task.plan_model import PlanModel, fit_plan_model
 from mixle.task.plan_refine import RefinementReport, outcome_refine_planner
+from mixle.task.probe_policy import ProbeHeadToHead, head_to_head_probe, myopic_eig_policy
 from mixle.task.propose import ProposeVerifyResult, RoundLog, SequenceProposal, propose_verify_retrain
 
 # post-training quantization: int8/int4 MLP weights (numpy-only inference) + LNS integer log-space
@@ -341,6 +342,9 @@ __all__ = [
     "replace_matcher",
     "route_stack",
     "RefinementReport",
+    "ProbeHeadToHead",
+    "head_to_head_probe",
+    "myopic_eig_policy",
     "outcome_refine_planner",
     "ProposeVerifyResult",
     "RoundLog",

--- a/mixle/task/probe_policy.py
+++ b/mixle/task/probe_policy.py
@@ -1,0 +1,112 @@
+"""Learned non-myopic probing policy vs myopic EIG (CARD PROBE-a, workstream C7, research spike).
+
+Kill criterion, stated before running (per the card): if the learned non-myopic policy does not beat
+myopic EIG on solve-rate at matched oracle budget in the exploration world (averaged over >= 20 seeds,
+held-out world families), record the negative result and KEEP myopic. Myopic is often near-optimal;
+this spike exists to find where delayed/combinatorial payoff makes it fail, not to add a learned
+policy for its own sake.
+
+Two policies compared head-to-head, same action menu, same budget:
+
+* :func:`myopic_eig_policy` -- greedy, ONE STEP of lookahead: at every decision, picks the action
+  (across ALL undrilled cells, survey or drill) with the highest per-cost expected information gain
+  about that cell's target status. A cell's current belief uncertainty is its survey-noise; a read's
+  "borderline-ness" (how close to the decision boundary between target/non-target reads) governs how
+  much resolving it is actually worth -- a read far from the boundary is already confidently
+  classified, so probing it teaches little.
+* the outcome-trained decomposer's plan model (:mod:`~mixle.task.outcome_decomposer`, CARD C2-a) --
+  trained via expert iteration against VERIFIER-GROUNDED reward (terminal world score, no learned
+  reward model): propose whole action-type sequences, execute, keep the verifiably-successful ones,
+  refit, iterate. Optimizing for a WHOLE sequence's terminal score (rather than one greedy step) is
+  the non-myopic half of this comparison -- it can trade an immediately-worse-looking step for a
+  better final outcome, which pure one-step EIG structurally cannot.
+
+    directed = train_outcome_decomposer(...)                    # CARD C2-a, already built
+    result = head_to_head_probe(directed.plan_model, held_out_seeds=range(...), ...)
+    result.non_myopic_wins                                       # the card's own decision
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+import numpy as np
+
+from mixle.task.explore_world import ExplorationWorld, run_episode
+from mixle.task.outcome_decomposer import evaluate_plan_model
+from mixle.task.plan_model import PlanModel
+
+# the world's own generative gap: a target cell's geology reads systematically +2.0 higher than a
+# non-target's (see ExplorationWorld.__post_init__); a read near the midpoint is the most ambiguous.
+# Known from the world's own construction, not fit from data -- a myopic policy operating on
+# synthetic ground truth is allowed to know its own world's scale.
+_DECISION_BOUNDARY = 1.0
+_DRILL_CONFIDENCE = 0.65  # p(target) above which drilling (exploit) beats surveying (explore) further
+
+
+def _p_target(read: float, noise: float) -> float:
+    """Logistic belief that a cell is a target, from its current noisy read: centered on the world's
+    own decision boundary, flattened by the read's own uncertainty (more noise = less confident)."""
+    z = (read - _DECISION_BOUNDARY) / max(noise, 0.3)
+    return float(1.0 / (1.0 + math.exp(-z)))
+
+
+def _entropy(p: float) -> float:
+    p = min(max(p, 1e-6), 1 - 1e-6)
+    return float(-(p * math.log(p) + (1 - p) * math.log(1 - p)))
+
+
+def myopic_eig_policy(world: ExplorationWorld) -> dict | None:
+    """One-step-lookahead policy, explicitly information-theoretic: EXPLOIT (drill) the most
+    confident current target-candidate once its belief clears ``_DRILL_CONFIDENCE``; otherwise
+    EXPLORE (survey) the single most UNCERTAIN cell -- maximum current entropy, i.e. the read closest
+    to the decision boundary relative to its own noise, the textbook expected-information-gain
+    target. No lookahead beyond this one step -- by construction, it cannot see that an
+    apparently-mediocre probe now sets up a better probe later."""
+    undrilled = [c for c in range(world.n_cells) if not world._drilled[c]]
+    if not undrilled:
+        return None
+
+    beliefs = {c: _p_target(world.prospectivity(c), float(world._survey_noise[c])) for c in undrilled}
+    best_drill = max(undrilled, key=lambda c: beliefs[c])
+    if beliefs[best_drill] >= _DRILL_CONFIDENCE and world.remaining_budget >= 5:
+        return {"type": "drill", "cell": best_drill}
+
+    if world.remaining_budget < 1:
+        return None
+    most_uncertain = max(undrilled, key=lambda c: _entropy(beliefs[c]))
+    return {"type": "survey", "cell": most_uncertain}
+
+
+@dataclass
+class ProbeHeadToHead:
+    non_myopic_score: float
+    myopic_score: float
+    non_myopic_wins: bool
+
+
+def head_to_head_probe(
+    plan_model: PlanModel,
+    *,
+    held_out_seeds,
+    n_cells: int,
+    n_targets: int,
+    budget: int,
+) -> ProbeHeadToHead:
+    """Compare the non-myopic (outcome-trained) plan model against the myopic EIG policy on the SAME
+    held-out seeds at matched budget -- the card's own kill-criterion computation."""
+    non_myopic_score = evaluate_plan_model(
+        plan_model, seeds=held_out_seeds, n_cells=n_cells, n_targets=n_targets, budget=budget
+    )
+    myopic_scores = [
+        run_episode(myopic_eig_policy, n_cells=n_cells, n_targets=n_targets, budget=budget, seed=s).score
+        for s in held_out_seeds
+    ]
+    myopic_score = float(np.mean(myopic_scores)) if myopic_scores else 0.0
+    return ProbeHeadToHead(
+        non_myopic_score=non_myopic_score, myopic_score=myopic_score, non_myopic_wins=non_myopic_score > myopic_score
+    )
+
+
+__all__ = ["ProbeHeadToHead", "head_to_head_probe", "myopic_eig_policy"]

--- a/mixle/tests/probe_policy_test.py
+++ b/mixle/tests/probe_policy_test.py
@@ -1,0 +1,70 @@
+"""CARD PROBE-a: myopic EIG vs the non-myopic (outcome-trained) plan model, head-to-head on held-out
+world seeds at matched budget -- computed, not assumed to favor either side, per the card's own kill
+criterion (if non-myopic does not win, the negative result is recorded and myopic is kept).
+"""
+
+import unittest
+
+from mixle.task.explore_world import random_policy, run_episode
+from mixle.task.outcome_decomposer import train_outcome_decomposer
+from mixle.task.probe_policy import head_to_head_probe, myopic_eig_policy
+
+N_CELLS, N_TARGETS, BUDGET = 20, 3, 30
+HELD_OUT_SEEDS = list(range(20_000, 20_020))  # >= 20 seeds, disjoint from any training seed range
+
+
+class MyopicEIGSanityTest(unittest.TestCase):
+    def test_myopic_eig_beats_random_on_average(self):
+        eig_scores = [
+            run_episode(myopic_eig_policy, n_cells=N_CELLS, n_targets=N_TARGETS, budget=BUDGET, seed=s).score
+            for s in range(20)
+        ]
+        random_scores = [
+            run_episode(random_policy, n_cells=N_CELLS, n_targets=N_TARGETS, budget=BUDGET, seed=s).score
+            for s in range(20)
+        ]
+        self.assertGreater(sum(eig_scores) / len(eig_scores), sum(random_scores) / len(random_scores))
+
+    def test_myopic_eig_returns_none_on_an_exhausted_world(self):
+        from mixle.task.explore_world import ExplorationWorld
+
+        world = ExplorationWorld(n_cells=5, n_targets=1, budget=0, seed=0)
+        self.assertIsNone(myopic_eig_policy(world))
+
+
+class HeadToHeadTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.decomposer = train_outcome_decomposer(
+            seed_worlds=40, n_cells=N_CELLS, n_targets=N_TARGETS, budget=BUDGET, rounds=3, seed=1
+        )
+        cls.result = head_to_head_probe(
+            cls.decomposer.plan_model,
+            held_out_seeds=HELD_OUT_SEEDS,
+            n_cells=N_CELLS,
+            n_targets=N_TARGETS,
+            budget=BUDGET,
+        )
+
+    def test_the_comparison_is_computed_on_at_least_20_held_out_seeds(self):
+        self.assertGreaterEqual(len(HELD_OUT_SEEDS), 20)
+
+    def test_the_decision_is_reported_either_way(self):
+        # the card's own discipline: whichever way this goes is a valid, reportable outcome -- the
+        # test only asserts the DECISION IS COMPUTED (a real bool from real scores), not which way.
+        self.assertIsInstance(self.result.non_myopic_wins, bool)
+        self.assertIsInstance(self.result.non_myopic_score, float)
+        self.assertIsInstance(self.result.myopic_score, float)
+
+    def test_held_out_seeds_disjoint_from_training(self):
+        self.assertTrue(min(HELD_OUT_SEEDS) >= 20_000)
+
+    def test_matches_the_recorded_kill_criterion_verdict(self):
+        # measured on this exact benchmark: myopic EIG wins (2.25 vs 2.00) -- the negative result is
+        # recorded in notes/c7-probing-policy-negative.md, per the card's own stop rule. Pinned here
+        # so a future change to either policy that silently flips the verdict is caught, not missed.
+        self.assertFalse(self.result.non_myopic_wins)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/notes/c7-probing-policy-negative.md
+++ b/notes/c7-probing-policy-negative.md
@@ -1,0 +1,63 @@
+# CARD PROBE-a: learned non-myopic probing policy vs myopic EIG -- negative result
+
+## What was built
+
+`mixle/task/probe_policy.py`:
+
+- `myopic_eig_policy`: one-step-lookahead policy. Maintains an explicit logistic belief
+  `p_target(cell)` from that cell's current noisy prospectivity read (`mixle/task/explore_world.py`),
+  centered on the world's own known decision boundary (target cells' geology reads systematically
+  +2.0 higher). EXPLOITs (drills) the most confident current candidate once its belief clears a
+  0.65 threshold; otherwise EXPLOREs (surveys) the single most uncertain cell -- the textbook
+  maximum-entropy expected-information-gain target.
+- `head_to_head_probe`: runs the non-myopic side (the outcome-trained decomposer's fitted plan
+  model, `mixle/task/outcome_decomposer.py`, CARD C2-a -- trained via expert iteration against
+  VERIFIER-GROUNDED reward, i.e. terminal world score, no learned reward model) and the myopic EIG
+  policy on the SAME held-out world seeds at matched budget, and reports which wins.
+
+An earlier version of the myopic policy ranked every action by raw `expected_information_gain / cost`
+across the whole action menu. That degenerated: drilling costs 5x surveying, and the raw EIG estimate
+for a drill was never large enough to clear that 5x cost penalty, so the policy essentially never
+drilled at all and scored *worse than random* (a real bug, not part of the reported result below --
+fixed before this comparison was run, by switching to an explicit exploit/explore threshold instead
+of a single per-cost ranking).
+
+## Measured result
+
+20 cells, 3 targets, budget 30, 20 held-out seeds (disjoint from every training seed used to fit the
+outcome-trained decomposer):
+
+```
+non-myopic (outcome-trained decomposer) mean score: 2.00
+myopic EIG policy mean score:                       2.25
+```
+
+## Kill-criterion verdict: LOSS -- myopic EIG wins, per the card's stop rule
+
+The card's kill criterion: if the learned/outcome-trained non-myopic policy does not beat myopic EIG
+on solve-rate at matched budget (averaged over >= 20 held-out seeds), record the negative result and
+KEEP myopic. It does not beat it here (2.00 vs 2.25) -- per the card's explicit instruction this is
+the valid, expected outcome, not a bug to chase: "myopic is often near-optimal; this spike exists to
+find the cases where delayed/combinatorial payoff makes it fail, not to add [a learned policy] for
+its own sake." The implementation and both policies are kept and tested (`myopic_eig_policy` is now
+the good baseline other future spikes in this world should compare against); no further tuning of the
+outcome-trained side was done to try to force a win.
+
+## Why this is plausible, not just an artifact
+
+The exploration world's reward structure rewards CORRECTLY IDENTIFYING targets, which is exactly the
+kind of task myopic EIG is suited for: the value of information about any one cell does not
+meaningfully depend on the order other cells are resolved in (little combinatorial/delayed payoff --
+no action opens up or forecloses a DIFFERENT cell's value), so a policy that always chases the
+single-step-best move has little to lose relative to one that optimizes for a whole plan's terminal
+score. The outcome-trained decomposer also only controls the ORDER/MIX of action TYPES (survey vs
+drill), delegating WHICH cell to the same kind of per-cost heuristic myopic EIG makes directly and
+per-step -- so its "non-myopic" advantage is thinner here than it would be in a world where probes
+have real delayed/combinatorial structure (e.g. a probe that only pays off in combination with a
+later, specific other probe). This matches the card's own framing of where a non-myopic policy should
+be expected to win, and this benchmark does not have that structure.
+
+## Scope note
+
+Per the card, this is reported after the first head-to-head, win or lose -- no further tuning,
+alternate reward shaping, or additional training rounds were attempted to try to reverse the result.


### PR DESCRIPTION
## Summary
Same content as #55, cherry-picked cleanly onto the current release tip. #55's base was the now-merged \`explore-world-core\` branch (#53); retargeting it directly produced a full-history merge conflict against release because #53 landed via squash-merge (different commit SHAs, same content). Rather than force-pushing over #55's branch (owned by another session), this PR carries just the incremental \`probe_policy\` commit cherry-picked onto release, with the one resulting trivial import-ordering conflict in \`mixle/task/__init__.py\` resolved (both \`propose\`'s and \`probe_policy\`'s imports kept, order-independent).

Please close #55 once this merges to avoid a duplicate.

## Test plan
- [x] \`.venv/bin/python -m pytest mixle/tests/probe_policy_test.py -q\` -- 6 passed
- [x] \`from mixle.task import ProbeHeadToHead, head_to_head_probe, myopic_eig_policy\` imports cleanly