### PR TITLE
task/META-a: improve_by_regret heuristic effort allocator (replaces #44)

### DIFF
--- a/mixle/meta.py
+++ b/mixle/meta.py
@@ -1,0 +1,88 @@
+"""``improve_by_regret`` -- heuristic improvement-effort allocator (workstream META-a research spike).
+
+Given a :class:`~mixle.system.System` and a set of :class:`ImprovementOption` (an amplify/refine/
+accumulate-style action, each with an estimated cost and an estimated "verified regret" -- how much
+scorecard quality it could plausibly recover), spend the budget on the highest regret-per-dollar option
+first. Only REALIZED gain is trusted: :func:`~mixle.scorecard.evaluate` re-measures the scorecard before
+and after each option actually runs, and the moment :func:`~mixle.scorecard.detect_regression` flags a
+worsening round, the whole allocation stops -- never silently absorbing a regression hoping a
+later, cheaper-looking option fixes it.
+
+Kill criterion (per the plan, stated before any learned variant is attempted): a learned meta-policy
+must beat this heuristic's REALIZED scorecard-gain-per-dollar before it replaces it. This card ships
+only the validated heuristic baseline; no learned policy is claimed or built here -- the heuristic has
+not yet been beaten, so per the plan's build order nothing has earned the right to replace it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
+
+from mixle.scorecard import RegressionReport, SystemScorecard, detect_regression, evaluate
+from mixle.system import Query, System
+
+
+@dataclass
+class ImprovementOption:
+    """One candidate improvement action -- amplify, refine, accumulate, or anything else that mutates
+    the system/store and is expected to raise scorecard quality by roughly ``estimated_regret``."""
+
+    name: str
+    cost: float
+    run: Callable[[], None]
+    estimated_regret: float  # a prior estimate of recoverable scorecard-quality gain; never trusted blindly
+
+    @property
+    def regret_per_dollar(self) -> float:
+        return self.estimated_regret / self.cost if self.cost > 0 else self.estimated_regret
+
+
+@dataclass
+class MetaImprovementReport:
+    order: list[str] = field(default_factory=list)  # options actually run, in the order they ran
+    skipped: list[str] = field(default_factory=list)  # over budget -- never attempted
+    scorecard_before: SystemScorecard | None = None
+    scorecard_after: SystemScorecard | None = None
+    realized_gain_per_dollar: dict[str, float] = field(default_factory=dict)  # measured, not estimated
+    spent: float = 0.0
+    stopped_on_regression: RegressionReport | None = None
+
+
+def improve_by_regret(
+    system: System,
+    question_set: Sequence[tuple[Query, str]],
+    options: Sequence[ImprovementOption],
+    *,
+    budget: float,
+) -> MetaImprovementReport:
+    """Run ``options`` highest-regret-per-dollar first, within ``budget``, measuring the scorecard
+    before and after EACH one and stopping immediately if a run regresses it."""
+    ordered = sorted(options, key=lambda o: o.regret_per_dollar, reverse=True)
+    report = MetaImprovementReport(scorecard_before=evaluate(system, question_set))
+    current = report.scorecard_before
+    spent = 0.0
+
+    for opt in ordered:
+        if spent + opt.cost > budget:
+            report.skipped.append(opt.name)
+            continue
+
+        before = current
+        opt.run()
+        after = evaluate(system, question_set)
+        report.realized_gain_per_dollar[opt.name] = (
+            (after.quality - before.quality) / opt.cost if opt.cost > 0 else (after.quality - before.quality)
+        )
+        report.order.append(opt.name)
+        spent += opt.cost
+        current = after
+
+        regression = detect_regression(before, after)
+        if regression.regressed:
+            report.stopped_on_regression = regression
+            break
+
+    report.scorecard_after = current
+    report.spent = spent
+    return report

--- a/mixle/tests/meta_test.py
+++ b/mixle/tests/meta_test.py
@@ -1,0 +1,78 @@
+"""improve_by_regret: heuristic effort allocation across improvement options, trusting only realized
+scorecard gain (workstream META-a)."""
+
+import unittest
+
+from mixle.meta import ImprovementOption, improve_by_regret
+from mixle.system import Query, System, SystemConfig
+
+_QUESTIONS = [(Query("Q1"), "A1"), (Query("Q2"), "A2"), (Query("Q3"), "A3")]
+
+
+def _make_system(knowledge: dict) -> System:
+    def teacher(prompt: str) -> str:
+        return knowledge.get(prompt, "unknown")
+
+    return System(SystemConfig(teacher=teacher))
+
+
+class ImproveByRegretTest(unittest.TestCase):
+    def test_runs_highest_regret_per_dollar_first_regardless_of_input_order(self):
+        knowledge: dict = {}
+        system = _make_system(knowledge)
+        options = [
+            ImprovementOption(name="low_value", cost=1.0, run=lambda: knowledge.update(Q2="A2"), estimated_regret=0.2),
+            ImprovementOption(name="high_value", cost=1.0, run=lambda: knowledge.update(Q1="A1"), estimated_regret=0.9),
+        ]
+        report = improve_by_regret(system, _QUESTIONS, options, budget=10.0)
+
+        self.assertEqual(report.order, ["high_value", "low_value"])  # ran in regret-per-dollar order
+        self.assertIsNone(report.stopped_on_regression)
+        self.assertAlmostEqual(report.scorecard_before.quality, 0.0)
+        self.assertAlmostEqual(report.scorecard_after.quality, 2 / 3)
+
+    def test_measures_realized_gain_not_the_estimate(self):
+        knowledge: dict = {}
+        system = _make_system(knowledge)
+        # a wildly over-optimistic estimate does not change what gets MEASURED after it runs
+        options = [
+            ImprovementOption(
+                name="accumulate_q1", cost=1.0, run=lambda: knowledge.update(Q1="A1"), estimated_regret=999.0
+            )
+        ]
+        report = improve_by_regret(system, _QUESTIONS, options, budget=10.0)
+
+        self.assertAlmostEqual(report.realized_gain_per_dollar["accumulate_q1"], 1 / 3)
+
+    def test_skips_options_that_do_not_fit_the_budget(self):
+        knowledge: dict = {}
+        system = _make_system(knowledge)
+        options = [
+            ImprovementOption(name="first", cost=1.0, run=lambda: knowledge.update(Q1="A1"), estimated_regret=0.9),
+            ImprovementOption(name="second", cost=1.0, run=lambda: knowledge.update(Q2="A2"), estimated_regret=0.5),
+        ]
+        report = improve_by_regret(system, _QUESTIONS, options, budget=1.0)
+
+        self.assertEqual(report.order, ["first"])
+        self.assertEqual(report.skipped, ["second"])
+        self.assertEqual(report.spent, 1.0)
+
+    def test_stops_immediately_on_a_regressing_option_never_absorbing_it_silently(self):
+        knowledge: dict = {"Q1": "A1"}  # start already answering Q1 correctly
+        system = _make_system(knowledge)
+        options = [
+            ImprovementOption(name="good", cost=1.0, run=lambda: knowledge.update(Q2="A2"), estimated_regret=0.9),
+            ImprovementOption(name="bad_regresses", cost=1.0, run=knowledge.clear, estimated_regret=0.5),
+        ]
+        report = improve_by_regret(system, _QUESTIONS, options, budget=10.0)
+
+        self.assertEqual(report.order, ["good", "bad_regresses"])
+        self.assertIsNotNone(report.stopped_on_regression)
+        self.assertTrue(report.stopped_on_regression.regressed)
+        self.assertIn("quality regressed", report.stopped_on_regression.reasons[0])
+        # the final scorecard reflects the regression honestly -- it is not silently discarded/reverted
+        self.assertAlmostEqual(report.scorecard_after.quality, 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Same content as #44, cherry-picked cleanly onto the current release tip. #44's branch was stacked on the SPEND/FAULT/SEED/SCORE chain, which has since merged individually via separate PRs -- retargeting #44 directly produced conflicts in spend.py/fault.py/scorecard.py/system.py from that divergent history (squash-merge SHAs differ even though content matches). This PR carries only the actual new commit (`mixle/meta.py` + `mixle/tests/meta_test.py`), cherry-picked with zero conflicts onto release as it stands now.

Please close #44 once this merges to avoid a duplicate.

## Test plan
- [x] `.venv/bin/python -m pytest mixle/tests/meta_test.py -q` -- 4 passed
- [x] `import mixle.meta` imports cleanly