### PR TITLE
pytest: cap -n auto to -n 4 to stop oversubscribing shared machines

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,7 @@ python_functions = ["test_*"]
 # line overrides this default, so the CI gates keep working:
 #   full correctness run : pytest -m "not optional and not benchmark"   (everything incl. slow)
 #   single file, serial  : pytest path/to/file_test.py -n0 -m ""        (-m "" clears the fast filter)
-addopts = "-ra --strict-markers -n auto -m fast"
+addopts = "-ra --strict-markers -n 4 -m fast"
 markers = [
     "fast: quick correctness tests suitable for every commit.",
     "slow: heavier stochastic, integration, or exhaustive tests for full CI.",


### PR DESCRIPTION
## Summary
- Root cause of the reported test slowness: system load is 65 on a 10-core box. `-n auto` spawns one worker per CPU core; with many concurrent agent sessions on the same machine each running their own `pytest -n auto`, every session tries to grab all 10 cores at once -- core-count workers times N concurrent sessions, all fighting over the same 10 physical cores. That's the actual bottleneck, not test content.
- One-line fix: cap the default worker count to a fixed, modest number (4) instead of `auto`. Bounds each session's own footprint so it stops compounding across concurrent runs.
- Not a full fix for "everyone else is also running pytest right now" -- that's inherent to running many concurrent sessions on one machine -- but it removes the self-inflicted multiplier.

## Test plan
- [x] Config-only change, no test logic touched.