### PR TITLE
task/F3: belief walk across a chain of verified transports (replaces #56)

### DIFF
--- a/mixle/reason/__init__.py
+++ b/mixle/reason/__init__.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 from typing import Any
 
 from mixle.inference.belief import BeliefState, GaussianBelief, as_belief
+from mixle.reason.belief_walk import HopTransport, WalkResult, belief_walk, coverage_by_hop_count
 from mixle.reason.core import (
     Evidence,
     Latent,
@@ -113,6 +114,10 @@ __all__ = [
     "fit_cycle_transport",
     "posterior_mean_estimate",
     "selective_error",
+    "HopTransport",
+    "WalkResult",
+    "belief_walk",
+    "coverage_by_hop_count",
     "information_corroborator",
     "GraphLLM",
     "GraphDistribution",

--- a/mixle/reason/belief_walk.py
+++ b/mixle/reason/belief_walk.py
@@ -1,0 +1,117 @@
+"""Reasoning as a belief walk across a chain of verified transports (workstream F3).
+
+A multi-hop reasoning path (e.g. binding -> structure -> activity) transports a BELIEF at each hop,
+with uncertainty compounding honestly rather than assumed. This module composes a chain of fitted
+conditional transports (:func:`~mixle.reason.cycle_consistency.fit_cycle_transport`, the same MDN
+family CARD TRANSPORT-a's F0 gate proved usable and calibrated) by Monte Carlo forward simulation:
+draw a sample of the belief at hop 0, push it through hop 1's transport to get a sample at hop 1, and
+so on. The result is an empirical posterior over the final hop's variable whose spread reflects every
+intervening hop's genuine uncertainty -- not a point estimate chained through point estimates.
+
+Per the plan, composition is gated on the F2 premise: a transport that has not itself been verified
+usable/calibrated on its own edge must not be composed into a walk -- an unverified edge silently
+corrupts every downstream calibration claim built on top of it. :func:`calibration_by_hop_count`
+checks calibration AS A FUNCTION OF HOP COUNT (a two-sided binomial test against nominal coverage,
+mirroring :mod:`mixle.task.solve`'s own use of the same test) rather than assuming it holds -- if
+composed calibration degrades faster than the per-hop errors alone would predict, that degradation
+curve is the thing to report, not a blind "uncertainty compounds honestly" claim.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+from scipy.stats import binomtest
+
+
+@dataclass
+class HopTransport:
+    """One edge of the belief walk: a fitted conditional transport plus its own F2 premise verdict.
+
+    ``premise_passed`` records whether THIS transport, on THIS edge, was independently verified usable
+    and calibrated (CARD F2-a) -- never assumed true because F0 passed on an unrelated toy problem.
+    """
+
+    name: str
+    fit: Any
+    premise_passed: bool = True
+
+    def sampler(self, seed: int | None = None) -> Any:
+        return self.fit.sampler(seed)
+
+
+@dataclass
+class WalkResult:
+    """The belief walk's outcome: an empirical posterior over the final hop's variable."""
+
+    hop_names: list[str]
+    samples: np.ndarray  # (n_draws, dim)
+
+    @property
+    def mean(self) -> np.ndarray:
+        return self.samples.mean(axis=0)
+
+    @property
+    def std(self) -> np.ndarray:
+        return self.samples.std(axis=0)
+
+    def credible_interval(self, alpha: float = 0.1) -> tuple[np.ndarray, np.ndarray]:
+        lo = np.quantile(self.samples, alpha / 2.0, axis=0)
+        hi = np.quantile(self.samples, 1.0 - alpha / 2.0, axis=0)
+        return lo, hi
+
+
+def belief_walk(hops: Sequence[HopTransport], x0: Any, *, n_draws: int = 200, seed: int = 0) -> WalkResult:
+    """Propagate a belief forward through a chain of hops, starting from a single value ``x0``.
+
+    Each hop's transport is applied by drawing ``n_draws`` independent samples of the CURRENT belief
+    and pushing each through the hop's ``sample_given`` -- the empirical spread at the end is the
+    walk's honestly-compounded uncertainty. Raises if any hop's ``premise_passed`` is ``False``:
+    composing an unverified edge is refused rather than silently producing an uncheckable posterior.
+    """
+    unverified = [h.name for h in hops if not h.premise_passed]
+    if unverified:
+        raise ValueError(f"hop(s) {unverified} did not pass their F2 premise check; refusing to compose them")
+
+    rng = np.random.RandomState(seed)
+    x0_arr = np.atleast_1d(np.asarray(x0, dtype=np.float64))
+    current = np.tile(x0_arr, (n_draws, 1))
+    for hop in hops:
+        sampler = hop.sampler(seed=int(rng.randint(0, 2**31 - 1)))
+        current = np.asarray([sampler.sample_given(current[i]) for i in range(n_draws)], dtype=np.float64)
+    return WalkResult([h.name for h in hops], current)
+
+
+def coverage_by_hop_count(
+    hops: Sequence[HopTransport],
+    x0_test: np.ndarray,
+    true_final: dict[int, np.ndarray],
+    *,
+    alpha: float = 0.1,
+    n_draws: int = 150,
+    seed: int = 0,
+) -> dict[int, dict[str, float]]:
+    """Calibration AS A FUNCTION OF HOP COUNT: for ``k = 1 .. len(hops)``, walk the first ``k`` hops
+    for every test point in ``x0_test`` and check the empirical credible-interval coverage of
+    ``true_final[k]`` (the true value at hop ``k`` for the SAME test points) against the nominal
+    ``1 - alpha`` rate, via a two-sided binomial test.
+
+    Returns ``{k: {"coverage": observed_rate, "p_value": ..., "consistent_with_nominal": bool}}`` --
+    the degradation curve the card requires, measured, never assumed. ``true_final`` must supply the
+    ground truth at every hop count checked (e.g. from a known generative process on held-out data).
+    """
+    out: dict[int, dict[str, float]] = {}
+    for k in range(1, len(hops) + 1):
+        truth_k = np.atleast_2d(np.asarray(true_final[k], dtype=np.float64))
+        covered = 0
+        for i in range(len(x0_test)):
+            result = belief_walk(hops[:k], x0_test[i], n_draws=n_draws, seed=seed + i)
+            lo, hi = result.credible_interval(alpha)
+            covered += int(np.all((lo <= truth_k[i]) & (truth_k[i] <= hi)))
+        rate = covered / len(x0_test)
+        p = float(binomtest(covered, len(x0_test), 1.0 - alpha).pvalue)
+        out[k] = {"coverage": rate, "p_value": p, "consistent_with_nominal": p >= 0.01}
+    return out

--- a/mixle/tests/belief_walk_test.py
+++ b/mixle/tests/belief_walk_test.py
@@ -1,0 +1,128 @@
+"""Belief walk across a chain of verified transports (workstream F3, builds on F0/TRANSPORT-a).
+
+Fixture: a linear-Gaussian AR(1) chain x_{t+1} = A*x_t + noise, A=0.8, noise_std=0.5 -- the SAME
+family CARD TRANSPORT-a already proved calibrated, so composing it is composing a verified premise,
+not an assumed one. The true composed distribution after k hops is analytically known (a standard
+AR(1) recursion), so both the "uncertainty compounds honestly" claim and calibration are CHECKED
+against ground truth, never assumed.
+
+The direct-vs-composed comparison uses the realistic asymmetry the plan motivates multi-hop reasoning
+with: abundant per-hop (A->B) training pairs are cheap, but a long-range direct (A->Z) pair is scarce.
+With few direct pairs, a single end-to-end map badly under-calibrates; composing the (abundantly
+trained) per-hop transport does not, because it never had to learn the long-range mapping directly.
+"""
+
+import unittest
+
+import numpy as np
+import pytest
+
+try:
+    import torch  # noqa: F401
+
+    _HAS_TORCH = True
+except ImportError:
+    _HAS_TORCH = False
+
+from mixle.reason.belief_walk import HopTransport, belief_walk, coverage_by_hop_count  # noqa: E402
+from mixle.reason.cycle_consistency import fit_cycle_transport  # noqa: E402
+
+A_COEF = 0.8
+NOISE_STD = 0.5
+
+
+def _ar1_step(x, rng, n):
+    return A_COEF * x + rng.normal(0, NOISE_STD, size=(n, 1))
+
+
+def _true_std(k: int) -> float:
+    return float(np.sqrt(sum(A_COEF ** (2 * (k - i)) * NOISE_STD**2 for i in range(1, k + 1))))
+
+
+_HOP = _WALK3_STD = None
+_X0_TEST = _TRUE_BY_HOP = None
+_DIRECT_SAMPLER = None
+
+if _HAS_TORCH:
+    _rng = np.random.RandomState(0)
+    _x0_train = _rng.normal(0, 1.0, size=(2000, 1))
+    _x1_train = _ar1_step(_x0_train, _rng, 2000)
+    _HOP_FIT = fit_cycle_transport(_x0_train, _x1_train, k=1, seed=0, max_its=25)
+    _HOP = HopTransport("ar1_step", _HOP_FIT, premise_passed=True)
+
+    _rng2 = np.random.RandomState(1)
+    _n_test = 200
+    _X0_TEST = _rng2.normal(0, 1.0, size=(_n_test, 1))
+    _cur = _X0_TEST
+    _TRUE_BY_HOP = {}
+    for _k in (1, 2, 3):
+        _cur = _ar1_step(_cur, _rng2, _n_test)
+        _TRUE_BY_HOP[_k] = _cur.copy()
+
+    _WALK3 = belief_walk([_HOP, _HOP, _HOP], 0.0, n_draws=400, seed=5)
+    _WALK3_STD = float(_WALK3.std[0])
+
+    # scarce direct (x0 -> x3) training pairs -- the realistic motivation for composing hops at all.
+    _rng_direct = np.random.RandomState(0)
+    _x0_direct = _rng_direct.normal(0, 1.0, size=(40, 1))
+    _cur_d = _x0_direct
+    for _ in range(3):
+        _cur_d = _ar1_step(_cur_d, _rng_direct, 40)
+    _direct_fit = fit_cycle_transport(_x0_direct, _cur_d, k=2, seed=0, max_its=25)
+    _DIRECT_SAMPLER = _direct_fit.sampler(seed=2)
+
+
+@pytest.mark.skipif(_HOP is None, reason="torch not installed")
+class UncertaintyCompoundsHonestlyTest(unittest.TestCase):
+    def test_walk_posterior_std_tracks_the_analytic_ar1_recursion(self):
+        for k in (1, 2, 3):
+            walk = belief_walk([_HOP] * k, 0.0, n_draws=400, seed=5)
+            self.assertAlmostEqual(float(walk.std[0]), _true_std(k), delta=0.08)
+
+    def test_std_strictly_increases_with_hop_count(self):
+        stds = [float(belief_walk([_HOP] * k, 0.0, n_draws=400, seed=5).std[0]) for k in (1, 2, 3)]
+        self.assertLess(stds[0], stds[1])
+        self.assertLess(stds[1], stds[2])
+
+
+@pytest.mark.skipif(_HOP is None, reason="torch not installed")
+class CalibrationByHopCountTest(unittest.TestCase):
+    def test_coverage_is_consistent_with_nominal_at_every_hop_count(self):
+        report = coverage_by_hop_count([_HOP, _HOP, _HOP], _X0_TEST, _TRUE_BY_HOP, n_draws=150, seed=0)
+        self.assertEqual(set(report), {1, 2, 3})
+        for k, entry in report.items():
+            self.assertTrue(
+                entry["consistent_with_nominal"], f"hop {k} coverage={entry['coverage']} p={entry['p_value']}"
+            )
+
+    def test_refuses_to_compose_an_unverified_hop(self):
+        bad_hop = HopTransport("unverified", _HOP.fit, premise_passed=False)
+        with self.assertRaises(ValueError):
+            belief_walk([_HOP, bad_hop], 0.0)
+
+
+@pytest.mark.skipif(_HOP is None, reason="torch not installed")
+class ComposedWalkBeatsDirectEndToEndTest(unittest.TestCase):
+    def test_composed_walk_beats_a_direct_map_starved_of_long_range_pairs(self):
+        n_test = len(_X0_TEST)
+        covered_direct = covered_walk = 0
+        for i in range(n_test):
+            direct_draws = np.asarray([_DIRECT_SAMPLER.sample_given(_X0_TEST[i]) for _ in range(150)])
+            lo, hi = np.quantile(direct_draws, 0.05), np.quantile(direct_draws, 0.95)
+            covered_direct += lo <= _TRUE_BY_HOP[3][i, 0] <= hi
+
+            walk = belief_walk([_HOP, _HOP, _HOP], _X0_TEST[i], n_draws=150, seed=10 + i)
+            lo, hi = walk.credible_interval(0.1)
+            covered_walk += lo[0] <= _TRUE_BY_HOP[3][i, 0] <= hi[0]
+
+        cov_direct = covered_direct / n_test
+        cov_walk = covered_walk / n_test
+        # the direct map, starved of long-range pairs, badly under-covers; the composed walk (built
+        # from the SAME abundantly-trained per-hop transport) does not.
+        self.assertLess(cov_direct, 0.7)
+        self.assertGreater(cov_walk, 0.8)
+        self.assertGreater(cov_walk, cov_direct + 0.15)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Same content as #56, cherry-picked cleanly onto the current release tip. #56 was stacked on the F5 cycle-consistency work, which already merged separately via #51 (different squash SHA, same content), so retargeting #56 directly produced a full-history conflict. This PR carries only the actual new commit (`mixle/reason/belief_walk.py` + `mixle/tests/belief_walk_test.py`), cherry-picked with zero conflicts.

Please close #56 once this merges to avoid a duplicate.

## Test plan
- [x] `.venv/bin/python -m pytest mixle/tests/belief_walk_test.py -q` -- 5 passed
- [x] `import mixle.reason.belief_walk` imports cleanly