### PR TITLE
Revert "pytest: cap default -n auto to -n 4"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,7 @@ python_functions = ["test_*"]
 # line overrides this default, so the CI gates keep working:
 #   full correctness run : pytest -m "not optional and not benchmark"   (everything incl. slow)
 #   single file, serial  : pytest path/to/file_test.py -n0 -m ""        (-m "" clears the fast filter)
-addopts = "-ra --strict-markers -n 4 -m fast"
+addopts = "-ra --strict-markers -n auto -m fast"
 markers = [
     "fast: quick correctness tests suitable for every commit.",
     "slow: heavier stochastic, integration, or exhaustive tests for full CI.",


### PR DESCRIPTION
Reverts #61 per explicit request. Restores `-n auto` as the default pytest worker count.