### PR TITLE
task/REFINE: diagnosis-directed correction vs blind search (recovers unique content from closed #46)

### DIFF
--- a/mixle/inference/__init__.py
+++ b/mixle/inference/__init__.py
@@ -191,6 +191,13 @@ from mixle.inference.project import collapse_mixture, fisher_merge, gaussian_kl,
 
 # receipts: bind ledger + trace + calibration + provenance into one offline-re-verifiable artifact (H3)
 from mixle.inference.receipt import Receipt, VerificationReport, verify_receipt
+from mixle.inference.refine import (
+    TrialsToTarget,
+    apply_add_edge_fix,
+    blind_search_trials_to_target,
+    directed_correction,
+    held_out_log_likelihood,
+)
 from mixle.inference.reproduce import (
     ReproReceipt,
     data_fingerprint,
@@ -347,6 +354,11 @@ __all__ = [
     "reduce_mixture",
     "moment_project",
     "gaussian_kl",
+    "TrialsToTarget",
+    "apply_add_edge_fix",
+    "blind_search_trials_to_target",
+    "directed_correction",
+    "held_out_log_likelihood",
     "fisher_merge",
     "fit",
     "EMStep",
@@ -419,6 +431,12 @@ __all__ = [
     "Receipt",
     "VerificationReport",
     "verify_receipt",
+    # REFINE-a: diagnosis-directed correction vs blind structure search (workstream A5 research spike)
+    "TrialsToTarget",
+    "apply_add_edge_fix",
+    "blind_search_trials_to_target",
+    "directed_correction",
+    "held_out_log_likelihood",
     # reproducibility receipts -- record a fit, replay it, check it comes out bit-for-bit
     "record_fit",
     "verify_reproducible",

--- a/mixle/inference/refine.py
+++ b/mixle/inference/refine.py
@@ -1,0 +1,122 @@
+"""REFINE-a: diagnosis-directed correction vs blind structure search (research spike, workstream A5 +
+the refinement loop).
+
+Kill criterion (stated before running the comparison, per the card): if diagnosis-directed correction
+does not reach the SAME held-out target in FEWER trials than blind structure search (`learn_bayesian_network`
+run with no diagnosis, over growing prefixes of data) on the planted-fault benchmark, this is a negative
+result -- record it in `notes/refine-directed-negative.md` and keep blind search; the critic did not earn
+its place.
+
+Only the `add_edge` fix is translated to a concrete structural edit here, because that is the only fix
+`mixle.inference.explain.diagnose` actually detects today (`upgrade_leaf`/`split_region`/`add_factor` are
+recognized vocabulary with no detector wired yet -- see that module's docstring). A `FaultReport` naming
+any other fix is reported as "not actionable," never guessed at.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+
+from mixle.inference.bayesian_network import HeterogeneousBayesianNetwork, _LinearGaussianFactor, learn_bayesian_network
+from mixle.inference.explain import FaultReport, diagnose
+
+
+def held_out_log_likelihood(model: Any, data: Sequence[tuple]) -> float:
+    """Total log-density of a fitted network (or anything exposing ``dist_to_encoder``/``seq_log_density``)
+    over held-out ``data`` -- the metric both paths below are compared on."""
+    enc = model.dist_to_encoder().seq_encode(list(data))
+    return float(np.sum(model.seq_log_density(enc)))
+
+
+def apply_add_edge_fix(
+    model: HeterogeneousBayesianNetwork, fault: FaultReport, data: Sequence[tuple]
+) -> HeterogeneousBayesianNetwork | None:
+    """Apply ONLY the fix ``diagnose`` actually named: add a linear-Gaussian edge between the two fields
+    in ``fault.dominant`` (parsed from its ``"field[i]|...field[j]|..."`` shape), refit that one factor on
+    ``data``, and return the corrected network -- every other factor is left untouched.
+
+    Returns ``None`` (never guesses) when ``fault.suggested_fix`` is not ``"add_edge"``, or ``dominant``
+    does not name exactly two fields (nothing dominant, or a shape this translation doesn't understand).
+    """
+    if fault.suggested_fix != "add_edge":
+        return None
+    idx = sorted({int(m) for m in re.findall(r"field\[(\d+)\]", fault.dominant)})
+    if len(idx) != 2:
+        return None
+    parent, child = idx
+    cols = [[row[i] for row in data] for i in range(len(data[0]))]
+    new_factor = _LinearGaussianFactor.fit(child, [parent], cols, {})
+    factors = [f for f in model.factors if f.child != child] + [new_factor]
+    return HeterogeneousBayesianNetwork(factors)
+
+
+@dataclass
+class TrialsToTarget:
+    """How many trials a path needed to reach its target (``None`` = never reached), plus its score history."""
+
+    n_trials: int | None
+    final_model: Any
+    history: list[float] = field(default_factory=list)
+
+
+def directed_correction(
+    model: Any,
+    cases: Sequence[tuple],
+    data: Sequence[tuple],
+    held_out: Sequence[tuple],
+    *,
+    background: Sequence[tuple] | None = None,
+) -> TrialsToTarget:
+    """One diagnosis, one targeted edit, one verification.
+
+    Costs exactly 1 trial if ``diagnose`` names an actionable fix AND it verifiably improves held-out
+    score over the original model; costs 0 (unreached) if the fix isn't actionable or doesn't verify --
+    a correction that does not improve held-out is a failed diagnosis, logged as such, never silently
+    kept anyway.
+    """
+    fault = diagnose(model, cases, background=background)
+    fixed = apply_add_edge_fix(model, fault, data)
+    before = held_out_log_likelihood(model, held_out)
+    if fixed is None:
+        return TrialsToTarget(n_trials=None, final_model=model, history=[before])
+    after = held_out_log_likelihood(fixed, held_out)
+    if after <= before:
+        return TrialsToTarget(n_trials=None, final_model=model, history=[before, after])
+    return TrialsToTarget(n_trials=1, final_model=fixed, history=[before, after])
+
+
+def blind_search_trials_to_target(
+    data: Sequence[tuple],
+    held_out: Sequence[tuple],
+    target_score: float,
+    *,
+    round_size: int = 10,
+    max_rounds: int = 20,
+    max_parents: int = 1,
+    seed: int = 0,
+) -> TrialsToTarget:
+    """The blind baseline: NO diagnosis. Re-run ``learn_bayesian_network`` from scratch on growing
+    prefixes of ``data`` (``round_size`` more examples each round, shuffled once up front) until the
+    discovered structure's held-out score reaches ``target_score`` (typically
+    :func:`directed_correction`'s own held-out score) or ``max_rounds`` is exhausted.
+    """
+    rng = np.random.RandomState(seed)
+    order = rng.permutation(len(data))
+    shuffled = [data[i] for i in order]
+    history: list[float] = []
+    model = None
+    for round_idx in range(1, max_rounds + 1):
+        n = min(round_idx * round_size, len(shuffled))
+        model = learn_bayesian_network(shuffled[:n], max_parents=max_parents)
+        score = held_out_log_likelihood(model, held_out)
+        history.append(score)
+        if score >= target_score:
+            return TrialsToTarget(n_trials=round_idx, final_model=model, history=history)
+        if n >= len(shuffled):
+            break
+    return TrialsToTarget(n_trials=None, final_model=model, history=history)

--- a/mixle/tests/refine_directed_test.py
+++ b/mixle/tests/refine_directed_test.py
@@ -1,0 +1,133 @@
+"""REFINE-a: diagnosis-directed correction vs blind structure search, on the planted-fault benchmark.
+
+Extends DIAGNOSE-a's exact planted fault (mixle/tests/diagnose_test.py's two-field missing-edge model)
+to four fields -- two independent noise fields alongside the one true (moderate, not near-deterministic)
+dependency -- so blind search has a real O(n^2) candidate-edge space to search blindly, instead of the
+trivial single-possible-edge case a bare two-field model would give it.
+
+Kill criterion (stated up front, per the card): if directed correction does not reach the SAME held-out
+target in FEWER trials than blind search, this is a negative result to record in
+notes/refine-directed-negative.md, not to paper over.
+"""
+
+import unittest
+
+import numpy as np
+
+from mixle.inference.bayesian_network import HeterogeneousBayesianNetwork, _MarginalFactor
+from mixle.inference.explain import diagnose
+from mixle.inference.refine import (
+    apply_add_edge_fix,
+    blind_search_trials_to_target,
+    directed_correction,
+)
+from mixle.stats import GaussianDistribution
+
+
+def _buggy_net():
+    """The planted fault: field1 = 0.6*field0 + noise, but modeled as fully independent; field2/field3 are
+    genuinely independent noise fields, correctly modeled -- diagnose() must not flag either of them."""
+    return HeterogeneousBayesianNetwork(
+        [
+            _MarginalFactor(0, GaussianDistribution(0.0, 1.0)),
+            _MarginalFactor(1, GaussianDistribution(0.0, 1.0)),
+            _MarginalFactor(2, GaussianDistribution(0.0, 1.0)),
+            _MarginalFactor(3, GaussianDistribution(0.0, 1.0)),
+        ]
+    )
+
+
+def _make_rows(n, seed):
+    rng = np.random.RandomState(seed)
+    f0 = rng.normal(0.0, 1.0, size=n)
+    f1 = 0.6 * f0 + rng.normal(0.0, 0.6, size=n)
+    f2 = rng.normal(0.0, 1.0, size=n)
+    f3 = rng.normal(0.0, 1.0, size=n)
+    return [(float(a), float(b), float(c), float(d)) for a, b, c, d in zip(f0, f1, f2, f3)]
+
+
+def _diagnose_probe_cases():
+    # a tight deterministic-ish grid probing the SAME true relationship (field1 ~ 0.6*field0), used only
+    # to feed diagnose() -- separate from the noisier i.i.d. `data` blind search fits on
+    a_grid = np.linspace(-3.0, 3.0, 41)
+    rows = [(float(a), float(0.6 * a), 0.0, 0.0) for a in a_grid]
+    background = [r for r in rows if abs(r[0]) <= 1.5]
+    failing = [r for r in rows if abs(r[0]) > 2.2]
+    return background, failing
+
+
+class ApplyAddEdgeFixTest(unittest.TestCase):
+    def test_planted_fault_is_named_dominant_and_the_fix_applies(self):
+        background, failing = _diagnose_probe_cases()
+        fault = diagnose(_buggy_net(), failing, background=background)
+        self.assertEqual(fault.suggested_fix, "add_edge")
+
+        data = _make_rows(300, seed=1)
+        fixed = apply_add_edge_fix(_buggy_net(), fault, data)
+        self.assertIsNotNone(fixed)
+        # the two untouched noise fields (2 and 3) still have zero parents; only field1 gained one
+        edges = fixed.edges()
+        self.assertEqual(len(edges), 1)
+        self.assertEqual(edges[0][1], 1)  # child is field 1
+
+    def test_non_add_edge_fix_returns_none_not_a_guess(self):
+        from mixle.inference.explain import FaultReport
+
+        fault = FaultReport(dominant="field[0]|x+field[1]|y", suggested_fix="upgrade_leaf")
+        result = apply_add_edge_fix(_buggy_net(), fault, _make_rows(50, seed=2))
+        self.assertIsNone(result)
+
+
+class RefineVsBlindSearchTest(unittest.TestCase):
+    def test_directed_correction_beats_blind_search_in_trials(self):
+        background, failing = _diagnose_probe_cases()
+        train = _make_rows(200, seed=10)
+        held_out = _make_rows(200, seed=11)
+
+        directed = directed_correction(_buggy_net(), failing, train, held_out, background=background)
+        self.assertEqual(directed.n_trials, 1)
+        target_score = directed.history[-1]
+
+        blind = blind_search_trials_to_target(train, held_out, target_score, round_size=10, max_rounds=20, seed=0)
+
+        # KILL CRITERION: directed must reach the target in fewer trials than blind search, or record
+        # the negative result in notes/refine-directed-negative.md and keep blind search.
+        directed_trials = directed.n_trials
+        blind_trials = blind.n_trials if blind.n_trials is not None else float("inf")
+        self.assertLess(
+            directed_trials,
+            blind_trials,
+            f"REFINE-a kill criterion failed: directed={directed_trials} trial(s), "
+            f"blind={blind.n_trials} round(s) (None = never reached target within max_rounds); "
+            "record the negative result in notes/refine-directed-negative.md",
+        )
+
+    def test_directed_correction_verifiably_improves_held_out_score(self):
+        background, failing = _diagnose_probe_cases()
+        train = _make_rows(200, seed=20)
+        held_out = _make_rows(200, seed=21)
+        result = directed_correction(_buggy_net(), failing, train, held_out, background=background)
+        self.assertEqual(result.n_trials, 1)
+        before, after = result.history
+        self.assertGreater(after, before)
+
+    def test_a_well_specified_model_has_no_actionable_fix(self):
+        from mixle.inference.bayesian_network import _LinearGaussianFactor
+
+        well_specified = HeterogeneousBayesianNetwork(
+            [
+                _MarginalFactor(0, GaussianDistribution(0.0, 1.0)),
+                _LinearGaussianFactor(1, [0], {}, np.array([0.6, 0.0]), 0.6),
+                _MarginalFactor(2, GaussianDistribution(0.0, 1.0)),
+                _MarginalFactor(3, GaussianDistribution(0.0, 1.0)),
+            ]
+        )
+        background, failing = _diagnose_probe_cases()
+        train = _make_rows(200, seed=30)
+        held_out = _make_rows(200, seed=31)
+        result = directed_correction(well_specified, failing, train, held_out, background=background)
+        self.assertIsNone(result.n_trials)  # nothing dominant -> no fix applied -> correctly unreached
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
PR #46 was closed as an apparent duplicate of #45, but it was actually an independent REFINE-a implementation at a different path (mixle/inference/refine.py + mixle/tests/refine_directed_test.py, using HeterogeneousBayesianNetwork + diagnose) that was never on release. Cherry-picked the one commit that adds it cleanly onto the current release tip, resolved one trivial import-list conflict in mixle/inference/__init__.py. Tests: mixle/tests/refine_directed_test.py -- 5 passed.