### PR TITLE
task/B3: decide() contracts for non-classification solve shapes

### DIFF
--- a/mixle/task/multilabel.py
+++ b/mixle/task/multilabel.py
@@ -102,6 +102,12 @@ class MultiLabelSolution:
             return [lab for lab, p in zip(self.labels, present) if p]
         return None
 
+    def decide(self, x: Any) -> list[str] | None:
+        """The ``CalibratedTaskModel.decide``-shaped contract (workstream B3): an alias of
+        :meth:`try_local`, so a :class:`~mixle.task.router.Router` tier can be a multilabel solution,
+        not just a classifier."""
+        return self.try_local(x)
+
     def __call__(self, x: Any) -> list[str]:
         self.n_requests += 1
         local = self.try_local(x)

--- a/mixle/task/regress.py
+++ b/mixle/task/regress.py
@@ -178,6 +178,16 @@ class RegressionSolution:
         """Whether the calibrated precision meets the tolerance at all (else everything escalates)."""
         return bool(np.isfinite(self.qhat) and self.qhat <= self.tol)
 
+    def decide(self, x: Any) -> float | None:
+        """The ``CalibratedTaskModel.decide``-shaped contract (workstream B3): the calibrated point
+        estimate when ``answers_locally``, else ``ESCALATE`` (``None``) -- unlike ``__call__``, this
+        never falls through to the teacher itself, so a :class:`~mixle.task.router.Router` tier can
+        decide whether to escalate to the NEXT tier rather than always landing on this solution's own
+        teacher."""
+        if self.answers_locally:
+            return float(self._predict([x])[0])
+        return None
+
     def __call__(self, x: Any) -> float:
         self.n_requests += 1
         if self.answers_locally:

--- a/mixle/task/structured_out.py
+++ b/mixle/task/structured_out.py
@@ -62,6 +62,12 @@ class StructuredSolution:
             out[key] = float(sub._predict([x])[0])
         return out
 
+    def decide(self, x: Any) -> dict[str, Any] | None:
+        """The ``CalibratedTaskModel.decide``-shaped contract (workstream B3): an alias of
+        :meth:`try_local`, so a :class:`~mixle.task.router.Router` tier can be a structured-output
+        solution, not just a classifier."""
+        return self.try_local(x)
+
     def __call__(self, x: Any) -> dict[str, Any]:
         self.n_requests += 1
         local = self.try_local(x)

--- a/mixle/tests/decide_non_classification_test.py
+++ b/mixle/tests/decide_non_classification_test.py
@@ -1,0 +1,87 @@
+"""decide() contracts for non-classification solve shapes (workstream B3): Router tiers are not
+classifier-only -- RegressionSolution/StructuredSolution/MultiLabelSolution all expose the same
+CalibratedTaskModel-shaped decide(x) -> value | ESCALATE contract Router requires of a tier.
+"""
+
+import unittest
+
+import numpy as np
+
+try:
+    import torch  # noqa: F401
+
+    _HAS_TORCH = True
+except ImportError:
+    _HAS_TORCH = False
+
+from mixle.task.calibrate import ESCALATE
+from mixle.task.multilabel import MultiLabelSolution
+from mixle.task.router import Router
+from mixle.task.structured_out import StructuredSolution
+
+
+def _price(item):
+    base = {"basic": 20.0, "pro": 80.0, "max": 150.0}[item["kind"]]
+    return base + 0.5 * item["size"] + 0.001 * item["size"] ** 2
+
+
+def _items(n, seed=0):
+    rng = np.random.RandomState(seed)
+    kinds = ["basic", "pro", "max"]
+    return [{"kind": kinds[rng.randint(0, 3)], "size": float(rng.uniform(0, 100))} for _ in range(n)]
+
+
+@unittest.skipUnless(_HAS_TORCH, "torch not installed")
+class RegressionSolutionDecideTest(unittest.TestCase):
+    def test_decide_matches_answers_locally_and_never_calls_the_teacher_itself(self):
+        from mixle.task import solve_regression
+
+        sol = solve_regression(_price, _items(500), tol=20.0, alpha=0.1, seed=0, epochs=400)
+        self.assertTrue(sol.answers_locally)
+
+        before_escalated = sol.n_escalated
+        result = sol.decide(_items(1, seed=9)[0])
+        self.assertIsInstance(result, float)
+        self.assertEqual(sol.n_escalated, before_escalated)  # decide() doesn't touch escalation bookkeeping
+
+        sol.tol = 1e-12  # nothing can meet an impossible tolerance
+        self.assertFalse(sol.answers_locally)
+        self.assertIs(sol.decide(_items(1, seed=9)[0]), ESCALATE)
+
+    def test_router_accepts_a_regression_solution_as_a_tier(self):
+        from mixle.task import solve_regression
+
+        sol = solve_regression(_price, _items(500), tol=20.0, alpha=0.1, seed=0, epochs=400)
+        self.assertTrue(sol.answers_locally)
+
+        router = Router(tiers=[("regression_tier", sol, 0.0), ("frontier", _price, 1.0)])
+        out = router(_items(1, seed=9)[0])
+        self.assertIsInstance(out, float)
+        self.assertEqual(router.stats.tiers[0].answered, 1)  # answered locally, never reached the frontier
+        self.assertEqual(router.stats.tiers[1].answered, 0)
+
+
+class StructuredSolutionDecideTest(unittest.TestCase):
+    def test_decide_is_an_alias_of_try_local(self):
+        sol = StructuredSolution(fields_cat={}, fields_num={}, teacher=lambda xs: [{} for _ in xs])
+        self.assertEqual(sol.decide({"anything": 1}), {})
+        self.assertEqual(sol.decide({"anything": 1}), sol.try_local({"anything": 1}))
+
+
+class MultiLabelSolutionDecideTest(unittest.TestCase):
+    def test_decide_is_an_alias_of_try_local(self):
+        sol = object.__new__(MultiLabelSolution)
+        sol.labels = ["a", "b"]
+        sol.upper_absent = np.array([0.7, 0.7])
+        sol.lower_present = np.array([0.3, 0.3])
+        sol._scores = lambda xs: np.array([[0.9, 0.1]])  # confidently present / confidently absent
+
+        self.assertEqual(sol.decide("x"), ["a"])
+        self.assertEqual(sol.decide("x"), sol.try_local("x"))
+
+        sol._scores = lambda xs: np.array([[0.5, 0.5]])  # ambiguous on both labels
+        self.assertIs(sol.decide("x"), ESCALATE)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
RegressionSolution/StructuredSolution/MultiLabelSolution now expose decide(x) -> value | ESCALATE, matching CalibratedTaskModel's contract so Router tiers are not classifier-only. Tests: 4 passed (regression decide + Router-with-regression-tier, structured/multilabel decide aliasing try_local). No regressions: task_regress_test, task_router_test, task_structured_out_test, task_multilabel_test all green.