### PR TITLE
task/FAULT-a: wire model_error and oracle_timeout into live consumers

### DIFF
--- a/mixle/doe/oracle.py
+++ b/mixle/doe/oracle.py
@@ -30,6 +30,7 @@ from typing import Any
 import numpy as np
 
 from mixle.doe.designs import Bounds
+from mixle.fault import abstain_on_timeout
 
 # The declared verifiability tiers, weakest to strongest. "self_graded" is deliberately NOT here: a
 # model grading its own candidates is the banned reward, rejected at VerifiableOracle construction.
@@ -60,6 +61,7 @@ class VerifiableOracle:
     tier: str
     score_fn: Callable[[Any], OracleResult]
     fidelity: str | None = None
+    timeout: float | None = None  # seconds; FAULT-a oracle_timeout: abstain rather than block or guess
 
     def __post_init__(self) -> None:
         if self.tier not in VERIFIABILITY_TIERS:
@@ -70,7 +72,34 @@ class VerifiableOracle:
             )
 
     def __call__(self, candidate: Any) -> OracleResult:
-        return self.score_fn(candidate)
+        if self.timeout is None:
+            return self.score_fn(candidate)
+        return self._call_with_timeout(candidate)
+
+    def _call_with_timeout(self, candidate: Any) -> OracleResult:
+        """FAULT-a ``oracle_timeout``: abstain (a maximally-uninformative, zero-cost, explicitly flagged
+        result) rather than block the caller or guess a score, if a single scoring call runs over budget.
+        Uses a worker thread so a ``score_fn`` that never returns cannot hang the caller either."""
+        from concurrent.futures import ThreadPoolExecutor
+
+        def _run() -> OracleResult:
+            pool = ThreadPoolExecutor(max_workers=1)
+            future = pool.submit(self.score_fn, candidate)
+            try:
+                return future.result(timeout=self.timeout)
+            finally:
+                # don't block __call__ waiting for a score_fn that already blew its budget -- let the
+                # worker thread finish (or leak, for a truly hung score_fn) on its own time, not ours.
+                pool.shutdown(wait=False)
+
+        outcome = abstain_on_timeout(_run)
+        if outcome.degraded:
+            return OracleResult(
+                score=float("-inf"),
+                receipt={"oracle_id": self.name, "tier": self.tier, **outcome.to_receipt_fields()},
+                cost=0.0,
+            )
+        return outcome.value
 
 
 @dataclass

--- a/mixle/task/router.py
+++ b/mixle/task/router.py
@@ -22,6 +22,7 @@ from typing import Any
 
 import numpy as np
 
+from mixle.fault import DegradedResult
 from mixle.task.calibrate import ESCALATE, CalibratedTaskModel
 
 
@@ -37,6 +38,7 @@ class RouterStats:
     tiers: list[TierStats] = field(default_factory=list)
     harvested_inputs: list[Any] = field(default_factory=list)
     harvested_labels: list[Any] = field(default_factory=list)
+    degraded: list[DegradedResult] = field(default_factory=list)  # FAULT-a model_error events, in order
 
     @property
     def n_requests(self) -> int:
@@ -77,9 +79,19 @@ class Router:
         return cls(tiers)
 
     def __call__(self, x: Any) -> Any:
-        """Answer with the cheapest confident tier; the final tier's answers are harvested as labels."""
+        """Answer with the cheapest confident tier; the final tier's answers are harvested as labels.
+
+        FAULT-a ``model_error``: a tier whose ``decide(x)`` raises is routed PAST -- flagged in
+        ``stats.degraded`` -- rather than crashing the request; the next tier gets the chance to answer.
+        """
         for i, (name, model, _) in enumerate(self.tiers[:-1]):
-            label = model.decide(x)
+            try:
+                label = model.decide(x)
+            except Exception as exc:  # noqa: BLE001 -- route past this tier to the next, whatever it raised
+                self.stats.degraded.append(
+                    DegradedResult(value=None, degraded=True, mode="model_error", reason=f"{name}: {exc}")
+                )
+                continue
             if label is not ESCALATE:
                 self.stats.tiers[i].answered += 1
                 return label

--- a/mixle/tests/fault_wired_modes_test.py
+++ b/mixle/tests/fault_wired_modes_test.py
@@ -1,0 +1,90 @@
+"""FAULT-a's last two modes wired into live consumers: model_error (Router routes past a raising tier)
+and oracle_timeout (VerifiableOracle abstains rather than block/guess on a slow score_fn).
+"""
+
+import time
+import unittest
+
+from mixle.doe.oracle import OracleResult, VerifiableOracle
+from mixle.task.router import Router
+
+
+class _RaisingTier:
+    def decide(self, x):
+        raise RuntimeError("tier is on fire")
+
+
+class _WorkingTier:
+    def __init__(self, label):
+        self.label = label
+
+    def decide(self, x):
+        return self.label
+
+
+class RouterModelErrorTest(unittest.TestCase):
+    def test_a_raising_tier_is_routed_past_and_flagged_not_crashed(self):
+        router = Router(tiers=[("broken", _RaisingTier(), 0.0), ("frontier", lambda x: "teacher-answer", 1.0)])
+        out = router(1)
+
+        self.assertEqual(out, "teacher-answer")
+        self.assertEqual(router.stats.tiers[-1].answered, 1)
+        self.assertEqual(len(router.stats.degraded), 1)
+        event = router.stats.degraded[0]
+        self.assertEqual(event.mode, "model_error")
+        self.assertIn("broken", event.reason)
+        self.assertIn("tier is on fire", event.reason)
+
+    def test_a_working_tier_after_a_broken_one_still_answers_locally(self):
+        router = Router(
+            tiers=[
+                ("broken", _RaisingTier(), 0.0),
+                ("cheap", _WorkingTier("cheap-answer"), 0.5),
+                ("frontier", lambda x: "teacher-answer", 1.0),
+            ]
+        )
+        out = router(1)
+
+        self.assertEqual(out, "cheap-answer")
+        self.assertEqual(router.stats.tiers[1].answered, 1)
+        self.assertEqual(router.stats.tiers[-1].answered, 0)  # never reached the frontier
+        self.assertEqual(len(router.stats.degraded), 1)
+
+    def test_no_degradation_recorded_when_every_tier_behaves(self):
+        router = Router(tiers=[("cheap", _WorkingTier("cheap-answer"), 0.0), ("frontier", lambda x: "x", 1.0)])
+        router(1)
+        self.assertEqual(router.stats.degraded, [])
+
+
+class OracleTimeoutTest(unittest.TestCase):
+    def test_a_slow_score_fn_abstains_instead_of_blocking(self):
+        def _slow_score(candidate):
+            time.sleep(5)
+            return OracleResult(score=1.0)
+
+        oracle = VerifiableOracle(name="slow", tier="executable", score_fn=_slow_score, timeout=0.2)
+
+        started = time.monotonic()
+        result = oracle(candidate=[0.0])
+        elapsed = time.monotonic() - started
+
+        self.assertLess(elapsed, 4.0)  # aborted well before the score_fn's own 5s sleep would return
+        self.assertEqual(result.score, float("-inf"))
+        self.assertEqual(result.cost, 0.0)
+        self.assertEqual(result.receipt["degraded_mode"], "oracle_timeout")
+        self.assertIn("oracle_id", result.receipt)
+
+    def test_a_fast_score_fn_is_unaffected_by_a_timeout_budget(self):
+        oracle = VerifiableOracle(
+            name="fast", tier="executable", score_fn=lambda c: OracleResult(score=3.0), timeout=5.0
+        )
+        result = oracle(candidate=[0.0])
+        self.assertEqual(result.score, 3.0)
+
+    def test_no_timeout_configured_behaves_exactly_as_before(self):
+        oracle = VerifiableOracle(name="plain", tier="executable", score_fn=lambda c: OracleResult(score=7.0))
+        self.assertEqual(oracle(candidate=[0.0]).score, 7.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes the last gap in FAULT-a: model_error (Router routes past a raising tier, flagged in stats.degraded) and oracle_timeout (VerifiableOracle aborts a slow score_fn via a worker thread, abstains with a flagged zero-cost OracleResult) are now wired into real call paths, not just standalone primitives. Caught and fixed a real hang bug along the way (ThreadPoolExecutor's context-manager shutdown blocked on the timed-out worker thread). Tests: 6 passed. No regressions: task_router_test, router_harvest_test, doe_oracle_test, fault_test all green.