### PR TITLE
fix: update stale test_uq_degrades_gracefully_when_unflattenable

### DIFF
--- a/mixle/tests/create_test.py
+++ b/mixle/tests/create_test.py
@@ -35,9 +35,16 @@ class CreateTest(unittest.TestCase):
         art = create(_scalar(300, 0), quantify_uq=True, seed=0)
         self.assertIsNotNone(art.uq)  # scalar Gaussian → Laplace posterior
 
-    def test_uq_degrades_gracefully_when_unflattenable(self):
+    def test_uq_attaches_for_a_structured_bn_model(self):
+        # HeterogeneousBayesianNetwork Laplace-flattening landed (bn-laplace-flatten); a structured
+        # fit over a mixed categorical+numeric record now gets a real parameter posterior too, not a
+        # graceful None -- assert the new capability, not the old gap.
         art = create(_plan_spend(300, 0), quantify_uq=True, seed=0)
-        self.assertIsNone(art.uq)  # BN not yet Laplace-flattenable → honest None, no crash
+        self.assertIsNotNone(art.uq)
+        self.assertEqual(art.uq.kind, "parameter_posterior")
+        self.assertIn("laplace", art.uq.method.lower())
+        models = art.uq.sample_models(5, seed=0)
+        self.assertEqual(len(models), 5)
         self.assertGreaterEqual(int(art.guarantee), 4)  # everything else still holds
 
     def test_budget_device_constrains_to_a_smaller_model(self):


### PR DESCRIPTION
## Summary
Found via a full-suite audit of the current release tip (\`origin/release/0.6.3-generic-capabilities\`, commit d6a6a585) -- \`mixle/tests/create_test.py::CreateTest::test_uq_degrades_gracefully_when_unflattenable\` was FAILING on a clean checkout, not caused by this PR.

- The test asserted \`create()\`'s UQ result is \`None\` for a structured (mixed categorical+numeric) fit, on the premise that \`HeterogeneousBayesianNetwork\` wasn't yet Laplace-flattenable.
- That gap was closed by \`bn-laplace-flatten\` (and its restore fix, #50) -- the fit now returns a real \`parameter_posterior\`, so the old assertion (\`assertIsNone(art.uq)\`) fails.
- Updated the test to assert the new, better behavior instead of re-asserting the closed capability gap: a real Laplace posterior attaches, with the expected \`kind\`/\`method\`, and \`sample_models()\` works.

## Test plan
- [x] \`mixle/tests/create_test.py\` -- 6/6 passed (was 5 passed, 1 failed before this fix).
- [x] Targeted regression: \`pytest -k "create or blackbox or bn_laplace or bayesian_network"\` -- 42 passed, 2 skipped (expected compiled-kernel skips), 0 failed.
- [x] \`ruff check\` / \`ruff format --check\` clean.