### PR TITLE
hardening: 4 real bugs found + fixed, positional-constructor cleanup

### DIFF
--- a/mixle/inference/explain.py
+++ b/mixle/inference/explain.py
@@ -236,7 +236,9 @@ def diagnose(
     """
     bg = list(background) if background is not None else list(cases)
     if not bg or not cases:
-        return FaultReport("", [], "", {"n_cases": len(cases), "n_background": len(bg)})
+        return FaultReport(
+            dominant="", evidence=[], suggested_fix="", receipt={"n_cases": len(cases), "n_background": len(bg)}
+        )
 
     bg_explanations = [explain(model, x) for x in bg]
     names = sorted({name for ex in bg_explanations for name, _ in ex.parts})

--- a/mixle/reason/anchor_harness.py
+++ b/mixle/reason/anchor_harness.py
@@ -41,6 +41,7 @@ from mixle.reason.belief_walk import HopTransport, belief_walk, coverage_by_hop_
 from mixle.reason.cycle_consistency import cycle_inconsistency, fit_cycle_transport
 from mixle.reason.modality import ModalityGraph, ModalityView
 from mixle.reason.task_projection import TaskReadout, read_out, task_sufficient_projection
+from mixle.reason.transport_edge import verify_edge_transport
 from mixle.stats.latent.gaussian_mixture import GaussianMixtureDistribution
 from mixle.stats.univariate.continuous.gaussian import GaussianDistribution
 from mixle.stats.univariate.discrete.categorical import CategoricalDistribution
@@ -119,18 +120,27 @@ def run_anchor_harness(*, n_train: int = 2000, n_test: int = 200, seed: int = 0)
 
     hop1_fit = fit_cycle_transport(gravity_train, density_train, k=1, seed=seed, max_its=25)
     hop2_fit = fit_cycle_transport(density_train, grade_train, k=1, seed=seed + 1, max_its=25)
-    hops = [
-        HopTransport("gravity_to_density", hop1_fit, premise_passed=True),
-        HopTransport("density_to_grade", hop2_fit, premise_passed=True),
-    ]
 
-    # --- F3: belief walk composing the 2 verified hops, honest compounding ---
+    # held-out pairs for the F2-a premise check -- generated BEFORE the hops are composed, since
+    # `premise_passed` must reflect a computed verdict, never an assumed one (F2-a's own contract).
     rng_test = np.random.RandomState(seed + 100)
     gravity_test = rng_test.normal(0, 1.0, size=(n_test, 1))
     density_true = _step(gravity_test, _GRAVITY_TO_DENSITY, rng_test)
     grade_true = _step(density_true, _DENSITY_TO_GRADE, rng_test)
     true_by_hop = {1: density_true, 2: grade_true}
 
+    # verify_edge_transport(sampler, x_test, y_test) checks coverage of the MODELED variable (x_test)
+    # from draws conditioned on the OBSERVED one (y_test, fed to sample_given) -- each hop here models
+    # its `target` conditioned on `given` (see fit_cycle_transport(given, target) above), so x_test is
+    # each hop's target and y_test is what it conditions on, not the other way around.
+    hop1_verdict = verify_edge_transport("gravity_to_density", hop1_fit.sampler(seed=seed), density_true, gravity_test)
+    hop2_verdict = verify_edge_transport("density_to_grade", hop2_fit.sampler(seed=seed + 1), grade_true, density_true)
+    hops = [
+        HopTransport("gravity_to_density", hop1_fit, premise_passed=hop1_verdict.usable),
+        HopTransport("density_to_grade", hop2_fit, premise_passed=hop2_verdict.usable),
+    ]
+
+    # --- F3: belief walk composing the 2 verified hops, honest compounding ---
     coverage_by_hop = coverage_by_hop_count(hops, gravity_test, true_by_hop, alpha=0.1, n_draws=150, seed=seed)
 
     walk_means = np.zeros(n_test)
@@ -158,7 +168,7 @@ def run_anchor_harness(*, n_train: int = 2000, n_test: int = 200, seed: int = 0)
     grade_tier_means = np.array([[-2.0], [-0.6], [0.6], [2.0]])  # low / lowmid / midhigh / high grade tiers
     grade_tier_cov = np.stack([np.array([[0.35]]) for _ in range(4)])
     grade_tier_w = np.full(4, 0.25)
-    grade_belief = GaussianMixtureDistribution(grade_tier_means, grade_tier_cov, grade_tier_w)
+    grade_belief = GaussianMixtureDistribution(mu=grade_tier_means, sig2=grade_tier_cov, w=grade_tier_w)
 
     driller_task = TaskReadout("exact_tier", lambda mean: round(float(mean[0]), 1))
     scout_task = TaskReadout("worth_drilling", lambda mean: bool(mean[0] > 0.0))

--- a/mixle/reason/cycle_consistency.py
+++ b/mixle/reason/cycle_consistency.py
@@ -25,6 +25,14 @@ import numpy as np
 from mixle.inference import optimize
 
 
+def _as_paired_batch(a: np.ndarray) -> np.ndarray:
+    """``(n,)`` -> ``(n, 1)`` (n scalar observations, NOT one n-dimensional row -- unlike
+    ``np.atleast_2d``, which assumes the opposite and would silently misinterpret a batch of scalar
+    samples as a single high-dimensional one); ``(n, d)`` passes through unchanged."""
+    a = np.asarray(a, dtype=np.float64)
+    return a.reshape(-1, 1) if a.ndim == 1 else a
+
+
 def fit_cycle_transport(
     given: np.ndarray,
     target: np.ndarray,
@@ -50,8 +58,12 @@ def fit_cycle_transport(
 
     from mixle.models.mixture_density import NeuralConditionalDensity, build_mdn
 
-    given = np.atleast_2d(np.asarray(given, dtype=np.float64))
-    target = np.atleast_2d(np.asarray(target, dtype=np.float64))
+    given = _as_paired_batch(given)
+    target = _as_paired_batch(target)
+    if len(given) != len(target):
+        raise ValueError(
+            f"given and target must have the same number of paired observations, got {len(given)} vs {len(target)}"
+        )
     torch.manual_seed(seed)  # optimize()'s rng seeds data order only; module init needs its own seed
     module = build_mdn(x_dim=given.shape[1], y_dim=target.shape[1], k=k, hidden=hidden, layers=layers)
     leaf = NeuralConditionalDensity(module, m_steps=m_steps, lr=lr)

--- a/mixle/task/orchestrate.py
+++ b/mixle/task/orchestrate.py
@@ -23,6 +23,7 @@ from typing import Any, Protocol, runtime_checkable
 from mixle.task.replay import ExecutionTrace, TraceStep
 
 _STOP_TOOLS = (None, "__stop__", "STOP")
+_NO_TOOL_KEY = object()  # distinguishes an EXPLICIT tool=None from a schema with no "tool" key at all
 
 
 @runtime_checkable
@@ -44,7 +45,24 @@ class OrchestrationResult:
 
 
 def _is_stop(step: dict[str, Any] | None) -> bool:
-    return step is None or step.get("tool") in _STOP_TOOLS
+    """A step is STOP only when it is ``None`` or has an EXPLICIT ``tool`` key set to a stop value.
+    A step whose schema has no ``"tool"`` key at all (e.g. EXPLORE-a's ``{"type": ..., "cell": ...}``)
+    is a real action, not a stop -- ``dict.get("tool")`` alone can't tell those apart, since a missing
+    key and an explicit ``tool=None`` both return ``None``."""
+    return step is None or step.get("tool", _NO_TOOL_KEY) in _STOP_TOOLS
+
+
+def _tool_name(step: dict[str, Any]) -> str:
+    """The identifier :class:`~mixle.task.replay.TraceStep` records for this step: ``"tool"`` when the
+    schema has one (the common case), else ``"type"`` (EXPLORE-a's action-kind field) -- rather than a
+    bare ``step["tool"]`` KeyError far from the real cause when a world uses neither."""
+    if "tool" in step:
+        return step["tool"]
+    if "type" in step:
+        return step["type"]
+    raise KeyError(
+        f"orchestrate() cannot name this step for the trace: it has neither a 'tool' nor a 'type' key ({step!r})"
+    )
 
 
 def orchestrate(
@@ -79,7 +97,7 @@ def orchestrate(
         except Exception as exc:
             # atypical/failed step: record the failure, then give the plan model one chance to re-plan
             # around it before giving up -- the trace shows what actually happened, not just the outcome
-            trace.steps.append(TraceStep(tool=step["tool"], args=step.get("args", {}), result={"error": str(exc)}))
+            trace.steps.append(TraceStep(tool=_tool_name(step), args=step.get("args", {}), result={"error": str(exc)}))
             retry_history = [*history, {**step, "error": str(exc)}]
             retry_step = plan_model(question, retry_history)
             if _is_stop(retry_step):
@@ -90,14 +108,14 @@ def orchestrate(
             except Exception as retry_exc:
                 trace.steps.append(
                     TraceStep(
-                        tool=retry_step["tool"], args=retry_step.get("args", {}), result={"error": str(retry_exc)}
+                        tool=_tool_name(retry_step), args=retry_step.get("args", {}), result={"error": str(retry_exc)}
                     )
                 )
                 stopped_reason = "replan_failed"
                 break
             step = retry_step
 
-        trace.steps.append(TraceStep(tool=step["tool"], args=step.get("args", {}), result=observation))
+        trace.steps.append(TraceStep(tool=_tool_name(step), args=step.get("args", {}), result=observation))
         history.append({**step, "result": observation})
     else:
         stopped_reason = "budget_exhausted"

--- a/mixle/task/router.py
+++ b/mixle/task/router.py
@@ -210,7 +210,14 @@ def resolve_from_harvest(
     inputs, labels = router.harvested()
     n_harvested = len(inputs)
     if n_harvested < 8:
-        return HarvestResolveResult(False, n_harvested, 1.0, 1.0, 0.0, 0.0)
+        return HarvestResolveResult(
+            accepted=False,
+            n_harvested=n_harvested,
+            escalation_before=1.0,
+            escalation_after=1.0,
+            escalation_drop=0.0,
+            agreement=0.0,
+        )
 
     kind = "text" if isinstance(inputs[0], str) else "record"
     str_labels = [str(y) for y in labels]
@@ -222,7 +229,14 @@ def resolve_from_harvest(
     train_in, train_lab = [inputs[i] for i in train_idx], [str_labels[i] for i in train_idx]
     cal_in, cal_lab = [inputs[i] for i in cal_idx], [str_labels[i] for i in cal_idx]
     if len(train_in) < 4 or len(cal_in) < 2:
-        return HarvestResolveResult(False, n_harvested, 1.0, 1.0, 0.0, 0.0)
+        return HarvestResolveResult(
+            accepted=False,
+            n_harvested=n_harvested,
+            escalation_before=1.0,
+            escalation_after=1.0,
+            escalation_drop=0.0,
+            agreement=0.0,
+        )
 
     kw = dict(distill_kw or {})
     kw.setdefault("seed", seed)
@@ -235,9 +249,29 @@ def resolve_from_harvest(
     drop = 1.0 - esc_after
 
     if drop < min_drop:
-        return HarvestResolveResult(False, n_harvested, 1.0, float(esc_after), float(drop), float(agree))
+        return HarvestResolveResult(
+            accepted=False,
+            n_harvested=n_harvested,
+            escalation_before=1.0,
+            escalation_after=float(esc_after),
+            escalation_drop=float(drop),
+            agreement=float(agree),
+        )
 
     new_tiers = list(router.tiers[:-1]) + [(name, cal, float(cost_per_request)), router.tiers[-1]]
+    # the input router's harvest is now consumed into the new tier -- clear it (mirrors
+    # Solution.improve()'s escalated_texts/labels.clear() after promoting) so a caller that keeps
+    # using `router` for observability, or calls resolve_from_harvest again after more traffic, does
+    # not double-count these same escalations as still-unresolved.
+    router.stats.harvested_inputs.clear()
+    router.stats.harvested_labels.clear()
     return HarvestResolveResult(
-        True, n_harvested, 1.0, float(esc_after), float(drop), float(agree), Router(new_tiers), name
+        accepted=True,
+        n_harvested=n_harvested,
+        escalation_before=1.0,
+        escalation_after=float(esc_after),
+        escalation_drop=float(drop),
+        agreement=float(agree),
+        router=Router(new_tiers),
+        tier_name=name,
     )

--- a/mixle/tests/anchor_harness_test.py
+++ b/mixle/tests/anchor_harness_test.py
@@ -58,6 +58,13 @@ class AnchorHarnessTest(unittest.TestCase):
         self.assertEqual(r1.abstained_site_ids, r2.abstained_site_ids)
         self.assertEqual(r1.walk_mae, r2.walk_mae)
 
+    def test_premise_check_is_real_not_assumed(self):
+        """CARD F2-a's contract: a hop's premise_passed must be a COMPUTED verdict, never hardcoded
+        True. Too little training data to calibrate must make the harness refuse to compose the hops
+        (belief_walk's own guard), not silently produce a full report anyway."""
+        with self.assertRaisesRegex(ValueError, "did not pass their F2 premise check"):
+            run_anchor_harness(n_train=8, n_test=20, seed=0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/mixle/tests/cycle_consistency_test.py
+++ b/mixle/tests/cycle_consistency_test.py
@@ -101,6 +101,31 @@ class CycleAbstentionBeatsMarginalConfidenceTest(unittest.TestCase):
         self.assertLess(se_cycle, float(_ERRORS.mean()) * 0.5)
 
 
+@pytest.mark.skipif(not _HAS_TORCH, reason="torch not installed")
+class FitCycleTransportShapeTest(unittest.TestCase):
+    """fit_cycle_transport must treat a 1D array as N scalar observations (n, 1), never as one
+    n-dimensional row -- np.atleast_2d does the opposite, which silently misinterprets the data
+    (this is the natural call shape for a scalar-valued modality reading, e.g. `given = rng.normal(size=n)`)."""
+
+    def test_1d_given_and_target_fit_without_crashing_and_sample_correctly(self):
+        rng = np.random.RandomState(0)
+        n = 200
+        given = rng.normal(size=n)
+        target = 2 * given + 0.1 * rng.normal(size=n)
+
+        fit = fit_cycle_transport(given, target, max_its=5, m_steps=5)
+        sampler = fit.sampler(seed=0)
+        draws = np.asarray(sampler.sample_given_batch(np.array([[0.5]])))
+        self.assertEqual(draws.shape, (1, 1))
+
+    def test_mismatched_1d_lengths_raise_a_clear_error_not_an_index_error(self):
+        rng = np.random.RandomState(0)
+        given = rng.normal(size=200)
+        target = rng.normal(size=150)  # deliberately mismatched
+        with self.assertRaisesRegex(ValueError, "same number of paired observations"):
+            fit_cycle_transport(given, target, max_its=2, m_steps=2)
+
+
 @pytest.mark.skipif(_ERRORS is None, reason="torch not installed")
 class CycleConsistencyGoNoGoTest(unittest.TestCase):
     def test_go_no_go_report(self):

--- a/mixle/tests/router_harvest_test.py
+++ b/mixle/tests/router_harvest_test.py
@@ -79,14 +79,30 @@ class HarvestResolveTest(unittest.TestCase):
         self.assertEqual(result.n_harvested, 0)
 
     def test_determinism_given_seed(self):
-        router, _tier0 = _build_router(seed=0)
-        router.serve(_make(400, [FAMILY_A, FAMILY_B], random.Random(1)))
+        # two INDEPENDENT routers, identically harvested -- resolve_from_harvest clears the input
+        # router's harvest on success (so a repeat call on the SAME router legitimately sees less
+        # data), so determinism is checked across two routers with the same harvested state instead.
+        router1, _tier0a = _build_router(seed=0)
+        router1.serve(_make(400, [FAMILY_A, FAMILY_B], random.Random(1)))
+        router2, _tier0b = _build_router(seed=0)
+        router2.serve(_make(400, [FAMILY_A, FAMILY_B], random.Random(1)))
 
-        r1 = resolve_from_harvest(router, cost_per_request=0.001, seed=0)
-        r2 = resolve_from_harvest(router, cost_per_request=0.001, seed=0)
+        r1 = resolve_from_harvest(router1, cost_per_request=0.001, seed=0)
+        r2 = resolve_from_harvest(router2, cost_per_request=0.001, seed=0)
         self.assertEqual(r1.accepted, r2.accepted)
         self.assertEqual(r1.escalation_after, r2.escalation_after)
         self.assertEqual(r1.agreement, r2.agreement)
+
+    def test_successful_resolve_clears_the_input_routers_harvest(self):
+        router, _tier0 = _build_router(seed=0)
+        router.serve(_make(400, [FAMILY_A, FAMILY_B], random.Random(1)))
+        self.assertGreater(len(router.harvested()[0]), 0)
+
+        result = resolve_from_harvest(router, cost_per_request=0.001, seed=0)
+        self.assertTrue(result.accepted)
+        harvested_inputs, harvested_labels = router.harvested()
+        self.assertEqual(harvested_inputs, [])
+        self.assertEqual(harvested_labels, [])
 
     def test_inserted_tier_sits_just_before_the_frontier(self):
         router, _tier0 = _build_router(seed=0)


### PR DESCRIPTION
## Summary

Audited recently-merged code for real bugs and for dataclasses constructed with several positional
arguments instead of keywords (fragile -- silent breakage on field reorder, not self-documenting).

**Real bugs fixed:**

- **`mixle/reason/cycle_consistency.py`** -- `fit_cycle_transport` used `np.atleast_2d` on
  `given`/`target`, which turns a 1D `(n,)` array into `(1, n)` (one n-dimensional row) instead of
  `(n, 1)` (N scalar observations) -- the natural call shape for a scalar-valued modality reading.
  Silently misinterpreted, crashing far from the mistake or raising a confusing `IndexError` on
  mismatched lengths. Fixed with a correct reshape helper + an explicit length-mismatch check.
- **`mixle/task/orchestrate.py`** -- `_is_stop(step)` used `step.get("tool") in _STOP_TOOLS`
  (which includes `None`), but a missing `"tool"` key *also* returns `None` from `.get()`. Any action
  schema without a `"tool"` key (e.g. EXPLORE-a's `{"type": ..., "cell": ...}`, which the module's own
  docstring names as supported) was silently treated as an explicit STOP -- zero steps ever executed,
  reported as a legitimate `stopped_reason="plan_stop"`. Fixed with an explicit sentinel. This
  surfaced a second bug one level deeper (trace recording did `step["tool"]` unconditionally) -- added
  a `_tool_name()` helper with a clear error instead of a bare `KeyError`.
- **`mixle/reason/anchor_harness.py`** (F7, the flagship harness) -- both hops were constructed with
  `premise_passed=True` **hardcoded**, never computed, despite the module's own docstring claiming the
  premise gates composition. Wired in the real `verify_edge_transport` check. Caught and fixed a
  second bug while wiring it in: I initially passed `x_test`/`y_test` swapped, producing ~70% coverage
  against a 90% target -- caught by checking actual numbers, not just "did it run." New regression
  test asserts too-little-data correctly makes the harness *refuse* (raise) rather than produce a
  full report anyway.

**Style (positional -> keyword constructors):** `router.py` (4 sites, `HarvestResolveResult`),
`inference/explain.py` (1 site, `FaultReport`), `anchor_harness.py` (1 site,
`GaussianMixtureDistribution`). A mechanical AST scan found ~260 more such call sites across the
wider, pre-existing codebase -- reported separately, not touched here (much larger, separate-scope
change).

**Also fixed:** `RouterStats.harvested_inputs`/`harvested_labels` only ever grew --
`resolve_from_harvest` read them but never cleared them, unlike `Solution.improve()`'s established
precedent. A long-running `Router`, or a second `resolve_from_harvest` call, would re-count/re-train
on the same already-consumed escalations forever and leak memory. Fixed to clear on success; updated
the affected determinism test and added a dedicated clearing test.

## Test plan

- [x] `anchor_harness_test.py` (8, was 7) + `belief_walk_test.py` + `transport_edge_test.py` +
      `cycle_consistency_test.py` (8, was 6) + `task_orchestrate_test.py` + `explore_world_test.py` +
      `router_harvest_test.py` (6, was 4) + `task_router_test.py` + `diagnose_test.py` -- **53 passed
      total**, no regressions.
- [x] `ruff check` + `ruff format --check` clean on all 8 changed files.