### PR TITLE
fix: silence spurious RuntimeWarning in EM's dll computation

### DIFF
--- a/mixle/inference/estimation.py
+++ b/mixle/inference/estimation.py
@@ -392,7 +392,12 @@ def _em_loop(
         nxt = step_fn(enc_data, estimator, model)
         _, ll = ll_fn(enc_data, nxt)
         vll = ll_fn(enc_vdata, nxt)[1] if has_v else ll
-        dll = ll - old_ll
+        # ll and old_ll can both be -inf (e.g. two successive collapsed/singular-covariance steps);
+        # -inf - -inf is nan by IEEE 754, which is the semantics every downstream nan-comparison below
+        # already relies on (nan >= 0 and nan < delta are both False, so a nan dll is inert) -- silence
+        # the resulting RuntimeWarning rather than changing behavior.
+        with np.errstate(invalid="ignore"):
+            dll = ll - old_ll
 
         # A non-finite step (e.g. a collapsed/singular covariance producing a NaN/-inf
         # log-likelihood) is never an improvement: never accept it, and do not let it


### PR DESCRIPTION
## Summary
- An estimation/optimization audit of `mixle/inference` (estimation.py, em.py, gradient_fit.py, blackbox.py, objectives.py, cross_validation.py, model_comparison.py) and `mixle/doe` (optimizer.py, trust_region.py, bayesopt.py, optimal.py) found no active correctness bugs — convergence criteria, numerical stability guards, and monotonicity handling are all sound.
- One cosmetic issue confirmed: `mixle/inference/estimation.py:395`'s `dll = ll - old_ll` can compute `-inf - -inf = nan` after two successive collapsed/singular-covariance EM steps, firing a `RuntimeWarning: invalid value encountered in scalar subtract` on every full-suite test run. Traced every downstream use of `dll` (accept gate, convergence test, logging) — a nan `dll` is already inert everywhere (`nan >= 0` and `nan < delta` are both `False`), so this was never a correctness bug, just warning noise. Silenced with `np.errstate(invalid="ignore")` around the one subtraction rather than changing any semantics.

## Test plan
- [x] `mixle/tests/em_nonfinite_guard_test.py mixle/tests/em_strategies_test.py mixle/tests/estimation_structure_default_test.py mixle/tests/coverage_estimation_test.py` run with `-W error::RuntimeWarning` (forces any RuntimeWarning to fail the test) — 38 passed, confirming the warning is gone with no behavior change.
- [x] `ruff check` / `ruff format --check` — clean.