### PR TITLE
inference/receipt: align Receipt with mixle-knowledge (workstream H3)

### DIFF
--- a/mixle/inference/receipt.py
+++ b/mixle/inference/receipt.py
@@ -54,6 +54,25 @@ class Receipt:
             "provenance": self.provenance,
         }
 
+    def to_knowledge_dict(self, *, id: str, project_id: str, task: str) -> dict[str, Any]:  # noqa: A002
+        """A plain dict shaped like ``mixle_knowledge.contracts.AnswerReceipt`` (id/project_id/task/
+        produced_by/answer/ledger/trace/calibration/provenance) -- workstream H3's receipt, aligned
+        with the mixle-knowledge receipt contracts per the plan. Distinct from
+        ``mixle_knowledge.contracts.ArtifactReceipt``, which certifies a trained model/artifact, not
+        one served answer -- this is the per-answer evidence trail an offline consumer re-verifies
+        (recompute the ledger, replay the trace, resolve the citations).
+
+        Stays a plain dict on purpose: mixle core carries no dependency on mixle-knowledge (platform
+        contract packages depend on core, never the other way); constructing the validated pydantic
+        object (``AnswerReceipt(**receipt.to_knowledge_dict(...))``) is the receiving side's job.
+        """
+        return {
+            "id": id,
+            "project_id": project_id,
+            "task": task,
+            **self.to_json(),
+        }
+
 
 @dataclass
 class VerificationReport:

--- a/mixle/system.py
+++ b/mixle/system.py
@@ -75,9 +75,11 @@ class SystemConfig:
 class Query:
     """The typed problem contract for :meth:`System.answer`.
 
-    Field names align with the ``mixle-knowledge`` ``ContextPacket``/manifest contracts (``task``,
-    ``expected_output`` <-> ``expected_output_schema``, ``scope``) so a ``Query`` can be built directly
-    from one when a caller already holds a manifest.
+    ``task``/``expected_output`` align with the ``mixle-knowledge`` ``ContextPacket`` contract's
+    ``task``/``expected_output_schema`` fields (see :meth:`from_knowledge_dict`), so a caller who
+    already holds an assembled packet does not hand-build a ``Query`` field by field. ``scope`` has
+    no ``ContextPacket`` counterpart (that contract carries no such key) and stays a ``Query``-only
+    knob, not an invented alignment.
     """
 
     text: str
@@ -85,6 +87,25 @@ class Query:
     fingerprint: Any = None
     expected_output: dict[str, Any] | None = None
     scope: str = "local"
+
+    @classmethod
+    def from_knowledge_dict(cls, packet: dict[str, Any], *, scope: str = "local") -> Query:
+        """Build a ``Query`` directly from a mixle-knowledge-shaped ``ContextPacket`` dict -- the
+        exact dict :meth:`mixle.substrate.context.ContextPacket.to_knowledge_dict` emits, or the same
+        shape validated through ``mixle_knowledge.contracts.ContextPacket`` (workstream E1).
+
+        ``text`` comes from ``payload["rendered"]`` (the assembled context string a receiver actually
+        consumes); ``task``/``expected_output`` map directly from the packet's ``task``/
+        ``expected_output_schema``. ``scope`` is not a ``ContextPacket`` field, so it is passed
+        through as given rather than guessed from the packet.
+        """
+        payload = packet.get("payload") or {}
+        return cls(
+            text=str(payload.get("rendered", "")),
+            task=str(packet.get("task", "")),
+            expected_output=packet.get("expected_output_schema") or None,
+            scope=scope,
+        )
 
 
 def _complete(teacher: LLM | Callable[..., str], prompt: str) -> str:

--- a/mixle/tests/receipt_test.py
+++ b/mixle/tests/receipt_test.py
@@ -98,5 +98,53 @@ class ReceiptVerifyTest(unittest.TestCase):
         self.assertIn("steps", blob["trace"])
 
 
+class KnowledgeReceiptTransferTest(unittest.TestCase):
+    """workstream H3: a Receipt -> a mixle-knowledge-shaped AnswerReceipt dict.
+
+    mixle core has no dependency on the mixle-knowledge package (platform contracts depend on core,
+    not the other way), so ``to_knowledge_dict`` produces a plain dict field-for-field matching
+    ``mixle_knowledge.contracts.AnswerReceipt`` rather than importing it; the exact field set is
+    pinned here as a regression guard against silent contract drift.
+    """
+
+    # mirrors mixle_knowledge.contracts.AnswerReceipt's fields exactly (created_at is defaulted
+    # there, so it is intentionally absent from this dict -- everything else must round-trip).
+    _KNOWLEDGE_ANSWER_RECEIPT_FIELDS = {
+        "id",
+        "project_id",
+        "task",
+        "answer",
+        "produced_by",
+        "ledger",
+        "trace",
+        "calibration",
+        "provenance",
+    }
+
+    def test_dict_shape_matches_the_knowledge_contract_field_for_field(self):
+        receipt = Receipt(
+            answer="a",
+            produced_by="student-v1",
+            ledger=_build_ledger(),
+            trace=_build_trace(),
+            calibration={"alpha": 0.1, "qhat": 0.83},
+            provenance={"source_id": "corpus-42"},
+        )
+        d = receipt.to_knowledge_dict(id="rcpt1", project_id="proj1", task="classify")
+        self.assertEqual(set(d.keys()), self._KNOWLEDGE_ANSWER_RECEIPT_FIELDS)
+        self.assertEqual(d["task"], "classify")
+        self.assertEqual(d["answer"], "a")
+        self.assertIn("parts", d["ledger"])
+        self.assertIn("steps", d["trace"])
+
+    def test_thin_shell_receipt_still_produces_a_valid_shape(self):
+        receipt = Receipt(answer="hi", produced_by="teacher")
+        d = receipt.to_knowledge_dict(id="rcpt2", project_id="proj1", task="chat")
+        self.assertEqual(set(d.keys()), self._KNOWLEDGE_ANSWER_RECEIPT_FIELDS)
+        self.assertIsNone(d["ledger"])
+        self.assertIsNone(d["trace"])
+        self.assertIsNone(d["calibration"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/mixle/tests/system_test.py
+++ b/mixle/tests/system_test.py
@@ -4,12 +4,41 @@ import builtins
 import unittest
 from unittest.mock import patch
 
+from mixle.substrate.context import ContextBudget, assemble_context
 from mixle.substrate.core import Substrate, SubstrateItem
+from mixle.substrate.ingest import ingest_documents
 from mixle.system import Query, System, SystemConfig
 
 
 def _fake_teacher(prompt: str) -> str:
     return f"answer to: {prompt}"
+
+
+class QueryKnowledgeAlignmentTest(unittest.TestCase):
+    """Query.from_knowledge_dict is the OTHER half of the mixle-knowledge alignment claim in Query's
+    own docstring: build a Query directly from a real assembled ContextPacket (workstream E1's own
+    to_knowledge_dict output), not just a claim that the field names happen to match."""
+
+    def test_query_built_from_a_real_assembled_context_packet(self):
+        substrate = Substrate()
+        ingest_documents(substrate, ["cats are mammals that purr"], source="animal facts")
+        pkt = assemble_context(substrate, "mammals", budget=ContextBudget(max_chars=200))
+        d = pkt.to_knowledge_dict(id="pkt1", project_id="proj1", target_kind="frontier_llm")
+
+        query = Query.from_knowledge_dict(d, scope="project")
+        self.assertEqual(query.task, "mammals")
+        self.assertEqual(query.text, pkt.render())
+        self.assertEqual(query.scope, "project")
+
+    def test_expected_output_schema_maps_to_expected_output(self):
+        d = {"task": "extract", "payload": {"rendered": "hi"}, "expected_output_schema": {"type": "object"}}
+        query = Query.from_knowledge_dict(d)
+        self.assertEqual(query.expected_output, {"type": "object"})
+
+    def test_missing_expected_output_schema_stays_none(self):
+        d = {"task": "chat", "payload": {"rendered": "hi"}}
+        query = Query.from_knowledge_dict(d)
+        self.assertIsNone(query.expected_output)
 
 
 class SystemAnswerTest(unittest.TestCase):


### PR DESCRIPTION
## Summary
Two gaps found during a full-plan audit -- both are cases where the plan explicitly required mixle-knowledge alignment, but it was never actually built/verified (unlike E1's ContextPacket, which does this correctly):

**1. H3 Receipt <-> mixle-knowledge (the plan: "aligned with the mixle-knowledge receipt contracts")**
- Adds \`Receipt.to_knowledge_dict(id=, project_id=, task=)\`: a plain dict shaped like a NEW mixle-knowledge contract, \`AnswerReceipt\` (companion PR in mixle-knowledge: gmboquet/mixle-knowledge#1). Distinct from \`ArtifactReceipt\` (certifies a trained model/artifact, not one served answer) -- \`AnswerReceipt\` is the per-answer evidence trail an offline consumer re-verifies.
- Stays a plain dict on purpose, mirroring \`ContextPacket.to_knowledge_dict()\`'s established pattern: mixle core carries no dependency on mixle-knowledge.

**2. SYS-a Query <-> mixle-knowledge (an unverified claim, not a built/tested one)**
- \`Query\`'s own docstring already claimed field-name alignment with \`ContextPacket\` (\`task\`, \`expected_output\` <-> \`expected_output_schema\`) but nothing ever built a \`Query\` from a real packet or tested the claim.
- Adds \`Query.from_knowledge_dict(packet, scope=)\`: builds a \`Query\` from the exact dict \`ContextPacket.to_knowledge_dict()\` emits. Also corrects the docstring -- \`ContextPacket\` has no \`scope\` field, so that part of the original claim was dropped rather than left as an overclaim.

## Test plan
- [x] \`mixle/tests/receipt_test.py\` (\`KnowledgeReceiptTransferTest\`, 2 new): emitted dict's field set matches \`AnswerReceipt\` exactly; a thin-shell receipt still produces a valid shape.
- [x] \`mixle/tests/system_test.py\` (\`QueryKnowledgeAlignmentTest\`, 3 new): a \`Query\` built from a REAL assembled \`ContextPacket\` (substrate -> \`assemble_context\` -> \`to_knowledge_dict\` -> \`Query\`) carries the right task/text/scope; \`expected_output_schema\` maps correctly; a missing schema stays \`None\`.
- [x] Targeted regression: \`pytest mixle/tests -k "system or context or receipt"\` -- 81 passed, 2 skipped (expected compiled-kernel skips), 0 failed.
- [x] \`ruff check\` / \`ruff format --check\` clean.
- [x] Companion mixle-knowledge PR (gmboquet/mixle-knowledge#1) adds \`AnswerReceipt\` + validation test -- the other half of gap 1's contract.