### PR TITLE
models: PINNRegression -- a physics-informed neural network leaf

### DIFF
--- a/mixle/models/__init__.py
+++ b/mixle/models/__init__.py
@@ -92,6 +92,7 @@ from mixle.models.partially_observable_markov_decision_process import (
     PartiallyObservableMarkovDecisionProcessModel,
     baum_welch_pomdp,
 )
+from mixle.models.pinn_leaf import PINNRegression, PINNRegressionEstimator
 from mixle.models.random_forest import (
     RandomForestConditional,
     RandomForestEstimator,
@@ -171,6 +172,8 @@ __all__ = [
     "PartiallyObservableMarkovDecisionProcessModel",
     "PartiallyDirectedGraph",
     "PCFGParseNode",
+    "PINNRegression",
+    "PINNRegressionEstimator",
     "PoissonRegressionNeuralNetwork",
     "RandomForestConditional",
     "RandomForestEstimator",

--- a/mixle/models/pinn_leaf.py
+++ b/mixle/models/pinn_leaf.py
@@ -1,0 +1,265 @@
+"""``PINNRegression`` -- a physics-informed neural network as a mixle conditional-density leaf.
+
+A :class:`~mixle.models.neural_leaf.NeuralGaussian` fits ``p(y | x) = N(y; module(x), noise^2 I)`` from labeled
+``(x, y)`` pairs alone. ``PINNRegression`` is the same leaf plus a **residual penalty**: at every M-step it also
+draws unlabeled collocation points from a box domain, evaluates a caller-supplied PDE/ODE residual on the
+module's output via autograd, and adds ``residual_weight * mean(residual**2)`` to the training loss -- the
+standard physics-informed-neural-network (PINN) loss, ``L = L_data + w * L_physics``.
+
+This makes the labeled-data term double as boundary/initial conditions (or scattered measurements) and the
+residual term enforce the governing equation *between* them, so the fitted module honors the physics even where
+it never saw labeled data -- the whole point of a PINN over plain regression. With zero labeled data
+(``suff_stat`` empty) the leaf still trains: pure PDE-residual fitting, a boundary-value/collocation solver.
+
+The reported density (:meth:`log_density`/:meth:`seq_log_density`, inherited unchanged from ``NeuralGaussian``)
+is the data-fit Gaussian NLL only -- the leaf never claims the residual penalty as part of its probability
+model. :func:`mixle.inference.planning.certify` already caps a bare gradient-fit leaf like this at
+``STATIONARY`` (no global-optimum claim), so ``penalized=`` adds nothing for a standalone fit; pass
+``certify(structure, penalized="PINN residual")`` when this leaf is composed as one block of a larger
+structure that otherwise contains closed-form EM blocks, so those blocks are honestly downgraded too
+(mirroring how :func:`mixle.ppl.core.ode_residual`'s soft-constraint fits are certified).
+
+Requires torch. ``residual_fn(module, collocation_points) -> tensor`` computes the residual using
+``torch.autograd.grad`` on the module's output w.r.t. ``collocation_points`` (which arrive with
+``requires_grad_(True)`` already set) -- ordinary PINN practice, e.g. for a 1-D heat equation
+``u_t = alpha * u_xx`` over inputs ``(t, x)``::
+
+    def heat_residual(module, coll):
+        u = module(coll)
+        grads = torch.autograd.grad(u, coll, grad_outputs=torch.ones_like(u), create_graph=True)[0]
+        u_t, u_x = grads[:, 0:1], grads[:, 1:2]
+        u_xx = torch.autograd.grad(u_x, coll, grad_outputs=torch.ones_like(u_x), create_graph=True)[0][:, 1:2]
+        return u_t - ALPHA * u_xx
+
+    leaf = PINNRegression(make_mlp(2, [32, 32], 1), heat_residual, domain=([0.0, -1.0], [1.0, 1.0]))
+"""
+
+from __future__ import annotations
+
+import base64
+import pickle
+from typing import Any
+
+import numpy as np
+
+from mixle.models._neural_serial import decode_module, encode_module
+from mixle.models.neural_leaf import (
+    NeuralGaussian,
+    NeuralGaussianAccumulatorFactory,
+    NeuralGaussianEncoder,
+    NeuralGaussianEstimator,
+    _resolve_device,
+    _torch,
+)
+
+
+def _encode_residual_fn(fn: Any) -> str:
+    """Base64-encode a residual function via pickle -- works for any module-level (non-lambda) callable."""
+    try:
+        return base64.b64encode(pickle.dumps(fn)).decode("ascii")
+    except Exception as e:
+        raise ValueError(
+            "PINNRegression.to_dict() needs residual_fn to be pickle-able (a module-level function, not a "
+            "lambda or closure); construct the leaf from a named function if you need serialization."
+        ) from e
+
+
+def _decode_residual_fn(payload: str) -> Any:
+    return pickle.loads(base64.b64decode(payload.encode("ascii")))
+
+
+class PINNRegression(NeuralGaussian):
+    """``NeuralGaussian`` plus a PDE/ODE-residual penalty evaluated on sampled collocation points.
+
+    ``domain`` is a ``(low, high)`` pair of per-dimension box bounds for collocation sampling; ``residual_fn``
+    computes the physics residual (see module docstring); ``residual_weight`` scales the penalty relative to
+    the data-fit NLL; ``n_collocation`` is how many collocation points are drawn fresh every M-step.
+    """
+
+    def __init__(
+        self,
+        module: Any,
+        residual_fn: Any,
+        domain: tuple[Any, Any],
+        *,
+        noise: float = 1.0,
+        residual_weight: float = 1.0,
+        n_collocation: int = 64,
+        m_steps: int = 40,
+        lr: float = 0.01,
+        seed: int = 0,
+        name: str | None = None,
+        device: Any = None,
+    ) -> None:
+        super().__init__(module, noise=noise, m_steps=m_steps, lr=lr, name=name, device=device)
+        self.residual_fn = residual_fn
+        self.domain = (np.asarray(domain[0], dtype=float), np.asarray(domain[1], dtype=float))
+        self.residual_weight = float(residual_weight)
+        self.n_collocation = int(n_collocation)
+        self.seed = int(seed)
+
+    def __str__(self) -> str:
+        return "PINNRegression(noise=%.3g, residual_weight=%.3g)" % (self.noise, self.residual_weight)
+
+    def estimator(self, pseudo_count: float | None = None) -> PINNRegressionEstimator:
+        return PINNRegressionEstimator(
+            self.module,
+            self.residual_fn,
+            self.domain,
+            noise=self.noise,
+            residual_weight=self.residual_weight,
+            n_collocation=self.n_collocation,
+            m_steps=self.m_steps,
+            lr=self.lr,
+            seed=self.seed,
+            name=self.name,
+            device=self.device,
+        )
+
+    def dist_to_encoder(self) -> NeuralGaussianEncoder:
+        return NeuralGaussianEncoder()
+
+    # --- serialization: same module-as-bytes pattern as NeuralGaussian, plus the residual_fn/domain/PINN
+    # hyperparameters. residual_fn must be a module-level (picklable) callable -- see _encode_residual_fn. ---
+    def __pysp_getstate__(self) -> dict[str, Any]:
+        state = dict(self.__dict__)
+        state["module"] = encode_module(self.module)
+        state["residual_fn"] = _encode_residual_fn(self.residual_fn)
+        state["domain"] = (self.domain[0].tolist(), self.domain[1].tolist())
+        return state
+
+    def __pysp_setstate__(self, state: dict[str, Any]) -> None:
+        self.__dict__.update(state)
+        self.module = decode_module(state["module"])
+        self.residual_fn = _decode_residual_fn(state["residual_fn"])
+        self.domain = (np.asarray(state["domain"][0], dtype=float), np.asarray(state["domain"][1], dtype=float))
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "noise": self.noise,
+            "m_steps": self.m_steps,
+            "lr": self.lr,
+            "name": self.name,
+            "device": self.device,
+            "module": encode_module(self.module),
+            "residual_fn": _encode_residual_fn(self.residual_fn),
+            "domain": (self.domain[0].tolist(), self.domain[1].tolist()),
+            "residual_weight": self.residual_weight,
+            "n_collocation": self.n_collocation,
+            "seed": self.seed,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> PINNRegression:
+        return cls(
+            decode_module(payload["module"]),
+            _decode_residual_fn(payload["residual_fn"]),
+            payload["domain"],
+            noise=payload["noise"],
+            residual_weight=payload["residual_weight"],
+            n_collocation=payload["n_collocation"],
+            m_steps=payload["m_steps"],
+            lr=payload["lr"],
+            seed=payload["seed"],
+            name=payload["name"],
+            device=payload["device"],
+        )
+
+
+class PINNRegressionEstimator(NeuralGaussianEstimator):
+    """EM estimator for :class:`PINNRegression`: the M-step adds a residual penalty on fresh collocation points
+    to the same weighted-NLL gradient descent :class:`~mixle.models.neural_leaf.NeuralGaussianEstimator` runs.
+
+    Collocation sampling is deterministic given ``seed`` (a private ``numpy.random.RandomState``, advanced
+    once per M-step) -- refitting with the same seed draws the same collocation batches.
+    """
+
+    def __init__(
+        self,
+        module: Any,
+        residual_fn: Any,
+        domain: tuple[np.ndarray, np.ndarray],
+        *,
+        noise: float = 1.0,
+        residual_weight: float = 1.0,
+        n_collocation: int = 64,
+        m_steps: int = 40,
+        lr: float = 0.01,
+        seed: int = 0,
+        name: str | None = None,
+        device: Any = None,
+    ) -> None:
+        super().__init__(module, noise, m_steps, lr, name, device)
+        self.residual_fn = residual_fn
+        self.domain = domain
+        self.residual_weight = float(residual_weight)
+        self.n_collocation = int(n_collocation)
+        self.seed = int(seed)
+        self._rng = np.random.RandomState(self.seed)
+
+    def accumulator_factory(self) -> NeuralGaussianAccumulatorFactory:
+        return NeuralGaussianAccumulatorFactory()
+
+    def _sample_collocation(self, dev: Any, torch: Any) -> Any:
+        low, high = self.domain
+        u = self._rng.uniform(0.0, 1.0, size=(self.n_collocation, low.shape[0]))
+        pts = low + u * (high - low)
+        return torch.as_tensor(pts, dtype=torch.float32, device=dev).requires_grad_(True)
+
+    def estimate(self, nobs: float | None, suff_stat: tuple) -> PINNRegression:
+        torch = _torch()
+        xs, ys, ws = suff_stat
+        has_data = len(xs) > 0
+        dev = _resolve_device(self.device, torch)
+        self.module.to(dev)
+
+        if has_data:
+            xt = torch.as_tensor(np.array(xs), dtype=torch.float32, device=dev)
+            yt = torch.as_tensor(np.array(ys), dtype=torch.float32, device=dev)
+            wt = torch.as_tensor(np.array(ws), dtype=torch.float32, device=dev)
+            wsum = float(wt.sum()) + 1e-8
+            d = yt.shape[1]
+
+        log_noise = torch.log(torch.tensor(float(self.noise), device=dev)).clone().detach().requires_grad_(True)
+        opt = torch.optim.Adam(list(self.module.parameters()) + [log_noise], lr=self.lr)
+        for _ in range(self.m_steps):
+            opt.zero_grad()
+            loss = torch.zeros((), device=dev)
+            if has_data:
+                mean = self.module(xt)
+                sig2 = torch.exp(2.0 * log_noise)
+                nll = (
+                    wt * (0.5 * ((yt - mean) ** 2).sum(1) / sig2 + 0.5 * d * torch.log(2.0 * np.pi * sig2))
+                ).sum() / wsum
+                loss = loss + nll
+            coll = self._sample_collocation(dev, torch)
+            residual = self.residual_fn(self.module, coll)
+            loss = loss + self.residual_weight * (residual**2).mean()
+            loss.backward()
+            opt.step()
+        if has_data:
+            self.noise = float(torch.exp(log_noise).detach())  # warm-start noise for the next EM iteration
+        return PINNRegression(
+            self.module,
+            self.residual_fn,
+            self.domain,
+            noise=self.noise,
+            residual_weight=self.residual_weight,
+            n_collocation=self.n_collocation,
+            m_steps=self.m_steps,
+            lr=self.lr,
+            seed=self.seed,
+            name=self.name,
+            device=self.device,
+        )
+
+
+def _register_serializable() -> None:
+    try:
+        from mixle.utils.serialization import register_serializable_class
+    except Exception:  # pragma: no cover
+        return
+    register_serializable_class(PINNRegression)
+
+
+_register_serializable()

--- a/mixle/tests/pinn_leaf_test.py
+++ b/mixle/tests/pinn_leaf_test.py
@@ -1,0 +1,181 @@
+"""PINNRegression: a physics-informed neural network leaf (data-fit NLL + PDE-residual penalty on collocation
+points), composing into the same NeuralGaussian-style estimator/accumulator contract."""
+
+import unittest
+
+import numpy as np
+
+try:
+    import torch
+
+    _HAS_TORCH = True
+except ImportError:
+    _HAS_TORCH = False
+
+
+def _mlp(dims):
+    layers = []
+    for i in range(len(dims) - 1):
+        layers.append(torch.nn.Linear(dims[i], dims[i + 1]))
+        if i < len(dims) - 2:
+            layers.append(torch.nn.Tanh())  # smooth activation: PINN residuals need well-behaved autograd
+    return torch.nn.Sequential(*layers)
+
+
+def _ode_residual(module, coll):
+    """du/dx = cos(x) -- the analytic solution through u(0)=0 is u(x) = sin(x)."""
+    u = module(coll)
+    (du,) = torch.autograd.grad(u, coll, grad_outputs=torch.ones_like(u), create_graph=True)
+    return du - torch.cos(coll)
+
+
+@unittest.skipUnless(_HAS_TORCH, "torch not installed")
+class PINNRegressionTest(unittest.TestCase):
+    def test_fits_the_analytic_solution_from_one_boundary_point_plus_the_residual(self):
+        from mixle.models.pinn_leaf import PINNRegression
+
+        torch.manual_seed(0)
+        module = _mlp([1, 32, 32, 1])
+        leaf = PINNRegression(
+            module,
+            _ode_residual,
+            domain=([-2.0], [2.0]),
+            noise=0.05,
+            residual_weight=5.0,
+            n_collocation=64,
+            m_steps=400,
+            lr=0.01,
+            seed=0,
+        )
+        est = leaf.estimator()
+        acc = est.accumulator_factory().make()
+        data = [(np.array([0.0]), np.array([0.0]))]  # the one boundary condition: u(0) = 0
+        enc = leaf.dist_to_encoder().seq_encode(data)
+        acc.seq_update(enc, np.ones(len(data)), leaf)
+        fitted = est.estimate(None, acc.value())
+
+        grid = np.linspace(-2.0, 2.0, 41)[:, None]
+        pred = fitted._forward(grid)[:, 0]
+        truth = np.sin(grid[:, 0])
+        self.assertLess(float(np.mean((pred - truth) ** 2)), 0.02)
+
+    def test_residual_shrinks_after_training(self):
+        from mixle.models.pinn_leaf import PINNRegression
+
+        torch.manual_seed(1)
+        module = _mlp([1, 32, 32, 1])
+        probe = torch.linspace(-2.0, 2.0, 50, requires_grad=True).reshape(-1, 1)
+        before = float((_ode_residual(module, probe) ** 2).mean().detach())
+
+        leaf = PINNRegression(
+            module,
+            _ode_residual,
+            domain=([-2.0], [2.0]),
+            residual_weight=1.0,
+            n_collocation=64,
+            m_steps=300,
+            lr=0.01,
+            seed=0,
+        )
+        fitted = leaf.estimator().estimate(None, (np.zeros((0, 1)), np.zeros((0, 1)), np.zeros((0,))))
+        probe2 = torch.linspace(-2.0, 2.0, 50, requires_grad=True).reshape(-1, 1)
+        after = float((_ode_residual(fitted.module, probe2) ** 2).mean().detach())
+        self.assertLess(after, before * 0.1)
+
+    def test_trains_with_zero_labeled_data_pure_pde_fit(self):
+        from mixle.models.pinn_leaf import PINNRegression
+
+        torch.manual_seed(2)
+        module = _mlp([1, 16, 16, 1])
+        leaf = PINNRegression(
+            module,
+            _ode_residual,
+            domain=([-2.0], [2.0]),
+            residual_weight=1.0,
+            n_collocation=64,
+            m_steps=200,
+            lr=0.01,
+            seed=0,
+        )
+        est = leaf.estimator()
+        empty = (np.zeros((0, 1)), np.zeros((0, 1)), np.zeros((0,)))
+        fitted = est.estimate(None, empty)  # no labeled data at all -- must not raise, must still train
+
+        probe = torch.linspace(-2.0, 2.0, 50, requires_grad=True).reshape(-1, 1)
+        resid = float((_ode_residual(fitted.module, probe) ** 2).mean().detach())
+        self.assertLess(resid, 0.05)  # honors du/dx = cos(x) even with no boundary condition to pin the constant
+
+    def test_reported_density_is_the_data_fit_nll_only(self):
+        from mixle.models.pinn_leaf import PINNRegression
+
+        torch.manual_seed(3)
+        module = _mlp([1, 16, 1])
+        leaf = PINNRegression(module, _ode_residual, domain=([-2.0], [2.0]), noise=1.0, seed=0)
+        x, y = np.array([0.3]), np.array([0.0])
+        ld = leaf.log_density((x, y))
+        self.assertTrue(np.isfinite(ld))
+        # matches the plain Gaussian NLL formula exactly (no residual term folded into the density), whatever
+        # the (untrained, effectively random) module output at x happens to be
+        mean = float(leaf._forward(x[None, :])[0, 0])
+        expected = -0.5 * (y[0] - mean) ** 2 - 0.5 * np.log(2.0 * np.pi)
+        self.assertAlmostEqual(ld, expected, places=4)
+
+    def test_deterministic_given_seed(self):
+        from mixle.models.pinn_leaf import PINNRegression
+
+        def _run():
+            torch.manual_seed(7)
+            module = _mlp([1, 16, 1])
+            leaf = PINNRegression(
+                module,
+                _ode_residual,
+                domain=([-2.0], [2.0]),
+                residual_weight=2.0,
+                n_collocation=32,
+                m_steps=60,
+                lr=0.01,
+                seed=5,
+            )
+            fitted = leaf.estimator().estimate(None, (np.zeros((0, 1)), np.zeros((0, 1)), np.zeros((0,))))
+            grid = np.linspace(-2.0, 2.0, 10)[:, None]
+            return fitted._forward(grid)[:, 0]
+
+        a, b = _run(), _run()
+        np.testing.assert_allclose(a, b, atol=1e-6)
+
+
+def _module_level_residual(module, coll):
+    return _ode_residual(module, coll)
+
+
+@unittest.skipUnless(_HAS_TORCH, "torch not installed")
+class PINNRegressionSerializationTest(unittest.TestCase):
+    def test_to_dict_from_dict_roundtrip_preserves_predictions(self):
+        from mixle.models.pinn_leaf import PINNRegression
+
+        torch.manual_seed(4)
+        module = _mlp([1, 16, 1])
+        leaf = PINNRegression(
+            module,
+            _module_level_residual,
+            domain=([-2.0], [2.0]),
+            noise=0.2,
+            residual_weight=1.5,
+            n_collocation=16,
+            m_steps=1,
+            lr=0.01,
+            seed=9,
+            name="ode-leaf",
+        )
+        payload = leaf.to_dict()
+        restored = PINNRegression.from_dict(payload)
+
+        grid = np.linspace(-2.0, 2.0, 5)[:, None]
+        np.testing.assert_allclose(leaf._forward(grid), restored._forward(grid), atol=1e-6)
+        self.assertEqual(restored.residual_weight, leaf.residual_weight)
+        self.assertEqual(restored.n_collocation, leaf.n_collocation)
+        self.assertEqual(restored.name, "ode-leaf")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- New `mixle/models/pinn_leaf.py`: `PINNRegression`, a `NeuralGaussian` subclass whose M-step adds a PDE/ODE-residual penalty on freshly sampled collocation points (evaluated via `torch.autograd`) to the weighted-NLL gradient loss -- the standard PINN objective `L = L_data + w * L_physics`.
- Labeled `(x, y)` pairs double as boundary/initial conditions; the leaf trains even with zero labeled data (pure PDE-residual/collocation fitting).
- Reuses `NeuralGaussian`'s data-fit density, sampler, and `(x, y)` encoder unchanged, so the reported `log_density`/`seq_log_density` never folds in the residual penalty -- it stays an honest density. Confirmed `certify()` already caps a bare gradient-fit leaf at `STATIONARY` without needing `penalized=`; documented when `penalized="PINN residual"` actually matters (composing this leaf into a larger structure alongside closed-form EM blocks).
- Exported from `mixle.models` (`PINNRegression`, `PINNRegressionEstimator`).

**Context**: an architecture survey of the existing neural-model landscape found shape/physics constraints only at the scalar PPL-curve level (`mixle.ppl.core.ode_residual`, a soft finite-difference penalty), nothing at the `torch.nn.Module` level. This fills that gap using the exact same leaf/estimator/accumulator/sampler/encoder contract every other neural leaf (`NeuralGaussian`, `NeuralCategorical`, `EnergyModel`) already implements, so it drops into `MixtureEstimator`/`CompositeDistribution`/`optimize()` with zero changes elsewhere.

Companion PR: #75 (an unrelated estimation/optimization audit fix found while researching this).

## Test plan
- [x] `mixle/tests/pinn_leaf_test.py` (new, 6 tests): fits the analytic solution of `du/dx = cos(x)` from one boundary point + residual; residual shrinks after training; trains with zero labeled data (pure PDE fit); reported density is the data-fit NLL only (no residual leakage); deterministic given seed; `to_dict`/`from_dict` round-trip preserves predictions and hyperparameters.
- [x] `mixle/tests/neural_leaf_test.py mixle/tests/neural_leaf_serialization_test.py mixle/tests/pinn_leaf_test.py` -- 18 passed, no regressions to the existing neural-leaf family.
- [x] Manual `certify()` integration check confirms correct `STATIONARY` capping.
- [x] `ruff check` / `ruff format --check` -- clean.