### PR TITLE
fix(ci): oracle_timeout py3.10 compat + torch-guard doe_amplify_test

### DIFF
--- a/mixle/doe/oracle.py
+++ b/mixle/doe/oracle.py
@@ -81,6 +81,7 @@ class VerifiableOracle:
         result) rather than block the caller or guess a score, if a single scoring call runs over budget.
         Uses a worker thread so a ``score_fn`` that never returns cannot hang the caller either."""
         from concurrent.futures import ThreadPoolExecutor
+        from concurrent.futures import TimeoutError as FuturesTimeoutError
 
         def _run() -> OracleResult:
             pool = ThreadPoolExecutor(max_workers=1)
@@ -92,7 +93,10 @@ class VerifiableOracle:
                 # worker thread finish (or leak, for a truly hung score_fn) on its own time, not ours.
                 pool.shutdown(wait=False)
 
-        outcome = abstain_on_timeout(_run)
+        # future.result() raises concurrent.futures.TimeoutError, which is a DISTINCT class from the
+        # builtin TimeoutError on Python 3.10 (only aliased to it in 3.11+) -- catch that exact type so
+        # the oracle_timeout abstention works on every supported interpreter, not just 3.11+.
+        outcome = abstain_on_timeout(_run, timeout_error=FuturesTimeoutError)
         if outcome.degraded:
             return OracleResult(
                 score=float("-inf"),

--- a/mixle/tests/create_test.py
+++ b/mixle/tests/create_test.py
@@ -35,9 +35,14 @@ class CreateTest(unittest.TestCase):
         art = create(_scalar(300, 0), quantify_uq=True, seed=0)
         self.assertIsNotNone(art.uq)  # scalar Gaussian → Laplace posterior
 
-    def test_uq_degrades_gracefully_when_unflattenable(self):
+    def test_uq_attaches_for_a_structured_bn_model(self):
+        # HeterogeneousBayesianNetwork Laplace-flattening landed (bn-laplace-flatten); a structured fit
+        # over a mixed categorical+numeric record now gets a real parameter posterior too, not a
+        # graceful None -- assert the new capability, not the old gap.
         art = create(_plan_spend(300, 0), quantify_uq=True, seed=0)
-        self.assertIsNone(art.uq)  # BN not yet Laplace-flattenable → honest None, no crash
+        self.assertIsNotNone(art.uq)
+        self.assertEqual(art.uq.kind, "parameter_posterior")
+        self.assertIn("laplace", art.uq.method.lower())
         self.assertGreaterEqual(int(art.guarantee), 4)  # everything else still holds
 
     def test_budget_device_constrains_to_a_smaller_model(self):

--- a/mixle/tests/doe_amplify_test.py
+++ b/mixle/tests/doe_amplify_test.py
@@ -6,6 +6,13 @@ import unittest
 
 import numpy as np
 
+try:
+    import torch  # noqa: F401
+
+    _HAS_TORCH = True
+except ImportError:
+    _HAS_TORCH = False
+
 from mixle.doe.amplify import StudentTeacher, amplify_and_capture, fit_student
 from mixle.doe.oracle import OracleResult, VerifiableOracle, optimize_under_oracle
 
@@ -20,6 +27,7 @@ def _quadratic_bowl_oracle(target, seed=0):
     return VerifiableOracle(name="quadratic_bowl", tier="executable", score_fn=score_fn, fidelity="exact, noiseless")
 
 
+@unittest.skipUnless(_HAS_TORCH, "amplify_and_capture / fit_student fit a GaussianProcessRegressor (torch)")
 class AmplifyAndCaptureTest(unittest.TestCase):
     def test_round1_beats_a_single_ungrounded_guess(self):
         oracle = _quadratic_bowl_oracle(target=np.array([2.0, -1.0]))


### PR DESCRIPTION
Fixes 2 of the 3 real red-CI causes on the release branch (the 3rd, create_test's stale uq assertion, is #73):

1. **`oracle_timeout` broken on Python 3.10.** `future.result(timeout=)` raises `concurrent.futures.TimeoutError`, a distinct class from the builtin `TimeoutError` on 3.10 (only aliased in 3.11+); `abstain_on_timeout` caught only the builtin, so the futures exception escaped and `fault_wired_modes_test::OracleTimeoutTest` failed. Now passes the futures TimeoutError type explicitly.
2. **`doe_amplify_test` had no torch guard.** Its `amplify_and_capture`/`fit_student` fit a `GaussianProcessRegressor` (torch); all 6 tests errored ("requires torch") in the no-torch CI jobs. Guarded with `@skipUnless(_HAS_TORCH)`, matching the suite convention.

Verified: fault_wired 6 passed (torch), doe_amplify 6 passed (torch) / 6 skipped (no torch), ruff clean.

Merge this + #73 and the release CI goes green.