### PR TITLE
fix: skip doe_amplify_test.py when torch is unavailable

### DIFF
--- a/mixle/tests/doe_amplify_test.py
+++ b/mixle/tests/doe_amplify_test.py
@@ -5,9 +5,12 @@ oracle doe_oracle_test.py uses, per the plan's own build order (no domain oracle
 import unittest
 
 import numpy as np
+import pytest
 
-from mixle.doe.amplify import StudentTeacher, amplify_and_capture, fit_student
-from mixle.doe.oracle import OracleResult, VerifiableOracle, optimize_under_oracle
+pytest.importorskip("torch")  # optimize_under_oracle's BayesianOptimizer surrogate needs GaussianProcessRegressor
+
+from mixle.doe.amplify import StudentTeacher, amplify_and_capture, fit_student  # noqa: E402
+from mixle.doe.oracle import OracleResult, VerifiableOracle, optimize_under_oracle  # noqa: E402
 
 _BOUNDS = [(-5.0, 5.0), (-5.0, 5.0)]
 


### PR DESCRIPTION
## Summary
Found while triaging the 5 open PRs (#73-#77): every one of them showed the same 7 baseline CI failures on the torch-free "fast" job, unrelated to any of their diffs. One is `doe_amplify_test.py`'s 6 failures — `optimize_under_oracle`'s `BayesianOptimizer` surrogate needs `GaussianProcessRegressor` (torch), but the file was missing the `pytest.importorskip("torch")` guard every other torch-dependent test uses, so it hard-failed instead of skipping. The 7th failure (`create_test.py::test_uq_degrades_gracefully_when_unflattenable`) is already fixed by #73.

## Test plan
- [x] `mixle/tests/doe_amplify_test.py` -- 6 passed locally (torch present).
- [x] `ruff check` / `ruff format --check` -- clean.