### PR TITLE
fix: oracle_timeout abstention on Python 3.10

### DIFF
--- a/mixle/doe/oracle.py
+++ b/mixle/doe/oracle.py
@@ -81,6 +81,7 @@ class VerifiableOracle:
         result) rather than block the caller or guess a score, if a single scoring call runs over budget.
         Uses a worker thread so a ``score_fn`` that never returns cannot hang the caller either."""
         from concurrent.futures import ThreadPoolExecutor
+        from concurrent.futures import TimeoutError as FuturesTimeoutError
 
         def _run() -> OracleResult:
             pool = ThreadPoolExecutor(max_workers=1)
@@ -92,7 +93,10 @@ class VerifiableOracle:
                 # worker thread finish (or leak, for a truly hung score_fn) on its own time, not ours.
                 pool.shutdown(wait=False)
 
-        outcome = abstain_on_timeout(_run)
+        # future.result() raises concurrent.futures.TimeoutError, which is a DISTINCT class from the
+        # builtin TimeoutError on Python 3.10 (only aliased to it in 3.11+) -- catch that exact type so
+        # oracle_timeout abstention works on every supported interpreter, not just 3.11+.
+        outcome = abstain_on_timeout(_run, timeout_error=FuturesTimeoutError)
         if outcome.degraded:
             return OracleResult(
                 score=float("-inf"),


### PR DESCRIPTION
## Summary
Extracted from #78 (which was otherwise redundant with already-merged #73 and #79 -- see #78 close comment). This is the one genuinely new fix in that PR: `future.result(timeout=...)` raises `concurrent.futures.TimeoutError`, a distinct class from the builtin `TimeoutError` on Python 3.10 (only aliased together in 3.11+). `abstain_on_timeout` defaults to catching the builtin, so `VerifiableOracle`'s `oracle_timeout` degraded-mode abstention silently failed to trigger on 3.10 -- the future's `TimeoutError` propagated as an uncaught exception instead of degrading gracefully. Pass `timeout_error=FuturesTimeoutError` explicitly.

## Test plan
- [x] `mixle/tests/fault_test.py mixle/tests/fault_wired_modes_test.py` -- 16 passed.
- [x] `ruff check` / `ruff format --check` -- clean.