### PR TITLE
models: rename pinn_leaf.py -> pinn.py, drop "leaf" from PINN wording

### DIFF
--- a/mixle/models/__init__.py
+++ b/mixle/models/__init__.py
@@ -92,7 +92,7 @@ from mixle.models.partially_observable_markov_decision_process import (
     PartiallyObservableMarkovDecisionProcessModel,
     baum_welch_pomdp,
 )
-from mixle.models.pinn_leaf import PINNRegression, PINNRegressionEstimator
+from mixle.models.pinn import PINNRegression, PINNRegressionEstimator
 from mixle.models.random_forest import (
     RandomForestConditional,
     RandomForestEstimator,

--- a/mixle/models/pinn.py
+++ b/mixle/models/pinn.py
@@ -1,7 +1,7 @@
-"""``PINNRegression`` -- a physics-informed neural network as a mixle conditional-density leaf.
+"""``PINNRegression`` -- a physics-informed neural network as a mixle conditional-density model.
 
 A :class:`~mixle.models.neural_leaf.NeuralGaussian` fits ``p(y | x) = N(y; module(x), noise^2 I)`` from labeled
-``(x, y)`` pairs alone. ``PINNRegression`` is the same leaf plus a **residual penalty**: at every M-step it also
+``(x, y)`` pairs alone. ``PINNRegression`` is the same model plus a **residual penalty**: at every M-step it also
 draws unlabeled collocation points from a box domain, evaluates a caller-supplied PDE/ODE residual on the
 module's output via autograd, and adds ``residual_weight * mean(residual**2)`` to the training loss -- the
 standard physics-informed-neural-network (PINN) loss, ``L = L_data + w * L_physics``.
@@ -9,13 +9,13 @@ standard physics-informed-neural-network (PINN) loss, ``L = L_data + w * L_physi
 This makes the labeled-data term double as boundary/initial conditions (or scattered measurements) and the
 residual term enforce the governing equation *between* them, so the fitted module honors the physics even where
 it never saw labeled data -- the whole point of a PINN over plain regression. With zero labeled data
-(``suff_stat`` empty) the leaf still trains: pure PDE-residual fitting, a boundary-value/collocation solver.
+(``suff_stat`` empty) the model still trains: pure PDE-residual fitting, a boundary-value/collocation solver.
 
 The reported density (:meth:`log_density`/:meth:`seq_log_density`, inherited unchanged from ``NeuralGaussian``)
-is the data-fit Gaussian NLL only -- the leaf never claims the residual penalty as part of its probability
-model. :func:`mixle.inference.planning.certify` already caps a bare gradient-fit leaf like this at
+is the data-fit Gaussian NLL only -- the model never claims the residual penalty as part of its probability
+model. :func:`mixle.inference.planning.certify` already caps a bare gradient-fit model like this at
 ``STATIONARY`` (no global-optimum claim), so ``penalized=`` adds nothing for a standalone fit; pass
-``certify(structure, penalized="PINN residual")`` when this leaf is composed as one block of a larger
+``certify(structure, penalized="PINN residual")`` when this model is composed as one block of a larger
 structure that otherwise contains closed-form EM blocks, so those blocks are honestly downgraded too
 (mirroring how :func:`mixle.ppl.core.ode_residual`'s soft-constraint fits are certified).
 
@@ -31,7 +31,7 @@ Requires torch. ``residual_fn(module, collocation_points) -> tensor`` computes t
         u_xx = torch.autograd.grad(u_x, coll, grad_outputs=torch.ones_like(u_x), create_graph=True)[0][:, 1:2]
         return u_t - ALPHA * u_xx
 
-    leaf = PINNRegression(make_mlp(2, [32, 32], 1), heat_residual, domain=([0.0, -1.0], [1.0, 1.0]))
+    model = PINNRegression(make_mlp(2, [32, 32], 1), heat_residual, domain=([0.0, -1.0], [1.0, 1.0]))
 """
 
 from __future__ import annotations
@@ -60,7 +60,7 @@ def _encode_residual_fn(fn: Any) -> str:
     except Exception as e:
         raise ValueError(
             "PINNRegression.to_dict() needs residual_fn to be pickle-able (a module-level function, not a "
-            "lambda or closure); construct the leaf from a named function if you need serialization."
+            "lambda or closure); construct the model from a named function if you need serialization."
         ) from e
 
 

--- a/mixle/tests/pinn_test.py
+++ b/mixle/tests/pinn_test.py
@@ -1,4 +1,4 @@
-"""PINNRegression: a physics-informed neural network leaf (data-fit NLL + PDE-residual penalty on collocation
+"""PINNRegression: a physics-informed neural network model (data-fit NLL + PDE-residual penalty on collocation
 points), composing into the same NeuralGaussian-style estimator/accumulator contract."""
 
 import unittest
@@ -32,11 +32,11 @@ def _ode_residual(module, coll):
 @unittest.skipUnless(_HAS_TORCH, "torch not installed")
 class PINNRegressionTest(unittest.TestCase):
     def test_fits_the_analytic_solution_from_one_boundary_point_plus_the_residual(self):
-        from mixle.models.pinn_leaf import PINNRegression
+        from mixle.models.pinn import PINNRegression
 
         torch.manual_seed(0)
         module = _mlp([1, 32, 32, 1])
-        leaf = PINNRegression(
+        model = PINNRegression(
             module,
             _ode_residual,
             domain=([-2.0], [2.0]),
@@ -47,11 +47,11 @@ class PINNRegressionTest(unittest.TestCase):
             lr=0.01,
             seed=0,
         )
-        est = leaf.estimator()
+        est = model.estimator()
         acc = est.accumulator_factory().make()
         data = [(np.array([0.0]), np.array([0.0]))]  # the one boundary condition: u(0) = 0
-        enc = leaf.dist_to_encoder().seq_encode(data)
-        acc.seq_update(enc, np.ones(len(data)), leaf)
+        enc = model.dist_to_encoder().seq_encode(data)
+        acc.seq_update(enc, np.ones(len(data)), model)
         fitted = est.estimate(None, acc.value())
 
         grid = np.linspace(-2.0, 2.0, 41)[:, None]
@@ -60,14 +60,14 @@ class PINNRegressionTest(unittest.TestCase):
         self.assertLess(float(np.mean((pred - truth) ** 2)), 0.02)
 
     def test_residual_shrinks_after_training(self):
-        from mixle.models.pinn_leaf import PINNRegression
+        from mixle.models.pinn import PINNRegression
 
         torch.manual_seed(1)
         module = _mlp([1, 32, 32, 1])
         probe = torch.linspace(-2.0, 2.0, 50, requires_grad=True).reshape(-1, 1)
         before = float((_ode_residual(module, probe) ** 2).mean().detach())
 
-        leaf = PINNRegression(
+        model = PINNRegression(
             module,
             _ode_residual,
             domain=([-2.0], [2.0]),
@@ -77,17 +77,17 @@ class PINNRegressionTest(unittest.TestCase):
             lr=0.01,
             seed=0,
         )
-        fitted = leaf.estimator().estimate(None, (np.zeros((0, 1)), np.zeros((0, 1)), np.zeros((0,))))
+        fitted = model.estimator().estimate(None, (np.zeros((0, 1)), np.zeros((0, 1)), np.zeros((0,))))
         probe2 = torch.linspace(-2.0, 2.0, 50, requires_grad=True).reshape(-1, 1)
         after = float((_ode_residual(fitted.module, probe2) ** 2).mean().detach())
         self.assertLess(after, before * 0.1)
 
     def test_trains_with_zero_labeled_data_pure_pde_fit(self):
-        from mixle.models.pinn_leaf import PINNRegression
+        from mixle.models.pinn import PINNRegression
 
         torch.manual_seed(2)
         module = _mlp([1, 16, 16, 1])
-        leaf = PINNRegression(
+        model = PINNRegression(
             module,
             _ode_residual,
             domain=([-2.0], [2.0]),
@@ -97,7 +97,7 @@ class PINNRegressionTest(unittest.TestCase):
             lr=0.01,
             seed=0,
         )
-        est = leaf.estimator()
+        est = model.estimator()
         empty = (np.zeros((0, 1)), np.zeros((0, 1)), np.zeros((0,)))
         fitted = est.estimate(None, empty)  # no labeled data at all -- must not raise, must still train
 
@@ -106,27 +106,27 @@ class PINNRegressionTest(unittest.TestCase):
         self.assertLess(resid, 0.05)  # honors du/dx = cos(x) even with no boundary condition to pin the constant
 
     def test_reported_density_is_the_data_fit_nll_only(self):
-        from mixle.models.pinn_leaf import PINNRegression
+        from mixle.models.pinn import PINNRegression
 
         torch.manual_seed(3)
         module = _mlp([1, 16, 1])
-        leaf = PINNRegression(module, _ode_residual, domain=([-2.0], [2.0]), noise=1.0, seed=0)
+        model = PINNRegression(module, _ode_residual, domain=([-2.0], [2.0]), noise=1.0, seed=0)
         x, y = np.array([0.3]), np.array([0.0])
-        ld = leaf.log_density((x, y))
+        ld = model.log_density((x, y))
         self.assertTrue(np.isfinite(ld))
         # matches the plain Gaussian NLL formula exactly (no residual term folded into the density), whatever
         # the (untrained, effectively random) module output at x happens to be
-        mean = float(leaf._forward(x[None, :])[0, 0])
+        mean = float(model._forward(x[None, :])[0, 0])
         expected = -0.5 * (y[0] - mean) ** 2 - 0.5 * np.log(2.0 * np.pi)
         self.assertAlmostEqual(ld, expected, places=4)
 
     def test_deterministic_given_seed(self):
-        from mixle.models.pinn_leaf import PINNRegression
+        from mixle.models.pinn import PINNRegression
 
         def _run():
             torch.manual_seed(7)
             module = _mlp([1, 16, 1])
-            leaf = PINNRegression(
+            model = PINNRegression(
                 module,
                 _ode_residual,
                 domain=([-2.0], [2.0]),
@@ -136,7 +136,7 @@ class PINNRegressionTest(unittest.TestCase):
                 lr=0.01,
                 seed=5,
             )
-            fitted = leaf.estimator().estimate(None, (np.zeros((0, 1)), np.zeros((0, 1)), np.zeros((0,))))
+            fitted = model.estimator().estimate(None, (np.zeros((0, 1)), np.zeros((0, 1)), np.zeros((0,))))
             grid = np.linspace(-2.0, 2.0, 10)[:, None]
             return fitted._forward(grid)[:, 0]
 
@@ -151,11 +151,11 @@ def _module_level_residual(module, coll):
 @unittest.skipUnless(_HAS_TORCH, "torch not installed")
 class PINNRegressionSerializationTest(unittest.TestCase):
     def test_to_dict_from_dict_roundtrip_preserves_predictions(self):
-        from mixle.models.pinn_leaf import PINNRegression
+        from mixle.models.pinn import PINNRegression
 
         torch.manual_seed(4)
         module = _mlp([1, 16, 1])
-        leaf = PINNRegression(
+        model = PINNRegression(
             module,
             _module_level_residual,
             domain=([-2.0], [2.0]),
@@ -165,16 +165,16 @@ class PINNRegressionSerializationTest(unittest.TestCase):
             m_steps=1,
             lr=0.01,
             seed=9,
-            name="ode-leaf",
+            name="ode-model",
         )
-        payload = leaf.to_dict()
+        payload = model.to_dict()
         restored = PINNRegression.from_dict(payload)
 
         grid = np.linspace(-2.0, 2.0, 5)[:, None]
-        np.testing.assert_allclose(leaf._forward(grid), restored._forward(grid), atol=1e-6)
-        self.assertEqual(restored.residual_weight, leaf.residual_weight)
-        self.assertEqual(restored.n_collocation, leaf.n_collocation)
-        self.assertEqual(restored.name, "ode-leaf")
+        np.testing.assert_allclose(model._forward(grid), restored._forward(grid), atol=1e-6)
+        self.assertEqual(restored.residual_weight, model.residual_weight)
+        self.assertEqual(restored.n_collocation, model.n_collocation)
+        self.assertEqual(restored.name, "ode-model")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
My earlier PR (#77, merged) named the new physics-informed neural network file `mixle/models/pinn_leaf.py` and described it with "leaf" terminology throughout, per this codebase's long-standing convention for its neural-model files. Per direct instruction, that word should not be used for this model. This PR:
- Renames `mixle/models/pinn_leaf.py` -> `mixle/models/pinn.py` and `mixle/tests/pinn_leaf_test.py` -> `mixle/tests/pinn_test.py`.
- Rewords all docstrings/comments describing `PINNRegression` to call it a model/component instead of a "leaf".
- Renames the `leaf` local variable throughout the test file to `model`.
- Updates the `mixle/models/__init__.py` import path.
- Leaves references to `mixle.models.neural_leaf` (the pre-existing, unrelated module `PINNRegression` subclasses) untouched -- that is a different file's actual name, not something this PR's scope covers.

## Test plan
- [x] `mixle/tests/pinn_test.py mixle/tests/neural_leaf_test.py mixle/tests/neural_leaf_serialization_test.py` -- 18 passed.
- [x] `grep -rn "pinn_leaf"` across the repo -- no remaining references.
- [x] `ruff check` / `ruff format --check` -- clean.