### PR TITLE
fix: break circular import in mixle.task.propose

### DIFF
--- a/mixle/task/propose.py
+++ b/mixle/task/propose.py
@@ -19,13 +19,20 @@ Same "no verifiable objective, no optimization" precondition as ``optimize_under
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from mixle.doe.oracle import OracleResult, VerifiableOracle
 from mixle.inference import optimize
 from mixle.stats.univariate.discrete.categorical import CategoricalDistribution
+
+if TYPE_CHECKING:
+    # Deferred: mixle.doe pulls in mixle.models -> mixle.inference, and this module is reachable from
+    # mixle.inference.receipt (via mixle.task.replay) while mixle.inference is still initializing --
+    # an eager import here creates a circular import. OracleResult/VerifiableOracle are used only as
+    # (lazily-evaluated, `from __future__ import annotations`) type annotations, never constructed or
+    # isinstance-checked here, so the real import is never needed at runtime.
+    from mixle.doe.oracle import OracleResult, VerifiableOracle
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- A regression introduced by task/I3 (#54): `mixle/task/propose.py` eagerly imports
  `mixle.doe.oracle` at module level, purely for type annotations. That pulls in
  `mixle.doe` -> `mixle.models` -> `mixle.inference`, which completes a cycle when
  reached from `mixle.inference.receipt` -> `mixle.task.replay` -> `mixle.task`
  (`__init__.py` eagerly imports `propose`) while `mixle.inference` is still
  initializing. Reproduced directly: `python -c "import mixle.inference"` raised
  `ImportError: cannot import name 'seq_estimate' from partially initialized module
  'mixle.inference'` on a clean checkout of the current release tip, no cherry-pick
  needed.
- Fix: move the `OracleResult`/`VerifiableOracle` import under `TYPE_CHECKING`. Both
  names are used only as annotations (already lazy via `from __future__ import
  annotations`), never constructed or isinstance-checked at runtime in this module,
  so the real import was never needed outside type-checking.

## Test plan
- `python -c "import mixle.inference"` / `import mixle.task"`: both succeed (previously
  the former raised ImportError).
- `python -m pytest mixle/tests/task_propose_test.py -q`: 9 passed, no behavior change.
- `ruff check` / `ruff format --check`: clean.