### PR TITLE
utils/automatic: fix crash-on-empty-data + detector factories dropping their own fit/pseudo_count

### DIFF
--- a/mixle/tests/automatic_stability_test.py
+++ b/mixle/tests/automatic_stability_test.py
@@ -1,0 +1,113 @@
+"""Stability fixes for mixle.utils.automatic: no crashes on degenerate input, and detector-backed
+families no longer silently drop pseudo_count/the family's own already-computed fit.
+
+Before this file's fixes:
+  - get_poisson_estimator/get_gaussian_estimator/get_lognormal_estimator raised ZeroDivisionError on
+    an empty (or entirely non-finite/non-positive) vdict -- reachable via get_length_estimator on an
+    empty length distribution, among other paths.
+  - every detector-registered family's _factory() (weibull, beta, gumbel, ...) discarded the
+    pseudo_count argument and returned a fixed-parameter estimator unrelated to the fit the SAME
+    detector already computed in _score()/_fit() moments earlier -- pseudo_count=1.0, the default in
+    get_estimator/get_prototype, silently applied NO regularization for any detector-selected family.
+"""
+
+import unittest
+
+import numpy as np
+
+from mixle.utils.automatic.factories import (
+    get_gaussian_estimator,
+    get_length_estimator,
+    get_lognormal_estimator,
+    get_poisson_estimator,
+)
+
+
+class DegenerateInputDoesNotCrashTest(unittest.TestCase):
+    def test_poisson_empty_vdict(self):
+        get_poisson_estimator({})  # must not raise ZeroDivisionError
+
+    def test_gaussian_empty_vdict(self):
+        get_gaussian_estimator({})
+
+    def test_lognormal_empty_vdict(self):
+        get_lognormal_estimator({})
+
+    def test_poisson_all_nan_keys(self):
+        get_poisson_estimator({float("nan"): 5.0})
+
+    def test_lognormal_all_non_positive_keys(self):
+        # every key filtered out (log-normal needs k > 0), same empty-accumulator shape as an empty dict
+        get_lognormal_estimator({-1.0: 3.0, -2.0: 5.0})
+
+    def test_length_estimator_on_an_empty_length_distribution(self):
+        # get_length_estimator falls through to get_poisson_estimator on a dense/empty support;
+        # an empty len_dict must not crash the fallback.
+        get_length_estimator({})
+
+    def test_gaussian_and_lognormal_still_use_real_data_when_present(self):
+        # the guard must not swallow the normal, well-populated path -- the estimator should still
+        # carry a suff_stat computed from the data, not silently fall back to None/defaults.
+        vdict = {1.0: 3.0, 2.0: 5.0, 3.0: 2.0}
+        est = get_gaussian_estimator(vdict, pseudo_count=None)
+        self.assertIsNotNone(est.suff_stat[0])
+
+
+class DetectorFactoryUsesTheAlreadyComputedFitTest(unittest.TestCase):
+    """The core bug: every detector _factory() ignored its own _fit()/_params() and pseudo_count."""
+
+    def test_weibull_factory_seeds_from_the_actual_fit_not_a_hardcoded_default(self):
+        from mixle.utils.automatic.detectors.weibull import _factory, _fit
+
+        rng = np.random.RandomState(0)
+        from scipy import stats
+
+        data = stats.weibull_min.rvs(5.0, scale=200.0, size=500, random_state=rng)
+        vdict: dict[float, float] = {}
+        for x in data:
+            vdict[float(x)] = vdict.get(float(x), 0.0) + 1.0
+
+        shape, scale = _fit(data)
+        est = _factory(vdict, pseudo_count=1.0, emp_suff_stat=True, use_bstats=False)
+        # suff_stat is the (mean, second-moment) of a Weibull(shape, scale) -- NOT of Weibull(1, 1),
+        # which would give (1.0, 2.0) regardless of the data.
+        mean, second = est.suff_stat
+        self.assertGreater(mean, 50.0)  # Weibull(1,1) would give mean=1.0; the real fit's mean is ~180
+        self.assertNotAlmostEqual(mean, 1.0, places=3)
+        self.assertNotAlmostEqual(second, 2.0, places=3)
+
+    def test_weibull_factory_threads_pseudo_count_through(self):
+        from mixle.utils.automatic.detectors.weibull import _factory
+
+        vdict = {1.0: 1.0, 2.0: 1.0, 3.0: 1.0}
+        est_with_pc = _factory(vdict, pseudo_count=5.0, emp_suff_stat=True, use_bstats=False)
+        est_without_pc = _factory(vdict, pseudo_count=None, emp_suff_stat=True, use_bstats=False)
+        self.assertEqual(est_with_pc.pseudo_count, 5.0)
+        self.assertIsNone(est_without_pc.pseudo_count)
+        self.assertIsNotNone(est_with_pc.suff_stat)
+        self.assertIsNone(est_without_pc.suff_stat)  # no pseudo_count -> estimator() builds no prior
+
+    def test_negative_binomial_factory_seeds_from_the_actual_fit(self):
+        from mixle.utils.automatic.detectors.negative_binomial import _factory, _params
+
+        rng = np.random.RandomState(1)
+        from scipy import stats
+
+        data = stats.nbinom.rvs(8.0, 0.3, size=500, random_state=rng).astype(float)
+        vdict: dict[float, float] = {}
+        for x in data:
+            vdict[float(x)] = vdict.get(float(x), 0.0) + 1.0
+
+        r_fit, p_fit = _params(data)
+        est = _factory(vdict, pseudo_count=None, emp_suff_stat=True, use_bstats=False)
+        self.assertIsNone(est.suff_stat)  # no pseudo_count given -> no prior suff_stat
+        # with a pseudo_count, NegativeBinomialDistribution(r, p).estimator() builds suff_stat=p and
+        # holds r fixed at the CONSTRUCTED r -- confirm both are the actual fit, not the hardcoded
+        # (1.0, 0.5) default (p=0.5, r=1.0 would fail these given p_fit/r_fit are far from that here).
+        est_with_pc = _factory(vdict, pseudo_count=2.0, emp_suff_stat=True, use_bstats=False)
+        self.assertAlmostEqual(est_with_pc.suff_stat, p_fit, places=6)
+        self.assertAlmostEqual(est_with_pc.r, r_fit, places=6)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mixle/utils/automatic/detectors/beta.py
+++ b/mixle/utils/automatic/detectors/beta.py
@@ -49,8 +49,11 @@ def _score(arr: np.ndarray, nobs: int) -> float | None:
 
 def _factory(vdict, pseudo_count, emp_suff_stat, use_bstats):
     from mixle.stats import BetaDistribution
+    from mixle.utils.automatic.profiling import _value_array_from_vdict
 
-    return BetaDistribution(1.0, 1.0).estimator()
+    fit = _fit(_value_array_from_vdict(vdict))
+    a, b = fit if fit is not None else (1.0, 1.0)
+    return BetaDistribution(a, b).estimator(pseudo_count=pseudo_count)
 
 
 def _cdf(arr: np.ndarray):

--- a/mixle/utils/automatic/detectors/exgaussian.py
+++ b/mixle/utils/automatic/detectors/exgaussian.py
@@ -84,8 +84,11 @@ def _score(arr: np.ndarray, nobs: int) -> float | None:
 
 def _factory(vdict, pseudo_count, emp_suff_stat, use_bstats):
     from mixle.stats import ExponentiallyModifiedGaussianDistribution
+    from mixle.utils.automatic.profiling import _value_array_from_vdict
 
-    return ExponentiallyModifiedGaussianDistribution(0.0, 1.0, 1.0).estimator()
+    fit = _fit(_value_array_from_vdict(vdict))
+    mu, sigma2, lam = fit if fit is not None else (0.0, 1.0, 1.0)
+    return ExponentiallyModifiedGaussianDistribution(mu, sigma2, lam).estimator(pseudo_count=pseudo_count)
 
 
 def _cdf(arr: np.ndarray):

--- a/mixle/utils/automatic/detectors/generalized_extreme_value.py
+++ b/mixle/utils/automatic/detectors/generalized_extreme_value.py
@@ -50,8 +50,11 @@ def _score(arr: np.ndarray, nobs: int) -> float | None:
 
 def _factory(vdict, pseudo_count, emp_suff_stat, use_bstats):
     from mixle.stats import GeneralizedExtremeValueDistribution
+    from mixle.utils.automatic.profiling import _value_array_from_vdict
 
-    return GeneralizedExtremeValueDistribution(0.0, 1.0, 0.1).estimator()
+    fit = _fit_params(_value_array_from_vdict(vdict))
+    c, loc, scale = fit if fit is not None else (0.1, 0.0, 1.0)
+    return GeneralizedExtremeValueDistribution(loc, scale, c).estimator(pseudo_count=pseudo_count)
 
 
 def _cdf(arr: np.ndarray):

--- a/mixle/utils/automatic/detectors/generalized_gaussian.py
+++ b/mixle/utils/automatic/detectors/generalized_gaussian.py
@@ -62,9 +62,11 @@ def _score(arr: np.ndarray, nobs: int) -> float | None:
 
 def _factory(vdict, pseudo_count, emp_suff_stat, use_bstats):
     from mixle.stats import GeneralizedGaussianDistribution
+    from mixle.utils.automatic.profiling import _value_array_from_vdict
 
-    # mu=0, alpha (scale)=1, beta (shape)=2 -> the estimator re-fits all three from data.
-    return GeneralizedGaussianDistribution(0.0, 1.0, 2.0).estimator()
+    fit = _fit(_value_array_from_vdict(vdict))
+    beta, loc, scale = fit if fit is not None else (2.0, 0.0, 1.0)
+    return GeneralizedGaussianDistribution(loc, scale, beta).estimator(pseudo_count=pseudo_count)
 
 
 def _cdf(arr: np.ndarray):

--- a/mixle/utils/automatic/detectors/generalized_pareto.py
+++ b/mixle/utils/automatic/detectors/generalized_pareto.py
@@ -76,10 +76,15 @@ def _score(arr: np.ndarray, nobs: int) -> float | None:
 
 def _factory(vdict, pseudo_count, emp_suff_stat, use_bstats):
     from mixle.stats import GeneralizedParetoDistribution
+    from mixle.utils.automatic.profiling import _value_array_from_vdict
 
-    keys = [float(k) for k in vdict.keys() if isinstance(k, (int, float, np.integer, np.floating))]
-    loc = min(keys) if keys else 0.0
-    return GeneralizedParetoDistribution(scale=1.0, shape=0.1, loc=loc).estimator()
+    fit = _fit(_value_array_from_vdict(vdict))
+    if fit is not None:
+        loc, scale, xi = fit
+    else:
+        keys = [float(k) for k in vdict.keys() if isinstance(k, (int, float, np.integer, np.floating))]
+        loc, scale, xi = (min(keys) if keys else 0.0), 1.0, 0.1
+    return GeneralizedParetoDistribution(scale=scale, shape=xi, loc=loc).estimator(pseudo_count=pseudo_count)
 
 
 def _cdf(arr: np.ndarray):

--- a/mixle/utils/automatic/detectors/gumbel.py
+++ b/mixle/utils/automatic/detectors/gumbel.py
@@ -63,8 +63,11 @@ def _score(arr: np.ndarray, nobs: int) -> float | None:
 
 def _factory(vdict, pseudo_count, emp_suff_stat, use_bstats):
     from mixle.stats import GumbelDistribution
+    from mixle.utils.automatic.profiling import _value_array_from_vdict
 
-    return GumbelDistribution(0.0, 1.0).estimator()
+    fit = _fit(_value_array_from_vdict(vdict))
+    loc, scale = fit if fit is not None else (0.0, 1.0)
+    return GumbelDistribution(loc, scale).estimator(pseudo_count=pseudo_count)
 
 
 def _cdf(arr: np.ndarray):

--- a/mixle/utils/automatic/detectors/inverse_gaussian.py
+++ b/mixle/utils/automatic/detectors/inverse_gaussian.py
@@ -52,8 +52,11 @@ def _score(arr: np.ndarray, nobs: int) -> float | None:
 
 def _factory(vdict, pseudo_count, emp_suff_stat, use_bstats):
     from mixle.stats import InverseGaussianDistribution
+    from mixle.utils.automatic.profiling import _value_array_from_vdict
 
-    return InverseGaussianDistribution(1.0, 1.0).estimator()
+    fit = _mle(_value_array_from_vdict(vdict))
+    mu, lam = fit if fit is not None else (1.0, 1.0)
+    return InverseGaussianDistribution(mu, lam).estimator(pseudo_count=pseudo_count)
 
 
 def _cdf(arr: np.ndarray):

--- a/mixle/utils/automatic/detectors/laplace.py
+++ b/mixle/utils/automatic/detectors/laplace.py
@@ -11,30 +11,42 @@ def _applies(arr: np.ndarray) -> bool:
     return arr.size > 0  # any real-valued data
 
 
-def _score(arr: np.ndarray, nobs: int) -> float | None:
-    from mixle.utils.automatic.profiling import _bic_penalty_bits
-
+def _fit(arr: np.ndarray) -> tuple[float, float] | None:
+    """Return the Laplace MLE ``(loc, b)`` (median, mean absolute deviation), or None if degenerate."""
     loc = float(np.median(arr))
     b = float(np.mean(np.abs(arr - loc)))
     if not (b > 0.0):
         return None
+    return loc, b
+
+
+def _score(arr: np.ndarray, nobs: int) -> float | None:
+    from mixle.utils.automatic.profiling import _bic_penalty_bits
+
+    fit = _fit(arr)
+    if fit is None:
+        return None
+    _loc, b = fit
     nll_nats_per_obs = math.log(2.0 * b) + 1.0  # Laplace NLL at its MLE (scale = mean abs deviation)
     return nll_nats_per_obs / math.log(2.0) + _bic_penalty_bits(2, nobs)
 
 
 def _factory(vdict, pseudo_count, emp_suff_stat, use_bstats):
     from mixle.stats import LaplaceDistribution
+    from mixle.utils.automatic.profiling import _value_array_from_vdict
 
-    return LaplaceDistribution(0.0, 1.0).estimator()
+    fit = _fit(_value_array_from_vdict(vdict))
+    loc, b = fit if fit is not None else (0.0, 1.0)
+    return LaplaceDistribution(loc, b).estimator(pseudo_count=pseudo_count)
 
 
 def _cdf(arr: np.ndarray):
     from scipy import stats
 
-    loc = float(np.median(arr))
-    b = float(np.mean(np.abs(arr - loc)))
-    if not (b > 0.0):
+    fit = _fit(arr)
+    if fit is None:
         return None
+    loc, b = fit
     return stats.laplace.cdf(arr, loc=loc, scale=b)
 
 

--- a/mixle/utils/automatic/detectors/logistic.py
+++ b/mixle/utils/automatic/detectors/logistic.py
@@ -43,8 +43,11 @@ def _score(arr: np.ndarray, nobs: int) -> float | None:
 
 def _factory(vdict, pseudo_count, emp_suff_stat, use_bstats):
     from mixle.stats import LogisticDistribution
+    from mixle.utils.automatic.profiling import _value_array_from_vdict
 
-    return LogisticDistribution(0.0, 1.0).estimator()
+    fit = _fit(_value_array_from_vdict(vdict))
+    loc, scale = fit if fit is not None else (0.0, 1.0)
+    return LogisticDistribution(loc, scale).estimator(pseudo_count=pseudo_count)
 
 
 def _cdf(arr: np.ndarray):

--- a/mixle/utils/automatic/detectors/negative_binomial.py
+++ b/mixle/utils/automatic/detectors/negative_binomial.py
@@ -44,8 +44,11 @@ def _score(arr: np.ndarray, nobs: int) -> float | None:
 
 def _factory(vdict, pseudo_count, emp_suff_stat, use_bstats):
     from mixle.stats import NegativeBinomialDistribution
+    from mixle.utils.automatic.profiling import _value_array_from_vdict
 
-    return NegativeBinomialDistribution(1.0, 0.5).estimator()
+    fit = _params(_value_array_from_vdict(vdict))
+    r, p = fit if fit is not None else (1.0, 0.5)
+    return NegativeBinomialDistribution(r, p).estimator(pseudo_count=pseudo_count)
 
 
 def _cdf(arr: np.ndarray):

--- a/mixle/utils/automatic/detectors/pareto.py
+++ b/mixle/utils/automatic/detectors/pareto.py
@@ -61,8 +61,11 @@ def _score(arr: np.ndarray, nobs: int) -> float | None:
 
 def _factory(vdict, pseudo_count, emp_suff_stat, use_bstats):
     from mixle.stats import ParetoDistribution
+    from mixle.utils.automatic.profiling import _value_array_from_vdict
 
-    return ParetoDistribution(1.0, 1.0).estimator()
+    fit = _fit(_value_array_from_vdict(vdict))
+    xm, alpha = fit if fit is not None else (1.0, 1.0)
+    return ParetoDistribution(xm, alpha).estimator(pseudo_count=pseudo_count)
 
 
 def _cdf(arr: np.ndarray):

--- a/mixle/utils/automatic/detectors/skew_normal.py
+++ b/mixle/utils/automatic/detectors/skew_normal.py
@@ -69,8 +69,11 @@ def _score(arr: np.ndarray, nobs: int) -> float | None:
 
 def _factory(vdict, pseudo_count, emp_suff_stat, use_bstats):
     from mixle.stats import SkewNormalDistribution
+    from mixle.utils.automatic.profiling import _value_array_from_vdict
 
-    return SkewNormalDistribution(0.0, 1.0, 1.0).estimator()
+    fit = _fit(_value_array_from_vdict(vdict))
+    shape, loc, scale = fit if fit is not None else (1.0, 0.0, 1.0)
+    return SkewNormalDistribution(loc, scale, shape).estimator(pseudo_count=pseudo_count)
 
 
 def _cdf(arr: np.ndarray):

--- a/mixle/utils/automatic/detectors/tweedie.py
+++ b/mixle/utils/automatic/detectors/tweedie.py
@@ -68,8 +68,11 @@ def _score(arr: np.ndarray, nobs: int) -> float | None:
 
 def _factory(vdict, pseudo_count, emp_suff_stat, use_bstats):
     from mixle.stats import TweedieDistribution
+    from mixle.utils.automatic.profiling import _value_array_from_vdict
 
-    return TweedieDistribution(1.0, 1.0, _P).estimator()
+    fit = _moments(_value_array_from_vdict(vdict))
+    mu, phi = fit if fit is not None else (1.0, 1.0)
+    return TweedieDistribution(mu, phi, _P).estimator(pseudo_count=pseudo_count)
 
 
 def _cdf(arr: np.ndarray):

--- a/mixle/utils/automatic/detectors/weibull.py
+++ b/mixle/utils/automatic/detectors/weibull.py
@@ -51,8 +51,11 @@ def _score(arr: np.ndarray, nobs: int) -> float | None:
 
 def _factory(vdict, pseudo_count, emp_suff_stat, use_bstats):
     from mixle.stats import WeibullDistribution
+    from mixle.utils.automatic.profiling import _value_array_from_vdict
 
-    return WeibullDistribution(1.0, 1.0).estimator()
+    fit = _fit(_value_array_from_vdict(vdict))
+    shape, scale = fit if fit is not None else (1.0, 1.0)
+    return WeibullDistribution(shape, scale).estimator(pseudo_count=pseudo_count)
 
 
 def _cdf(arr: np.ndarray):

--- a/mixle/utils/automatic/factories.py
+++ b/mixle/utils/automatic/factories.py
@@ -249,7 +249,10 @@ def get_poisson_estimator(
                 ss_0 += v
                 ss_1 += k * v
 
-        ss_1 = ss_1 / ss_0
+        # ss_0 is 0 when vdict is empty or every key was filtered out (non-finite) -- no data to
+        # estimate a mean from, so fall back the same way the emp_suff_stat=False branch does below,
+        # rather than dividing by zero.
+        ss_1 = ss_1 / ss_0 if ss_0 > 0.0 else (1.0 if pseudo_count is not None else None)
 
     elif pseudo_count is not None:
         ss_1 = 1.0
@@ -276,8 +279,15 @@ def get_gaussian_estimator(
                 ss_0 += v
                 ss_1 += k * v
                 ss_2 += k * k * v
-        ss_1 = ss_1 / ss_0
-        ss_2 = (ss_2 / ss_0) - ss_1 * ss_1
+        # ss_0 is 0 when vdict is empty or every key was non-finite -- no data to estimate mean/variance
+        # from, so fall back the same way the emp_suff_stat=False branch does below.
+        if ss_0 > 0.0:
+            ss_1 = ss_1 / ss_0
+            ss_2 = (ss_2 / ss_0) - ss_1 * ss_1
+        elif pseudo_count is not None:
+            ss_1, ss_2 = 1.0e-6, 1.0e-6
+        else:
+            ss_1, ss_2 = None, None
 
     elif pseudo_count is not None:
         ss_1 = 1.0e-6
@@ -311,8 +321,16 @@ def get_lognormal_estimator(
                 ss_0 += v
                 ss_1 += lk * v
                 ss_2 += lk * lk * v
-        ss_1 = ss_1 / ss_0
-        ss_2 = (ss_2 / ss_0) - ss_1 * ss_1
+        # ss_0 is 0 when vdict is empty or every key was non-positive/non-finite (log-normal needs
+        # strictly positive values) -- no data to estimate mean/variance from, fall back like the
+        # emp_suff_stat=False branch does below rather than dividing by zero.
+        if ss_0 > 0.0:
+            ss_1 = ss_1 / ss_0
+            ss_2 = (ss_2 / ss_0) - ss_1 * ss_1
+        elif pseudo_count is not None:
+            ss_1, ss_2 = 1.0e-6, 1.0e-6
+        else:
+            ss_1, ss_2 = None, None
     elif pseudo_count is not None:
         ss_1 = 1.0e-6
         ss_2 = 1.0e-6


### PR DESCRIPTION
## Summary
Stability audit of `mixle.utils.automatic` (the automatic data-type detection / estimator recommendation subsystem), requested because it "should be stable, not janky." Two real bugs found and fixed, both confirmed by direct reproduction:

**1. Crash on empty/degenerate data.** `get_poisson_estimator`/`get_gaussian_estimator`/`get_lognormal_estimator` in `factories.py` raised `ZeroDivisionError` whenever every key in `vdict` got filtered out (empty dict, all-non-finite keys, or -- for log-normal -- all-non-positive keys). `get_gamma_estimator`/`get_student_t_estimator` in the same file already guard this correctly (`if ss_0 > 0.0:`) and fall back to sane defaults -- these three were inconsistent outliers. Reachable via `get_length_estimator` on an empty length distribution, among other paths.

**2. Every detector-registered family's `_factory()` discarded its own fit and the caller's `pseudo_count`.** All 14 detector files (beta, exgaussian, GEV, generalized-gaussian, generalized-pareto, gumbel, inverse-gaussian, laplace, logistic, negative-binomial, pareto, skew-normal, tweedie, weibull) compute a real MLE/moment fit in `_fit()`/`_params()`/`_moments()` to WIN the BIC-based family selection, then `_factory()` threw that fit away and returned a hardcoded-parameter estimator instead -- with no `pseudo_count` at all. Since `get_estimator`/`get_prototype` default to `pseudo_count=1.0`, every detector-selected family was silently getting zero regularization regardless of what the caller asked for, and when `pseudo_count` *was* passed explicitly, the resulting prior was centered on an arbitrary default (e.g. `Weibull(1,1)`, i.e. an Exponential) rather than the family actually detected in the data.

Fixed by having each `_factory()` reuse its own already-computed fit and thread `pseudo_count` through via `.estimator(pseudo_count=pseudo_count)` -- verified against each Distribution's real `__init__` parameter order (GEV and skew-normal needed reordering vs. what `_fit` returns). `laplace.py` also had its loc/b computation duplicated inline in `_score`/`_cdf`; extracted a shared `_fit()` so `_factory` reuses it too.

## Test plan
- [x] `mixle/tests/automatic_stability_test.py` -- 10 new tests: all three `factories.py` crashes reproduced and confirmed fixed on empty/degenerate input, well-populated path unaffected; weibull and negative-binomial factories confirmed to seed from the real fit (not the hardcoded default) and correctly thread `pseudo_count` (present and absent).
- [x] Full existing suite: `mixle/tests/automatic_*.py` = 132 passed, 26 subtests passed, **unchanged** -- these fixes did not alter any existing detector's selection or scoring behavior.
- [x] `ruff check` + `ruff format --check` clean on all 15 changed files.