### PR TITLE
models: monotonic MLPs and input-convex energy networks

### DIFF
--- a/mixle/models/__init__.py
+++ b/mixle/models/__init__.py
@@ -46,7 +46,7 @@ from mixle.models.dirichlet_process_mixture import (
 )
 from mixle.models.dpo_leaf import DPOLeaf, DPOModel
 from mixle.models.embedding import CategoricalEmbedding
-from mixle.models.energy import EnergyModel, build_energy_net
+from mixle.models.energy import EnergyModel, build_convex_energy_net, build_energy_net
 from mixle.models.feature_map import FeatureMapDensity, FeatureMapEstimator, feature_fn, register_feature_fn
 from mixle.models.gaussian_process import GaussianProcessRegressor
 from mixle.models.grammar import (
@@ -70,6 +70,7 @@ from mixle.models.neural import (
     GaussianRegressionNeuralNetwork,
     PoissonRegressionNeuralNetwork,
     make_mlp,
+    make_monotonic_mlp,
 )
 from mixle.models.neural_density import (
     NeuralDensity,
@@ -196,12 +197,14 @@ __all__ = [
     "build_autoregressive_categorical",
     "build_conditional_autoregressive_categorical",
     "build_conditional_flow",
+    "build_convex_energy_net",
     "build_coupling_flow",
     "build_energy_net",
     "build_maf",
     "build_mdn",
     "build_vae",
     "make_mlp",
+    "make_monotonic_mlp",
     "mean_stick_weights",
     "orient_v_structures",
     "pcfg_log_likelihood",

--- a/mixle/models/energy.py
+++ b/mixle/models/energy.py
@@ -345,9 +345,72 @@ def _energy_net_class() -> Any:
     return EnergyNet
 
 
-def __getattr__(name: str) -> Any:  # PEP 562: lets ``pickle`` resolve the hoisted EnergyNet by name
+_CONVEX_ENERGY_NET_CLASS: list[Any] = []
+
+
+def _convex_energy_net_class() -> Any:
+    """An input-convex energy net (ICNN, Amos et al. 2017): ``E(x)`` is convex in ``x`` BY CONSTRUCTION.
+
+    Each hidden layer takes the previous layer's activation ``z`` through a NON-NEGATIVE weight matrix
+    (``softplus``-reparameterized, same trick as :func:`~mixle.models.neural.make_monotonic_mlp`) plus an
+    unconstrained affine "skip" of the raw input ``x``, then a convex non-decreasing activation
+    (``Softplus``). A non-negative-weight combination of convex functions, composed with a convex
+    non-decreasing activation, is itself convex, and that property is closed under composition -- so the
+    whole energy is provably convex everywhere, not just where training data landed. The unconstrained
+    ``x``-skip at every layer is what makes this expressive (a purely non-negative-weight-in-``x`` network
+    would be far too restricted); only the ``z``-path weights carry the non-negativity constraint.
+    """
+    if _CONVEX_ENERGY_NET_CLASS:
+        return _CONVEX_ENERGY_NET_CLASS[0]
+    import torch
+    import torch.nn as nn
+
+    class _ICNNLayer(nn.Module):
+        def __init__(self, z_dim: int | None, x_dim: int, out_dim: int) -> None:
+            super().__init__()
+            self.x_path = nn.Linear(x_dim, out_dim)
+            self.raw_z_weight = nn.Parameter(torch.randn(out_dim, z_dim) * 0.1) if z_dim is not None else None
+
+        def forward(self, z: Any, x: Any) -> Any:
+            out = self.x_path(x)
+            if self.raw_z_weight is not None:
+                out = out + torch.nn.functional.linear(z, torch.nn.functional.softplus(self.raw_z_weight))
+            return out
+
+    class ConvexEnergyNet(nn.Module):
+        def __init__(self, dim: int, hidden: int = 64, layers: int = 3) -> None:
+            super().__init__()
+            self.dim = int(dim)
+            self.hidden = int(hidden)
+            self.layers = int(layers)
+            out_dims = [self.hidden] * (self.layers - 1) + [1]
+            self.icnn_layers = nn.ModuleList()
+            prev_dim: int | None = None
+            for out_dim in out_dims:
+                self.icnn_layers.append(_ICNNLayer(prev_dim, self.dim, out_dim))
+                prev_dim = out_dim
+            self.log_norm = nn.Parameter(torch.zeros(()))  # the NCE-learned scalar log-normalizer
+
+        def energy(self, x: Any) -> Any:
+            z = None
+            for i, layer in enumerate(self.icnn_layers):
+                z = layer(z, x)
+                if i < len(self.icnn_layers) - 1:
+                    z = torch.nn.functional.softplus(z)
+            return z.squeeze(-1)
+
+    ConvexEnergyNet.__module__ = __name__
+    ConvexEnergyNet.__qualname__ = "ConvexEnergyNet"
+    ConvexEnergyNet.__name__ = "ConvexEnergyNet"
+    _CONVEX_ENERGY_NET_CLASS.append(ConvexEnergyNet)
+    return ConvexEnergyNet
+
+
+def __getattr__(name: str) -> Any:  # PEP 562: lets ``pickle`` resolve the hoisted net classes by name
     if name == "EnergyNet":
         return _energy_net_class()
+    if name == "ConvexEnergyNet":
+        return _convex_energy_net_class()
     raise AttributeError("module %r has no attribute %r" % (__name__, name))
 
 
@@ -359,6 +422,17 @@ def build_energy_net(dim: int, *, hidden: int = 64, layers: int = 3) -> Any:
     ``log_norm`` parameter and a ``dim`` attribute.
     """
     return _energy_net_class()(dim, hidden, layers)
+
+
+def build_convex_energy_net(dim: int, *, hidden: int = 64, layers: int = 3) -> Any:
+    """An input-convex MLP energy ``E(x): R^dim -> R``, convex in ``x`` BY CONSTRUCTION -- ready to wrap
+    in an :class:`EnergyModel` exactly like :func:`build_energy_net`. A convex energy gives Langevin
+    sampling (:class:`EnergyModelSampler`) a unimodal target with no spurious local minima to get stuck
+    in, and gives any consumer of the fitted energy a certified-convex scalar-valued potential (e.g. a
+    verified optimum for a downstream ``mixle.doe`` search over ``-E(x)``). See :func:`_convex_energy_net_class`
+    for the construction.
+    """
+    return _convex_energy_net_class()(dim, hidden, layers)
 
 
 def _register_serializable() -> None:

--- a/mixle/models/neural.py
+++ b/mixle/models/neural.py
@@ -307,6 +307,68 @@ def make_mlp(input_dim: int, hidden_dims: Sequence[int], output_dim: int = 1, ac
     return torch.nn.Sequential(*layers)
 
 
+def make_monotonic_mlp(
+    input_dim: int, hidden_dims: Sequence[int], output_dim: int = 1, *, increasing: bool = True
+) -> Any:
+    """A fully connected Torch MLP that is monotonic in every input dimension jointly, BY CONSTRUCTION.
+
+    Each layer's weight matrix is reparameterized through ``softplus`` before use, so every weight is
+    strictly non-negative; composed with the (smooth, strictly increasing) ``Softplus`` activation, a
+    non-negative-weight affine map followed by an increasing activation is itself increasing, and that
+    property is closed under composition -- so the whole network is provably non-decreasing in every
+    input coordinate, with no penalty term and no post-hoc check needed. ``increasing=False`` negates the
+    output, giving a network non-increasing in every coordinate instead.
+
+    This is a hard architectural constraint (unlike :class:`~mixle.models.pinn.PINNRegression`'s soft
+    residual penalty): the guarantee holds at every point in input space, not just where training data
+    landed. Drops into the same wrappers as :func:`make_mlp` -- :class:`~mixle.models.neural_leaf.NeuralGaussian`
+    for regression, :class:`~mixle.models.softmax_leaf.NeuralCategorical` for classification -- no other
+    changes needed. Only jointly monotonic in ALL inputs; a network monotonic in some coordinates and free
+    in others needs a two-path (monotonic + unconstrained) variant, not built here.
+    """
+    try:
+        import torch
+    except ImportError as e:  # pragma: no cover
+        raise ImportError("make_monotonic_mlp requires torch.") from e
+    if int(input_dim) <= 0 or int(output_dim) <= 0 or any(int(h) <= 0 for h in hidden_dims):
+        raise ValueError(
+            "make_monotonic_mlp dims must be positive; got input_dim=%r hidden_dims=%r output_dim=%r"
+            % (input_dim, list(hidden_dims), output_dim)
+        )
+
+    class _NonNegativeLinear(torch.nn.Module):
+        def __init__(self, in_features: int, out_features: int) -> None:
+            super().__init__()
+            # softplus(0) = log(2) =~ 0.69, NOT ~0 -- a naive small-mean raw_weight init would put every
+            # effective weight near 0.69 rather than near 0, exploding the signal through depth. Instead
+            # init the EFFECTIVE weight at a normal fan-in scale, then invert softplus to get raw_weight.
+            fan_in = max(in_features, 1)
+            target = torch.empty(out_features, in_features).uniform_(1e-3, 1.0 / fan_in**0.5)
+            self.raw_weight = torch.nn.Parameter(target + torch.log(-torch.expm1(-target)))  # softplus^-1
+            self.bias = torch.nn.Parameter(torch.zeros(out_features))
+
+        def forward(self, x: Any) -> Any:
+            weight = torch.nn.functional.softplus(self.raw_weight)
+            return torch.nn.functional.linear(x, weight, self.bias)
+
+    class _NegateOutput(torch.nn.Module):
+        def __init__(self, module: Any) -> None:
+            super().__init__()
+            self.module = module
+
+        def forward(self, x: Any) -> Any:
+            return -self.module(x)
+
+    dims = [int(input_dim)] + [int(h) for h in hidden_dims] + [int(output_dim)]
+    layers: list[Any] = []
+    for i in range(len(dims) - 1):
+        layers.append(_NonNegativeLinear(dims[i], dims[i + 1]))
+        if i < len(dims) - 2:
+            layers.append(torch.nn.Softplus())
+    module = torch.nn.Sequential(*layers)
+    return module if increasing else _NegateOutput(module)
+
+
 def _torch_engine(
     engine: Any | None, precision: Any | None = None, owner: str = "GaussianRegressionNeuralNetwork"
 ) -> tuple[Any, Any]:

--- a/mixle/tests/energy_test.py
+++ b/mixle/tests/energy_test.py
@@ -15,7 +15,7 @@ torch = pytest.importorskip("torch")
 
 import mixle.stats as st  # noqa: E402
 from mixle.inference import optimize  # noqa: E402
-from mixle.models.energy import EnergyModel, build_energy_net  # noqa: E402
+from mixle.models.energy import EnergyModel, build_convex_energy_net, build_energy_net  # noqa: E402
 
 
 def _seed(s=0):
@@ -65,6 +65,34 @@ class EnergyModelTest(unittest.TestCase):
         s = np.asarray(fit.sampler(0).sample(300))
         self.assertEqual(s.shape, (300, 2))
         self.assertTrue(np.any(s[:, 0] > 1.0) and np.any(s[:, 0] < -1.0))  # Langevin reaches both modes
+
+
+class ConvexEnergyNetTest(unittest.TestCase):
+    def test_convex_by_construction_at_random_init(self):
+        # Jensen's inequality (E(midpoint) <= average of endpoints) must hold everywhere for a convex
+        # function -- checked here at a RANDOM, untrained initialization, since the guarantee comes from
+        # the architecture (non-negative z-path weights + convex activations), not from what got fit.
+        _seed()
+        net = build_convex_energy_net(4, hidden=32, layers=4)
+        a = torch.randn(200, 4)
+        b = torch.randn(200, 4)
+        mid = (a + b) / 2.0
+        with torch.no_grad():
+            ea, eb, emid = net.energy(a), net.energy(b), net.energy(mid)
+        violation = float((emid - 0.5 * (ea + eb)).clamp(min=0.0).max())
+        self.assertLessEqual(violation, 1e-4)
+
+    def test_wraps_into_energy_model_and_fits_a_unimodal_density(self):
+        _seed()
+        data = [np.array([v]) for v in np.random.RandomState(0).randn(300) * 0.5 + 1.0]
+        em = EnergyModel(build_convex_energy_net(1, hidden=32), m_steps=300, lr=5e-3, noise_ratio=2)
+        fit = optimize(data, em.estimator(), prev_estimate=em, max_its=6, out=None)
+        grid = np.linspace(-6.0, 6.0, 2001)
+        density = np.exp(fit.seq_log_density(grid.reshape(-1, 1)))
+        integral = float(np.trapezoid(density, grid))
+        self.assertAlmostEqual(integral, 1.0, delta=0.3)
+        # a convex energy is unimodal: the fitted density should peak near the data's mean, not elsewhere
+        self.assertAlmostEqual(float(grid[np.argmax(density)]), 1.0, delta=1.0)
 
 
 if __name__ == "__main__":

--- a/mixle/tests/monotonic_mlp_test.py
+++ b/mixle/tests/monotonic_mlp_test.py
@@ -1,0 +1,84 @@
+"""make_monotonic_mlp (mixle.models.neural): a Torch MLP monotonic in every input by construction, and its
+composition with the existing NeuralGaussian regression wrapper."""
+
+import unittest
+
+import numpy as np
+
+try:
+    import torch
+
+    _HAS_TORCH = True
+except ImportError:
+    _HAS_TORCH = False
+
+
+@unittest.skipUnless(_HAS_TORCH, "torch not installed")
+class MakeMonotonicMlpTest(unittest.TestCase):
+    def test_increasing_by_construction_at_random_init(self):
+        # the monotonicity guarantee comes from the non-negative-weight architecture, not from training --
+        # checked here at several random, untrained initializations.
+        from mixle.models.neural import make_monotonic_mlp
+
+        for seed in range(5):
+            torch.manual_seed(seed)
+            module = make_monotonic_mlp(3, [16, 16], 1)
+            x = torch.randn(100, 3, requires_grad=True)
+            y = module(x)
+            (grad,) = torch.autograd.grad(y.sum(), x)
+            self.assertGreaterEqual(float(grad.min()), 0.0)
+
+    def test_decreasing_flag_negates_the_gradient_sign(self):
+        from mixle.models.neural import make_monotonic_mlp
+
+        torch.manual_seed(0)
+        module = make_monotonic_mlp(2, [16], 1, increasing=False)
+        x = torch.randn(100, 2, requires_grad=True)
+        y = module(x)
+        (grad,) = torch.autograd.grad(y.sum(), x)
+        self.assertLessEqual(float(grad.max()), 0.0)
+
+    def test_monotone_1d_curve_is_actually_nondecreasing_pointwise(self):
+        from mixle.models.neural import make_monotonic_mlp
+
+        torch.manual_seed(1)
+        module = make_monotonic_mlp(1, [8, 8], 1)
+        grid = torch.linspace(-5.0, 5.0, 200).reshape(-1, 1)
+        with torch.no_grad():
+            y = module(grid).flatten().numpy()
+        self.assertTrue(np.all(np.diff(y) >= -1e-6))
+
+    def test_invalid_dims_raise(self):
+        from mixle.models.neural import make_monotonic_mlp
+
+        with self.assertRaises(ValueError):
+            make_monotonic_mlp(0, [8], 1)
+        with self.assertRaises(ValueError):
+            make_monotonic_mlp(2, [0], 1)
+
+    def test_fits_a_monotone_regression_target_through_neural_gaussian(self):
+        from mixle.models.neural import make_monotonic_mlp
+        from mixle.models.neural_leaf import NeuralGaussian
+
+        torch.manual_seed(0)
+        rng = np.random.RandomState(0)
+        x = rng.uniform(-2, 2, 200).astype("float32")
+        y = (2.0 * x + 0.05 * rng.randn(200)).astype("float32")  # a monotone increasing target
+        data = list(zip(x[:, None], y[:, None]))
+
+        model = NeuralGaussian(make_monotonic_mlp(1, [32, 32], 1), noise=1.0, m_steps=800, lr=0.03)
+        est = model.estimator()
+        acc = est.accumulator_factory().make()
+        enc = model.dist_to_encoder().seq_encode(data)
+        acc.seq_update(enc, np.ones(len(data)), model)
+        fitted = est.estimate(None, acc.value())
+
+        pred = fitted._forward(x[:, None])[:, 0]
+        self.assertLess(float(np.mean((pred - y) ** 2)), 1.0)  # tracks y = 2x well (data variance itself ~0.0025)
+        # the fit is monotone by construction even though the fitting loop never checked for it
+        order = np.argsort(x)
+        self.assertTrue(np.all(np.diff(pred[order]) >= -1e-4))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Follow-up to #77 (PINNRegression) and the original architecture survey, which identified five gaps in constrained-neural-network support: hard output constraints, physics-informed residuals (built in #77), monotonic networks, input-convex networks (ICNN), and symmetry/equivariance beyond the existing translation-quotient model. This PR closes two more:

- **`mixle.models.neural.make_monotonic_mlp`**: an MLP non-decreasing (or non-increasing, via `increasing=False`) in every input jointly, by construction. Every weight matrix is softplus-reparameterized to stay non-negative, composed with the increasing `Softplus` activation -- non-negative-weight affine + increasing activation is increasing, closed under composition. The guarantee holds everywhere in input space, not just where training data landed (unlike PINNRegression's soft residual penalty). Drops into `NeuralGaussian`/`NeuralCategorical` unchanged -- no new estimator needed.
- **`mixle.models.energy.build_convex_energy_net`**: an input-convex energy net (ICNN, Amos et al. 2017) -- `E(x)` convex in `x` by construction via non-negative "z-path" weights plus unconstrained per-layer input skip connections. Drops into `EnergyModel` unchanged; gives Langevin sampling a unimodal target with no spurious local minima.

Found and fixed a real bug during testing: my first `make_monotonic_mlp` draft initialized `raw_weight ~ N(0, 0.1)`, but `softplus(0) = log(2) ≈ 0.69`, not ~0 -- every effective weight started near 0.69 rather than near a normal small-fan-in scale, exploding the signal through depth (initial loss ~170k on a trivial linear target). Fixed by initializing the *effective* weight at a normal fan-in scale and inverting softplus to get `raw_weight`.

**Remaining gap**: symmetry/equivariance beyond translation (the existing `mixle/models/quotient.py`) is not addressed here -- a general equivariance framework is a larger, separate undertaking.

## Test plan
- [x] `mixle/tests/monotonic_mlp_test.py` (new, 5 tests): monotone-by-construction at 5 random inits (gradient sign check), decreasing flag negates the sign, a 1-D curve is pointwise nondecreasing, invalid dims raise, and it fits a real monotone regression target through `NeuralGaussian` while staying monotone.
- [x] `mixle/tests/energy_test.py` (extended, +2 tests): convex-by-construction at random init (Jensen's inequality check), and it wraps into `EnergyModel` + fits a unimodal density via NCE.
- [x] `mixle/tests/monotonic_mlp_test.py mixle/tests/energy_test.py mixle/tests/neural_leaf_test.py` -- 10 passed.
- [x] `ruff check` / `ruff format --check` -- clean.