### PR TITLE
utils/automatic: make model suggestion act on held-out validation, not just note it

### DIFF
--- a/mixle/tests/automatic_robust_recommendation_test.py
+++ b/mixle/tests/automatic_robust_recommendation_test.py
@@ -1,0 +1,106 @@
+"""MarginalFieldProfile.robust_recommendation(): combine the in-sample (BIC) model choice with the
+held-out validation check into one principled final answer, instead of leaving their disagreement as
+a text note nobody acts on. Held-out generalization is stronger evidence than in-sample penalized
+likelihood, but a validation preference that is itself ambiguous (a small, noisy gap) should not
+overturn BIC -- only a decisive disagreement should.
+"""
+
+import unittest
+
+import numpy as np
+
+from mixle.utils.automatic import analyze_structure
+from mixle.utils.automatic.profiling import AMBIGUOUS_SCORE_GAP_BITS, MarginalFieldProfile
+
+
+def _profile(recommendation, validation_recommendation=None, validation_score_gap_bits=None):
+    return MarginalFieldProfile(
+        path=(),
+        role="field",
+        count=100,
+        missing_count=0,
+        missing_fraction=0.0,
+        observed_count=100,
+        kind="numeric",
+        recommendation=recommendation,
+        validation_recommendation=validation_recommendation,
+        validation_score_gap_bits=validation_score_gap_bits,
+    )
+
+
+class RobustRecommendationUnitTest(unittest.TestCase):
+    def test_no_validation_evidence_keeps_the_marginal_recommendation(self):
+        p = _profile("gaussian")
+        self.assertEqual(p.robust_recommendation(), "gaussian")
+
+    def test_validation_agrees_no_change(self):
+        p = _profile("gaussian", validation_recommendation="gaussian", validation_score_gap_bits=1.0)
+        self.assertEqual(p.robust_recommendation(), "gaussian")
+
+    def test_decisive_validation_disagreement_overrides(self):
+        gap = AMBIGUOUS_SCORE_GAP_BITS + 0.01
+        p = _profile("lognormal", validation_recommendation="gamma", validation_score_gap_bits=gap)
+        self.assertEqual(p.robust_recommendation(), "gamma")
+
+    def test_ambiguous_validation_disagreement_does_not_override(self):
+        gap = AMBIGUOUS_SCORE_GAP_BITS - 0.001
+        p = _profile("lognormal", validation_recommendation="gamma", validation_score_gap_bits=gap)
+        self.assertEqual(p.robust_recommendation(), "lognormal")
+
+    def test_exactly_at_the_ambiguous_boundary_overrides(self):
+        # the gate is a strict '<' check against the shared AMBIGUOUS_SCORE_GAP_BITS constant (the
+        # same "is this gap ambiguous" check used elsewhere in this module, e.g. the "top validation
+        # models are close" note), so the exact boundary value itself counts as decisive: only a gap
+        # STRICTLY BELOW the threshold is "too close to call".
+        p = _profile("lognormal", validation_recommendation="gamma", validation_score_gap_bits=AMBIGUOUS_SCORE_GAP_BITS)
+        self.assertEqual(p.robust_recommendation(), "gamma")
+
+    def test_missing_gap_with_disagreement_does_not_override(self):
+        p = _profile("lognormal", validation_recommendation="gamma", validation_score_gap_bits=None)
+        self.assertEqual(p.robust_recommendation(), "lognormal")
+
+
+class RobustRecommendationIntegrationTest(unittest.TestCase):
+    def test_a_known_decisive_disagreement_is_surfaced_and_overrides(self):
+        # a few large outliers pull the marginal (in-sample) BIC toward integer_categorical, but a
+        # held-out split clearly favors Poisson -- a real, reproducible disagreement case.
+        data = [0] * 30 + [1] * 10 + [10] * 2
+        profile = analyze_structure(
+            data, pairwise=False, validation_seed=17, validation_fraction=0.25, validation_min_count=10
+        )
+        field = profile.fields[0]
+        self.assertEqual(field.recommendation, "integer_categorical")
+        self.assertEqual(field.validation_recommendation, "poisson")
+        self.assertEqual(field.robust_recommendation(), "poisson")
+        self.assertIn("gap is decisive -- robust_recommendation() overrides to poisson", field.validation_notes)
+
+    def test_robust_recommendation_is_serialized_in_summary(self):
+        data = list(np.random.RandomState(3).normal(0.0, 1.0, 300))
+        profile = analyze_structure(data, pairwise=False)
+        summary = profile.fields[0].summary()
+        self.assertIn("robust_recommendation", summary)
+        self.assertEqual(summary["robust_recommendation"], profile.fields[0].robust_recommendation())
+
+    def test_no_disagreement_case_robust_recommendation_matches_marginal(self):
+        # plain, well-behaved Gaussian data: no reason for validation to disagree, so robust_recommendation
+        # should just equal the marginal recommendation.
+        data = list(np.random.RandomState(4).normal(5.0, 2.0, 500))
+        profile = analyze_structure(data, pairwise=False)
+        field = profile.fields[0]
+        self.assertEqual(field.robust_recommendation(), field.recommendation)
+
+    def test_existing_disagreement_note_wording_is_unchanged(self):
+        # regression guard: the pre-existing exact note text must survive untouched (other consumers
+        # may match on it) -- the new decisive-override note is a SEPARATE, additional entry.
+        data = [0] * 30 + [1] * 10 + [10] * 2
+        profile = analyze_structure(
+            data, pairwise=False, validation_seed=17, validation_fraction=0.25, validation_min_count=10
+        )
+        field = profile.fields[0]
+        self.assertIn(
+            "validation prefers poisson over marginal recommendation integer_categorical", field.validation_notes
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mixle/utils/automatic/profiling.py
+++ b/mixle/utils/automatic/profiling.py
@@ -88,6 +88,25 @@ class MarginalFieldProfile:
     gof_pvalue: float | None = None
     notes: list[str] = field(default_factory=list)
 
+    def robust_recommendation(self) -> str:
+        """The model choice to actually trust, combining the in-sample (BIC) pick with the held-out
+        validation check rather than leaving their disagreement as a note for a human to notice.
+
+        Held-out generalization is stronger evidence than an in-sample penalized-likelihood score:
+        a flexible family (a 3-parameter shape family, a 2-component mixture) can win BIC by fitting
+        noise/outliers in the training data that do not repeat in held-out data, which is exactly the
+        failure mode BIC's asymptotic parameter-count penalty does not always catch at small-to-moderate
+        n. So: agree with ``recommendation`` whenever there is no held-out evidence, or the two already
+        agree; defer to ``validation_recommendation`` only when it disagrees by a DECISIVE margin (the
+        same ``AMBIGUOUS_SCORE_GAP_BITS`` threshold already used to flag a close call elsewhere in this
+        module) -- a marginal, ambiguous validation preference is not enough evidence to overturn BIC.
+        """
+        if self.validation_recommendation is None or self.validation_recommendation == self.recommendation:
+            return self.recommendation
+        if self.validation_score_gap_bits is None or self.validation_score_gap_bits < AMBIGUOUS_SCORE_GAP_BITS:
+            return self.recommendation
+        return self.validation_recommendation
+
     def model_weights(self) -> dict[str, float]:
         """Return Schwarz (BIC) model weights over the scored candidates, summing to 1.
 
@@ -108,6 +127,7 @@ class MarginalFieldProfile:
             "observed_count": self.observed_count,
             "kind": self.kind,
             "recommendation": self.recommendation,
+            "robust_recommendation": self.robust_recommendation(),
             "bits_per_obs": self.bits_per_obs,
             "entropy_bits": self.entropy_bits,
             "cardinality": self.cardinality,
@@ -212,9 +232,14 @@ class StructureProfile:
         lines = []
         for field_profile in self.fields:
             bits = "" if field_profile.bits_per_obs is None else " (~%.3f bits/obs)" % field_profile.bits_per_obs
+            robust = field_profile.robust_recommendation()
+            overridden = (
+                " (validation-overridden from %s)" % field_profile.recommendation
+                if robust != field_profile.recommendation
+                else ""
+            )
             lines.append(
-                "%s: %s -> %s%s"
-                % (format_path(field_profile.path), field_profile.kind, field_profile.recommendation, bits)
+                "%s: %s -> %s%s%s" % (format_path(field_profile.path), field_profile.kind, robust, overridden, bits)
             )
             for note in field_profile.notes:
                 lines.append("  - %s" % note)
@@ -981,6 +1006,10 @@ def _validate_marginal_profile(
         profile.validation_notes.append(
             "validation prefers %s over marginal recommendation %s" % (recommendation, profile.recommendation)
         )
+        if profile.robust_recommendation() == recommendation:
+            profile.validation_notes.append(
+                "gap is decisive -- robust_recommendation() overrides to %s" % recommendation
+            )
     return profile
 
 


### PR DESCRIPTION
## Summary
`analyze_structure()` already computes a held-out validation check for every marginal field by default (`validate_marginals=True`) alongside the primary in-sample BIC recommendation -- but when they disagreed, the only thing that happened was a text note nobody downstream reads or acts on. The actual `recommendation` field, the one surfaced everywhere (`summary()`, `explain()`), stayed whatever in-sample BIC picked regardless of what held-out data said.

Held-out generalization is stronger evidence than an in-sample penalized-likelihood score: a flexible family (a 3-parameter shape detector, a 2-component mixture) can win BIC by fitting noise/outliers in the training data that don't repeat in held-out data -- exactly the failure mode BIC's asymptotic parameter-count penalty doesn't always catch at small-to-moderate n. That's the textbook definition of an unstable model suggestion.

**New `MarginalFieldProfile.robust_recommendation()`**: agrees with the in-sample recommendation whenever there's no held-out evidence or the two already agree; defers to the validation recommendation only when it disagrees by a *decisive* margin (the same `AMBIGUOUS_SCORE_GAP_BITS` threshold this module already uses elsewhere to flag a close call). A marginal, noisy validation preference is not enough evidence to overturn BIC.

Purely additive -- doesn't change any existing field's value or meaning:
- New method; `recommendation` itself is untouched.
- Surfaced in `summary()` as a new `"robust_recommendation"` key (existing keys unchanged).
- `explain()`'s per-field line now shows the robust choice, annotated `(validation-overridden from X)` only in the rare decisive-disagreement case -- byte-identical to before when the two already agree.
- The pre-existing `validation_notes` disagreement message is left exactly as it was (verified against an existing exact-string test assertion); the override decision is a separate, additional note.

## Test plan
- [x] `mixle/tests/automatic_robust_recommendation_test.py` (10 tests): unit coverage of the decision rule (no evidence, agreement, decisive override, ambiguous non-override, missing gap, the exact boundary), plus integration coverage via `analyze_structure` -- a reproducible decisive-disagreement case overrides and is noted, `summary()` serializes the new field, a well-behaved Gaussian case shows no disagreement, and the pre-existing note wording survives unchanged.
- [x] Full suite: `mixle/tests/automatic_*.py` = 142 passed (132 pre-existing, unchanged + 10 new), 26 subtests passed.
- [x] `ruff check` + `ruff format --check` clean.