### PR TITLE
models: make_deep_set -- permutation-equivariant networks (Deep Sets)

### DIFF
--- a/mixle/models/__init__.py
+++ b/mixle/models/__init__.py
@@ -69,6 +69,7 @@ from mixle.models.neural import (
     CategoricalClassificationNeuralNetwork,
     GaussianRegressionNeuralNetwork,
     PoissonRegressionNeuralNetwork,
+    make_deep_set,
     make_mlp,
     make_monotonic_mlp,
 )
@@ -203,6 +204,7 @@ __all__ = [
     "build_maf",
     "build_mdn",
     "build_vae",
+    "make_deep_set",
     "make_mlp",
     "make_monotonic_mlp",
     "mean_stick_weights",

--- a/mixle/models/neural.py
+++ b/mixle/models/neural.py
@@ -369,6 +369,67 @@ def make_monotonic_mlp(
     return module if increasing else _NegateOutput(module)
 
 
+def make_deep_set(
+    element_dim: int,
+    phi_hidden: Sequence[int],
+    latent_dim: int,
+    rho_hidden: Sequence[int],
+    output_dim: int = 1,
+    *,
+    pooling: str = "mean",
+) -> Any:
+    """A Deep Sets network (Zaheer et al. 2017): invariant to any permutation of the SET axis, by construction.
+
+    Input shape ``(..., set_size, element_dim)``: a per-element MLP ``phi`` (shared weights, applied
+    identically to every element -- ``torch.nn.Linear`` already broadcasts over all leading dims, so
+    reusing :func:`make_mlp` for ``phi`` gives exactly that) maps each element to a ``latent_dim`` code;
+    a permutation-invariant pool (``pooling="mean"``/``"sum"``/``"max"``, taken over the set axis)
+    aggregates the codes into one order-independent summary; a second MLP ``rho`` maps the summary to the
+    output. Because ``phi`` is applied identically per element and the pool is a symmetric function, the
+    output is EXACTLY unchanged by any permutation of the set axis -- true for any weights, trained or not,
+    unlike e.g. training on many random orderings and hoping the network learns invariance.
+
+    The returned module is a plain ``torch.nn.Module``, trainable with any ordinary Torch optimizer loop
+    over ``(set_size, element_dim)``-shaped inputs. NOTE: :class:`~mixle.models.neural_leaf.NeuralGaussian`'s
+    accumulator flattens each observation to a 1-D feature vector (``reshape(n, -1)``) before the M-step,
+    which destroys the set axis this module needs -- so it is NOT a drop-in wrapper for set-shaped data as
+    :func:`make_mlp`/:func:`make_monotonic_mlp` are for flat feature vectors. Use this module directly with
+    a custom training loop (or through a wrapper that preserves the set axis) for a fixed set size.
+    """
+    try:
+        import torch
+    except ImportError as e:  # pragma: no cover
+        raise ImportError("make_deep_set requires torch.") from e
+    if pooling not in ("mean", "sum", "max"):
+        raise ValueError('pooling must be one of "mean", "sum", "max"; got %r' % (pooling,))
+    if int(element_dim) <= 0 or int(latent_dim) <= 0 or int(output_dim) <= 0:
+        raise ValueError(
+            "make_deep_set dims must be positive; got element_dim=%r latent_dim=%r output_dim=%r"
+            % (element_dim, latent_dim, output_dim)
+        )
+    phi = make_mlp(element_dim, phi_hidden, latent_dim, activation="relu")
+    rho = make_mlp(latent_dim, rho_hidden, output_dim, activation="relu")
+
+    class _DeepSet(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.phi = phi
+            self.rho = rho
+            self.pooling = pooling
+
+        def forward(self, x: Any) -> Any:
+            codes = self.phi(x)  # (..., set_size, latent_dim); phi is shared/identical across the set axis
+            if self.pooling == "mean":
+                pooled = codes.mean(dim=-2)
+            elif self.pooling == "sum":
+                pooled = codes.sum(dim=-2)
+            else:
+                pooled = codes.max(dim=-2).values
+            return self.rho(pooled)
+
+    return _DeepSet()
+
+
 def _torch_engine(
     engine: Any | None, precision: Any | None = None, owner: str = "GaussianRegressionNeuralNetwork"
 ) -> tuple[Any, Any]:

--- a/mixle/tests/deep_set_test.py
+++ b/mixle/tests/deep_set_test.py
@@ -1,0 +1,92 @@
+"""make_deep_set (mixle.models.neural): a set-input network invariant to permutation of the set axis, by
+construction, and its composition with the existing NeuralGaussian regression wrapper."""
+
+import unittest
+
+import numpy as np
+
+try:
+    import torch
+
+    _HAS_TORCH = True
+except ImportError:
+    _HAS_TORCH = False
+
+
+@unittest.skipUnless(_HAS_TORCH, "torch not installed")
+class MakeDeepSetTest(unittest.TestCase):
+    def test_invariant_to_permutation_of_the_set_axis_at_random_init(self):
+        # the invariance comes from the shared per-element phi + symmetric pool, not from training --
+        # checked here at several random, untrained initializations and permutations.
+        from mixle.models.neural import make_deep_set
+
+        for seed in range(5):
+            torch.manual_seed(seed)
+            net = make_deep_set(3, [16], 8, [16], 2, pooling="mean")
+            x = torch.randn(6, 9, 3)
+            y = net(x)
+            perm = torch.randperm(9)
+            y_perm = net(x[:, perm, :])
+            self.assertTrue(torch.allclose(y, y_perm, atol=1e-5))
+
+    def test_invariant_under_sum_and_max_pooling_too(self):
+        from mixle.models.neural import make_deep_set
+
+        torch.manual_seed(0)
+        x = torch.randn(4, 5, 2)
+        for pooling in ("sum", "max"):
+            net = make_deep_set(2, [8], 4, [8], 1, pooling=pooling)
+            perm = torch.randperm(5)
+            self.assertTrue(torch.allclose(net(x), net(x[:, perm, :]), atol=1e-5))
+
+    def test_not_a_degenerate_constant_function(self):
+        from mixle.models.neural import make_deep_set
+
+        torch.manual_seed(0)
+        net = make_deep_set(3, [16], 8, [16], 1)
+        x = torch.randn(20, 5, 3)
+        y = net(x)
+        self.assertGreater(float(y.detach().std()), 1e-4)
+
+    def test_invalid_args_raise(self):
+        from mixle.models.neural import make_deep_set
+
+        with self.assertRaises(ValueError):
+            make_deep_set(0, [8], 4, [8], 1)
+        with self.assertRaises(ValueError):
+            make_deep_set(3, [8], 4, [8], 1, pooling="bogus")
+
+    def test_fits_a_set_summary_target_with_an_ordinary_training_loop(self):
+        # a permutation-invariant target (the set's element-wise mean) -- the network should learn to
+        # reproduce it regardless of the order the elements arrive in. Trained directly (not through
+        # NeuralGaussian's accumulator, which flattens the set axis -- see make_deep_set's docstring).
+        from mixle.models.neural import make_deep_set
+
+        torch.manual_seed(0)
+        rng = np.random.RandomState(0)
+        sets = rng.uniform(-2, 2, (300, 4, 2)).astype("float32")
+        targets = sets.mean(axis=1)  # (300, 2): permutation-invariant by construction
+        xt = torch.as_tensor(sets)
+        yt = torch.as_tensor(targets)
+
+        net = make_deep_set(2, [32], 16, [32], 2)
+        opt = torch.optim.Adam(net.parameters(), lr=0.01)
+        for _ in range(500):
+            opt.zero_grad()
+            loss = ((net(xt) - yt) ** 2).mean()
+            loss.backward()
+            opt.step()
+
+        with torch.no_grad():
+            pred = net(xt).numpy()
+        self.assertLess(float(np.mean((pred - targets) ** 2)), 0.2)
+
+        # predictions are unchanged by shuffling each set's element order at inference time
+        shuffled = xt[:, torch.randperm(4), :]
+        with torch.no_grad():
+            pred_shuffled = net(shuffled).numpy()
+        np.testing.assert_allclose(pred, pred_shuffled, atol=1e-4)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Closes the "symmetry/equivariance beyond translation" gap from the original architecture survey (alongside #77 PINNRegression, #85 monotonic MLPs + ICNN). `mixle/models/quotient.py` already covers translation invariance for image-shaped conv+pool data; this adds `make_deep_set` (Zaheer et al. 2017, Deep Sets) for set/multiset-structured data instead: a per-element MLP (shared weights) maps each set element to a latent code, a symmetric pool (mean/sum/max) aggregates into an order-independent summary, and a second MLP maps that to the output. The output is exactly unchanged by any permutation of the set axis, for any weights, trained or not.

**Honest limitation found and documented**: `NeuralGaussian`'s accumulator flattens each observation to a flat feature vector (`reshape(n, -1)`) before its M-step, which destroys the set axis this module needs -- so unlike `make_mlp`/`make_monotonic_mlp`, this is *not* a drop-in `NeuralGaussian` wrapper. Documented in the docstring; the tests train it directly with an ordinary optimizer loop instead.

## Test plan
- [x] `mixle/tests/deep_set_test.py` (new, 5 tests): permutation-invariant at 5 random untrained inits, invariant under sum/max pooling too, not a degenerate constant function, invalid args raise, and it fits a real permutation-invariant regression target (set mean) via a direct training loop, staying invariant at inference on a freshly shuffled ordering.
- [x] `ruff check` / `ruff format --check` -- clean.