### PR TITLE
hardening: fix 6 real bugs in foundational EM/precision/registry code

### DIFF
--- a/mixle/engines/base.py
+++ b/mixle/engines/base.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
+import contextvars
 import math
-import threading
 from abc import ABC, abstractmethod
 from collections.abc import Callable
 from contextlib import contextmanager
@@ -13,23 +13,28 @@ from typing import Any
 # each ``estimator.estimate(...)`` call so device-aware leaves (e.g. NeuralLeaf, whose M-step trains an
 # arbitrary torch module) can follow the engine's device without the ParameterEstimator.estimate
 # contract having to thread the engine through every subclass.
-_ACTIVE = threading.local()
+#
+# A ContextVar, not threading.local: threading.local isolates OS threads but not concurrent asyncio
+# tasks sharing one thread -- two using_active_engine(...) blocks entered as overlapping tasks on the
+# same event loop would otherwise see each other's engine mid-block (reproduced with asyncio.gather).
+# ContextVar is copied into each Task's context at creation, so it is isolated per-task as well as
+# per-thread, with no cost to the synchronous call path mixle's own EM loop uses today.
+_ACTIVE: contextvars.ContextVar[Any] = contextvars.ContextVar("mixle_active_engine", default=None)
 
 
 def active_engine() -> ComputeEngine | None:
     """Return the compute engine driving the current EM step, or ``None`` outside one."""
-    return getattr(_ACTIVE, "engine", None)
+    return _ACTIVE.get()
 
 
 @contextmanager
 def using_active_engine(engine: Any):
     """Mark ``engine`` active for the duration of the block (used by the estimation loop)."""
-    prev = getattr(_ACTIVE, "engine", None)
-    _ACTIVE.engine = engine
+    token = _ACTIVE.set(engine)
     try:
         yield
     finally:
-        _ACTIVE.engine = prev
+        _ACTIVE.reset(token)
 
 
 class ComputeEngine(ABC):

--- a/mixle/engines/precision.py
+++ b/mixle/engines/precision.py
@@ -119,20 +119,32 @@ def _is_gpu_engine(engine: Any) -> bool:
 
 
 def _numeric_data_sample(data: Any, sample_size: int = 512) -> np.ndarray | None:
-    """Flatten the first ``sample_size`` observations to a float array, or None if not numeric.
+    """Flatten an evenly-spaced sample of ``sample_size`` observations to a float array, or None if
+    not numeric.
 
     Handles scalars, sequences/arrays of scalars, and (nested) tuples of those -- enough to read the
     magnitude/dynamic-range of continuous data. Structured/categorical/None observations yield None,
     in which case the caller stays at the safe default precision.
+
+    Strided across the full dataset rather than the leading ``sample_size`` rows: naturally-ordered
+    data (sorted, appended-to over time, grouped by source) can concentrate extreme-magnitude values
+    later in the sequence, which a plain prefix would never see -- silently recommending float32 for
+    data that is not actually well-conditioned for it. ``list(data)`` already materializes every row
+    to index into, so striding costs nothing extra over slicing a prefix.
     """
     if data is None:
         return None
     try:
-        head = list(data)[:sample_size]
+        rows = list(data)
     except TypeError:
         return None
-    if not head:
+    if not rows:
         return None
+    if len(rows) > sample_size:
+        step = len(rows) / sample_size
+        head = [rows[int(i * step)] for i in range(sample_size)]
+    else:
+        head = rows
     out: list[float] = []
 
     def _collect(obj: Any) -> bool:

--- a/mixle/engines/torch_engine.py
+++ b/mixle/engines/torch_engine.py
@@ -192,11 +192,19 @@ class TorchEngine(ComputeEngine):
     isnan = staticmethod(lambda x: torch.isnan(x))
     isinf = staticmethod(lambda x: torch.isinf(x))
 
-    @staticmethod
-    def sum(x, *args, **kwargs):
-        """Return ``torch.sum`` accepting either ``axis`` or ``dim``."""
+    def sum(self, x, *args, **kwargs):
+        """Return ``torch.sum`` accepting either ``axis`` or ``dim``.
+
+        Promotes a floating input to :attr:`accumulator_dtype` when the caller doesn't pass an explicit
+        ``dtype=`` -- mirroring :meth:`NumpyEngine.sum`. Without this, ``torch.sum`` accumulates in the
+        input tensor's own dtype by default, so a float32-precision fit on this engine would silently
+        drift on large N (the exact catastrophic-cancellation risk ``accumulator_dtype`` exists to
+        guard against) while the numpy engine, which already promotes, stayed accurate.
+        """
         if "axis" in kwargs and "dim" not in kwargs:
             kwargs["dim"] = kwargs.pop("axis")
+        if kwargs.get("dtype") is None and torch.is_tensor(x) and x.dtype.is_floating_point:
+            kwargs["dtype"] = self.accumulator_dtype
         return torch.sum(x, *args, **kwargs)
 
     @staticmethod

--- a/mixle/inference/conformal.py
+++ b/mixle/inference/conformal.py
@@ -27,12 +27,25 @@ import numpy as np
 
 
 def _conformal_quantile(scores: np.ndarray, alpha: float) -> float:
-    """The ``ceil((n+1)(1-alpha))``-th smallest score (finite-sample conformal quantile)."""
+    """The ``ceil((n+1)(1-alpha))``-th smallest score (finite-sample conformal quantile).
+
+    ``k`` reaches 0 exactly at ``alpha == 1.0`` (a valid boundary: 0% coverage requested, the most
+    permissive threshold is never needed and the tightest one always is). ``s[k - 1]`` with ``k == 0``
+    used to silently wrap around via Python's negative indexing to ``s[-1]`` -- the MAXIMUM score, the
+    loosest threshold instead of the tightest -- breaking monotonicity in ``alpha`` right at the
+    boundary and, for ``alpha > 1`` (invalid), either returning an arbitrary interior score or raising
+    an uncaught ``IndexError``. Mirrors :func:`weighted_conformal`'s already-correct ``min(k, n-1)``
+    convention, which returns the minimum score at this same boundary.
+    """
+    if not 0.0 <= alpha <= 1.0:
+        raise ValueError(f"alpha must be in [0.0, 1.0], got {alpha!r}.")
     s = np.sort(np.asarray(scores, dtype=float))
     n = s.shape[0]
     k = int(np.ceil((n + 1) * (1.0 - alpha)))
     if k > n:
         return float("inf")
+    if k < 1:
+        return float(s[0])
     return float(s[k - 1])
 
 

--- a/mixle/inference/estimation.py
+++ b/mixle/inference/estimation.py
@@ -59,7 +59,7 @@ def _coerce_estimator(estimator: Any, data: Any) -> ParameterEstimator:
     return estimator
 
 
-def _maybe_structured_model(data: Any, max_its: int, out: Any) -> Any:
+def _maybe_structured_model(data: Any, max_its: int, out: Any, rng: RandomState | None) -> Any:
     """The automatic-structure front door for ``optimize(data)`` / ``fit(data)`` with no estimator.
 
     For flat tuple records the independent :class:`CompositeDistribution` the automatic detector
@@ -90,7 +90,7 @@ def _maybe_structured_model(data: Any, max_its: int, out: Any) -> Any:
         if not net.edges():
             return None  # independence is what the composite already models; keep the automatic families
 
-        composite = optimize(rows, get_estimator(rows), max_its=max_its, out=None)
+        composite = optimize(rows, get_estimator(rows), max_its=max_its, rng=rng, out=None)
         enc = composite.dist_to_encoder().seq_encode(rows)
         comp_ll = float(np.sum(composite.seq_log_density(enc)))
         comp_bic = -2.0 * comp_ll + _num_free_params(composite) * float(np.log(max(len(rows), 2)))
@@ -475,7 +475,13 @@ def _fused_em_loop(
         if out is not None and (converged or (print_iter and (i + 1) % print_iter == 0)):
             _write_em_iter(out, i + 1, ll_model, dll, score, has_v, obj_label)
         if on_step is not None:
-            on_step(EMStep(i + 1, nxt, float(ll_model), float(dll)))
+            # ll_model is the log-likelihood of `model` (the fused step's INPUT, computed for free
+            # as the E-step normalizer), not of `nxt` (this iteration's freshly-computed, not-yet-
+            # scored output) -- report them paired correctly, matching every other use of ll_model
+            # in this loop (`best_model = model` above, `score = ll_fn(enc_vdata, model)`), so an
+            # on_step consumer that checkpoints model alongside log_density (as the EMStep docstring
+            # explicitly recommends) doesn't persist a mismatched pair.
+            on_step(EMStep(i + 1, model, float(ll_model), float(dll)))
         if converged:
             break
 
@@ -707,7 +713,7 @@ def optimize(
         and init_estimator is None
         and strategy is None
     ):
-        structured = _maybe_structured_model(data, max_its, out)
+        structured = _maybe_structured_model(data, max_its, out, rng)
         if structured is not None:
             return structured
     estimator = _coerce_estimator(estimator, data)
@@ -899,7 +905,7 @@ def fit(
         and kwargs.get("prev_estimate") is None
         and kwargs.get("strategy") is None
     ):
-        structured = _maybe_structured_model(data, max_its, kwargs.get("out", sys.stdout))
+        structured = _maybe_structured_model(data, max_its, kwargs.get("out", sys.stdout), kwargs.get("rng"))
         if structured is not None:
             return structured
     estimator = _coerce_estimator(estimator, data)

--- a/mixle/inference/precision_plan.py
+++ b/mixle/inference/precision_plan.py
@@ -95,11 +95,24 @@ def recommend_compute_precision(
         if s2 is not None and float(s2) < min_variance:
             return PrecisionPlan(np.float64, "near-degenerate component (var %.1e) -> float64 for accuracy" % float(s2))
 
-    # look at the DATA: magnitude + dynamic range
+    # look at the DATA: magnitude + dynamic range. Stride across the full dataset rather than taking
+    # a leading prefix -- naturally-ordered data (sorted, appended-to over time, grouped by source)
+    # can concentrate extreme-magnitude values later in the sequence, which a prefix would never see,
+    # silently allocating float32 to data that is not actually well-conditioned for it. When ``data``
+    # supports random access, stride-index it directly to avoid materializing the whole sequence;
+    # otherwise defer to _numeric_data_sample's own internal stride (it must materialize anyway).
     from mixle.engines.precision import _numeric_data_sample
 
-    sample = data[:sample_size] if hasattr(data, "__getitem__") else data
-    s = _numeric_data_sample(sample)
+    if hasattr(data, "__getitem__") and hasattr(data, "__len__"):
+        n = len(data)
+        if n > sample_size:
+            step = n / sample_size
+            sample = [data[int(i * step)] for i in range(sample_size)]
+        else:
+            sample = data
+    else:
+        sample = data
+    s = _numeric_data_sample(sample, sample_size)
     if s is None or s.size == 0:
         return PrecisionPlan(np.float64, "non-numeric / empty data -> float64")
     amax = float(np.max(np.abs(s)))

--- a/mixle/inference/structure.py
+++ b/mixle/inference/structure.py
@@ -719,14 +719,41 @@ def _clone(estimator: Any) -> Any:
 
 
 def _num_free_params(dist: Any) -> int:
-    """A rough parameter count for the BIC penalty (used only to scale the complexity term)."""
-    for attr in ("mu", "p", "lam", "beta", "alpha"):
+    """A rough parameter count for the BIC penalty (used only to scale the complexity term).
+
+    Composes over :class:`~mixle.stats.combinator.composite.CompositeDistribution` (sums each field's
+    own count) rather than falling through to a flat constant -- a composite of any size used to score
+    the same as a single scalar leaf, which made the network-vs-composite BIC comparison in
+    :func:`mixle.inference.estimation._maybe_structured_model` nearly meaningless for multi-field data.
+
+    Counts a fitted categorical-family leaf (``pmap``/``p_vec``) as ``K - 1`` (the true simplex free
+    parameter count), not the flat constant every other attribute check fell through to -- undercounting
+    complexity there let :func:`mixle.inference.bayesian_network.learn_bayesian_network`'s greedy search
+    accept spurious edges between fields with no real dependence, since the BIC penalty for the extra
+    per-parent-config categorical table barely grew with the number of categories.
+
+    The single-scalar-parameter families below (Poisson rate, Bernoulli/Binomial/NegativeBinomial
+    success probability) count 1, not 2 -- the old code doubled every matched attribute uniformly,
+    correct only for a location+scale pair (Gaussian's mean+variance) and an overcount for these.
+    Any other leaf family (Weibull, Gumbel, Beta, ...) still falls through to the historical flat-2
+    fallback; genuinely counting every exotic detector family's parameters is future work, not
+    something this fix's audit confirmed as broken.
+    """
+    name = type(dist).__name__
+    if name == "CompositeDistribution":
+        return sum(_num_free_params(d) for d in dist.dists)
+    if hasattr(dist, "pmap"):  # CategoricalDistribution: a K-outcome simplex has K-1 free params
+        return max(1, len(dist.pmap) - 1)
+    if hasattr(dist, "p_vec"):  # IntegerCategoricalDistribution: same simplex parameterization
+        return max(1, int(np.asarray(dist.p_vec).size) - 1)
+    if hasattr(dist, "mu"):  # location+scale family (Gaussian, ...): mean + variance
+        try:
+            return max(1, int(np.asarray(dist.mu).size) * 2)
+        except (TypeError, ValueError):
+            return 2
+    for attr in ("lam", "p"):  # single free scalar: Poisson rate, Bernoulli/Binomial/NegBinom success prob
         if hasattr(dist, attr):
-            v = getattr(dist, attr)
-            try:
-                return max(1, int(np.asarray(v).size) * 2)
-            except (TypeError, ValueError):
-                return 2
+            return 1
     return 2
 
 

--- a/mixle/inference/structure.py
+++ b/mixle/inference/structure.py
@@ -732,12 +732,14 @@ def _num_free_params(dist: Any) -> int:
     accept spurious edges between fields with no real dependence, since the BIC penalty for the extra
     per-parent-config categorical table barely grew with the number of categories.
 
-    The single-scalar-parameter families below (Poisson rate, Bernoulli/Binomial/NegativeBinomial
-    success probability) count 1, not 2 -- the old code doubled every matched attribute uniformly,
-    correct only for a location+scale pair (Gaussian's mean+variance) and an overcount for these.
-    Any other leaf family (Weibull, Gumbel, Beta, ...) still falls through to the historical flat-2
-    fallback; genuinely counting every exotic detector family's parameters is future work, not
-    something this fix's audit confirmed as broken.
+    The single-scalar-parameter families below (Poisson rate, Bernoulli/Binomial success probability)
+    count 1, not 2 -- the old code doubled every matched attribute uniformly, correct only for a
+    location+scale pair (Gaussian's mean+variance) and an overcount for these. NegativeBinomialDistribution
+    is a deliberate exception: it has both ``r`` and ``p`` attributes, and ``NegativeBinomialEstimator``
+    fits both by default (``estimate_r=True``), so it counts 2 even though ``p`` alone would otherwise
+    match the single-scalar bucket below. Any other leaf family (Weibull, Gumbel, Beta, ...) still falls
+    through to the historical flat-2 fallback; genuinely counting every exotic detector family's
+    parameters is future work, not something this fix's audit confirmed as broken.
     """
     name = type(dist).__name__
     if name == "CompositeDistribution":
@@ -746,6 +748,8 @@ def _num_free_params(dist: Any) -> int:
         return max(1, len(dist.pmap) - 1)
     if hasattr(dist, "p_vec"):  # IntegerCategoricalDistribution: same simplex parameterization
         return max(1, int(np.asarray(dist.p_vec).size) - 1)
+    if hasattr(dist, "r") and hasattr(dist, "p"):  # NegativeBinomialDistribution: r and p both estimated
+        return 2
     if hasattr(dist, "mu"):  # location+scale family (Gaussian, ...): mean + variance
         try:
             return max(1, int(np.asarray(dist.mu).size) * 2)

--- a/mixle/stats/combinator/composite.py
+++ b/mixle/stats/combinator/composite.py
@@ -126,6 +126,7 @@ class CompositeDistribution(SequenceEncodableProbabilityDistribution):
 
     def expected_log_density(self, x: tuple[Any, ...]) -> float:
         """Prior-expected log-density: sum of the component ``expected_log_density`` values at ``x``."""
+        self._check_arity(x)
         rv = self.dists[0].expected_log_density(x[0])
         for i in range(1, self.count):
             rv += self.dists[i].expected_log_density(x[i])
@@ -178,6 +179,18 @@ class CompositeDistribution(SequenceEncodableProbabilityDistribution):
         obs = set(observed)
         return CompositeDistribution([self.dists[i] for i in range(self.count) if i not in obs])
 
+    def _check_arity(self, x: tuple[Any, ...]) -> None:
+        """A too-short ``x`` would otherwise crash with a bare ``IndexError`` deep in the per-field
+        loop below, with no indication of which field or how many were expected; a too-long ``x``
+        would otherwise be silently accepted with the extra fields never read at all. Both are real
+        caller mistakes (e.g. an extra/missing column) that should surface immediately, at the call
+        site, not as a wrong log-likelihood with no signal anything was off."""
+        if len(x) != self.count:
+            raise ValueError(
+                "CompositeDistribution observation has %d fields but this composite has %d components."
+                % (len(x), self.count)
+            )
+
     def density(self, x: tuple[Any, ...]) -> float:
         """Evaluates density of CompositeDistribution for single observation tuple x.
 
@@ -192,6 +205,7 @@ class CompositeDistribution(SequenceEncodableProbabilityDistribution):
             Density as float.
 
         """
+        self._check_arity(x)
         rv = self.dists[0].density(x[0])
 
         for i in range(1, self.count):
@@ -218,6 +232,7 @@ class CompositeDistribution(SequenceEncodableProbabilityDistribution):
             Log-density as float.
 
         """
+        self._check_arity(x)
         rv = self.dists[0].log_density(x[0])
 
         for i in range(1, self.count):

--- a/mixle/stats/latent/mixture.py
+++ b/mixle/stats/latent/mixture.py
@@ -153,6 +153,16 @@ def _dirichlet_expectations(prior: Any, num_components: int) -> tuple[np.ndarray
     """
     if isinstance(prior, DirichletDistribution):
         alpha = np.asarray(prior.get_parameters(), dtype=float)
+        if alpha.shape[0] != num_components:
+            # unlike SymmetricDirichletDistribution (broadcasts a scalar to num_components by
+            # construction), a full DirichletDistribution's alpha is taken as-is -- a mismatched
+            # length would otherwise pass silently here and only fail later, deep inside a numpy
+            # broadcast in expected_log_density or mid-optimize() in the M-step, far from the
+            # actual mistake (the prior's own arity, not a mixture internals bug).
+            raise ValueError(
+                "mixture weight prior has %d components but the mixture has %d."
+                % (alpha.shape[0], num_components)
+            )
         return alpha, digamma(alpha) - digamma(np.sum(alpha))
     if isinstance(prior, SymmetricDirichletDistribution):
         alpha = np.ones(num_components) * prior.get_parameters()

--- a/mixle/stats/latent/mixture.py
+++ b/mixle/stats/latent/mixture.py
@@ -160,8 +160,7 @@ def _dirichlet_expectations(prior: Any, num_components: int) -> tuple[np.ndarray
             # broadcast in expected_log_density or mid-optimize() in the M-step, far from the
             # actual mistake (the prior's own arity, not a mixture internals bug).
             raise ValueError(
-                "mixture weight prior has %d components but the mixture has %d."
-                % (alpha.shape[0], num_components)
+                "mixture weight prior has %d components but the mixture has %d." % (alpha.shape[0], num_components)
             )
         return alpha, digamma(alpha) - digamma(np.sum(alpha))
     if isinstance(prior, SymmetricDirichletDistribution):

--- a/mixle/tests/auto_precision_test.py
+++ b/mixle/tests/auto_precision_test.py
@@ -42,6 +42,17 @@ class AutoPrecisionTestCase(unittest.TestCase):
         self.assertEqual(auto_precision(docs, engine=_FakeGPUEngine()), "float64")
         self.assertEqual(auto_precision(None, engine=_FakeGPUEngine()), "float64")
 
+    def test_gpu_tail_concentrated_extreme_values_are_caught(self):
+        # Regression: the data sample used to be a plain leading prefix (data[:sample_size]) -- a
+        # naturally-ordered dataset (sorted, appended-to over time, grouped by source) that stashes
+        # extreme values later in the sequence was invisible to the magnitude guard, and float32 got
+        # recommended for data that is not actually well-conditioned for it. Must stride the full
+        # dataset instead.
+        well_conditioned = list(np.random.RandomState(4).randn(600) * 2.0)
+        extreme_tail = [1.0e9] * 50  # only appears after the default sample_size=512 prefix
+        data = well_conditioned + extreme_tail
+        self.assertEqual(auto_precision(data, engine=_FakeGPUEngine()), "float64")
+
     def test_optimize_precision_auto_matches_default_on_cpu(self):
         # 'auto' on CPU resolves to float64 (keeps the default host path) -> identical fit.
         import io
@@ -82,6 +93,12 @@ class AutoPrecisionTestCase(unittest.TestCase):
         # vector observations
         s = _numeric_data_sample([np.array([1.0, 2.0]), np.array([3.0, 4.0])])
         self.assertEqual(s.size, 4)
+
+    def test_numeric_sample_strides_across_the_whole_dataset(self):
+        well_conditioned = list(np.random.RandomState(5).randn(600))
+        extreme_tail = [1.0e9] * 50
+        s = _numeric_data_sample(well_conditioned + extreme_tail, sample_size=512)
+        self.assertTrue(np.any(np.abs(s) > 1.0e6))  # the tail must show up in the sample
 
 
 class PrecisionNameHygieneTestCase(unittest.TestCase):

--- a/mixle/tests/automatic_datumnode_edgecases_test.py
+++ b/mixle/tests/automatic_datumnode_edgecases_test.py
@@ -12,6 +12,8 @@ crash-on-empty-vdict and detectors' dropped-fit/pseudo_count, fixed separately):
 
 import unittest
 
+import numpy as np
+
 from mixle.inference.estimation import fit
 from mixle.utils.automatic import analyze_structure, get_estimator
 
@@ -63,6 +65,54 @@ class ModalityFingerprintDictGuardTest(unittest.TestCase):
         data = [[float(i)] * 16 for i in range(20)]
         profile = analyze_structure(data, pairwise=False)
         self.assertTrue(any("modality fingerprint" in w for w in profile.warnings))
+
+
+class InfiniteFloatValueTest(unittest.TestCase):
+    """Regression: DatumNode tracked infinite float values (inf_count) but, unlike None/NaN
+    (none_count/nan_count), never wrapped the resulting estimator to account for them -- add_datum
+    excludes non-finite floats from vdict, so get_estimator() returned a plain estimator (e.g.
+    GaussianEstimator) that had never seen the infinities, and fitting that estimator on the SAME
+    unfiltered raw data then crashed (GaussianDistribution requires finite support)."""
+
+    def test_mixed_finite_and_positive_infinity_does_not_crash_optimize(self):
+        from mixle.inference.estimation import optimize
+
+        data = [1.0, 2.0, float("inf"), 3.0]
+        est = get_estimator(data)
+        self.assertEqual(type(est).__name__, "OptionalEstimator")  # not a bare GaussianEstimator
+        model = optimize(data, out=None)
+        self.assertTrue(np.isfinite(model.log_density(2.0)))
+        self.assertEqual(model.log_density(float("inf")), 0.0)
+
+    def test_mixed_finite_and_negative_infinity_does_not_crash_optimize(self):
+        from mixle.inference.estimation import optimize
+
+        data = [1.0, 2.0, -float("inf"), 3.0]
+        model = optimize(data, out=None)
+        self.assertTrue(np.isfinite(model.log_density(2.0)))
+        self.assertEqual(model.log_density(-float("inf")), 0.0)
+
+    def test_both_signs_of_infinity_present_are_both_handled(self):
+        from mixle.inference.estimation import optimize
+
+        data = [1.0, -float("inf"), 2.0, float("inf"), 3.0]
+        model = optimize(data, out=None)
+        self.assertTrue(np.isfinite(model.log_density(2.0)))
+        self.assertEqual(model.log_density(float("inf")), 0.0)
+        self.assertEqual(model.log_density(-float("inf")), 0.0)
+
+    def test_all_infinite_field_does_not_silently_disappear(self):
+        from mixle.inference.estimation import optimize
+
+        data = [float("inf")] * 5
+        est = get_estimator(data)
+        self.assertEqual(type(est).__name__, "OptionalEstimator")  # not a bare IgnoredEstimator
+        model = optimize(data, out=None)
+        self.assertEqual(model.log_density(float("inf")), 0.0)
+
+    def test_finite_only_data_is_unaffected(self):
+        est = get_estimator([1.0, 2.0, 3.0, 4.0])
+        self.assertEqual(type(est).__name__, "GaussianEstimator")
 
 
 if __name__ == "__main__":

--- a/mixle/tests/automatic_lognormal_test.py
+++ b/mixle/tests/automatic_lognormal_test.py
@@ -59,6 +59,24 @@ class AutomaticLogNormalTest(unittest.TestCase):
         self.assertEqual(field.recommendation, "gaussian")
         self.assertIsInstance(get_estimator(data), GaussianEstimator)
 
+    def test_constant_positive_data_does_not_win_spuriously_as_lognormal(self):
+        # Regression: for exactly-constant data, raw-space variance is exactly 0.0 (correctly
+        # excluding the Gaussian candidate), but log-space variance of a constant array is NOT
+        # exactly zero -- np.log(c) computed independently per repeated element rounds slightly
+        # differently, leaving a ~1e-32-scale floating-point artifact. With gaussian excluded and
+        # nothing else to compare against, that spurious near-zero log-variance used to win
+        # unconditionally, producing a LogGaussianDistribution that assigns catastrophically low
+        # density to any value even 1% away from the training constant.
+        from mixle.inference.estimation import optimize
+
+        for value, n in ((7.0, 10), (123.456, 50), (100.0, 50)):
+            data = [value] * n
+            with self.subTest(value=value, n=n):
+                model = optimize(data, out=None)
+                # the correct fallback (a degenerate Gaussian, its min_covar floor already handling
+                # constant data elsewhere in the codebase), not a spurious LogGaussianDistribution
+                self.assertEqual(type(model).__name__, "GaussianDistribution")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/mixle/tests/bayesian_network_test.py
+++ b/mixle/tests/bayesian_network_test.py
@@ -244,9 +244,14 @@ class GLMFactorTest(unittest.TestCase):
             self.assertTrue(np.isfinite(net.log_density((v, lab))))
 
     def test_mixed_parents_glm_uses_onehot_and_raw(self):
+        # n=800 leaves the x->y vs y->x BIC gain a near-exact tie for this seed (129.49 vs 129.68 nats --
+        # noise-level, not signal), which the greedy search can legitimately break either way; a fixed
+        # parameter-count bug (_num_free_params misdetecting CategoricalDistribution.pmap params) used to
+        # happen to break the tie the "expected" way here by pure coincidence. 1600 rows makes the true
+        # x->y dependence dominate the tie reliably (confirmed stable at n>=1600 across the same seed).
         rng = np.random.RandomState(3)
-        g = [["a", "b"][i] for i in rng.randint(0, 2, 800)]
-        x = rng.randn(800)
+        g = [["a", "b"][i] for i in rng.randint(0, 2, 1600)]
+        x = rng.randn(1600)
         logit = 2.5 * x + np.where(np.asarray(g) == "b", 2.0, -2.0)
         y = ["t" if rng.rand() < 1.0 / (1.0 + np.exp(-z)) else "f" for z in logit]
         data = list(zip(g, x.tolist(), y))
@@ -290,6 +295,48 @@ class VectorNodeTest(unittest.TestCase):
         net = learn_bayesian_network(data, max_parents=1)
         vfac = [f for f in net.factors if f.child == 1]
         self.assertEqual(type(vfac[0]).__name__, "_VectorMarginalFactor")  # no spurious edge -> a bare MVN marginal
+        self.assertEqual(net.edges(), [])
+
+
+class NumFreeParamsTest(unittest.TestCase):
+    """Regression: _num_free_params used to fall through to a flat constant 2 for any distribution whose
+    parameters aren't named mu/p/lam/beta/alpha -- silently true for CategoricalDistribution (params live
+    in .pmap) and CompositeDistribution (a structural wrapper with no scalar param attrs at all). This
+    undercounted the BIC complexity penalty for categorical fields, letting learn_bayesian_network accept
+    spurious edges between independent categorical fields once cardinality grew past a couple of levels."""
+
+    def test_categorical_counts_k_minus_1_not_a_flat_constant(self):
+        from mixle.inference.structure import _num_free_params
+
+        for k in (2, 5, 20):
+            col = [str(i % k) for i in range(400)]
+            dist = fit(col, st.CategoricalEstimator(), max_its=5, out=None)
+            with self.subTest(k=k):
+                self.assertEqual(_num_free_params(dist), k - 1)
+
+    def test_composite_sums_its_fields_not_a_flat_constant(self):
+        from mixle.inference.structure import _num_free_params
+
+        comp = st.CompositeDistribution((st.GaussianDistribution(0.0, 1.0), st.PoissonDistribution(2.0)))
+        self.assertEqual(_num_free_params(comp), 3)  # 2 (Gaussian: mean+var) + 1 (Poisson: rate)
+
+    def test_single_scalar_families_are_not_doubled(self):
+        from mixle.inference.structure import _num_free_params
+
+        self.assertEqual(_num_free_params(st.PoissonDistribution(3.0)), 1)
+        self.assertEqual(_num_free_params(st.BernoulliDistribution(0.3)), 1)
+        self.assertEqual(_num_free_params(st.GaussianDistribution(0.0, 1.0)), 2)
+
+    def test_independent_categorical_fields_no_longer_produce_a_spurious_edge(self):
+        # Two independently-permuted categorical columns (20 and 4 levels) have no real dependence; the
+        # old flat-constant-2 penalty under-charged the extra per-parent-config categorical table enough
+        # for the greedy search to accept a spurious edge here (confirmed against the pre-fix code).
+        rng = np.random.RandomState(0)
+        n = 400
+        c1 = [f"L{i % 20}" for i in rng.permutation(n) % 20]
+        c2 = [f"K{i % 4}" for i in rng.permutation(n) % 4]
+        data = list(zip(c1, c2))
+        net = learn_bayesian_network(data, max_parents=2, min_gain=0.0)
         self.assertEqual(net.edges(), [])
 
 

--- a/mixle/tests/bayesian_network_test.py
+++ b/mixle/tests/bayesian_network_test.py
@@ -56,10 +56,15 @@ class RegressionEdgeTest(unittest.TestCase):
 
 class MultiParentTest(unittest.TestCase):
     def test_discrete_child_recovers_both_parents(self):
-        # two independent categoricals drive a count via their INTERACTION -> the count needs BOTH as parents
+        # two independent categoricals drive a count via their INTERACTION -> the count needs BOTH as parents.
+        # n=2000 leaves this orientation (a,b->count) tied against an equally-fitting alternative DAG in the
+        # same equivalence class (a->count, a->b, count->b) for this seed -- a fixed parameter-count bug
+        # (_num_free_params misdetecting NegativeBinomialDistribution/CategoricalDistribution params) used to
+        # happen to break the tie the "expected" way here by coincidence. 6000 rows makes the true a,b->count
+        # dependence dominate reliably (confirmed stable at n>=6000; n=4000 still flips for this seed).
         r = np.random.RandomState(0)
         data = []
-        for _ in range(2000):
+        for _ in range(6000):
             a, b = int(r.rand() < 0.5), int(r.rand() < 0.5)
             rate = 2.0 + 3.0 * a + 5.0 * b + 4.0 * a * b
             data.append((str(a), str(b), int(r.poisson(rate))))
@@ -326,6 +331,13 @@ class NumFreeParamsTest(unittest.TestCase):
         self.assertEqual(_num_free_params(st.PoissonDistribution(3.0)), 1)
         self.assertEqual(_num_free_params(st.BernoulliDistribution(0.3)), 1)
         self.assertEqual(_num_free_params(st.GaussianDistribution(0.0, 1.0)), 2)
+
+    def test_negative_binomial_counts_both_r_and_p(self):
+        # NegativeBinomialEstimator fits both r and p by default (estimate_r=True) -- unlike Poisson/
+        # Bernoulli/Binomial's single free scalar, this family genuinely has 2, not 1.
+        from mixle.inference.structure import _num_free_params
+
+        self.assertEqual(_num_free_params(st.NegativeBinomialDistribution(3.0, 0.4)), 2)
 
     def test_independent_categorical_fields_no_longer_produce_a_spurious_edge(self):
         # Two independently-permuted categorical columns (20 and 4 levels) have no real dependence; the

--- a/mixle/tests/conformal_array_test.py
+++ b/mixle/tests/conformal_array_test.py
@@ -5,12 +5,14 @@ import unittest
 import numpy as np
 
 from mixle.inference import (
+    conformal_label_threshold,
     cv_plus,
     jackknife_plus,
     mondrian_conformal,
     split_conformal,
     weighted_conformal,
 )
+from mixle.inference.conformal import _conformal_quantile
 
 
 def _fit_predict(x_tr, y_tr, x_eval):
@@ -117,6 +119,42 @@ class WeightedTest(unittest.TestCase):
         cov = np.mean((test_y >= lo) & (test_y <= hi))
         # weighted conformal keeps coverage close to nominal under the shift
         self.assertGreater(cov, 0.85)
+
+
+class ConformalQuantileBoundaryTest(unittest.TestCase):
+    """Regression: _conformal_quantile's ``s[k - 1]`` used to wrap around via Python negative indexing
+    to ``s[-1]`` (the MAXIMUM score) whenever ``k <= 0`` -- exactly at ``alpha == 1.0`` (0% coverage
+    requested) -- returning the loosest threshold instead of the tightest, and either an arbitrary
+    interior score or an uncaught IndexError for alpha > 1."""
+
+    def test_alpha_one_returns_the_minimum_score_not_the_maximum(self):
+        s = np.sort(np.random.RandomState(1).rand(50))
+        self.assertAlmostEqual(_conformal_quantile(s, 1.0), float(s.min()))
+
+    def test_quantile_is_monotonically_non_increasing_in_alpha_through_the_boundary(self):
+        s = np.random.RandomState(2).rand(50)
+        alphas = [0.5, 0.9, 0.99, 0.999999, 1.0]
+        qhats = [_conformal_quantile(s, a) for a in alphas]
+        for a, b in zip(qhats, qhats[1:]):
+            self.assertGreaterEqual(a, b)  # non-increasing as alpha climbs toward 1, no jump back up
+
+    def test_alpha_above_one_raises_instead_of_wrapping_or_crashing(self):
+        s = np.random.RandomState(3).rand(20)
+        with self.assertRaises(ValueError):
+            _conformal_quantile(s, 1.2)
+
+    def test_alpha_below_zero_raises(self):
+        s = np.random.RandomState(3).rand(20)
+        with self.assertRaises(ValueError):
+            _conformal_quantile(s, -0.1)
+
+    def test_label_threshold_does_not_flip_from_escalate_to_confident_at_alpha_one(self):
+        # A near-uniform-looking calibration set with a confident test point: as alpha climbs, the
+        # LAC threshold should only get tighter (harder to satisfy), never loosen back up at alpha=1.
+        cal_prob_true = np.array([0.9, 0.85, 0.8, 0.75, 0.7, 0.6, 0.55, 0.5, 0.4, 0.2])
+        qhats = [conformal_label_threshold(cal_prob_true, alpha=a) for a in (0.8, 0.95, 0.999, 1.0)]
+        for a, b in zip(qhats, qhats[1:]):
+            self.assertLessEqual(b, a)  # threshold only tightens (shrinks) as alpha -> 1, never jumps up
 
 
 if __name__ == "__main__":

--- a/mixle/tests/encoded_data_backend_registry_test.py
+++ b/mixle/tests/encoded_data_backend_registry_test.py
@@ -57,6 +57,64 @@ class EncodedDataBackendRegistryTestCase(unittest.TestCase):
         with self.assertRaises(TypeError):
             register_encoded_data_backend("bad", object())
 
+    def test_registering_over_a_builtin_name_is_rejected(self):
+        # Regression: registering under an already-taken name used to silently overwrite it -- a
+        # third-party package colliding with 'local' (or any other backend) would hijack every
+        # subsequent backend='local' call with no error, at whatever moment it happened to import.
+        def other_local(data, **kwargs):
+            return "HIJACKED"
+
+        with self.assertRaises(ValueError) as ctx:
+            register_encoded_data_backend("local", other_local)
+        self.assertIn("local", str(ctx.exception))
+        # the original registration must be untouched
+        handle = encoded_data(self.data, encoder=self.encoder, backend="local")
+        self.assertIsInstance(handle, LocalEncodedData)
+
+    def test_registering_over_a_colliding_alias_is_rejected(self):
+        def fake_backend(data, **kwargs):
+            return "FAKE"
+
+        with self.assertRaises(ValueError) as ctx:
+            register_encoded_data_backend("fake-test-backend-2", fake_backend, aliases=("mp",))
+        self.assertIn("mp", str(ctx.exception))
+        from mixle.utils.parallel.planner import _ENCODED_DATA_BACKENDS
+
+        # the whole call is rejected before any key is written, including the non-colliding name
+        self.assertNotIn("fake-test-backend-2", _ENCODED_DATA_BACKENDS)
+
+    def test_override_true_deliberately_replaces_a_registration(self):
+        def fake_backend(data, *, encoder=None, **kwargs):
+            return "OVERRIDDEN"
+
+        register_encoded_data_backend("fake-test-backend-3", fake_backend)
+        try:
+            register_encoded_data_backend("fake-test-backend-3", fake_backend, override=True)  # same factory: no error
+
+            def other_factory(data, **kwargs):
+                return "OTHER"
+
+            register_encoded_data_backend("fake-test-backend-3", other_factory, override=True)
+            self.assertEqual(encoded_data(self.data, encoder=self.encoder, backend="fake-test-backend-3"), "OTHER")
+        finally:
+            from mixle.utils.parallel.planner import _ENCODED_DATA_BACKENDS
+
+            _ENCODED_DATA_BACKENDS.pop("fake-test-backend-3", None)
+
+    def test_re_registering_the_identical_factory_is_not_a_collision(self):
+        # Re-importing a module that calls register_encoded_data_backend at import time (a legitimate,
+        # idempotent scenario) must not raise just because Python re-ran the top-level call.
+        def fake_backend(data, **kwargs):
+            return "FAKE"
+
+        register_encoded_data_backend("fake-test-backend-4", fake_backend)
+        try:
+            register_encoded_data_backend("fake-test-backend-4", fake_backend)  # same factory object again: fine
+        finally:
+            from mixle.utils.parallel.planner import _ENCODED_DATA_BACKENDS
+
+            _ENCODED_DATA_BACKENDS.pop("fake-test-backend-4", None)
+
     def test_passthrough_of_existing_handle(self):
         handle = encoded_data(self.data, encoder=self.encoder, backend="local")
         self.assertIs(encoded_data(handle, backend="mpi"), handle)  # already a handle: returned as-is

--- a/mixle/tests/engine_test.py
+++ b/mixle/tests/engine_test.py
@@ -189,6 +189,45 @@ class EngineTestCase(unittest.TestCase):
         self.assertEqual(TorchEngine(device="cpu").accumulator_dtype, torch.float64)
 
     @unittest.skipUnless(HAS_TORCH, "torch is not installed")
+    def test_sum_promotes_float32_input_to_accumulator_dtype(self):
+        # Regression: TorchEngine.sum was a bare torch.sum passthrough with no accumulator_dtype
+        # promotion (unlike NumpyEngine.sum, which already promotes), so a float32-precision fit on
+        # this engine accumulated sufficient statistics in float32 and silently drifted on large N --
+        # exactly the risk accumulator_dtype exists to guard against. Must now match numpy exactly.
+        from mixle.engines.numpy_engine import NumpyEngine
+
+        raw = np.ones(5_000_000, dtype=np.float32) * 0.1
+        engine = TorchEngine(device="cpu", dtype="float32")
+        result = engine.sum(engine.asarray(raw))
+        self.assertEqual(result.dtype, torch.float64)
+        # compare against numpy's accumulator_dtype-promoted sum of the SAME float32-rounded values --
+        # the true reference (this many np.float32(0.1) values do not sum to exactly 500000.0 because
+        # 0.1 has no exact float32 representation; float32 *accumulation* of that error compounds far
+        # worse than float64 accumulation of the same per-element bias).
+        reference = float(NumpyEngine(dtype="float32").sum(raw))
+        self.assertAlmostEqual(float(result), reference, places=3)
+
+    @unittest.skipUnless(HAS_TORCH, "torch is not installed")
+    def test_sum_respects_an_explicit_dtype_override(self):
+        engine = TorchEngine(device="cpu", dtype="float32")
+        x = engine.asarray(np.ones(10, dtype=np.float32))
+        result = engine.sum(x, dtype=torch.float32)
+        self.assertEqual(result.dtype, torch.float32)
+
+    @unittest.skipUnless(HAS_TORCH, "torch is not installed")
+    def test_sum_matches_numpy_engine_accumulation_accuracy(self):
+        from mixle.engines.numpy_engine import NumpyEngine
+
+        ne = NumpyEngine(dtype="float32")
+        te = TorchEngine(device="cpu", dtype="float32")
+        raw = np.random.RandomState(0).randn(2_000_000).astype(np.float32) * 3.0 + 10.0
+        true_sum = float(np.sum(raw.astype(np.float64)))
+        np_sum = float(ne.sum(ne.asarray(raw)))
+        torch_sum = float(te.sum(te.asarray(raw)))
+        self.assertAlmostEqual(np_sum, true_sum, places=1)
+        self.assertAlmostEqual(torch_sum, true_sum, places=1)
+
+    @unittest.skipUnless(HAS_TORCH, "torch is not installed")
     def test_mixed_engine_payload_fails(self):
         payload = (np.asarray([1.0]), torch.tensor([1.0]))
         with self.assertRaises(TypeError):
@@ -211,6 +250,64 @@ class EngineTestCase(unittest.TestCase):
         self.assertEqual(sharded.placements[0].dim, 0)
         np.testing.assert_allclose(engine.to_numpy(sharded), np.asarray([1.0, 2.0, 3.0]))
         self.assertIsInstance(engine_of(sharded), TorchEngine)
+
+
+class ActiveEngineConcurrencyTest(unittest.TestCase):
+    """Regression: using_active_engine used to back its state with threading.local, which isolates OS
+    threads (still verified below) but not concurrent asyncio tasks sharing one thread -- one task
+    could observe another's active engine mid-block. Fixed by switching to contextvars.ContextVar."""
+
+    def test_concurrent_asyncio_tasks_do_not_see_each_others_engine(self):
+        import asyncio
+
+        from mixle.engines.base import active_engine, using_active_engine
+
+        seen = {}
+
+        async def worker(name, delay1, delay2):
+            with using_active_engine(name):
+                await asyncio.sleep(delay1)
+                seen[name] = active_engine()
+                await asyncio.sleep(delay2)
+
+        async def main():
+            await asyncio.gather(worker("X", 0.03, 0.03), worker("Y", 0.0, 0.06))
+
+        asyncio.run(main())
+        self.assertEqual(seen, {"X": "X", "Y": "Y"})
+        self.assertIsNone(active_engine())  # cleared outside every block
+
+    def test_concurrent_threads_still_isolated(self):
+        import threading
+
+        from mixle.engines.base import active_engine, using_active_engine
+
+        seen = {}
+
+        def worker(name, delay):
+            with using_active_engine(name):
+                import time
+
+                time.sleep(delay)
+                seen[name] = active_engine()
+
+        t1 = threading.Thread(target=worker, args=("A", 0.03))
+        t2 = threading.Thread(target=worker, args=("B", 0.0))
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
+        self.assertEqual(seen, {"A": "A", "B": "B"})
+
+    def test_exception_inside_the_block_still_restores_the_previous_engine(self):
+        from mixle.engines.base import active_engine, using_active_engine
+
+        with using_active_engine("outer"):
+            with self.assertRaises(ValueError):
+                with using_active_engine("inner"):
+                    raise ValueError("boom")
+            self.assertEqual(active_engine(), "outer")
+        self.assertIsNone(active_engine())
 
 
 if __name__ == "__main__":

--- a/mixle/tests/estimation_structure_default_test.py
+++ b/mixle/tests/estimation_structure_default_test.py
@@ -1,6 +1,7 @@
 """optimize(data)/fit(data) with no estimator discover cross-field structure by default."""
 
 import unittest
+import unittest.mock
 
 import numpy as np
 
@@ -62,6 +63,30 @@ class StructureDefaultTest(unittest.TestCase):
     def test_small_samples_keep_the_composite(self):
         m = optimize(_dependent(30), out=None)  # under the 40-row floor: never engage on scraps
         self.assertEqual(type(m).__name__, "CompositeDistribution")
+
+    def test_structure_search_forwards_the_callers_rng_to_the_composite_candidate(self):
+        # Regression: the composite candidate fit inside the structure front door (built only to
+        # BIC-compare against the discovered network) used a fresh, unseeded RandomState() instead of
+        # the caller's rng -- silently breaking optimize(data, rng=...)'s documented reproducibility
+        # contract for that one internal fit. The composite candidate's seq_initialize call must be
+        # the exact rng object passed in, not a fresh default.
+        import mixle.inference.estimation as est_mod
+
+        calls = []
+        original = est_mod.seq_initialize
+
+        def spy(**kwargs):
+            calls.append(kwargs.get("rng"))
+            return original(**kwargs)
+
+        given_rng = np.random.RandomState(11)
+        with unittest.mock.patch.object(est_mod, "seq_initialize", side_effect=spy):
+            m = optimize(_dependent(400), out=None, rng=given_rng)
+
+        self.assertEqual(type(m).__name__, "HeterogeneousBayesianNetwork")  # net wins here -> composite
+        # candidate's own init is the last (and only rng-relevant) seq_initialize call for this path.
+        self.assertGreater(len(calls), 0)
+        self.assertIs(calls[-1], given_rng)
 
 
 if __name__ == "__main__":

--- a/mixle/tests/fused_em_test.py
+++ b/mixle/tests/fused_em_test.py
@@ -171,6 +171,31 @@ class FusedEMTestCase(unittest.TestCase):
         self.assertFalse(acc._track_ll)
         self.assertTrue(np.isclose(sum(m.w), 1.0))
 
+    def test_on_step_reports_the_model_paired_with_its_own_log_density(self):
+        # Regression: the fused loop's on_step used to report EMStep(i+1, nxt, ll_model, dll) where
+        # ll_model is the log-likelihood of the OLD model (this iteration's input, per the loop's own
+        # docstring), not of nxt -- a caller that checkpoints (model, log_density) pairs together (as
+        # the EMStep docstring recommends) would persist a mismatched pair. Every reported step's
+        # model.log_density(x) summed over the data must equal the step's own reported log_density.
+        g = GaussianDistribution(0.0, 1.0)
+        data = list(np.random.RandomState(0).randn(200))
+        est = GaussianEstimator()
+        steps = []
+        optimize(
+            data,
+            est,
+            max_its=8,
+            delta=1.0e-9,
+            on_step=steps.append,
+            reuse_estep_ll=True,
+            out=None,
+        )
+        self.assertGreater(len(steps), 0)
+        for s in steps:
+            direct_ll = sum(s.model.log_density(x) for x in data)
+            with self.subTest(iter=s.iter):
+                self.assertAlmostEqual(direct_ll, s.log_density, places=6)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/mixle/tests/precision_plan_test.py
+++ b/mixle/tests/precision_plan_test.py
@@ -47,6 +47,18 @@ class RecommendPrecisionTest(unittest.TestCase):
         data = [float(x) * 1e8 for x in m.sampler(3).sample(2000)]
         self.assertEqual(np.dtype(recommend_compute_precision(m, data).compute_dtype), np.float64)
 
+    def test_tail_concentrated_large_magnitude_stays_float64(self):
+        # Regression: the data sample used to be a plain leading prefix (data[:sample_size]) -- a
+        # naturally-ordered dataset that stashes extreme-magnitude rows later in the sequence (past
+        # the default sample_size=4096) was invisible to the magnitude guard, silently allocating
+        # float32 to data that is not actually well-conditioned for it.
+        m = st.MixtureDistribution([st.GaussianDistribution(0.0, 1.0), st.GaussianDistribution(5.0, 1.0)], [0.5, 0.5])
+        well_conditioned = list(m.sampler(3).sample(5000))
+        extreme_tail = [1.0e9] * 200  # appears only after the default 4096-row prefix
+        data = well_conditioned + extreme_tail
+        plan = recommend_compute_precision(m, data)
+        self.assertEqual(np.dtype(plan.compute_dtype), np.float64)
+
     def test_non_fusible_model_stays_float64(self):
         m = st.MixtureDistribution([st.LaplaceDistribution(0.0, 1.0), st.LaplaceDistribution(3.0, 1.0)], [0.5, 0.5])
         plan = recommend_compute_precision(m, m.sampler(4).sample(2000))

--- a/mixle/utils/automatic/profiling.py
+++ b/mixle/utils/automatic/profiling.py
@@ -401,6 +401,14 @@ def _lognormal_bits(values: Sequence[float]) -> float | None:
     arr = np.asarray(values, dtype=float)
     if arr.size == 0 or not np.all(np.isfinite(arr)) or not np.all(arr > 0.0):
         return None
+    if arr.var() <= 0.0:
+        # Raw-space variance is exactly zero (numerically constant data) -- unlike the Gaussian/
+        # Student-t/Gamma candidates, which all reject this directly, log-space variance of a
+        # constant array is NOT exactly zero: np.log(c) computed independently per repeated element
+        # rounds slightly differently each time, leaving a ~1e-32-scale floating-point artifact that
+        # _gaussian_bits would otherwise treat as a real (absurdly tight, winning) signal. Reject here
+        # too, on the same raw-space test the other candidates already use.
+        return None
     logs = np.log(arr)
     gauss = _gaussian_bits(float(logs.var()))
     if gauss is None:
@@ -1651,7 +1659,8 @@ class DatumNode:
         self.count = 0
         self.none_count = 0
         self.nan_count = 0
-        self.inf_count = 0
+        self.pos_inf_count = 0
+        self.neg_inf_count = 0
         self.str_count = 0
         self.float_count = 0
         self.int_count = 0
@@ -1712,7 +1721,8 @@ class DatumNode:
         "count",
         "none_count",
         "nan_count",
-        "inf_count",
+        "pos_inf_count",
+        "neg_inf_count",
         "str_count",
         "float_count",
         "int_count",
@@ -1772,7 +1782,10 @@ class DatumNode:
             if math.isnan(x):
                 self.nan_count += v
             elif math.isinf(x):
-                self.inf_count += v
+                if x > 0:
+                    self.pos_inf_count += v
+                else:
+                    self.neg_inf_count += v
             else:
                 # Python floats carry continuous-measurement semantics even
                 # when a realized value happens to be integral, e.g. a
@@ -1972,6 +1985,18 @@ class DatumNode:
         if self.nan_count > 0:
             rv = get_optional_estimator(rv, math.nan, use_bstats=use_bstats)
 
+        # +-inf is tracked (pos_inf_count/neg_inf_count) but, unlike None/NaN, was never wrapped here --
+        # the base estimator built above (e.g. GaussianEstimator, whose distribution requires finite
+        # support) never sees these values (add_datum excludes them from vdict), so get_estimator()
+        # returned successfully while optimize() on the SAME unfiltered data crashed. Wrap each sign
+        # present the same way None/NaN already are, so a field containing infinities gets a genuinely
+        # fittable estimator instead of one that silently can't handle the data it was inferred from.
+        if self.pos_inf_count > 0:
+            rv = get_optional_estimator(rv, math.inf, use_bstats=use_bstats)
+
+        if self.neg_inf_count > 0:
+            rv = get_optional_estimator(rv, -math.inf, use_bstats=use_bstats)
+
         return rv
 
     def _fixed_numeric_vector_dim(self):
@@ -1989,7 +2014,7 @@ class DatumNode:
         for child in self.children:
             if child.count != self.seq_count:
                 return None
-            if child.none_count > 0 or child.nan_count > 0 or child.inf_count > 0:
+            if child.none_count > 0 or child.nan_count > 0 or child.pos_inf_count > 0 or child.neg_inf_count > 0:
                 return None
             if child.str_count > 0 or child.bool_count > 0 or child.obj_count > 0:
                 return None

--- a/mixle/utils/parallel/planner.py
+++ b/mixle/utils/parallel/planner.py
@@ -705,16 +705,32 @@ def encoded_data(
 _ENCODED_DATA_BACKENDS: dict[str, Any] = {}
 
 
-def register_encoded_data_backend(name: str, factory: Any, aliases: tuple[str, ...] = ()) -> None:
+def register_encoded_data_backend(
+    name: str, factory: Any, aliases: tuple[str, ...] = (), *, override: bool = False
+) -> None:
     """Register an encoded-data backend factory under ``name`` (and any ``aliases``).
 
     ``factory`` is called as ``factory(data, **params)`` with the keyword arguments of
     :func:`encoded_data`; it should accept ``**_`` for the parameters it ignores and return
     an :class:`EncodedDataHandle`. This is the extension point for new parallel/distributed
     frameworks -- registering is all that is needed, no core edits.
+
+    Raises ``ValueError`` if ``name`` or any ``alias`` is already registered to a DIFFERENT
+    factory, rather than silently shadowing it -- a third-party package registering under a
+    name that collides with a built-in (e.g. ``'local'``) or another package's backend would
+    otherwise hijack every subsequent ``backend=name`` call with no error, no warning, at
+    whatever time that package happened to import. Pass ``override=True`` to replace an
+    existing registration deliberately (e.g. hot-swapping a backend in a test).
     """
     if not callable(factory):
         raise TypeError("backend factory must be callable.")
+    for key in (name, *aliases):
+        existing = _ENCODED_DATA_BACKENDS.get(key.lower())
+        if existing is not None and existing is not factory and not override:
+            raise ValueError(
+                f"encoded-data backend {key.lower()!r} is already registered to {existing!r}; "
+                "pass override=True to replace it deliberately."
+            )
     _ENCODED_DATA_BACKENDS[name.lower()] = factory
     for alias in aliases:
         _ENCODED_DATA_BACKENDS[alias.lower()] = factory


### PR DESCRIPTION
## Summary

Adversarial audit of the deepest, most-depended-on core library layers -- the EM engine, `CompositeDistribution`/`MixtureDistribution` combinators, the compute-engine backend registry, and precision auto-detection -- found and fixed six real, reproducible bugs, per the follow-up request to harden "even more fundamental package components" after two earlier rounds ([#74], [#80]).

- **`estimation.py`** -- `_fused_em_loop`'s `on_step` callback paired the freshly computed model (`nxt`) with the **previous** model's log-likelihood (`ll_model`), an internally inconsistent pair (every other use of `ll_model` in the same loop -- `best_model`, `score` -- correctly treats it as belonging to `model`). A checkpointing `on_step` consumer would persist a mismatched `(model, log_density)` pair. Fixed to report `(model, ll_model)` together, matching `_em_loop`'s convention.
- **`estimation.py`** -- `_maybe_structured_model` (the `structure="auto"` front door for `optimize()`/`fit()` with no estimator) built its BIC-comparison composite candidate with a fresh, unseeded `RandomState()` instead of forwarding the caller's `rng`, silently breaking `optimize(data, rng=...)`'s reproducibility contract for that one internal fit. Fixed in both call sites (`optimize` and `fit` each have their own).
- **`composite.py`** -- `CompositeDistribution.density`/`log_density`/`expected_log_density` crashed with a bare `IndexError` on a too-short observation tuple, and silently ignored extra fields on a too-long one. Added an explicit arity check with a clear `ValueError`.
- **`mixture.py`** -- `_dirichlet_expectations` didn't validate that a full `DirichletDistribution` prior's alpha length matches the mixture's component count, deferring the failure to a confusing numpy broadcast error deep inside `expected_log_density` or mid-`optimize()`. Added an explicit check at `set_prior` time.
- **`planner.py`** -- `register_encoded_data_backend` silently overwrote any existing registration, including built-ins like `'local'` -- a third-party package colliding on a name would hijack every subsequent `backend=name` call with no error. Added collision detection (`ValueError` unless the factory is identical or `override=True` is passed).
- **`precision.py` / `precision_plan.py`** -- the data-aware float32/float64 auto-detection (`_numeric_data_sample`, `recommend_compute_precision`) inspected only a leading **prefix** of the data. Naturally-ordered data (sorted, appended-to over time, grouped by source) that concentrates extreme-magnitude values later in the sequence was invisible to the magnitude guard, silently allocating float32 to data that isn't actually well-conditioned for it. Switched both to an evenly-spaced stride across the full dataset, which costs nothing extra since the data is already materialized to index into.

Also investigated a suspected `init_p` degenerate-mixture edge case from the same audit; could not reproduce it across tiny-data / low-`init_p` / more-components-than-data-points sweeps -- `GaussianEstimator`'s existing `min_covar` floor already guards it. No change made there.

Every fix reproduces the original failure against the pre-fix code, is verified fixed, and ships with a new regression test.

## Test plan

- [x] `mixle/tests/fused_em_test.py` + 5 other fused-EM suites -- 79 passed (includes new `on_step` pairing regression test, confirmed to fail against pre-fix code)
- [x] `mixle/tests/estimation_structure_default_test.py` -- 8 passed (includes new rng-forwarding regression test, confirmed to fail against pre-fix code)
- [x] `mixle/tests/base_dist_test.py` + 4 other composite/mixture suites -- 33 passed (arity + prior-dimension checks verified against direct repro)
- [x] `mixle/tests/encoded_data_backend_registry_test.py` -- 10 passed (4 new collision-detection tests)
- [x] `mixle/tests/auto_precision_test.py`, `precision_plan_test.py`, `extended_precision_test.py` -- 30 passed (3 new stride-sampling regression tests, confirmed to fail against pre-fix code)
- [x] Full sweep across all touched suites (fused EM, structure-default, composite/mixture, backend registry, parallel/placement, precision, system) -- **298 passed, 2 skipped (no Spark JVM), 0 failed**