### PR TITLE
utils/automatic: fix DatumNode IndexError crash + misleading modality-fingerprint warning

### DIFF
--- a/mixle/tests/automatic_datumnode_edgecases_test.py
+++ b/mixle/tests/automatic_datumnode_edgecases_test.py
@@ -1,0 +1,69 @@
+"""DatumNode edge cases found in a follow-up audit of mixle.utils.automatic (beyond factories.py's
+crash-on-empty-vdict and detectors' dropped-fit/pseudo_count, fixed separately):
+
+1. A sequence-typed field whose every observed value is EMPTY (e.g. an always-empty tags/history
+   list) crashed with IndexError -- DatumNode._merged_child() indexed self.children[0] with zero
+   children, since no element was ever added to merge a type from.
+2. The modality-fingerprint checks (_fixed_numeric_vector_dim/_fixed_numeric_matrix_shape) never
+   checked dict_count, so a field mixing dict rows with fixed-length numeric-vector rows could still
+   report a vector/matrix dimension and emit a "routed to a hybrid neural density" warning -- while
+   the actual estimator (correctly) drops the field entirely as unmodelable (mixed container kinds).
+"""
+
+import unittest
+
+from mixle.inference.estimation import fit
+from mixle.utils.automatic import analyze_structure, get_estimator
+
+
+class AlwaysEmptySequenceTest(unittest.TestCase):
+    def test_bare_list_of_empty_lists_does_not_crash(self):
+        est = get_estimator([[], [], []])
+        self.assertEqual(type(est).__name__, "SequenceEstimator")
+
+    def test_nested_always_empty_list_field_does_not_crash(self):
+        data = [{"tags": []}, {"tags": []}, {"tags": []}]
+        est = get_estimator(data)
+        self.assertEqual(type(est).__name__, "RecordEstimator")
+
+    def test_the_length_model_still_correctly_says_always_empty(self):
+        data = [[], [], [], []]
+        model = fit(data, get_estimator(data), max_its=5, out=None)
+        # every observed length was 0 -- the fitted length distribution must say so, and the model
+        # must not crash scoring the (empty) sequences it was fit on.
+        for x in data:
+            ll = model.log_density(x)
+            self.assertTrue(ll == float("-inf") or ll <= 0.0)
+
+    def test_a_mix_of_empty_and_non_empty_sequences_is_unaffected(self):
+        # sanity: the fix only changes behavior when self.children is EMPTY; a field with at least
+        # one non-empty observation must still merge element types exactly as before.
+        data = [[], [1.0, 2.0], [], [3.0]]
+        est = get_estimator(data)
+        self.assertEqual(type(est).__name__, "SequenceEstimator")
+
+
+class ModalityFingerprintDictGuardTest(unittest.TestCase):
+    def test_mixed_dict_and_vector_rows_does_not_claim_an_embedding_dimension(self):
+        data = [{"a": 1}, [0.0] * 16, {"a": 2}, [0.0] * 16] * 5
+        profile = analyze_structure(data, pairwise=False)
+        self.assertFalse(any("modality fingerprint" in w for w in profile.warnings))
+        # the actual estimator (mixed container kinds) drops the field -- the diagnostic must agree.
+        self.assertEqual(type(get_estimator(data)).__name__, "IgnoredEstimator")
+
+    def test_mixed_dict_and_matrix_rows_does_not_claim_a_matrix_shape(self):
+        row = [[0.0] * 4 for _ in range(4)]
+        data = [{"a": 1}, row, {"a": 2}, row] * 5
+        profile = analyze_structure(data, pairwise=False)
+        self.assertFalse(any("modality fingerprint" in w for w in profile.warnings))
+
+    def test_pure_embedding_field_without_dict_rows_is_unaffected(self):
+        # sanity: the dict_count guard must not suppress the warning when there are genuinely no
+        # dict rows -- only the mixed case should change.
+        data = [[float(i)] * 16 for i in range(20)]
+        profile = analyze_structure(data, pairwise=False)
+        self.assertTrue(any("modality fingerprint" in w for w in profile.warnings))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mixle/utils/automatic/profiling.py
+++ b/mixle/utils/automatic/profiling.py
@@ -1886,6 +1886,12 @@ class DatumNode:
         return POISSON_DISPERSION_MIN <= dispersion <= POISSON_DISPERSION_MAX
 
     def _merged_child(self):
+        if not self.children:
+            # every observed sequence was empty (e.g. data = [[], [], []]) -- no element was ever
+            # added, so there is no element type to merge. An empty DatumNode's own get_estimator()
+            # already resolves to "ignored" (typed == 0), the honest answer: the length model (built
+            # separately from self.len_dict, e.g. {0: n}) still captures "always empty" correctly.
+            return DatumNode()
         child = self.children[0].copy()
         for u in self.children[1:]:
             child = child.merge(u)
@@ -1969,7 +1975,13 @@ class DatumNode:
         return rv
 
     def _fixed_numeric_vector_dim(self):
-        if self.tuple_count > 0 or self.seq_count == 0 or self.set_count > 0 or len(self.len_dict) != 1:
+        if (
+            self.tuple_count > 0
+            or self.seq_count == 0
+            or self.set_count > 0
+            or self.dict_count > 0
+            or len(self.len_dict) != 1
+        ):
             return None
         dim = next(iter(self.len_dict))
         if dim <= 1 or len(self.children) != dim:
@@ -1992,7 +2004,13 @@ class DatumNode:
         sequence whose every row is itself a fixed-length numeric vector of the same width. A 2-D/3-D
         numpy array iterates row-by-row into nested Iterables, so this is what an image datum looks like
         by the time it reaches DatumNode."""
-        if self.tuple_count > 0 or self.seq_count == 0 or self.set_count > 0 or len(self.len_dict) != 1:
+        if (
+            self.tuple_count > 0
+            or self.seq_count == 0
+            or self.set_count > 0
+            or self.dict_count > 0
+            or len(self.len_dict) != 1
+        ):
             return None
         rows = next(iter(self.len_dict))
         if rows <= 1 or len(self.children) != rows:


### PR DESCRIPTION
## Summary
Third bug-hunting pass over `mixle.utils.automatic`, this time `DatumNode` (the class that builds estimators from arbitrary nested/heterogeneous Python data) and the previously-unexamined helper functions. Two real, confirmed-reproducible bugs found and fixed.

**1. IndexError crash on a sequence-typed field whose every observed value is empty.** `DatumNode._merged_child()` unconditionally indexed `self.children[0]` to seed the merged element type. For `data = [[], [], []]` (or nested, e.g. `[{'tags': []}, {'tags': []}]`), no element was ever added to any row, so `self.children` stays empty and falls through to the generic "variable-length sequences" branch, which crashes trying to merge a type from zero children. An always-empty list-valued field (an unused tags/history/log-entries column) is a realistic shape. Fixed by returning a fresh, empty `DatumNode()` when `self.children` is empty -- its own `get_estimator()` already resolves to "ignored" (the honest answer when no element type was ever observed); the length model still correctly says "always empty".

**2. Misleading modality-fingerprint diagnostic on mixed dict/vector fields.** `_fixed_numeric_vector_dim()`/`_fixed_numeric_matrix_shape()` never checked `dict_count` -- so a field alternating between dict rows and fixed-length numeric-vector rows could still report a valid vector dimension (dict rows never touch `self.children`/`len_dict`). This made `analyze_structure()` claim "routed to a hybrid neural density" while the actual estimator (correctly, mixed container kinds are unmodelable) drops the field entirely -- the diagnostic actively contradicted what was built. Fixed by adding the missing `dict_count == 0` guard to both functions.

## Test plan
- [x] `mixle/tests/automatic_datumnode_edgecases_test.py` (7 tests): always-empty top-level and nested sequence fields no longer crash and still build/fit correctly; a mixed empty/non-empty sequence field is unaffected; mixed dict+vector/dict+matrix fields no longer emit the misleading warning and the diagnostic now agrees with the actual estimator; a pure embedding field (no dict rows) still emits the warning as before.
- [x] Full suite: `mixle/tests/automatic_*.py` = 159 passed (152 pre-existing, unchanged + 7 new), 26 subtests passed.
- [x] `ruff check` + `ruff format --check` clean.