### PR TITLE
data/schema: fix silent data corruption in Boolean.coerce + conform_record

### DIFF
--- a/mixle/data/schema.py
+++ b/mixle/data/schema.py
@@ -46,12 +46,27 @@ class Count(FieldType):
         return int(value)
 
 
+_BOOLEAN_FALSE_STRINGS = frozenset({"false", "f", "no", "n", "0"})
+_BOOLEAN_TRUE_STRINGS = frozenset({"true", "t", "yes", "y", "1"})
+
+
 class Boolean(FieldType):
     """A boolean flag."""
 
     numpy_dtype = np.bool_
 
     def coerce(self, value: Any) -> bool:
+        # bool(value) alone is wrong for the primary use case this module exists for (CSV/SQL/Mongo
+        # sources hand back string-typed booleans): bool("False") is True, since any non-empty string
+        # is truthy. Parse the common string spellings explicitly; a string that isn't one of them is
+        # a real data problem, so it raises rather than guessing.
+        if isinstance(value, str):
+            s = value.strip().lower()
+            if s in _BOOLEAN_FALSE_STRINGS:
+                return False
+            if s in _BOOLEAN_TRUE_STRINGS:
+                return True
+            raise ValueError("cannot coerce string %r to Boolean" % value)
         return bool(value)
 
 
@@ -149,7 +164,15 @@ class Schema:
             return self.fields[0].type.coerce(record)
         if isinstance(record, dict):
             return {f.name: f.type.coerce(record[f.name]) for f in self.fields}
-        return tuple(f.type.coerce(v) for f, v in zip(self.fields, record))
+        # zip() silently stops at the shorter side, so an unchecked zip here would silently drop
+        # trailing values (or fields) instead of raising -- the exact "connectors silently get wrong"
+        # failure mode this module exists to prevent. Materialize once and check length explicitly.
+        values = record if isinstance(record, (tuple, list)) else list(record)
+        if len(values) != len(self.fields):
+            raise ValueError(
+                "record has %d value(s) but schema %r has %d field(s)" % (len(values), self.names, len(self.fields))
+            )
+        return tuple(f.type.coerce(v) for f, v in zip(self.fields, values))
 
     def conform(self, records: Any) -> list[Any]:
         """Coerce every record in ``records`` to this schema (raising clear errors on mismatch)."""

--- a/mixle/tests/data_schema_test.py
+++ b/mixle/tests/data_schema_test.py
@@ -1,0 +1,86 @@
+"""mixle.data.schema: two real bugs found in an audit and fixed here.
+
+1. Boolean.coerce used bare bool(value), which is True for ANY non-empty string -- including the
+   string "False" itself. Since this module's whole reason for existing is coercing string-typed
+   values from CSV/SQL/Mongo connectors, this silently inverted the primary intended use case.
+2. Schema.conform_record built the positional (non-dict) case via zip(self.fields, record), which
+   silently stops at the shorter side instead of raising on a record/field-count mismatch -- exactly
+   the "connectors silently get wrong" failure mode this module's own docstring says it exists to
+   prevent.
+"""
+
+import unittest
+
+import numpy as np
+
+from mixle.data.schema import Boolean, Field, Real, Schema, Vector
+
+
+class BooleanCoerceTest(unittest.TestCase):
+    def test_the_string_false_coerces_to_false(self):
+        self.assertIs(Boolean().coerce("False"), False)
+        self.assertIs(Boolean().coerce("false"), False)
+        self.assertIs(Boolean().coerce("FALSE"), False)
+        self.assertIs(Boolean().coerce("0"), False)
+        self.assertIs(Boolean().coerce("no"), False)
+
+    def test_the_string_true_coerces_to_true(self):
+        self.assertIs(Boolean().coerce("True"), True)
+        self.assertIs(Boolean().coerce("true"), True)
+        self.assertIs(Boolean().coerce("1"), True)
+        self.assertIs(Boolean().coerce("yes"), True)
+
+    def test_leading_trailing_whitespace_is_tolerated(self):
+        self.assertIs(Boolean().coerce("  false  "), False)
+
+    def test_an_unrecognized_string_raises_rather_than_guesses(self):
+        with self.assertRaises(ValueError):
+            Boolean().coerce("maybe")
+
+    def test_real_python_bools_and_ints_still_work(self):
+        self.assertIs(Boolean().coerce(True), True)
+        self.assertIs(Boolean().coerce(False), False)
+        self.assertIs(Boolean().coerce(1), True)
+        self.assertIs(Boolean().coerce(0), False)
+
+
+class ConformRecordLengthTest(unittest.TestCase):
+    def _schema(self):
+        return Schema((Field("a", Real()), Field("b", Real()), Field("c", Real())))
+
+    def test_matching_length_still_works(self):
+        s = self._schema()
+        self.assertEqual(s.conform_record((1.0, 2.0, 3.0)), (1.0, 2.0, 3.0))
+
+    def test_a_short_record_raises_instead_of_silently_dropping_fields(self):
+        s = self._schema()
+        with self.assertRaises(ValueError):
+            s.conform_record((1.0, 2.0))
+
+    def test_a_long_record_raises_instead_of_silently_dropping_values(self):
+        s = self._schema()
+        with self.assertRaises(ValueError):
+            s.conform_record((1.0, 2.0, 3.0, 4.0))
+
+    def test_a_generator_record_is_still_length_checked(self):
+        s = self._schema()
+        with self.assertRaises(ValueError):
+            s.conform_record(x for x in (1.0, 2.0))
+
+    def test_single_field_free_length_vector_schema_raises_instead_of_silently_truncating(self):
+        # the specific real-world trap: a single-field Vector(dim=None) schema fed the raw vector as
+        # the record used to pair only the FIRST element with the field and silently drop the rest
+        # (components 2.0, 3.0 vanished with no error). This fix does not attempt to guess that the
+        # whole list was meant as the one field's vector value -- that's a real ambiguity a caller
+        # should resolve explicitly (e.g. wrap it: conform_record(([1.0, 2.0, 3.0],))) -- but it DOES
+        # convert the silent data loss into a clear, loud error instead.
+        s = Schema((Field("v", Vector(dim=None)),))
+        with self.assertRaises(ValueError):
+            s.conform_record([1.0, 2.0, 3.0])
+        # the unambiguous, correctly-wrapped form still works.
+        result = s.conform_record(([1.0, 2.0, 3.0],))
+        np.testing.assert_array_equal(result[0], np.array([1.0, 2.0, 3.0]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Bug-hunting pass over `mixle/data/` (the ingestion layer `normalize_input` and every `DataSource` adapter funnel through). Two real, confirmed silent-wrong-result bugs, both in `mixle/data/schema.py`.

**1. `Boolean.coerce` silently inverted string-typed "False" values.** It was bare `bool(value)` — `bool()` on a string is `True` for any *non-empty* string, including the literal string `"False"`. This module's own docstring says it exists specifically to coerce string-typed values from CSV/SQL/Mongo connectors ("CSV columns are all strings until coerced") — so this silently inverted its primary intended use case: a CSV boolean column literally containing the text `"False"` coerced to `True`, no error, no warning. Fixed by parsing the common string spellings explicitly (`false`/`f`/`no`/`n`/`0`, `true`/`t`/`yes`/`y`/`1`, case-insensitive, whitespace-tolerant) and raising `ValueError` on an unrecognized string rather than guessing. Real bool/int/None-like values still fall through to `bool(value)` unchanged.

**2. `Schema.conform_record` silently truncated mismatched records via `zip`.** The positional (non-dict) branch built the record via `zip(self.fields, record)`, which silently stops at the shorter side instead of raising on a field-count mismatch — exactly the "connectors silently get wrong" failure mode this module's own docstring says it exists to prevent, and directly contradicts `conform()`'s own docstring promise ("raising clear errors on mismatch"). A short/malformed record from any adapter (a ragged CSV row, an upstream bug emitting fewer values than expected) silently produced a shorter output tuple instead of raising. Fixed by materializing the record once and checking its length against the field count before zipping, raising a clear `ValueError` naming both counts on mismatch.

## Test plan
- [x] `mixle/tests/data_schema_test.py` (10 new tests): `Boolean.coerce` covers true/false string spellings (with whitespace), rejects an unrecognized string, leaves real bool/int values unchanged; `conform_record` covers matching length (unaffected), short and long records now raising instead of silently truncating, a generator-typed record still being length-checked, and the specific single-field-`Vector` trap this bug enabled (documents that the fix converts silent data loss into a clear error, and that the unambiguous wrapped form still works correctly).
- [x] Regression: `dataframe_adapter_test` + `data_layer_test` + `missing_data_test` + `compute_metadata_test` + `data_schema_test` = 81 passed, 157 subtests passed.
- [x] `ruff check` + `ruff format --check` clean.