### PR TITLE
stats/combinator: CopulaDistribution -- arbitrary marginals + a dependence core

### DIFF
--- a/mixle/stats/__init__.py
+++ b/mixle/stats/__init__.py
@@ -640,6 +640,12 @@ __all__ = [
     "CensoredAccumulator",
     "CensoredAccumulatorFactory",
     "CensoredDataEncoder",
+    "CopulaDistribution",
+    "CopulaSampler",
+    "CopulaEstimator",
+    "CopulaAccumulator",
+    "CopulaAccumulatorFactory",
+    "CopulaDataEncoder",
     "ExponentiallyModifiedGaussianDistribution",
     "ExponentiallyModifiedGaussianSampler",
     "ExponentiallyModifiedGaussianEstimator",
@@ -865,6 +871,14 @@ from mixle.stats.combinator.conditional import (
     ConditionalDistributionSampler,
     ConditionalEnumerator,
     ConditionalEstimator,
+)
+from mixle.stats.combinator.copula import (
+    CopulaAccumulator,
+    CopulaAccumulatorFactory,
+    CopulaDataEncoder,
+    CopulaDistribution,
+    CopulaEstimator,
+    CopulaSampler,
 )
 from mixle.stats.combinator.exponential_tilt import (
     ExponentialTiltedDataEncoder,

--- a/mixle/stats/combinator/copula.py
+++ b/mixle/stats/combinator/copula.py
@@ -1,0 +1,319 @@
+"""Copula combinator: glue arbitrary marginal distributions to a dependence structure (Sklar's theorem).
+
+``GaussianCopulaDistribution`` (``mixle.stats.multivariate``) models *only* dependence, on the unit cube
+``(0,1)^d`` -- it assumes its inputs are already the uniform scores ``u_i``. This combinator is the piece
+that makes copulas *composable*: give it your marginals (any mixle leaves exposing ``cdf`` -- a Gamma, a
+StudentT, a VonMises, mixed freely) and a copula core, and it forms the joint
+
+    f(x_1, ..., x_d) = c(F_1(x_1), ..., F_d(x_d)) * prod_i f_i(x_i)                       (Sklar)
+
+where each ``F_i = marginals[i].cdf`` is the probability-integral transform (PIT) and ``c`` is the copula
+density. That is the whole point of copulas: pick any marginals you like and couple them through one
+dependence object, instead of hand-writing a bespoke multivariate leaf for every marginal combination.
+
+Estimation is **IFM** (Inference Functions for Margins): fit each marginal on its own column, PIT the data
+through the fitted marginals, then fit the copula on the uniform scores. This is exact in a single M-step
+(the accumulator buffers the raw columns, the same pattern the neural leaves use), not an approximate
+coupled iteration.
+
+The copula core is pluggable: any distribution on ``(0,1)^d`` implementing the mixle five-piece contract
+works. :class:`~mixle.stats.multivariate.gaussian_copula.GaussianCopulaDistribution` is the first supported
+core; Clayton/Frank/t cores can be dropped in later with no change here.
+
+Reference: Nelsen, *An Introduction to Copulas* (2nd ed., Springer, 2006); Joe, *Dependence Modeling with
+Copulas* (CRC, 2014).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+import numpy as np
+
+from mixle.stats.compute.pdist import (
+    DataSequenceEncoder,
+    DistributionSampler,
+    ParameterEstimator,
+    SequenceEncodableProbabilityDistribution,
+    SequenceEncodableStatisticAccumulator,
+    StatisticAccumulatorFactory,
+)
+
+_CLIP = 1.0e-12  # keep PIT scores strictly inside (0,1) so the copula's Phi^{-1} stays finite
+
+
+class CopulaDistribution(SequenceEncodableProbabilityDistribution):
+    """Joint over ``d`` scalar fields = ``d`` marginals coupled by a copula core (Sklar's theorem).
+
+    ``marginals`` is a length-``d`` sequence of mixle leaves, each exposing ``log_density``, ``cdf``, a
+    ``sampler()`` with ``sample()``, and the estimator/encoder contract. ``copula`` is a distribution on
+    ``(0,1)^d`` (e.g. :class:`GaussianCopulaDistribution`). An observation is a length-``d`` tuple/array of
+    scalars ``(x_1, ..., x_d)``.
+    """
+
+    def __init__(
+        self,
+        marginals: Sequence[SequenceEncodableProbabilityDistribution],
+        copula: SequenceEncodableProbabilityDistribution,
+        name: str | None = None,
+        keys: str | None = None,
+    ) -> None:
+        self.marginals = list(marginals)
+        self.dim = len(self.marginals)
+        if self.dim < 2:
+            raise ValueError("CopulaDistribution needs at least 2 marginals; got %d" % self.dim)
+        self.copula = copula
+        self.name = name
+        self.keys = keys
+
+    def __str__(self) -> str:
+        return "CopulaDistribution([%s], %s)" % (", ".join(map(str, self.marginals)), str(self.copula))
+
+    def _pit_row(self, x: Sequence[float]) -> np.ndarray:
+        """Probability-integral transform of one observation: ``u_i = clip(F_i(x_i))`` in ``(0,1)``."""
+        u = np.array([float(self.marginals[i].cdf(x[i])) for i in range(self.dim)], dtype=np.float64)
+        return np.clip(u, _CLIP, 1.0 - _CLIP)
+
+    def _pit_columns(self, cols: np.ndarray) -> np.ndarray:
+        """PIT an ``(n, d)`` array of raw observations to an ``(n, d)`` array of uniform scores."""
+        cols = np.asarray(cols, dtype=np.float64)
+        u = np.empty_like(cols)
+        for i in range(self.dim):
+            u[:, i] = [float(self.marginals[i].cdf(v)) for v in cols[:, i]]
+        return np.clip(u, _CLIP, 1.0 - _CLIP)
+
+    def density(self, x: Sequence[float]) -> float:
+        return float(np.exp(self.log_density(x)))
+
+    def log_density(self, x: Sequence[float]) -> float:
+        """Sklar's decomposition: sum of marginal log-densities + the copula log-density at the PIT scores."""
+        marg = sum(float(self.marginals[i].log_density(x[i])) for i in range(self.dim))
+        return marg + float(self.copula.log_density(self._pit_row(x)))
+
+    def seq_log_density(self, enc: Any) -> np.ndarray:
+        """Vectorized: per-column marginal log-densities (summed) plus the copula log-density at the PIT scores."""
+        marg_encs, raw_cols = enc
+        rv = self.marginals[0].seq_log_density(marg_encs[0])
+        for i in range(1, self.dim):
+            rv = rv + self.marginals[i].seq_log_density(marg_encs[i])
+        u = self._pit_columns(raw_cols)
+        cop_enc = self.copula.dist_to_encoder().seq_encode(u)
+        return rv + np.asarray(self.copula.seq_log_density(cop_enc), dtype=np.float64)
+
+    def sampler(self, seed: int | None = None) -> CopulaSampler:
+        return CopulaSampler(self, seed)
+
+    def estimator(self, pseudo_count: float | None = None) -> CopulaEstimator:
+        return CopulaEstimator(
+            [m.estimator() for m in self.marginals],
+            self.copula.estimator(),
+            dim=self.dim,
+            name=self.name,
+            keys=self.keys,
+        )
+
+    def dist_to_encoder(self) -> CopulaDataEncoder:
+        return CopulaDataEncoder([m.dist_to_encoder() for m in self.marginals])
+
+
+class CopulaSampler(DistributionSampler):
+    """Sample by drawing uniform scores from the copula, then inverting each marginal by its quantile.
+
+    Requires each marginal's sampler to expose ``quantile`` OR the marginal itself to expose ``ppf``/``quantile``;
+    falls back to inverse-CDF root finding on ``cdf`` when neither is present, so any ``cdf``-bearing marginal
+    is sampleable.
+    """
+
+    def __init__(self, dist: CopulaDistribution, seed: int | None = None) -> None:
+        self.dist = dist
+        self.rng = np.random.RandomState(seed)
+        self._cop_sampler = dist.copula.sampler(seed if seed is None else seed + 1)
+
+    def _invert(self, marginal: Any, u: float) -> float:
+        for owner in (marginal, marginal.sampler()):
+            for attr in ("quantile", "ppf", "inverse_cdf"):
+                fn = getattr(owner, attr, None)
+                if callable(fn):
+                    return float(fn(u))
+        return self._bisect_cdf(marginal, u)
+
+    def _bisect_cdf(self, marginal: Any, u: float, lo: float = -1e6, hi: float = 1e6, iters: int = 100) -> float:
+        # monotone bisection on the CDF -- a last-resort inverse for a marginal exposing only cdf
+        for _ in range(iters):
+            mid = 0.5 * (lo + hi)
+            if float(marginal.cdf(mid)) < u:
+                lo = mid
+            else:
+                hi = mid
+        return 0.5 * (lo + hi)
+
+    def sample(self, size: int | None = None) -> Any:
+        n = 1 if size is None else int(size)
+        u = np.atleast_2d(self._cop_sampler.sample(n)).reshape(n, self.dist.dim)
+        out = [
+            tuple(self._invert(self.dist.marginals[i], float(u[r, i])) for i in range(self.dist.dim)) for r in range(n)
+        ]
+        return out[0] if size is None else out
+
+
+class CopulaDataEncoder(DataSequenceEncoder):
+    """Encode a batch as ``(per-marginal encodings, raw (n, d) column array)``.
+
+    The raw columns ride along because the copula's uniform scores ``u = F(x)`` depend on the marginals'
+    *current* parameters (they change during fitting), so they cannot be baked in at encode time -- they are
+    recomputed by :meth:`CopulaDistribution._pit_columns` against whatever distribution is scoring/estimating.
+    """
+
+    def __init__(self, marginal_encoders: Sequence[DataSequenceEncoder]) -> None:
+        self.marginal_encoders = list(marginal_encoders)
+        self.dim = len(self.marginal_encoders)
+
+    def __str__(self) -> str:
+        return "CopulaDataEncoder([%s])" % ", ".join(map(str, self.marginal_encoders))
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, CopulaDataEncoder) and self.marginal_encoders == other.marginal_encoders
+
+    def seq_encode(self, x: Sequence[Sequence[float]]) -> tuple[tuple[Any, ...], np.ndarray]:
+        cols = np.asarray([[float(row[i]) for i in range(self.dim)] for row in x], dtype=np.float64)
+        marg_encs = tuple(self.marginal_encoders[i].seq_encode(cols[:, i].tolist()) for i in range(self.dim))
+        return marg_encs, cols
+
+
+class CopulaAccumulator(SequenceEncodableStatisticAccumulator):
+    """Delegate per-column sufficient stats to marginal sub-accumulators; buffer raw columns for the copula.
+
+    The copula stage is fit AFTER the marginals (IFM): it needs the marginals' fitted CDFs to PIT the data,
+    so the raw columns are buffered (weighted) here and PIT-ed inside :meth:`CopulaEstimator.estimate`. This
+    is the same buffer-the-rows pattern the neural leaves use, and it makes the IFM fit exact in one M-step.
+    """
+
+    def __init__(self, marginal_accumulators: Sequence[Any], dim: int, keys: str | None = None) -> None:
+        self.marginal_accumulators = list(marginal_accumulators)
+        self.dim = dim
+        self.keys = keys
+        self._cols: list[np.ndarray] = []
+        self._w: list[np.ndarray] = []
+
+    def update(self, x: Sequence[float], weight: float, estimate: CopulaDistribution | None) -> None:
+        marg_est = estimate.marginals if estimate is not None else [None] * self.dim
+        for i in range(self.dim):
+            self.marginal_accumulators[i].update(x[i], weight, marg_est[i])
+        self._cols.append(np.asarray([float(x[i]) for i in range(self.dim)], dtype=np.float64).reshape(1, self.dim))
+        self._w.append(np.asarray([float(weight)], dtype=np.float64))
+
+    def initialize(self, x: Sequence[float], weight: float, rng: np.random.RandomState | None) -> None:
+        for i in range(self.dim):
+            self.marginal_accumulators[i].initialize(x[i], weight, rng)
+        self._cols.append(np.asarray([float(x[i]) for i in range(self.dim)], dtype=np.float64).reshape(1, self.dim))
+        self._w.append(np.asarray([float(weight)], dtype=np.float64))
+
+    def seq_update(self, enc: Any, weights: np.ndarray, estimate: CopulaDistribution | None) -> None:
+        marg_encs, raw_cols = enc
+        marg_est = estimate.marginals if estimate is not None else [None] * self.dim
+        for i in range(self.dim):
+            self.marginal_accumulators[i].seq_update(marg_encs[i], weights, marg_est[i])
+        self._cols.append(np.asarray(raw_cols, dtype=np.float64).reshape(-1, self.dim))
+        self._w.append(np.asarray(weights, dtype=np.float64).ravel())
+
+    def seq_initialize(self, enc: Any, weights: np.ndarray, rng: np.random.RandomState | None) -> None:
+        marg_encs, raw_cols = enc
+        for i in range(self.dim):
+            self.marginal_accumulators[i].seq_initialize(marg_encs[i], weights, rng)
+        self._cols.append(np.asarray(raw_cols, dtype=np.float64).reshape(-1, self.dim))
+        self._w.append(np.asarray(weights, dtype=np.float64).ravel())
+
+    def combine(self, suff_stat: tuple[tuple[Any, ...], np.ndarray, np.ndarray]) -> CopulaAccumulator:
+        marg_stats, cols, w = suff_stat
+        for i in range(self.dim):
+            self.marginal_accumulators[i].combine(marg_stats[i])
+        if len(cols):
+            self._cols.append(np.asarray(cols, dtype=np.float64).reshape(-1, self.dim))
+            self._w.append(np.asarray(w, dtype=np.float64).ravel())
+        return self
+
+    def value(self) -> tuple[tuple[Any, ...], np.ndarray, np.ndarray]:
+        marg_vals = tuple(acc.value() for acc in self.marginal_accumulators)
+        cols = np.concatenate(self._cols, axis=0) if self._cols else np.zeros((0, self.dim))
+        w = np.concatenate(self._w) if self._w else np.zeros((0,))
+        return marg_vals, cols, w
+
+    def from_value(self, x: tuple[tuple[Any, ...], np.ndarray, np.ndarray]) -> CopulaAccumulator:
+        marg_vals, cols, w = x
+        for i in range(self.dim):
+            self.marginal_accumulators[i].from_value(marg_vals[i])
+        cols = np.asarray(cols, dtype=np.float64).reshape(-1, self.dim)
+        self._cols = [cols] if len(cols) else []
+        self._w = [np.asarray(w, dtype=np.float64).ravel()] if len(cols) else []
+        return self
+
+    def key_merge(self, stats_dict: dict[str, Any]) -> None:
+        for acc in self.marginal_accumulators:
+            if hasattr(acc, "key_merge"):
+                acc.key_merge(stats_dict)
+
+    def key_replace(self, stats_dict: dict[str, Any]) -> None:
+        for acc in self.marginal_accumulators:
+            if hasattr(acc, "key_replace"):
+                acc.key_replace(stats_dict)
+
+    def acc_to_encoder(self) -> CopulaDataEncoder:
+        return CopulaDataEncoder([acc.acc_to_encoder() for acc in self.marginal_accumulators])
+
+
+class CopulaAccumulatorFactory(StatisticAccumulatorFactory):
+    def __init__(self, marginal_factories: Sequence[Any], dim: int, keys: str | None = None) -> None:
+        self.marginal_factories = list(marginal_factories)
+        self.dim = dim
+        self.keys = keys
+
+    def make(self) -> CopulaAccumulator:
+        return CopulaAccumulator([f.make() for f in self.marginal_factories], self.dim, keys=self.keys)
+
+
+class CopulaEstimator(ParameterEstimator):
+    """IFM estimator: fit each marginal from its sub-stats, PIT the buffered data, fit the copula on the scores."""
+
+    def __init__(
+        self,
+        marginal_estimators: Sequence[ParameterEstimator],
+        copula_estimator: ParameterEstimator,
+        dim: int,
+        name: str | None = None,
+        keys: str | None = None,
+    ) -> None:
+        self.marginal_estimators = list(marginal_estimators)
+        self.copula_estimator = copula_estimator
+        self.dim = dim
+        self.name = name
+        self.keys = keys
+
+    def accumulator_factory(self) -> CopulaAccumulatorFactory:
+        return CopulaAccumulatorFactory(
+            [e.accumulator_factory() for e in self.marginal_estimators], self.dim, keys=self.keys
+        )
+
+    def estimate(
+        self, nobs: float | None, suff_stat: tuple[tuple[Any, ...], np.ndarray, np.ndarray]
+    ) -> CopulaDistribution:
+        marg_stats, cols, w = suff_stat
+        marginals = [self.marginal_estimators[i].estimate(nobs, marg_stats[i]) for i in range(self.dim)]
+
+        # IFM stage 2: PIT the buffered data through the freshly-fitted marginals, fit the copula on the scores.
+        fitted = CopulaDistribution(marginals, self.copula_estimator_prototype(), name=self.name, keys=self.keys)
+        if len(cols):
+            u = fitted._pit_columns(np.asarray(cols, dtype=np.float64))
+            cop_enc = fitted.copula.dist_to_encoder().seq_encode(u)
+            cop_acc = self.copula_estimator.accumulator_factory().make()
+            cop_acc.seq_update(cop_enc, np.asarray(w, dtype=np.float64).ravel(), None)
+            copula = self.copula_estimator.estimate(nobs, cop_acc.value())
+        else:
+            copula = fitted.copula
+        return CopulaDistribution(marginals, copula, name=self.name, keys=self.keys)
+
+    def copula_estimator_prototype(self) -> SequenceEncodableProbabilityDistribution:
+        """A copula instance usable for PIT-encoding before the copula is refit -- the estimator's own default."""
+        # estimate() with an empty accumulator returns the copula's default (e.g. identity-correlation Gaussian).
+        empty = self.copula_estimator.accumulator_factory().make()
+        return self.copula_estimator.estimate(0.0, empty.value())

--- a/mixle/tests/copula_combinator_test.py
+++ b/mixle/tests/copula_combinator_test.py
@@ -1,0 +1,108 @@
+"""CopulaDistribution (mixle.stats.combinator.copula): glue arbitrary marginals to a copula core via
+Sklar's theorem, fit by IFM. Recovers a known correlation + heterogeneous marginals, beats independence,
+samples with the right marginals and rank dependence, and composes as a mixle five-piece distribution."""
+
+import unittest
+
+import numpy as np
+from scipy.stats import gamma as spgamma
+from scipy.stats import norm, spearmanr
+
+import mixle.stats as st
+from mixle.inference import optimize
+from mixle.stats.combinator.copula import CopulaDistribution
+from mixle.stats.multivariate.gaussian_copula import GaussianCopulaDistribution
+
+
+def _correlated_heterogeneous(seed, n=800, r=0.7):
+    # latent Gaussian dependence pushed through a Gamma(2,2) marginal and a Gaussian(5,2) marginal
+    rng = np.random.RandomState(seed)
+    z = rng.multivariate_normal([0.0, 0.0], [[1.0, r], [r, 1.0]], size=n)
+    u = norm.cdf(z)
+    x0 = spgamma.ppf(u[:, 0], a=2.0, scale=2.0)
+    x1 = norm.ppf(u[:, 1], loc=5.0, scale=2.0)
+    return list(zip(x0.tolist(), x1.tolist()))
+
+
+def _proto():
+    return CopulaDistribution(
+        [st.GammaDistribution(1.0, 1.0), st.GaussianDistribution(0.0, 1.0)],
+        GaussianCopulaDistribution(np.eye(2)),
+    )
+
+
+class CopulaDistributionTest(unittest.TestCase):
+    def test_ifm_recovers_the_correlation_and_the_marginals(self):
+        data = _correlated_heterogeneous(0, r=0.7)
+        fit = optimize(data, _proto().estimator(), prev_estimate=_proto(), max_its=5, out=None)
+        self.assertAlmostEqual(float(fit.copula.corr[0, 1]), 0.7, delta=0.08)
+        # Gamma(shape k=2, scale theta=2); GaussianDistribution stores (mean mu, variance sigma2) = (5, 4)
+        self.assertAlmostEqual(float(fit.marginals[0].k), 2.0, delta=0.4)
+        self.assertAlmostEqual(float(fit.marginals[1].mu), 5.0, delta=0.3)
+
+    def test_beats_the_independence_copula_on_dependent_data(self):
+        data = _correlated_heterogeneous(1, r=0.7)
+        fit = optimize(data, _proto().estimator(), prev_estimate=_proto(), max_its=5, out=None)
+        indep = CopulaDistribution(fit.marginals, GaussianCopulaDistribution(np.eye(2)))
+        ll_fit = float(np.sum(fit.seq_log_density(fit.dist_to_encoder().seq_encode(data))))
+        ll_indep = float(np.sum(indep.seq_log_density(indep.dist_to_encoder().seq_encode(data))))
+        self.assertGreater(ll_fit, ll_indep + 50.0)  # dependence is real and worth many nats
+
+    def test_scalar_log_density_matches_the_sklar_decomposition(self):
+        cop = CopulaDistribution(
+            [st.GammaDistribution(2.0, 2.0), st.GaussianDistribution(5.0, 4.0)],
+            GaussianCopulaDistribution(np.array([[1.0, 0.5], [0.5, 1.0]])),
+        )
+        x = (3.0, 4.5)
+        u = np.clip([cop.marginals[0].cdf(x[0]), cop.marginals[1].cdf(x[1])], 1e-12, 1 - 1e-12)
+        expected = cop.marginals[0].log_density(x[0]) + cop.marginals[1].log_density(x[1]) + cop.copula.log_density(u)
+        self.assertAlmostEqual(cop.log_density(x), expected, places=10)
+
+    def test_seq_and_scalar_log_density_agree(self):
+        data = _correlated_heterogeneous(2, n=50)
+        cop = CopulaDistribution(
+            [st.GammaDistribution(2.0, 2.0), st.GaussianDistribution(5.0, 4.0)],
+            GaussianCopulaDistribution(np.array([[1.0, 0.6], [0.6, 1.0]])),
+        )
+        seq = cop.seq_log_density(cop.dist_to_encoder().seq_encode(data))
+        scalar = np.array([cop.log_density(x) for x in data])
+        np.testing.assert_allclose(seq, scalar, atol=1e-9)
+
+    def test_sampling_has_the_right_marginals_and_dependence(self):
+        cop = CopulaDistribution(
+            [st.GammaDistribution(2.0, 2.0), st.GaussianDistribution(5.0, 4.0)],
+            GaussianCopulaDistribution(np.array([[1.0, 0.8], [0.8, 1.0]])),
+        )
+        s = np.array(cop.sampler(0).sample(3000))
+        self.assertAlmostEqual(s[:, 0].mean(), 4.0, delta=0.4)  # Gamma mean = shape*scale = 4
+        self.assertAlmostEqual(s[:, 1].mean(), 5.0, delta=0.3)  # Gaussian mean = 5
+        rho, _ = spearmanr(s[:, 0], s[:, 1])
+        self.assertGreater(rho, 0.6)  # strong positive rank dependence, as the copula prescribes
+
+    def test_requires_at_least_two_marginals(self):
+        with self.assertRaises(ValueError):
+            CopulaDistribution([st.GaussianDistribution(0.0, 1.0)], GaussianCopulaDistribution(np.eye(1)))
+
+    def test_composes_inside_a_mixture(self):
+        # two dependence regimes: a positively- and a negatively-correlated cluster, same marginals
+        rng = np.random.RandomState(3)
+        a = _correlated_heterogeneous(10, n=300, r=0.8)
+        b = _correlated_heterogeneous(11, n=300, r=-0.8)
+        data = a + b
+        rng.shuffle(data)
+        comp = [
+            CopulaDistribution(
+                [st.GammaDistribution(2.0, 2.0), st.GaussianDistribution(5.0, 4.0)],
+                GaussianCopulaDistribution(np.array([[1.0, s], [s, 1.0]])),
+            )
+            for s in (0.5, -0.5)
+        ]
+        mix = st.MixtureDistribution(comp, [0.5, 0.5])
+        fit = optimize(data, mix.estimator(), prev_estimate=mix, max_its=8, out=None)
+        corrs = sorted(float(c.copula.corr[0, 1]) for c in fit.components)
+        self.assertLess(corrs[0], -0.3)  # one regime recovered as negatively dependent
+        self.assertGreater(corrs[1], 0.3)  # the other as positively dependent
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
First of three new combinators. `CopulaDistribution` is the *composable* copula the codebase was missing: `GaussianCopulaDistribution` (in `mixle.stats.multivariate`) models only dependence on `(0,1)^d` assuming already-PIT'd uniforms; this combinator glues arbitrary mixle marginals (any leaf exposing `cdf` -- Gamma, Gaussian, StudentT, VonMises, mixed freely) to a pluggable copula core via Sklar's theorem:

```
f(x_1, ..., x_d) = c(F_1(x_1), ..., F_d(x_d)) * prod_i f_i(x_i)
```

- **Estimation is IFM** (inference functions for margins): fit each marginal on its own column, PIT the buffered data through the fitted marginals, then fit the copula on the uniform scores -- exact in one M-step (buffers the raw columns, the same pattern the neural leaves use).
- **Full five-piece contract** (Distribution/Sampler/Encoder/Accumulator/Estimator), so it composes as a component -- a *mixture of copulas* recovers per-cluster dependence regimes (tested).
- **Pluggable core**: `GaussianCopulaDistribution` is the first supported core; Clayton/Frank/t cores drop in later with no change to this file.
- 30 of 36 univariate leaves already expose `cdf`, so most marginal combinations work out of the box.

## Test plan
- [x] `mixle/tests/copula_combinator_test.py` (new, 7 tests): IFM recovers a known correlation (0.7) + heterogeneous Gamma/Gaussian marginals; beats the independence copula by >50 nats on dependent data; scalar `log_density` matches the Sklar decomposition exactly; seq/scalar log-density agree to 1e-9; sampling has the right marginals + rank dependence (Spearman); `<2` marginals raises; and it composes inside a `MixtureDistribution` to recover positive- and negative-dependence regimes.
- [x] `ruff check` / `ruff format --check` -- clean.

Part 1 of 3 (Copula, GatedMixture, ProductOfExperts).