### PR TITLE
task/distill: soft-label distillation from a frontier teacher's probabilities

### DIFF
--- a/mixle/task/__init__.py
+++ b/mixle/task/__init__.py
@@ -71,6 +71,7 @@ from mixle.task.distill import (
     distill_structured,
     distill_structured_from_labels,
 )
+from mixle.task.distill_soft import distill_from_soft_labels, distill_soft, soft_agreement
 from mixle.task.economics import (
     CostModel,
     RoutePlan,
@@ -321,6 +322,9 @@ __all__ = [
     "distill_records_from_labels_for_routing",
     "distill_structured",
     "distill_structured_from_labels",
+    "distill_from_soft_labels",
+    "distill_soft",
+    "soft_agreement",
     "extraction_f1",
     "harvest_agent_traces",
     "keyboard_typo_corruption",

--- a/mixle/task/distill_soft.py
+++ b/mixle/task/distill_soft.py
@@ -1,0 +1,156 @@
+"""Soft-label distillation from a frontier teacher's PROBABILITIES, not just its argmax label.
+
+:mod:`mixle.task.distill` distills a frontier teacher's *hard* labels into a tiny student. That throws
+away the teacher's "dark knowledge" -- the relative probability it put on the runner-up classes, which
+says *how* confident it was and *which* wrong answers were plausible. When the teacher can expose a
+probability (or top-k logprob) vector per example -- as modern LLM APIs do -- matching that full
+distribution transfers strictly more than matching the argmax.
+
+This is the frontier-label analog of the temperature-softened Hinton distillation in
+:mod:`mixle.task.distill_methods` (which needs a torch teacher exposing logits): here the teacher is any
+callable returning a per-example probability vector, and the student is the same small hashed-n-gram MLP
+:mod:`mixle.task.distill` trains, but fit to the teacher's SOFT targets by temperature-scaled KL
+(optionally mixed with the hard-label loss). The result is an ordinary :class:`~mixle.task.model.TaskModel`
+whose ``proba_batch`` matches the teacher's calibrated distribution, not just its top-1 -- so it drops into
+:class:`~mixle.task.calibrate.CalibratedTaskModel` / :class:`~mixle.task.router.Router` like any student,
+but carries better-calibrated confidence into the routing decision.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from typing import Any
+
+import numpy as np
+
+from mixle.task.model import HashedNGram, TaskModel, TextClassifierIO
+
+_EPS = 1e-12
+
+
+def _as_prob_matrix(rows: Sequence[Any], n_labels: int | None) -> np.ndarray:
+    """Coerce teacher output to an ``(N, C)`` row-stochastic matrix (renormalize; clip tiny negatives)."""
+    p = np.atleast_2d(np.asarray(rows, dtype=np.float64))
+    if p.ndim != 2:
+        raise ValueError("teacher_probs must be a 2-D (N, C) array of per-example class probabilities.")
+    if n_labels is not None and p.shape[1] != n_labels:
+        raise ValueError(f"teacher_probs has {p.shape[1]} columns but {n_labels} labels were given.")
+    p = np.clip(p, 0.0, None)
+    sums = p.sum(axis=1, keepdims=True)
+    if np.any(sums <= 0.0):
+        raise ValueError("every teacher_probs row must have positive total mass.")
+    return p / sums
+
+
+def distill_from_soft_labels(
+    texts: Sequence[str],
+    teacher_probs: Sequence[Any],
+    *,
+    labels: Sequence[str],
+    temperature: float = 2.0,
+    hard_weight: float = 0.0,
+    n: int = 3,
+    dim: int = 256,
+    hidden: Sequence[int] = (64,),
+    epochs: int = 300,
+    lr: float = 1e-2,
+    seed: int = 0,
+    task: str = "",
+    device: str = "cpu",
+) -> TaskModel:
+    """Fit a student to a teacher's per-example SOFT distribution ``teacher_probs`` over ``labels``.
+
+    ``teacher_probs`` is ``(N, C)`` with rows summing to 1 (renormalized if not), column ``j`` the
+    teacher's probability of ``labels[j]``. The student minimizes the temperature-softened
+    ``T^2 * KL(teacher || student)`` (Hinton's scaling, so the soft gradients keep magnitude as ``T``
+    grows), optionally mixed with ``hard_weight`` times the hard cross-entropy against the teacher's
+    argmax. ``temperature > 1`` softens both sides so the runner-up structure (the dark knowledge) drives
+    the fit. Deterministic given ``seed``; returns a :class:`TaskModel` whose ``proba_batch`` approximates
+    the teacher's distribution, not just its top-1.
+    """
+    import torch
+
+    from mixle.models.neural import make_mlp
+
+    if not 0.0 <= hard_weight <= 1.0:
+        raise ValueError("hard_weight must be in [0, 1].")
+    if temperature <= 0.0:
+        raise ValueError("temperature must be positive.")
+    label_list = [str(v) for v in labels]
+    texts = [str(t) for t in texts]
+    p_teacher = _as_prob_matrix(teacher_probs, len(label_list))
+    if p_teacher.shape[0] != len(texts):
+        raise ValueError("teacher_probs must have one row per text.")
+
+    feat = HashedNGram(n=n, dim=dim, seed=seed)
+    x = np.asarray(feat.transform(texts), dtype=np.float32)
+    cfg = {
+        "input_dim": int(x.shape[1]),
+        "hidden_dims": [int(h) for h in hidden],
+        "output_dim": len(label_list),
+        "activation": "relu",
+    }
+    torch.manual_seed(int(seed))
+    module = make_mlp(**cfg).to(device)
+
+    xb = torch.as_tensor(x, device=device)
+    pt = torch.as_tensor(p_teacher, dtype=torch.float32, device=device)
+    pt_soft = torch.softmax(torch.log(pt.clamp_min(_EPS)) / temperature, dim=1)  # teacher at temperature T
+    hard_idx = torch.as_tensor(np.argmax(p_teacher, axis=1), device=device)
+    opt = torch.optim.Adam(module.parameters(), lr=float(lr))
+    module.train()
+    for _ in range(int(epochs)):
+        opt.zero_grad()
+        logits = module(xb)
+        log_ps_T = torch.log_softmax(logits / temperature, dim=1)
+        # KL(teacher || student) = sum pt_soft * (log pt_soft - log ps_T); the pt log-term is constant in
+        # the student, so cross-entropy suffices -- scaled by T^2 to preserve soft-gradient magnitude.
+        soft_loss = (temperature**2) * -(pt_soft * log_ps_T).sum(dim=1).mean()
+        loss = (1.0 - hard_weight) * soft_loss
+        if hard_weight > 0.0:
+            loss = loss + hard_weight * torch.nn.functional.cross_entropy(logits, hard_idx)
+        loss.backward()
+        opt.step()
+    module.eval()
+
+    return TaskModel(
+        module,
+        TextClassifierIO(feat, label_list),
+        builder="mixle.mlp",
+        config=cfg,
+        task=task or "soft-distilled text classifier",
+        meta={
+            "distilled": True,
+            "soft": True,
+            "temperature": float(temperature),
+            "hard_weight": float(hard_weight),
+            "n_examples": len(texts),
+            "labels": label_list,
+            "recipe": {"n": n, "dim": dim, "hidden": list(cfg["hidden_dims"]), "epochs": epochs, "lr": lr},
+        },
+    )
+
+
+def distill_soft(
+    teacher_proba: Callable[[list[str]], Any],
+    texts: Sequence[str],
+    *,
+    labels: Sequence[str],
+    **kwargs: Any,
+) -> TaskModel:
+    """Query a probability-returning teacher once over ``texts`` and soft-distill it (see
+    :func:`distill_from_soft_labels`). ``teacher_proba(texts) -> (N, C)`` returns each example's class
+    distribution over ``labels`` (e.g. an LLM's normalized top-k logprobs)."""
+    probs = teacher_proba(list(str(t) for t in texts))
+    return distill_from_soft_labels(texts, probs, labels=labels, **kwargs)
+
+
+def soft_agreement(student: TaskModel, teacher_probs: Sequence[Any], texts: Sequence[str]) -> float:
+    """Mean KL divergence ``KL(teacher || student)`` over ``texts`` -- how faithfully the student matches
+    the teacher's full SOFT distribution (0 = identical), the soft-distillation analog of
+    :func:`mixle.task.distill.agreement`. Lower is better; use it to compare soft vs hard students."""
+    p_teacher = _as_prob_matrix(teacher_probs, None)
+    p_student = np.asarray(student.adapter.proba_batch(student.model, [str(t) for t in texts]), dtype=np.float64)
+    p_student = np.clip(p_student, _EPS, None)
+    kl = np.sum(p_teacher * (np.log(np.clip(p_teacher, _EPS, None)) - np.log(p_student)), axis=1)
+    return float(np.mean(kl))

--- a/mixle/tests/distill_soft_test.py
+++ b/mixle/tests/distill_soft_test.py
@@ -1,0 +1,121 @@
+"""Soft-label distillation (mixle.task.distill_soft): matching a frontier teacher's probability vector,
+not just its argmax, transfers the teacher's dark knowledge -- the student's SOFT distribution ends up
+closer to the teacher's than a hard-label student's does.
+"""
+
+import unittest
+
+import numpy as np
+import pytest
+
+pytest.importorskip("torch")
+
+from mixle.task.distill import distill_from_labels  # noqa: E402
+from mixle.task.distill_soft import (  # noqa: E402
+    distill_from_soft_labels,
+    distill_soft,
+    soft_agreement,
+)
+
+_LABELS = ["A", "B", "C"]
+# A is distinct; B and C share most of their vocabulary, so a text is genuinely ambiguous between them
+# -- the teacher's split probability over B vs C is the dark knowledge a hard label throws away.
+_BANK = {
+    "A": ["alpha", "apex", "atom", "arc", "axis"],
+    "B": ["beta", "band", "blue", "bard"],
+    "C": ["gamma", "core", "cave", "card"],
+    "shared_BC": ["signal", "node", "cell", "wave", "field"],
+}
+
+
+def _oracle_probs(text: str) -> np.ndarray:
+    """A fixed soft 'teacher': class scores from word-bank counts, softmax -> an informative distribution
+    that splits mass between B and C on shared vocabulary."""
+    words = text.split()
+    score = np.zeros(3)
+    for w in words:
+        if w in _BANK["A"]:
+            score[0] += 2.0
+        if w in _BANK["B"]:
+            score[1] += 1.6
+        if w in _BANK["C"]:
+            score[2] += 1.6
+        if w in _BANK["shared_BC"]:  # shared vocab lifts BOTH B and C -> confusable
+            score[1] += 0.7
+            score[2] += 0.7
+    e = np.exp(score - score.max())
+    return e / e.sum()
+
+
+def _corpus(n, seed):
+    rng = np.random.RandomState(seed)
+    texts = []
+    for _ in range(n):
+        cls = rng.choice(3)
+        own = _BANK[_LABELS[cls]]
+        pool = own + _BANK["shared_BC"]
+        k = rng.randint(3, 7)
+        texts.append(" ".join(rng.choice(pool, size=k)))
+    probs = np.array([_oracle_probs(t) for t in texts])
+    return texts, probs
+
+
+class SoftDistillTest(unittest.TestCase):
+    def setUp(self):
+        self.train_texts, self.train_probs = _corpus(300, seed=0)
+        self.test_texts, self.test_probs = _corpus(120, seed=99)
+
+    def test_soft_student_matches_teacher_distribution_better_than_a_hard_student(self):
+        soft = distill_from_soft_labels(
+            self.train_texts, self.train_probs, labels=_LABELS, temperature=3.0, epochs=400, seed=0
+        )
+        hard_labels = [_LABELS[i] for i in np.argmax(self.train_probs, axis=1)]
+        hard = distill_from_labels(self.train_texts, hard_labels, labels=_LABELS, epochs=400, seed=0)
+
+        soft_kl = soft_agreement(soft, self.test_probs, self.test_texts)
+        hard_kl = soft_agreement(hard, self.test_probs, self.test_texts)
+        # the soft student's distribution is closer to the teacher's on held-out text
+        self.assertLess(soft_kl, hard_kl)
+
+    def test_student_probabilities_are_well_formed(self):
+        soft = distill_from_soft_labels(self.train_texts, self.train_probs, labels=_LABELS, epochs=200, seed=0)
+        p = np.asarray(soft.adapter.proba_batch(soft.model, self.test_texts), dtype=float)
+        self.assertEqual(p.shape, (len(self.test_texts), 3))
+        np.testing.assert_allclose(p.sum(axis=1), 1.0, atol=1e-5)
+
+    def test_argmax_agreement_stays_high(self):
+        soft = distill_from_soft_labels(self.train_texts, self.train_probs, labels=_LABELS, epochs=400, seed=0)
+        pred = soft.batch(self.test_texts)
+        teacher_hard = [_LABELS[i] for i in np.argmax(self.test_probs, axis=1)]
+        acc = np.mean([p == t for p, t in zip(pred, teacher_hard)])
+        self.assertGreater(acc, 0.75)
+
+    def test_deterministic_given_seed(self):
+        a = distill_from_soft_labels(self.train_texts, self.train_probs, labels=_LABELS, epochs=100, seed=7)
+        b = distill_from_soft_labels(self.train_texts, self.train_probs, labels=_LABELS, epochs=100, seed=7)
+        pa = a.adapter.proba_batch(a.model, self.test_texts)
+        pb = b.adapter.proba_batch(b.model, self.test_texts)
+        np.testing.assert_allclose(pa, pb, atol=1e-6)
+
+    def test_distill_soft_calls_the_probability_teacher_once(self):
+        calls = {"n": 0}
+
+        def teacher_proba(texts):
+            calls["n"] += 1
+            return np.array([_oracle_probs(t) for t in texts])
+
+        student = distill_soft(teacher_proba, self.train_texts, labels=_LABELS, epochs=100, seed=0)
+        self.assertEqual(calls["n"], 1)  # one batched query, not one per example
+        self.assertEqual(student.meta["soft"], True)
+
+    def test_bad_inputs_are_rejected(self):
+        with self.assertRaises(ValueError):
+            distill_from_soft_labels(self.train_texts, self.train_probs, labels=_LABELS, temperature=0.0)
+        with self.assertRaises(ValueError):
+            distill_from_soft_labels(self.train_texts, self.train_probs, labels=_LABELS, hard_weight=1.5)
+        with self.assertRaises(ValueError):
+            distill_from_soft_labels(self.train_texts[:5], self.train_probs, labels=_LABELS)  # length mismatch
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fills a real gap in the distillation stack: `distill()` distills only the teacher's **argmax**, throwing away its dark knowledge (the mass it put on runner-up classes). The soft KD in `distill_methods` needs a torch teacher's logits — there was no path to distill from a **frontier LLM's per-example probability vector** (which modern APIs expose as top-k logprobs).

- `distill_from_soft_labels(texts, teacher_probs, labels=..., temperature=, hard_weight=)` — fits the same hashed-n-gram MLP student to the teacher's full distribution via temperature-softened `T^2 * KL(teacher || student)`, optionally mixed with the hard-label loss (Hinton, applied to the frontier-label path).
- `distill_soft(teacher_proba, texts, labels=...)` — wraps a probability-returning teacher callable (one batched query).
- `soft_agreement(student, teacher_probs, texts)` — the student's mean KL to the teacher's distribution (soft counterpart of `agreement()`).

The student's `proba_batch` now approximates the teacher's *calibrated* distribution, so it carries better confidence into `CalibratedTaskModel`/`Router`.

Tests (6): the load-bearing one shows that on a corpus with two confusable classes, the soft student's held-out distribution is measurably closer to the teacher's than a hard-label student's (dark knowledge transfers); plus well-formed probabilities, argmax agreement stays high, determinism, one-batched-query, input validation. torch-gated.