### PR TITLE
models/energy: build_product_energy_net -- energy-based product of experts

### DIFF
--- a/mixle/models/__init__.py
+++ b/mixle/models/__init__.py
@@ -46,7 +46,12 @@ from mixle.models.dirichlet_process_mixture import (
 )
 from mixle.models.dpo_leaf import DPOLeaf, DPOModel
 from mixle.models.embedding import CategoricalEmbedding
-from mixle.models.energy import EnergyModel, build_convex_energy_net, build_energy_net
+from mixle.models.energy import (
+    EnergyModel,
+    build_convex_energy_net,
+    build_energy_net,
+    build_product_energy_net,
+)
 from mixle.models.feature_map import FeatureMapDensity, FeatureMapEstimator, feature_fn, register_feature_fn
 from mixle.models.gaussian_process import GaussianProcessRegressor
 from mixle.models.grammar import (
@@ -206,6 +211,7 @@ __all__ = [
     "build_energy_net",
     "build_maf",
     "build_mdn",
+    "build_product_energy_net",
     "build_vae",
     "make_deep_set",
     "make_mlp",

--- a/mixle/models/energy.py
+++ b/mixle/models/energy.py
@@ -406,11 +406,64 @@ def _convex_energy_net_class() -> Any:
     return ConvexEnergyNet
 
 
+_PRODUCT_ENERGY_NET_CLASS: list[Any] = []
+
+
+def _product_energy_net_class() -> Any:
+    """A product-of-experts energy: ``E(x) = sum_k E_k(x)``, so ``p(x) ∝ prod_k exp(-E_k(x)) = prod_k p_k(x)``.
+
+    A mixture (:class:`~mixle.stats.latent.mixture.MixtureDistribution`) *adds* densities -- a disjunction,
+    "x looks like expert A OR expert B". A product of experts *multiplies* them -- a conjunction, "x is
+    plausible under expert A AND expert B AND ..." -- so each expert acts as a soft constraint and the
+    product is their intersection (Hinton, "Training Products of Experts by Minimizing Contrastive
+    Divergence", Neural Computation 2002). The normalizer of a product is intractable in general, which is
+    exactly the problem the energy stack already solves: sum the expert energies into one energy module and
+    fit the shared ``log_norm`` by NCE, sample by Langevin -- all inherited from :class:`EnergyModel` with
+    no new machinery. Each expert stays a separately-specified, interpretable factor (``.experts``).
+    """
+    if _PRODUCT_ENERGY_NET_CLASS:
+        return _PRODUCT_ENERGY_NET_CLASS[0]
+    import torch
+    import torch.nn as nn
+
+    class ProductEnergyNet(nn.Module):
+        def __init__(self, experts: Any) -> None:
+            super().__init__()
+            experts = list(experts)
+            if len(experts) < 2:
+                raise ValueError("ProductEnergyNet needs at least 2 experts; got %d" % len(experts))
+            dims = {int(e.dim) for e in experts}
+            if len(dims) != 1:
+                raise ValueError("all experts must share one input dim; got %s" % sorted(dims))
+            self.experts = nn.ModuleList(experts)
+            self.dim = int(next(iter(dims)))
+            self.log_norm = nn.Parameter(torch.zeros(()))  # the product's own NCE-learned normalizer
+
+        def expert_energies(self, x: Any) -> Any:
+            """``(n, K)`` per-expert energies -- the interpretable decomposition of the total energy."""
+            import torch as _t
+
+            return _t.stack([e.energy(x) for e in self.experts], dim=-1)
+
+        def energy(self, x: Any) -> Any:
+            # sum the experts' energies; their OWN log_norms are constants that only shift the (separate)
+            # product log_norm, so they are harmless here and the product's log_norm absorbs the offset.
+            return sum(e.energy(x) for e in self.experts)
+
+    ProductEnergyNet.__module__ = __name__
+    ProductEnergyNet.__qualname__ = "ProductEnergyNet"
+    ProductEnergyNet.__name__ = "ProductEnergyNet"
+    _PRODUCT_ENERGY_NET_CLASS.append(ProductEnergyNet)
+    return ProductEnergyNet
+
+
 def __getattr__(name: str) -> Any:  # PEP 562: lets ``pickle`` resolve the hoisted net classes by name
     if name == "EnergyNet":
         return _energy_net_class()
     if name == "ConvexEnergyNet":
         return _convex_energy_net_class()
+    if name == "ProductEnergyNet":
+        return _product_energy_net_class()
     raise AttributeError("module %r has no attribute %r" % (__name__, name))
 
 
@@ -433,6 +486,26 @@ def build_convex_energy_net(dim: int, *, hidden: int = 64, layers: int = 3) -> A
     for the construction.
     """
     return _convex_energy_net_class()(dim, hidden, layers)
+
+
+def build_product_energy_net(experts: Any) -> Any:
+    """Combine expert energy modules multiplicatively: one module with ``energy(x) = sum_k experts[k].energy(x)``.
+
+    A product of experts, ``p(x) ∝ prod_k p_k(x)`` -- a *conjunction* (each expert a soft constraint, the
+    product their intersection), as opposed to a mixture's disjunction. This is the ENERGY-BASED,
+    arbitrary-density complement to :func:`mixle.ops.product_of_experts`, which pools *tractable* families
+    (Categorical, Gaussian) in closed form but deliberately raises on the general continuous case because
+    the product normalizer is then intractable. That intractable normalizer is exactly what the energy
+    stack already handles: wrap the result here in an :class:`EnergyModel` to fit the shared ``log_norm``
+    by NCE and sample by Langevin, no new machinery.
+
+    Each expert must expose ``energy(x) -> (n,)`` and a ``dim`` attribute (e.g. any :func:`build_energy_net` /
+    :func:`build_convex_energy_net` module, all sharing one input dim), and stays individually inspectable via
+    the built module's ``.experts`` / ``.expert_energies(x)``. Fit it in one line::
+
+        model = EnergyModel(build_product_energy_net([expert_a, expert_b]), m_steps=250)
+    """
+    return _product_energy_net_class()(experts)
 
 
 def _register_serializable() -> None:

--- a/mixle/tests/product_energy_net_test.py
+++ b/mixle/tests/product_energy_net_test.py
@@ -1,0 +1,94 @@
+"""build_product_energy_net (mixle.models.energy): the energy-based product of experts -- multiply arbitrary
+expert densities and renormalize by NCE. This is the general-continuous complement to the closed-form
+mixle.ops.product_of_experts (which handles only Categorical/Gaussian and raises otherwise).
+
+Correctness is checked analytically with quadratic (Gaussian) energy experts whose product has a known
+closed form, so the combinator is verified independently of NCE fitting quality; one test fits the whole
+product by NCE on easy data and checks it integrates to ~1."""
+
+import unittest
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+import torch.nn as nn  # noqa: E402
+
+from mixle.inference import optimize  # noqa: E402
+from mixle.models.energy import EnergyModel, build_energy_net, build_product_energy_net  # noqa: E402
+
+
+class _GaussianEnergy(nn.Module):
+    """E(x) = ||x - mu||^2 / (2 s^2), the energy of N(mu, s^2 I) -- exact and fixed, for analytic checks."""
+
+    def __init__(self, mu, s=1.0):
+        super().__init__()
+        self.dim = len(mu)
+        self.register_buffer("mu", torch.tensor(mu, dtype=torch.float32))
+        self.s = float(s)
+        self.log_norm = nn.Parameter(torch.zeros(()))
+
+    def energy(self, x):
+        return ((x - self.mu) ** 2).sum(-1) / (2.0 * self.s**2)
+
+
+class ProductEnergyNetTest(unittest.TestCase):
+    def test_product_energy_is_the_sum_of_expert_energies(self):
+        a, b = _GaussianEnergy([-2.0, 0.0]), _GaussianEnergy([2.0, 1.0])
+        prod = build_product_energy_net([a, b])
+        x = torch.randn(20, 2)
+        with torch.no_grad():
+            total = prod.energy(x).numpy()
+            summed = (a.energy(x) + b.energy(x)).numpy()
+        np.testing.assert_allclose(total, summed, atol=1e-6)
+
+    def test_expert_energies_decomposition_sums_to_total(self):
+        a, b, c = _GaussianEnergy([0.0, 0.0]), _GaussianEnergy([1.0, 1.0]), _GaussianEnergy([-1.0, 2.0])
+        prod = build_product_energy_net([a, b, c])
+        x = torch.randn(15, 2)
+        with torch.no_grad():
+            per = prod.expert_energies(x)
+            total = prod.energy(x)
+        self.assertEqual(tuple(per.shape), (15, 3))
+        np.testing.assert_allclose(per.sum(-1).numpy(), total.numpy(), atol=1e-6)
+
+    def test_gaussian_product_has_the_analytic_precision_weighted_mode_and_shape(self):
+        # N(-2,1) x N(2,1) along x0 => N(0, 1/2): mode at 0, and the unnormalized log-density drop from
+        # x0=0 to x0=1 is exactly 1.0 (the summed quadratics give -x0^2 - const along x0).
+        poe = EnergyModel(build_product_energy_net([_GaussianEnergy([-2.0, 0.0]), _GaussianEnergy([2.0, 0.0])]))
+        grid = np.linspace(-4.0, 4.0, 17)
+        pts = np.c_[grid, np.zeros_like(grid)]
+        ld = poe.seq_log_density(pts)
+        self.assertAlmostEqual(float(grid[int(np.argmax(ld))]), 0.0, places=6)
+        self.assertAlmostEqual(float(ld[8] - ld[10]), 1.0, places=4)  # ld(x0=0) - ld(x0=1)
+
+    def test_product_concentrates_at_the_intersection(self):
+        # two experts sharp around the origin; their product (conjunction) peaks at the intersection
+        a, b = _GaussianEnergy([0.0, 0.0], s=0.5), _GaussianEnergy([0.0, 0.0], s=0.5)
+        poe = EnergyModel(build_product_energy_net([a, b]))
+        ld = poe.seq_log_density(np.array([[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [1.0, 1.0]]))
+        self.assertEqual(int(np.argmax(ld)), 0)
+
+    def test_wraps_into_energy_model_and_normalizes_after_nce(self):
+        np.random.seed(0)
+        torch.manual_seed(0)
+        data = [row for row in (np.random.randn(500, 1) * 0.7 + 1.0)]
+        poe = EnergyModel(
+            build_product_energy_net([build_energy_net(1, hidden=16), build_energy_net(1, hidden=16)]), m_steps=250
+        )
+        fit = optimize(data, poe.estimator(), prev_estimate=poe, max_its=6, out=None)
+        grid = np.linspace(-6.0, 8.0, 3001)
+        integral = float(np.trapezoid(np.exp(fit.seq_log_density(grid.reshape(-1, 1))), grid))
+        self.assertAlmostEqual(integral, 1.0, delta=0.3)
+
+    def test_requires_at_least_two_experts(self):
+        with self.assertRaises(ValueError):
+            build_product_energy_net([_GaussianEnergy([0.0])])
+
+    def test_experts_must_share_a_dim(self):
+        with self.assertRaises(ValueError):
+            build_product_energy_net([_GaussianEnergy([0.0, 0.0]), _GaussianEnergy([0.0])])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Third of three new combinators. During implementation I found a **pre-existing `mixle.ops.product_of_experts`** that pools *tractable* families (Categorical over shared support, Gaussian precision-weighted) in **closed form** and deliberately raises `CapabilityError` on the general continuous case (intractable normalizer). This PR fills exactly that refused gap: `build_product_energy_net` is the **energy-based, arbitrary-density** complement.

- Sums expert energy modules into one: `energy(x) = sum_k experts[k].energy(x)`, so `p(x) ∝ prod_k p_k(x)` -- a **conjunction** of soft constraints (their intersection), the multiplicative dual of a mixture's disjunction.
- The intractable product normalizer is handled by the **existing energy stack**: wrap in `EnergyModel` to fit the shared `log_norm` by NCE and sample by Langevin -- no new machinery (the survey's exact recommendation).
- Each expert stays individually inspectable via the built module's `.experts` / `.expert_energies(x)`.
- Matches the existing `build_energy_net` / `build_convex_energy_net` pattern (a `build_*` returning a torch module); **no name collision** with `ops.product_of_experts`, and its docstring cross-references it.

## Test plan
- [x] `mixle/tests/product_energy_net_test.py` (new, 7 tests): product energy = sum of expert energies (exact); `expert_energies` decomposition sums to total; **analytic** check that the product of `N(-2,1)` and `N(2,1)` is `N(0,1/2)` (mode at 0, log-density curvature exactly 1.0) -- verified independently of NCE quality; product concentrates at the intersection of two experts; wraps into `EnergyModel` and NCE-fits to a density that integrates to ~1; `<2` experts raises; mismatched dims raise.
- [x] Pre-existing `mixle/tests/product_of_experts_test.py` (for `ops.product_of_experts`) + `energy_test.py` still pass (21 passed) -- no regression.
- [x] `ruff check` / `ruff format --check` -- clean.

Part 3 of 3 (Copula #93, GatedMixture #94, ProductOfExperts).