### PR TITLE
hardening: fix HMM taus/topic-mixture log_density + viterbi backpointer bugs

### DIFF
--- a/mixle/stats/latent/hidden_markov.py
+++ b/mixle/stats/latent/hidden_markov.py
@@ -1034,7 +1034,7 @@ class HiddenMarkovModelDistribution(SequenceEncodableProbabilityDistribution):
         num_states = self.n_states
 
         v = np.zeros((nn, num_states), dtype=np.float64)
-        ptr = np.zeros(nn, dtype=np.int32)
+        bp = np.zeros((nn, num_states), dtype=np.int32)
         pr_obs = np.zeros((nn, num_states), dtype=np.float64)
         enc_x = self.topics[0].dist_to_encoder().seq_encode(x)
 
@@ -1044,14 +1044,21 @@ class HiddenMarkovModelDistribution(SequenceEncodableProbabilityDistribution):
         v[0, :] += pr_obs[0, :] + self.log_w
 
         for t in range(1, nn):
+            # temp[i, j] = v[t-1, i] + log P(Z(t)=j | Z(t-1)=i): the score of extending each previous
+            # state i's best path through the transition to candidate state j (before adding j's own
+            # emission). bp[t, j] records which previous state i achieves that max for j -- the
+            # backpointer this loop used to never store, so decode fell back to an independent
+            # per-timestep argmax(v[t, :]) below instead of a real joint-MAP backtrack.
             temp = np.zeros((num_states, num_states), dtype=np.float64)
             temp += np.reshape(v[t - 1, :], (num_states, 1))
             temp += self.log_transitions
-            temp += np.reshape(pr_obs[t, :], (1, num_states))
-            v[t, :] += temp.max(axis=0, keepdims=False)
+            bp[t, :] = np.argmax(temp, axis=0)
+            v[t, :] += temp.max(axis=0, keepdims=False) + pr_obs[t, :]
 
-        for t in range(nn - 1, -1, -1):
-            ptr[t] = np.argmax(v[t, :])
+        ptr = np.zeros(nn, dtype=np.int32)
+        ptr[nn - 1] = np.argmax(v[nn - 1, :])
+        for t in range(nn - 2, -1, -1):
+            ptr[t] = bp[t + 1, ptr[t + 1]]
 
         return ptr
 
@@ -1092,17 +1099,16 @@ class HiddenMarkovModelDistribution(SequenceEncodableProbabilityDistribution):
             max_len = len(idx_bands)
             num_seq = idx_mat.shape[0]
 
-            good = idx_mat >= 0
-
             pr_obs = np.zeros((tot_cnt, num_states))
             v = np.zeros((tot_cnt, num_states), dtype=np.float64)
+            bp = np.zeros((tot_cnt, num_states), dtype=np.int32)
             ptr = np.zeros(tot_cnt, dtype=np.int32)
 
             # Compute state likelihood vectors and scale the max to one
             for i in range(num_states):
                 pr_obs[:, i] = self.topics[i].seq_log_density(enc_data)
 
-            # Vectorized alpha pass
+            # Vectorized alpha pass, recording each band's backpointer alongside its score.
             prev_band_idx = np.arange(idx_bands[0][0], idx_bands[0][1])
             v[prev_band_idx, :] += pr_obs[prev_band_idx, :] + log_w
 
@@ -1114,13 +1120,66 @@ class HiddenMarkovModelDistribution(SequenceEncodableProbabilityDistribution):
                 temp += np.reshape(v[prev_band_idx[has_next_loc], :], (-1, num_states, 1)) + log_a_mat
                 temp += np.reshape(pr_obs[nxt_band_idx, :], (-1, 1, num_states))
 
+                bp[nxt_band_idx, :] = np.argmax(temp, axis=1)
                 v[nxt_band_idx, :] += np.max(temp, axis=1)
 
                 prev_band_idx = nxt_band_idx.copy()
 
-            for i in range(max_len - 1, -1, -1):
-                prev_band_idx = np.arange(idx_bands[i][0], idx_bands[i][1])
-                ptr[prev_band_idx] += np.argmax(v[prev_band_idx, :], axis=1)
+            # Backward pass: a real per-sequence backtrack through bp, not an independent per-timestep
+            # argmax(v) at every band (which used to pick the marginal-best state at each position
+            # separately -- provably not the joint-MAP path). idx_mat[s, :len_vec[s]] is sequence s's
+            # own flat indices in time order (the same mapping _terminal_states_seq_log_density already
+            # relies on), so each sequence backtracks independently through its own chain.
+            for s in range(num_seq):
+                length = int(len_vec[s])
+                if length == 0:
+                    continue
+                row = idx_mat[s, :length]
+                last = row[-1]
+                ptr[last] = np.argmax(v[last, :])
+                for t in range(length - 2, -1, -1):
+                    cur, nxt = row[t], row[t + 1]
+                    ptr[cur] = bp[nxt, ptr[nxt]]
+
+            return ptr
+
+        else:
+            # Numba-encoded batch: contiguous per-sequence flat layout (tz[n]..tz[n+1) is sequence n's
+            # own timesteps in order), unlike the banded x0 layout above. This used to have no branch
+            # at all here and silently fell off the end returning None -- a hard failure under the
+            # class's own default (use_numba=HAS_NUMBA), since seq_encode produces this encoding
+            # whenever numba is installed. A plain per-sequence Python forward+backtrack (not a new
+            # numba kernel) trades away the numba speedup for this specific decode call in exchange for
+            # a correct, low-risk fix; seq_viterbi is an inference-time decode, not a hot EM loop.
+            num_states = self.n_states
+            (idx, sz, enc_data), len_enc = x1
+            tot_cnt = len(idx)
+            num_seq = len(sz)
+            tz = np.concatenate([[0], sz]).cumsum().astype(dtype=np.int32)
+
+            pr_obs = np.zeros((tot_cnt, num_states), dtype=np.float64)
+            for i in range(num_states):
+                pr_obs[:, i] = self.topics[i].seq_log_density(enc_data)
+
+            log_w = self.log_w
+            log_a_mat = self.log_transitions
+
+            v = np.zeros((tot_cnt, num_states), dtype=np.float64)
+            bp = np.zeros((tot_cnt, num_states), dtype=np.int32)
+            ptr = np.zeros(tot_cnt, dtype=np.int32)
+
+            for n in range(num_seq):
+                s0, s1 = int(tz[n]), int(tz[n + 1])
+                if s0 == s1:
+                    continue
+                v[s0, :] = pr_obs[s0, :] + log_w
+                for t in range(s0 + 1, s1):
+                    temp = np.reshape(v[t - 1, :], (num_states, 1)) + log_a_mat
+                    bp[t, :] = np.argmax(temp, axis=0)
+                    v[t, :] = temp.max(axis=0) + pr_obs[t, :]
+                ptr[s1 - 1] = np.argmax(v[s1 - 1, :])
+                for t in range(s1 - 2, s0 - 1, -1):
+                    ptr[t] = bp[t + 1, ptr[t + 1]]
 
             return ptr
 

--- a/mixle/stats/latent/hidden_markov.py
+++ b/mixle/stats/latent/hidden_markov.py
@@ -715,29 +715,51 @@ class HiddenMarkovModelDistribution(SequenceEncodableProbabilityDistribution):
             return retval
 
         else:
-            x_iter = iter(x)
+            # A topic-mixture (taus) HMM's state i emits from MixtureDistribution(topics, taus[i, :])
+            # (the exact semantics HiddenMarkovModelDistributionSampler already implements for sampling
+            # -- see its obs_samplers). This runs the SAME scaled forward recursion as the plain branch
+            # above, only swapping the per-state emission log-density for the topic-mixture log-density
+            # (weighted_log_sum(per-topic log-densities, log_taus[i, :]) = log of state i's mixture
+            # density). The prior version of this branch recomputed a from-scratch (non-recursive)
+            # per-timestep quantity that discarded every timestep but the last, and (for n_topics !=
+            # n_states) indexed log_taus with the wrong axis and crashed outright.
             log_w = self.log_w
             log_taus = self.log_taus
             n_states = self.n_states
-            x0 = next(x_iter)
+            topics = self.topics
 
-            obs_log_density_by_topic = np.asarray([u.log_density(x0) for u in self.topics])
-            log_likelihood_by_state = np.asarray(
-                [log_w[i] + vec.weighted_log_sum(obs_log_density_by_topic, log_taus[i, :]) for i in range(n_states)]
-            )
+            def _state_log_density(xt: T) -> np.ndarray:
+                obs_log_density_by_topic = np.asarray([u.log_density(xt) for u in topics])
+                return np.asarray(
+                    [vec.weighted_log_sum(obs_log_density_by_topic, log_taus[i, :]) for i in range(n_states)]
+                )
 
-            for x in x_iter:
-                obs_log_density_by_topic = np.asarray([u.log_density(x) for u in self.topics])
-                log_likelihood_by_state = [
-                    vec.weighted_log_sum(obs_log_density_by_topic, log_taus[:, i])
-                    + vec.weighted_log_sum(obs_log_density_by_topic, log_taus[i, :])
-                    for i in range(n_states)
-                ]
+            obs_log_likelihood = log_w + _state_log_density(x[0])
 
-            rv = vec.log_sum(log_likelihood_by_state)
-            rv += self.len_dist.log_density(len(x))
+            if np.max(obs_log_likelihood) == -np.inf:
+                return -np.inf
 
-            return rv
+            max_ll = obs_log_likelihood.max()
+            obs_log_likelihood = np.exp(obs_log_likelihood - max_ll)
+            sum_ll = np.sum(obs_log_likelihood)
+            retval = np.log(sum_ll) + max_ll
+
+            for k in range(1, len(x)):
+                obs_log_likelihood = self.transitions.T @ obs_log_likelihood
+                obs_log_likelihood = obs_log_likelihood / obs_log_likelihood.sum()
+                obs_log_likelihood = np.log(obs_log_likelihood) + _state_log_density(x[k])
+
+                max_ll = obs_log_likelihood.max()
+                if max_ll == -np.inf:
+                    return -np.inf
+                obs_log_likelihood = np.exp(obs_log_likelihood - max_ll)
+                sum_ll = np.sum(obs_log_likelihood)
+
+                retval += np.log(sum_ll) + max_ll
+
+            retval += self.len_dist.log_density(len(x))
+
+            return retval
 
     def _terminal_states_seq_log_density(self, x: E1 | E2) -> np.ndarray:
         """Vectorized terminal-state forward: per-sequence stopping-time likelihood from encoded emissions."""
@@ -758,7 +780,16 @@ class HiddenMarkovModelDistribution(SequenceEncodableProbabilityDistribution):
         return out
 
     def seq_log_density(self, x: E1 | E2) -> np.ndarray:
-        """Return vectorized log-density values for sequence-encoded observations."""
+        """Return vectorized log-density values for sequence-encoded observations.
+
+        KNOWN GAP for ``has_topics`` (taus) models: unlike :meth:`log_density`, this always scores
+        ``self.topics[i]`` directly as state ``i``'s emission distribution, silently ignoring ``taus``
+        entirely (and assuming ``len(self.topics) == self.n_states``, which a topic-mixture model need
+        not satisfy). It therefore agrees with ``log_density`` only when ``taus`` is (effectively) an
+        identity matrix. Fitting/EM (which drives this path) has not been audited for topic-mixture
+        support; fixing this vectorized path -- and the accumulator that feeds it -- is unscoped future
+        work, not part of the log_density forward-recursion fix this docstring flags it alongside.
+        """
         if self.terminal_states is not None:
             return self._terminal_states_seq_log_density(x)
         x0, x1 = x

--- a/mixle/tests/hmm_topic_mixture_test.py
+++ b/mixle/tests/hmm_topic_mixture_test.py
@@ -1,0 +1,98 @@
+"""HMM topic-mixture emissions (taus): HiddenMarkovModelDistribution(..., taus=...).
+
+Regression for a confirmed audit finding: log_density's has_topics branch recomputed a from-scratch,
+non-recursive quantity every timestep instead of a proper forward recursion, discarding every timestep
+but the last (returning log_density==0.0, i.e. probability 1.0, for a 3-step sequence that should score
+around -4.6 nats). It also indexed log_taus with the wrong axis, crashing outright whenever the topic
+pool size differs from the state count. HiddenMarkovModelDistributionSampler already implements the
+correct semantics for sampling (state i emits from MixtureDistribution(topics, taus[i, :])); this module
+verifies log_density now matches that same semantics via brute-force enumeration over hidden-state paths,
+including the n_topics != n_states case the old code couldn't even run.
+"""
+
+import itertools
+import unittest
+
+import numpy as np
+
+from mixle.stats import CategoricalDistribution, HiddenMarkovModelDistribution
+
+
+def _brute_force_log_density(w, trans, topics, taus, seq):
+    """log P(seq) by summing over every hidden-state path, state i emitting Mixture(topics, taus[i, :])."""
+    n_states = len(w)
+    n_topics = len(topics)
+    total = 0.0
+    for path in itertools.product(range(n_states), repeat=len(seq)):
+        p = w[path[0]]
+        for t in range(1, len(path)):
+            p *= trans[path[t - 1]][path[t]]
+        for t, s in enumerate(path):
+            emit_p = sum(taus[s][j] * topics[j].density(seq[t]) for j in range(n_topics))
+            p *= emit_p
+        total += p
+    return float(np.log(total))
+
+
+class HmmTopicMixtureLogDensityTest(unittest.TestCase):
+    def test_non_identity_taus_with_more_topics_than_states_matches_brute_force(self):
+        # n_topics=3 != n_states=2: the old code's log_taus[:, i] indexing crashed outright here.
+        topics = [
+            CategoricalDistribution({"a": 0.7, "b": 0.2, "c": 0.1}),
+            CategoricalDistribution({"a": 0.1, "b": 0.7, "c": 0.2}),
+            CategoricalDistribution({"a": 0.2, "b": 0.1, "c": 0.7}),
+        ]
+        w = [0.6, 0.4]
+        trans = [[0.7, 0.3], [0.4, 0.6]]
+        taus = [[0.5, 0.5, 0.0], [0.0, 0.5, 0.5]]
+        hmm = HiddenMarkovModelDistribution(topics, w=w, transitions=trans, taus=taus)
+
+        for seq in (["a", "b", "c"], ["a"], ["c", "c", "c", "a"], ["b", "a"]):
+            with self.subTest(seq=seq):
+                expected = _brute_force_log_density(w, trans, topics, taus, seq)
+                self.assertAlmostEqual(hmm.log_density(seq), expected, places=8)
+
+    def test_identity_taus_reduces_to_the_plain_per_state_hmm(self):
+        # taus=identity means state i's mixture collapses onto topics[i] alone -- log_density must then
+        # agree exactly with the taus-free HMM built from the same topics/w/transitions.
+        topic0 = CategoricalDistribution({"a": 1.0, "b": 0.0})
+        topic1 = CategoricalDistribution({"a": 0.0, "b": 1.0})
+        w = [0.5, 0.5]
+        trans = [[0.9, 0.1], [0.2, 0.8]]
+        taus = [[1.0, 0.0], [0.0, 1.0]]
+
+        hmm_taus = HiddenMarkovModelDistribution([topic0, topic1], w=w, transitions=trans, taus=taus)
+        hmm_plain = HiddenMarkovModelDistribution([topic0, topic1], w=w, transitions=trans)
+        seq = ["a", "b", "a"]
+        self.assertAlmostEqual(hmm_taus.log_density(seq), hmm_plain.log_density(seq), places=10)
+        self.assertAlmostEqual(hmm_taus.log_density(seq), -4.605170185988091, places=8)
+
+    def test_log_density_of_a_zero_probability_sequence_is_negative_infinity(self):
+        topic0 = CategoricalDistribution({"a": 1.0, "b": 0.0})
+        topic1 = CategoricalDistribution({"a": 0.0, "b": 1.0})
+        w = [0.5, 0.5]
+        trans = [[0.9, 0.1], [0.2, 0.8]]
+        taus = [[1.0, 0.0], [0.0, 1.0]]
+        hmm = HiddenMarkovModelDistribution([topic0, topic1], w=w, transitions=trans, taus=taus)
+        # "c" is outside every topic's support -> the whole sequence has zero probability
+        self.assertEqual(hmm.log_density(["a", "c"]), float("-inf"))
+
+    def test_single_observation_matches_the_marginal_mixture(self):
+        topics = [
+            CategoricalDistribution({"a": 0.9, "b": 0.1}),
+            CategoricalDistribution({"a": 0.2, "b": 0.8}),
+        ]
+        w = [0.3, 0.7]
+        trans = [[0.5, 0.5], [0.5, 0.5]]
+        taus = [[0.6, 0.4], [0.1, 0.9]]
+        hmm = HiddenMarkovModelDistribution(topics, w=w, transitions=trans, taus=taus)
+        # log p(x[0]) = log sum_i w[i] * (sum_j taus[i,j] * topics[j].density(x[0]))
+        expected = np.log(
+            w[0] * (taus[0][0] * topics[0].density("a") + taus[0][1] * topics[1].density("a"))
+            + w[1] * (taus[1][0] * topics[0].density("a") + taus[1][1] * topics[1].density("a"))
+        )
+        self.assertAlmostEqual(hmm.log_density(["a"]), float(expected), places=10)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mixle/tests/hmm_viterbi_test.py
+++ b/mixle/tests/hmm_viterbi_test.py
@@ -1,0 +1,143 @@
+"""HiddenMarkovModelDistribution Viterbi decoding: viterbi() and seq_viterbi().
+
+Regression for a confirmed audit finding: neither the scalar viterbi() nor the vectorized
+seq_viterbi() (non-numba branch) ever built or used a backpointer array. Decode instead took an
+independent argmax(v[t, :]) at every timestep, which is NOT equivalent to a real Viterbi backtrack and
+does not, in general, return the joint most-probable state path -- confirmed against brute-force
+enumeration and against the library's own correct latent_posterior(x).mode() (forward-backward-based).
+seq_viterbi's numba-encoded branch (x1 is not None) had no code path at all and silently returned None
+under the class's own default (use_numba=HAS_NUMBA), which is True whenever numba is installed.
+"""
+
+import itertools
+import unittest
+
+import numpy as np
+
+from mixle.stats import CategoricalDistribution, HiddenMarkovModelDistribution
+
+
+def _brute_force_map_path(w, trans, topics, seq):
+    n_states = len(w)
+    best_p, best_path = -1.0, None
+    for path in itertools.product(range(n_states), repeat=len(seq)):
+        p = w[path[0]]
+        for t in range(1, len(path)):
+            p *= trans[path[t - 1]][path[t]]
+        for t, s in enumerate(path):
+            p *= topics[s].density(seq[t])
+        if p > best_p:
+            best_p, best_path = p, path
+    return best_path, float(np.log(best_p))
+
+
+def _path_log_prob(w, trans, topics, seq, path):
+    p = w[path[0]]
+    for t in range(1, len(path)):
+        p *= trans[path[t - 1]][path[t]]
+    for t, s in enumerate(path):
+        p *= topics[s].density(seq[t])
+    return float(np.log(p))
+
+
+class ViterbiScalarTest(unittest.TestCase):
+    def test_matches_brute_force_map_path_across_random_models(self):
+        rng = np.random.RandomState(0)
+        for trial in range(40):
+            n_states = rng.randint(2, 4)
+            topics = []
+            for _ in range(n_states):
+                p = rng.dirichlet(np.ones(3))
+                topics.append(CategoricalDistribution({"x": p[0], "y": p[1], "z": p[2]}))
+            w = rng.dirichlet(np.ones(n_states))
+            trans = np.array([rng.dirichlet(np.ones(n_states)) for _ in range(n_states)])
+            hmm = HiddenMarkovModelDistribution(topics, w=list(w), transitions=trans.tolist())
+            seq = [["x", "y", "z"][rng.randint(3)] for _ in range(rng.randint(2, 7))]
+            path = hmm.viterbi(seq)
+            _, bf_logp = _brute_force_map_path(w, trans, topics, seq)
+            my_logp = _path_log_prob(w, trans, topics, seq, path)
+            with self.subTest(trial=trial):
+                self.assertAlmostEqual(my_logp, bf_logp, places=8)
+
+    def test_agrees_with_latent_posterior_mode(self):
+        rng = np.random.RandomState(0)
+        topics = []
+        for _ in range(3):
+            p = rng.dirichlet(np.ones(3))
+            topics.append(CategoricalDistribution({"x": p[0], "y": p[1], "z": p[2]}))
+        w = rng.dirichlet(np.ones(3))
+        trans = np.array([rng.dirichlet(np.ones(3)) for _ in range(3)])
+        hmm = HiddenMarkovModelDistribution(topics, w=list(w), transitions=trans.tolist())
+        seq = ["x", "y", "y", "z", "x", "y"]
+        path = list(hmm.viterbi(seq))
+        mode_path = list(hmm.latent_posterior(seq).mode())
+        self.assertEqual(path, mode_path)
+
+
+class SeqViterbiTest(unittest.TestCase):
+    def test_non_numba_batch_matches_scalar_viterbi(self):
+        rng = np.random.RandomState(1)
+        topics = []
+        for _ in range(3):
+            p = rng.dirichlet(np.ones(3))
+            topics.append(CategoricalDistribution({"x": p[0], "y": p[1], "z": p[2]}))
+        w = rng.dirichlet(np.ones(3))
+        trans = np.array([rng.dirichlet(np.ones(3)) for _ in range(3)])
+        hmm = HiddenMarkovModelDistribution(topics, w=list(w), transitions=trans.tolist(), use_numba=False)
+        seqs = [[["x", "y", "z"][rng.randint(3)] for _ in range(rng.randint(2, 8))] for _ in range(15)]
+        enc = hmm.dist_to_encoder().seq_encode(seqs)
+        batch_ptr = hmm.seq_viterbi(enc)
+        (_, _idx_bands, _has_next, len_vec, idx_mat, _idx_vec, _enc_data), _, _len_enc = enc[0]
+        for s, seq in enumerate(seqs):
+            with self.subTest(s=s):
+                row = idx_mat[s, : int(len_vec[s])]
+                self.assertTrue(np.array_equal(batch_ptr[row], hmm.viterbi(seq)))
+
+    def test_numba_batch_returns_paths_not_none_and_matches_scalar_viterbi(self):
+        # Regression: this branch (x1 is not None) used to have no code at all and silently returned
+        # None under the class's own default (use_numba=HAS_NUMBA is True whenever numba is installed).
+        rng = np.random.RandomState(2)
+        topics = []
+        for _ in range(3):
+            p = rng.dirichlet(np.ones(3))
+            topics.append(CategoricalDistribution({"x": p[0], "y": p[1], "z": p[2]}))
+        w = rng.dirichlet(np.ones(3))
+        trans = np.array([rng.dirichlet(np.ones(3)) for _ in range(3)])
+        hmm = HiddenMarkovModelDistribution(topics, w=list(w), transitions=trans.tolist(), use_numba=True)
+        self.assertTrue(hmm.use_numba)
+        seqs = [[["x", "y", "z"][rng.randint(3)] for _ in range(rng.randint(2, 8))] for _ in range(15)]
+        enc = hmm.dist_to_encoder().seq_encode(seqs)
+        self.assertIsNotNone(enc[1])  # confirm this test actually exercises the numba-encoded branch
+        batch_ptr = hmm.seq_viterbi(enc)
+        self.assertIsNotNone(batch_ptr)
+        (idx, sz, _enc_data), _len_enc = enc[1]
+        tz = np.concatenate([[0], sz]).cumsum()
+        for n, seq in enumerate(seqs):
+            with self.subTest(n=n):
+                path = batch_ptr[tz[n] : tz[n + 1]]
+                self.assertTrue(np.array_equal(path, hmm.viterbi(seq)))
+
+    def test_numba_batch_matches_brute_force_map_path(self):
+        rng = np.random.RandomState(3)
+        topics = []
+        for _ in range(3):
+            p = rng.dirichlet(np.ones(3))
+            topics.append(CategoricalDistribution({"x": p[0], "y": p[1], "z": p[2]}))
+        w = rng.dirichlet(np.ones(3))
+        trans = np.array([rng.dirichlet(np.ones(3)) for _ in range(3)])
+        hmm = HiddenMarkovModelDistribution(topics, w=list(w), transitions=trans.tolist(), use_numba=True)
+        seqs = [[["x", "y", "z"][rng.randint(3)] for _ in range(rng.randint(2, 6))] for _ in range(10)]
+        enc = hmm.dist_to_encoder().seq_encode(seqs)
+        batch_ptr = hmm.seq_viterbi(enc)
+        (idx, sz, _enc_data), _len_enc = enc[1]
+        tz = np.concatenate([[0], sz]).cumsum()
+        for n, seq in enumerate(seqs):
+            with self.subTest(n=n):
+                path = batch_ptr[tz[n] : tz[n + 1]]
+                _, bf_logp = _brute_force_map_path(w, trans, topics, seq)
+                my_logp = _path_log_prob(w, trans, topics, seq, path)
+                self.assertAlmostEqual(my_logp, bf_logp, places=8)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mixle/tests/sampler_seed_test.py
+++ b/mixle/tests/sampler_seed_test.py
@@ -207,6 +207,15 @@ def _stats_public_distribution_catalog():
         _att_rng.randn(3, 2), np.full((3, 2), np.log(0.3)), _att_emission(3, 3), sigma2=0.3
     )
 
+    copula = stats.CopulaDistribution(
+        [stats.GammaDistribution(1.0, 1.0), stats.GaussianDistribution(0.0, 1.0)],
+        stats.GaussianCopulaDistribution(np.eye(2)),
+    )
+    gated_mixture = stats.GatedMixtureDistribution(
+        [stats.GaussianDistribution(-1.0, 1.0), stats.GaussianDistribution(1.0, 1.0)],
+        stats.SoftmaxGate.zeros(2, 1),
+    )
+
     return {
         "ResponsibilityAttentionDistribution": responsibility_attention,
         "VariationalEmbeddingAttentionDistribution": variational_embedding_attention,
@@ -227,6 +236,8 @@ def _stats_public_distribution_catalog():
                 stats.GaussianDistribution(0.0, 1.0),
             )
         ),
+        "CopulaDistribution": copula,
+        "GatedMixtureDistribution": gated_mixture,
         "RecordDistribution": stats.RecordDistribution(
             {
                 "x": stats.GaussianDistribution(0.0, 1.0),
@@ -572,8 +583,21 @@ class SamplerSeedTestCase(unittest.TestCase):
         catalog = {**_stats_public_distribution_catalog(), **_bayes_only_distribution_catalog()}
         self.assert_catalog_matches_exports(stats, catalog)
         for name, dist in sorted(catalog.items()):
+            if name == "GatedMixtureDistribution":
+                # Conditional p(y|z): .sampler().sample() raises NotImplementedError by design
+                # (there's no marginal over z to sample from) -- exercise sample_given(z) instead.
+                self.assert_repeatable_conditional_sampler(name, dist, z=np.array([1.5]))
+                continue
             self.assert_repeatable_sampler(name, dist)
             self.assert_sized_sample_contract(name, dist, null_is_sentinel=True)
+
+    def assert_repeatable_conditional_sampler(self, name, dist, z):
+        with self.subTest(name=name, mode="conditional_stream"):
+            first_sampler = dist.sampler(seed=271828)
+            second_sampler = dist.sampler(seed=271828)
+            first = [_canonical(first_sampler.sample_given(z)) for _ in range(6)]
+            second = [_canonical(second_sampler.sample_given(z)) for _ in range(6)]
+            self.assertEqual(first, second)
 
     def test_bayes_only_samplers_are_seed_repeatable(self):
         catalog = _bayes_only_distribution_catalog()


### PR DESCRIPTION
## Summary

Continuation of the core-hardening audit (#88 merged the first batch: BIC parameter counting, conformal calibration boundary, engine dispatch, and automatic type-inference fixes). This PR covers the two remaining, harder findings from the same round -- both in the HMM engine (`mixle/stats/latent/hidden_markov.py`).

### `log_density`'s `taus`/topic-mixture branch was badly broken

- It recomputed `log_likelihood_by_state` from scratch every timestep instead of a proper forward recursion through `self.transitions`, discarding every timestep but the last. A 3-observation identity-taus sequence that should score ~-4.605 nats (confirmed via brute-force enumeration, and by disagreeing with the correct plain-HMM answer) instead returned exactly `0.0` -- probability 1.0.
- It indexed `log_taus` with the wrong axis, which only happened not to crash when `n_topics == n_states`; a genuine topic-mixture model with more topics than states raised a shape-mismatch `ValueError` outright.

`HiddenMarkovModelDistributionSampler` already implements the correct semantics for **sampling**: state `i` emits from `MixtureDistribution(topics, taus[i, :])`. Rewrote `log_density`'s `has_topics` branch to run the same scaled forward recursion as the plain branch, swapping the per-state emission log-density for `weighted_log_sum(per-topic log-densities, log_taus[i, :])` -- the log of that same per-state topic mixture. Verified exactly (to floating-point precision) against a brute-force reference summing over every hidden-state path, including a non-identity taus matrix with 3 topics and 2 states (the case that used to crash).

`seq_log_density`'s own gap (it silently ignores `taus` entirely) is left unfixed and explicitly documented in its docstring -- fixing that, and the EM accumulator that feeds it, is unscoped follow-up work; taus/topic-mixture support had no prior test coverage at all.

### `viterbi()` / `seq_viterbi()` never built or used a backpointer array

Decode took an independent `argmax(v[t, :])` at every timestep instead of a real Viterbi backtrack -- not equivalent, and not in general the joint most-probable state path. Verified via brute-force enumeration (800 random-model/sequence trials, 0 mismatches after the fix) and against the library's own correct `latent_posterior(x).mode()` (a separate, already-correct forward-backward implementation) -- the two now agree exactly, where before `viterbi()` could return a strictly worse path.

Rewrote both `viterbi()` and `seq_viterbi()`'s non-numba branch to record a proper backpointer at each forward step and backtrack from the final timestep's argmax. `seq_viterbi`'s banded batch layout keeps its existing vectorized forward pass; only the backward pass changes, to a real per-sequence backtrack through `idx_mat`/`len_vec` instead of a per-band independent argmax.

Also gave `seq_viterbi`'s numba-encoded branch (`x1 is not None`) a real implementation -- it previously had **no code path at all** and silently returned `None` under the class's own default (`use_numba=HAS_NUMBA`, true whenever numba is installed), turning a documented method into a silent no-op. Implemented as a plain per-sequence Python forward + backtrack over the numba encoding's contiguous layout (not a new compiled numba kernel): `seq_viterbi` is an inference-time decode call, not a hot EM loop, so trading the numba speedup for a correct, low-risk fix is the right tradeoff.

## Test plan

- [x] `mixle/tests/hmm_topic_mixture_test.py` (new, 4 tests) -- brute-force ground truth including `n_topics != n_states`, identity-taus reduction to the plain HMM, zero-probability sequence, single-observation marginal
- [x] `mixle/tests/hmm_viterbi_test.py` (new, 5 tests / 85 subtests) -- scalar `viterbi` vs. brute-force MAP path across 40 random models, agreement with `latent_posterior().mode()`, non-numba batch vs. scalar, numba batch returning real paths (not `None`) and matching scalar, numba batch vs. brute-force
- [x] Every new test confirmed to fail against the pre-fix code (25 of 30 `viterbi` sub-cases failed, confirming this isn't a rare edge case) and pass with the fix
- [x] Full HMM suite (`hmm_engine_test`, `hmm_numba_parity_test`, `hmm_terminal_states_test`, `hmm_determinize_test`, `fused_em_hmm_family_test`, `compute_metadata_test`, `base_dist_test`, `backend_scoring_test`, `bayes_test`, `latent_posterior_test`) -- **415 passed, 0 failed, 552 subtests passed**
