### PR TITLE
doe: noise-robust incumbent selection for Bayesian optimization

### DIFF
--- a/mixle/doe/__init__.py
+++ b/mixle/doe/__init__.py
@@ -123,6 +123,7 @@ from mixle.doe.oracle import (
     optimize_under_oracle,
 )
 from mixle.doe.propagate import propagate, register_propagator, unscented_transform
+from mixle.doe.robust import IncumbentResult, noisy_minimize, posterior_incumbent
 from mixle.doe.sensitivity import dgsm, fast_indices, morris_screening, sobol_indices
 from mixle.doe.trust_region import TrustRegion, turbo_minimize
 
@@ -213,6 +214,9 @@ __all__ = [
     "propagate",
     "register_propagator",
     "unscented_transform",
+    "noisy_minimize",
+    "posterior_incumbent",
+    "IncumbentResult",
     "calibrate",
     "KOCalibration",
 ]

--- a/mixle/doe/robust.py
+++ b/mixle/doe/robust.py
@@ -1,0 +1,100 @@
+"""Noise-robust incumbent selection for Bayesian optimization (a correctness fix for noisy objectives).
+
+:func:`mixle.doe.bayesopt.minimize` returns the incumbent as ``argmin`` of the OBSERVED objective values.
+That is correct for a deterministic objective, but optimistically biased for a NOISY one: the lowest
+observed value is often just the point that drew the luckiest negative noise, not the true optimum, so
+``best_x`` chases noise and ``best_y`` is a downward-biased estimate.
+
+The standard fix (Jones et al.; the "noisy BO" recommendation) is to report the incumbent by the
+surrogate's POSTERIOR MEAN, which averages out observation noise: fit the GP over every evaluated point
+and return the evaluated point whose posterior-mean prediction is best. :func:`posterior_incumbent` is
+that primitive; :func:`noisy_minimize` runs the ordinary BO loop and then re-selects the incumbent this
+way -- so the exploration is unchanged, only the *reported answer* is made robust.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+from mixle.doe.bayesopt import BayesOptResult, minimize
+
+Bounds = Any
+
+
+@dataclass
+class IncumbentResult:
+    """The posterior-mean incumbent among evaluated points: its location, posterior mean, and index."""
+
+    best_x: np.ndarray
+    best_mean: float
+    best_index: int
+
+
+def _fit_gp(x: np.ndarray, y: np.ndarray, gp: Any, fit_kwargs: dict[str, Any] | None) -> Any:
+    if gp is None:
+        from mixle.models.gaussian_process import GaussianProcessRegressor
+
+        scale = float(np.std(y)) or 1.0
+        gp = GaussianProcessRegressor(lengthscale=1.0, amplitude=scale, noise=0.1 * scale + 1.0e-6)
+    gp.fit(x, y, **{"out": None, **(fit_kwargs or {})})
+    return gp
+
+
+def posterior_incumbent(
+    x: np.ndarray,
+    y: np.ndarray,
+    *,
+    maximize: bool = False,
+    gp: Any = None,
+    fit_kwargs: dict[str, Any] | None = None,
+) -> IncumbentResult:
+    """Among the evaluated points ``x``, return the one with the best GP POSTERIOR MEAN (min by default).
+
+    Fits a GP surrogate on ``(x, y)`` -- the same surrogate the BO loop uses -- and predicts the
+    denoised mean at every evaluated point, so the reported optimum reflects the model's belief, not a
+    single lucky noisy observation. For a deterministic objective the posterior mean at the observed
+    points is ~the observations, so this reduces to the ordinary argmin/argmax.
+    """
+    x = np.atleast_2d(np.asarray(x, dtype=np.float64))
+    y = np.asarray(y, dtype=np.float64).reshape(-1)
+    if x.shape[0] != y.shape[0]:
+        raise ValueError("x and y must have the same number of rows.")
+    if x.shape[0] == 0:
+        raise ValueError("need at least one evaluated point.")
+    fitted = _fit_gp(x, y, gp, fit_kwargs)
+    mean = np.asarray(fitted.predict(x, y, x, return_cov=False), dtype=np.float64).reshape(-1)
+    idx = int(np.argmax(mean)) if maximize else int(np.argmin(mean))
+    return IncumbentResult(best_x=x[idx].copy(), best_mean=float(mean[idx]), best_index=idx)
+
+
+def noisy_minimize(
+    objective: Callable[[np.ndarray], float],
+    bounds: Bounds,
+    n_init: int = 5,
+    n_iter: int = 15,
+    seed: Any = None,
+    *,
+    maximize: bool = False,
+    gp: Any = None,
+    fit_kwargs: dict[str, Any] | None = None,
+    **minimize_kwargs: Any,
+) -> BayesOptResult:
+    """Bayesian optimization of a NOISY objective, reporting the posterior-mean incumbent.
+
+    Runs :func:`mixle.doe.bayesopt.minimize` (same exploration), then replaces the raw ``argmin``-of-
+    observations incumbent with the posterior-mean incumbent (:func:`posterior_incumbent`), so ``best_x``
+    is the model's believed optimum rather than the luckiest noisy draw and ``best_y`` is its denoised
+    estimate. The full ``(x, y)`` evaluation history is preserved on the result.
+    """
+    result = minimize(objective, bounds, n_init=n_init, n_iter=n_iter, seed=seed, maximize=maximize, **minimize_kwargs)
+    incumbent = posterior_incumbent(result.x, result.y, maximize=maximize, gp=gp, fit_kwargs=fit_kwargs)
+    return BayesOptResult(
+        best_x=incumbent.best_x,
+        best_y=incumbent.best_mean,
+        x=result.x,
+        y=result.y,
+    )

--- a/mixle/tests/doe_robust_test.py
+++ b/mixle/tests/doe_robust_test.py
@@ -1,0 +1,74 @@
+"""Noise-robust incumbent selection for BO (mixle.doe.robust): under a noisy objective, reporting the
+posterior-mean incumbent recovers the true optimum better than argmin-of-observed, which chases noise.
+"""
+
+import unittest
+
+import numpy as np
+import pytest
+
+pytest.importorskip("torch")
+
+from mixle.doe.bayesopt import minimize  # noqa: E402
+from mixle.doe.robust import noisy_minimize, posterior_incumbent  # noqa: E402
+
+_TARGET = np.array([1.0, -0.5])
+_BOUNDS = [(-3.0, 3.0), (-3.0, 3.0)]
+
+
+def _noisy_bowl(noise_std, seed):
+    rng = np.random.RandomState(seed)
+
+    def obj(x):
+        clean = float(np.sum((np.asarray(x, dtype=float) - _TARGET) ** 2))
+        return clean + rng.normal(0.0, noise_std)
+
+    return obj
+
+
+class PosteriorIncumbentTest(unittest.TestCase):
+    def test_deterministic_case_reduces_to_argmin(self):
+        rng = np.random.RandomState(0)
+        x = rng.uniform(-3, 3, size=(15, 2))
+        y = np.sum((x - _TARGET) ** 2, axis=1)  # noiseless
+        inc = posterior_incumbent(x, y, maximize=False)
+        # with no noise the posterior-mean incumbent is (essentially) the observed argmin
+        self.assertLess(float(np.linalg.norm(inc.best_x - x[int(np.argmin(y))])), 0.5)
+
+    def test_validates_shapes(self):
+        with self.assertRaises(ValueError):
+            posterior_incumbent(np.zeros((3, 2)), np.zeros(2))
+        with self.assertRaises(ValueError):
+            posterior_incumbent(np.zeros((0, 2)), np.zeros(0))
+
+
+class NoisyIncumbentBeatsArgminTest(unittest.TestCase):
+    def test_posterior_incumbent_is_closer_to_the_true_optimum_under_noise(self):
+        seeds = range(10)
+        noise_std = 1.5  # comparable to the objective's spread -> argmin-of-observed gets fooled
+        argmin_err, robust_err = [], []
+        for s in seeds:
+            res = minimize(_noisy_bowl(noise_std, seed=100 + s), _BOUNDS, n_init=6, n_iter=14, seed=s)
+            argmin_x = res.x[int(np.argmin(res.y))]  # what plain minimize reports
+            robust_x = posterior_incumbent(res.x, res.y, maximize=False).best_x  # the robust rule
+            argmin_err.append(float(np.linalg.norm(argmin_x - _TARGET)))
+            robust_err.append(float(np.linalg.norm(robust_x - _TARGET)))
+        # averaged over seeds, the denoised incumbent lands closer to the true optimum
+        self.assertLess(float(np.mean(robust_err)), float(np.mean(argmin_err)))
+
+    def test_noisy_minimize_reports_the_robust_incumbent_end_to_end(self):
+        res = noisy_minimize(_noisy_bowl(1.0, seed=42), _BOUNDS, n_init=6, n_iter=12, seed=1)
+        # best_x is a point actually evaluated (the believed optimum among them), history preserved
+        self.assertEqual(res.x.shape[1], 2)
+        self.assertEqual(len(res.y), res.x.shape[0])
+        self.assertTrue(np.any(np.all(np.isclose(res.x, res.best_x), axis=1)))
+
+    def test_deterministic_given_seed(self):
+        a = noisy_minimize(_noisy_bowl(1.0, seed=5), _BOUNDS, n_init=5, n_iter=8, seed=3)
+        b = noisy_minimize(_noisy_bowl(1.0, seed=5), _BOUNDS, n_init=5, n_iter=8, seed=3)
+        np.testing.assert_allclose(a.best_x, b.best_x)
+        np.testing.assert_allclose(a.y, b.y)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes a real correctness gap in the DoE stack: `bayesopt.minimize` reports the incumbent as `argmin` of the **observed** objective. That's correct for a deterministic objective but optimistically biased for a **noisy** one — the lowest observation is often just the luckiest noise draw, so `best_x` chases noise and `best_y` is downward-biased.

- `posterior_incumbent(x, y)` — fits the GP surrogate over all evaluated points and returns the point with the best **posterior mean** (the standard noisy-BO recommendation; averages out observation noise). Reduces to plain argmin when deterministic.
- `noisy_minimize(objective, bounds, ...)` — runs the ordinary BO loop (unchanged exploration) then re-selects the incumbent robustly, so only the *reported answer* changes.

Tests (5): the load-bearing one shows that on a noisy bowl, averaged over seeds, the posterior-mean incumbent lands closer to the true optimum than argmin-of-observed; plus deterministic-reduces-to-argmin, end-to-end, determinism, input validation. torch-gated.