### PR TITLE
task/rl+irl: tabular Q-learning and maximum-entropy inverse RL

### DIFF
--- a/mixle/task/__init__.py
+++ b/mixle/task/__init__.py
@@ -123,6 +123,7 @@ from mixle.task.imagine import (
     ceiling_report,
     propose_structure,
 )
+from mixle.task.irl import MaxEntIRLResult, max_ent_irl, rollout_states, state_features
 from mixle.task.llm import (
     CallableLLM,
     OpenAICompatLLM,
@@ -177,6 +178,7 @@ from mixle.task.refine import (
 )
 from mixle.task.regress import RegressionSolution, solve_regression
 from mixle.task.replay import ExecutionTrace, TraceStep, is_bit_identical_replay, record_step, replay
+from mixle.task.rl import GridWorld, QLearningResult, rollout, tabular_q_learning
 from mixle.task.router import HarvestResolveResult, Router, RouterStats, resolve_from_harvest, route_stack
 from mixle.task.scorecard import Scorecard, scorecard
 from mixle.task.sft_plan import GenerativePlanner, sample_plans, score_plan, sft_planner
@@ -356,6 +358,14 @@ __all__ = [
     "RoundLog",
     "SequenceProposal",
     "propose_verify_retrain",
+    "GridWorld",
+    "QLearningResult",
+    "tabular_q_learning",
+    "rollout",
+    "MaxEntIRLResult",
+    "max_ent_irl",
+    "rollout_states",
+    "state_features",
     "sample_plans",
     "score_plan",
     "scorecard",

--- a/mixle/task/irl.py
+++ b/mixle/task/irl.py
@@ -1,0 +1,161 @@
+"""Maximum-entropy inverse reinforcement learning (Ziebart et al., 2008): recover a REWARD from
+expert demonstrations, rather than assume one is given.
+
+This is the complementary direction to :mod:`mixle.task.rl` (which learns a POLICY given a KNOWN
+reward): given expert trajectories -- state sequences produced by an expert acting optimally under
+some UNKNOWN reward -- :func:`max_ent_irl` recovers linear reward weights over a state feature map
+such that the maximum-entropy (Boltzmann-rational) policy induced by those weights matches the
+expert's empirical feature expectations. That match is the algorithm's own optimality certificate
+(feature-expectation matching at convergence), not a proxy metric graded after the fact.
+
+Differs from :mod:`mixle.task.plan_model` (CARD C1-a), which fits a Markov chain directly over
+observed action sequences -- it models WHAT the expert did. This module additionally explains WHY,
+recovering the reward the expert's behavior is consistent with, over the same
+:class:`~mixle.task.rl.GridWorld` environment shape.
+
+    world = GridWorld(size=5, goal=(4, 4))
+    demos = [rollout_states(world, expert_policy, start=(0, 0)) for _ in range(20)]
+    result = max_ent_irl(world, demos)
+    result.reward_weights.reshape(world.size, world.size)   # recovered per-cell reward
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from mixle.task.rl import ACTIONS, GridWorld, State
+
+
+def state_features(env: GridWorld) -> np.ndarray:
+    """Default feature map: a one-hot indicator per grid cell (``n_states x n_states``) -- a fully
+    expressive tabular basis, so recovering per-feature weights is equivalent to recovering the
+    per-state reward directly."""
+    return np.eye(env.n_states)
+
+
+def rollout_states(env: GridWorld, policy: dict[State, str], *, start: State = (0, 0)) -> list[State]:
+    """The state-only trace of a deterministic policy from ``start`` (the demonstration format
+    :func:`max_ent_irl` expects: what the expert visited, not what it was thinking)."""
+    state = env.reset(start)
+    trace = [state]
+    for _ in range(env.max_steps):
+        if state == env.goal:
+            break
+        state, _, done = env.step(policy[state])
+        trace.append(state)
+        if done:
+            break
+    return trace
+
+
+def _transition_table(env: GridWorld) -> np.ndarray:
+    """Precompute the deterministic ``next_state[s, a]`` index table for every state/action."""
+    next_state = np.zeros((env.n_states, len(ACTIONS)), dtype=int)
+    for s_idx in range(env.n_states):
+        state = env.index_state(s_idx)
+        for a_idx, action in enumerate(ACTIONS):
+            next_state[s_idx, a_idx] = env.state_index(env.transition(state, action))
+    return next_state
+
+
+def _expert_feature_expectation(env: GridWorld, features: np.ndarray, trajectories: list[list[State]]) -> np.ndarray:
+    total = np.zeros(features.shape[1])
+    count = 0
+    for traj in trajectories:
+        for state in traj:
+            total += features[env.state_index(state)]
+            count += 1
+    return total / count
+
+
+def _soft_value_iteration(
+    reward: np.ndarray, next_state: np.ndarray, *, gamma: float, iterations: int = 200
+) -> np.ndarray:
+    """Soft (log-sum-exp) Bellman backup -> the Boltzmann-rational policy ``pi(a|s) ~ exp(Q(s,a))``,
+    the maximum-entropy-optimal policy for ``reward``."""
+    n_states = next_state.shape[0]
+    v = np.zeros(n_states)
+    for _ in range(iterations):
+        q = reward[:, None] + gamma * v[next_state]
+        q_max = q.max(axis=1, keepdims=True)
+        v_new = np.log(np.sum(np.exp(q - q_max), axis=1)) + q_max.squeeze(-1)
+        if np.max(np.abs(v_new - v)) < 1e-8:
+            v = v_new
+            break
+        v = v_new
+    q = reward[:, None] + gamma * v[next_state]
+    q = q - q.max(axis=1, keepdims=True)
+    policy = np.exp(q)
+    policy /= policy.sum(axis=1, keepdims=True)
+    return policy
+
+
+def _expected_state_visitation(
+    policy: np.ndarray, next_state: np.ndarray, *, start_index: int, horizon: int
+) -> np.ndarray:
+    """Forward pass: expected visitation count per state over ``horizon`` steps from ``start_index``,
+    under ``policy`` and the deterministic ``next_state`` transition (the MaxEnt IRL algorithm's own
+    state-visitation-frequency computation)."""
+    n_states, n_actions = policy.shape
+    d = np.zeros((horizon, n_states))
+    d[0, start_index] = 1.0
+    for t in range(1, horizon):
+        prev = d[t - 1]
+        active = np.nonzero(prev)[0]
+        for s in active:
+            for a in range(n_actions):
+                d[t, next_state[s, a]] += prev[s] * policy[s, a]
+    return d.sum(axis=0)
+
+
+@dataclass
+class MaxEntIRLResult:
+    """The recovered reward, its induced Boltzmann-rational policy, and the convergence trace
+    (``||expert_feature_expectation - policy_feature_expectation||`` per iteration -- should
+    decrease toward zero as the algorithm's own certificate of fit)."""
+
+    reward_weights: np.ndarray
+    policy: np.ndarray
+    history: list[float]
+
+    def reward(self, features: np.ndarray) -> np.ndarray:
+        return features @ self.reward_weights
+
+
+def max_ent_irl(
+    env: GridWorld,
+    expert_trajectories: list[list[State]],
+    *,
+    start: State = (0, 0),
+    gamma: float = 0.9,
+    iterations: int = 150,
+    lr: float = 0.5,
+    features: np.ndarray | None = None,
+) -> MaxEntIRLResult:
+    """Recover linear reward weights whose maximum-entropy-optimal policy matches the expert's
+    empirical feature expectations, via gradient ascent on trajectory likelihood:
+    ``weights += lr * (expert_feature_expectation - policy_feature_expectation)``. Requires only
+    ``expert_trajectories`` (state sequences); never sees the expert's true reward or the actions
+    that produced them."""
+    if not expert_trajectories:
+        raise ValueError("max_ent_irl requires at least one expert trajectory.")
+    features = state_features(env) if features is None else features
+    next_state = _transition_table(env)
+    expert_fe = _expert_feature_expectation(env, features, expert_trajectories)
+    horizon = max(len(t) for t in expert_trajectories)
+    start_index = env.state_index(start)
+
+    weights = np.zeros(features.shape[1])
+    history = []
+    policy = np.ones((env.n_states, len(ACTIONS))) / len(ACTIONS)
+    for _ in range(iterations):
+        reward = features @ weights
+        policy = _soft_value_iteration(reward, next_state, gamma=gamma)
+        visitation = _expected_state_visitation(policy, next_state, start_index=start_index, horizon=horizon)
+        expected_fe = (visitation[:, None] * features).sum(axis=0) / visitation.sum()
+        grad = expert_fe - expected_fe
+        weights = weights + lr * grad
+        history.append(float(np.linalg.norm(grad)))
+    return MaxEntIRLResult(reward_weights=weights, policy=policy, history=history)

--- a/mixle/task/rl.py
+++ b/mixle/task/rl.py
@@ -1,0 +1,173 @@
+"""Reinforcement learning: tabular Q-learning over a discrete MDP with a KNOWN reward.
+
+This is the classical value-based counterpart the plan's expert-iteration cards (C2-a
+``outcome_decomposer``, PROBE-a ``probe_policy``) deliberately avoided: those optimize a WHOLE
+action sequence's terminal, oracle-verified score by propose/filter/refit, with no per-step value
+estimate. This module is the other end of the design space -- a per-step Bellman backup,
+``Q(s, a) <- Q(s, a) + alpha * [r + gamma * max_a' Q(s', a') - Q(s, a)]`` -- for problems that ARE
+naturally modeled as a finite MDP with a known step reward. It composes with :mod:`mixle.task.irl`
+(the complementary direction: reward FROM demonstrations, not policy from a known reward) via the
+shared :class:`GridWorld` environment.
+
+    world = GridWorld(size=5, goal=(4, 4))
+    result = tabular_q_learning(world, episodes=500, seed=0)
+    policy = result.greedy_policy(world)     # {state: best action}, the recovered optimal policy
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass, field
+
+import numpy as np
+
+Action = str
+State = tuple[int, int]
+
+_DELTA: dict[Action, tuple[int, int]] = {"up": (-1, 0), "down": (1, 0), "left": (0, -1), "right": (0, 1)}
+ACTIONS: tuple[Action, ...] = ("up", "down", "left", "right")
+
+
+@dataclass
+class GridWorld:
+    """A deterministic ``size`` x ``size`` grid MDP: a goal cell worth ``goal_reward``, a per-step
+    cost of ``step_cost``, and optional impassable ``obstacles`` (moving into a wall or obstacle
+    leaves the agent in place, still paying the step cost). The optimal policy is the shortest
+    obstacle-free path to the goal -- computable independently via :meth:`optimal_path_length`
+    (BFS), which is what makes this a closed-form-known-optimum test environment."""
+
+    size: int
+    goal: State
+    obstacles: frozenset[State] = field(default_factory=frozenset)
+    step_cost: float = -1.0
+    goal_reward: float = 10.0
+    max_steps: int = 100
+
+    def __post_init__(self) -> None:
+        self._state: State = (0, 0)
+        self._steps = 0
+
+    @property
+    def n_states(self) -> int:
+        return self.size * self.size
+
+    def state_index(self, state: State) -> int:
+        return state[0] * self.size + state[1]
+
+    def index_state(self, index: int) -> State:
+        r, c = divmod(index, self.size)
+        return (r, c)
+
+    def states(self) -> list[State]:
+        return [(r, c) for r in range(self.size) for c in range(self.size)]
+
+    def transition(self, state: State, action: Action) -> State:
+        """The deterministic next state for ``action`` at ``state`` (walls/obstacles are a no-op)."""
+        dr, dc = _DELTA[action]
+        r, c = state
+        nr, nc = r + dr, c + dc
+        if not (0 <= nr < self.size and 0 <= nc < self.size) or (nr, nc) in self.obstacles:
+            return state
+        return (nr, nc)
+
+    def reset(self, start: State = (0, 0)) -> State:
+        self._state = start
+        self._steps = 0
+        return self._state
+
+    def step(self, action: Action) -> tuple[State, float, bool]:
+        self._state = self.transition(self._state, action)
+        self._steps += 1
+        at_goal = self._state == self.goal
+        reward = self.goal_reward if at_goal else self.step_cost
+        done = at_goal or self._steps >= self.max_steps
+        return self._state, reward, done
+
+    def optimal_path_length(self, start: State = (0, 0)) -> int:
+        """BFS shortest obstacle-free path length from ``start`` to ``goal`` -- ground truth for
+        tests, computed independently of any learning algorithm in this module."""
+        if start == self.goal:
+            return 0
+        visited = {start}
+        queue: deque[tuple[State, int]] = deque([(start, 0)])
+        while queue:
+            state, dist = queue.popleft()
+            for action in ACTIONS:
+                nxt = self.transition(state, action)
+                if nxt == state or nxt in visited:
+                    continue
+                if nxt == self.goal:
+                    return dist + 1
+                visited.add(nxt)
+                queue.append((nxt, dist + 1))
+        raise ValueError("goal is unreachable from start given the obstacles.")
+
+
+@dataclass
+class QLearningResult:
+    """The fitted Q-table plus the per-episode return trace (the learning curve)."""
+
+    q_table: np.ndarray
+    rewards_per_episode: list[float]
+
+    def greedy_action_index(self, state_index: int) -> int:
+        return int(np.argmax(self.q_table[state_index]))
+
+    def greedy_policy(self, env: GridWorld) -> dict[State, Action]:
+        """The recovered deterministic policy: the argmax action at every non-goal state."""
+        return {s: ACTIONS[self.greedy_action_index(env.state_index(s))] for s in env.states() if s != env.goal}
+
+
+def tabular_q_learning(
+    env: GridWorld,
+    *,
+    episodes: int = 500,
+    alpha: float = 0.3,
+    gamma: float = 0.95,
+    epsilon: float = 0.2,
+    seed: int | None = None,
+) -> QLearningResult:
+    """Epsilon-greedy tabular Q-learning: ``episodes`` full rollouts from ``env.reset()``, each step
+    updating ``Q(s, a)`` toward the observed one-step Bellman target."""
+    rng = np.random.RandomState(seed)
+    q = np.zeros((env.n_states, len(ACTIONS)))
+    rewards_per_episode = []
+    for _ in range(episodes):
+        state = env.reset()
+        total_reward = 0.0
+        done = False
+        while not done:
+            s_idx = env.state_index(state)
+            if rng.random_sample() < epsilon:
+                a_idx = int(rng.randint(len(ACTIONS)))
+            else:
+                a_idx = int(np.argmax(q[s_idx]))
+            next_state, reward, done = env.step(ACTIONS[a_idx])
+            ns_idx = env.state_index(next_state)
+            target = reward + (0.0 if done else gamma * np.max(q[ns_idx]))
+            q[s_idx, a_idx] += alpha * (target - q[s_idx, a_idx])
+            total_reward += reward
+            state = next_state
+        rewards_per_episode.append(total_reward)
+    return QLearningResult(q_table=q, rewards_per_episode=rewards_per_episode)
+
+
+def rollout(env: GridWorld, policy: dict[State, Action], *, start: State = (0, 0)) -> list[tuple[State, Action]]:
+    """Roll out a deterministic state -> action ``policy`` from ``start``; the ``(state, action)``
+    trace (stops at the goal or ``env.max_steps``, whichever first)."""
+    state = env.reset(start)
+    trace: list[tuple[State, Action]] = []
+    for _ in range(env.max_steps):
+        if state == env.goal:
+            break
+        action = policy[state]
+        trace.append((state, action))
+        state, _, done = env.step(action)
+        if done:
+            break
+    return trace
+
+
+def random_policy(env: GridWorld, rng: np.random.RandomState) -> dict[State, Action]:
+    """Baseline: an independent uniform-random action at every non-goal state."""
+    return {s: ACTIONS[int(rng.randint(len(ACTIONS)))] for s in env.states() if s != env.goal}

--- a/mixle/tests/task_irl_test.py
+++ b/mixle/tests/task_irl_test.py
@@ -1,0 +1,74 @@
+"""Maximum-entropy IRL: recover a reward from expert demonstrations, verify it reproduces the
+expert's optimal behavior -- never checked against the true reward the expert used to generate them
+(IRL never sees it; the recovered reward only ever sees expert STATE trajectories)."""
+
+import numpy as np
+
+from mixle.task.irl import max_ent_irl, rollout_states, state_features
+from mixle.task.rl import ACTIONS, GridWorld, tabular_q_learning
+
+
+def _expert_policy(world: GridWorld, seed: int = 0):
+    result = tabular_q_learning(world, episodes=800, seed=seed)
+    return result.greedy_policy(world)
+
+
+def test_convergence_history_decreases():
+    world = GridWorld(size=4, goal=(3, 3))
+    expert_policy = _expert_policy(world)
+    demos = [rollout_states(world, expert_policy)]
+
+    result = max_ent_irl(world, demos, iterations=150, lr=0.5)
+    early = np.mean(result.history[:10])
+    late = np.mean(result.history[-10:])
+    assert late < early
+
+
+def test_recovered_reward_peaks_at_the_goal_among_visited_states():
+    world = GridWorld(size=4, goal=(3, 3))
+    expert_policy = _expert_policy(world)
+    demos = [rollout_states(world, expert_policy)]
+
+    result = max_ent_irl(world, demos, iterations=150, lr=0.5)
+    reward_map = result.reward(state_features(world))
+
+    visited = {s for traj in demos for s in traj}
+    visited_indices = [world.state_index(s) for s in visited]
+    goal_index = world.state_index(world.goal)
+    assert reward_map[goal_index] == max(reward_map[i] for i in visited_indices)
+
+
+def test_recovered_policy_matches_expert_actions_at_every_visited_state():
+    world = GridWorld(size=5, goal=(4, 4), obstacles=frozenset({(1, 1), (2, 1), (1, 2)}))
+    expert_policy = _expert_policy(world, seed=1)
+    trajectory = rollout_states(world, expert_policy, start=(0, 0))
+    demos = [trajectory]
+
+    result = max_ent_irl(world, demos, iterations=150, lr=0.5, gamma=0.9)
+    recovered_policy = {
+        s: ACTIONS[int(np.argmax(result.policy[world.state_index(s)]))] for s in world.states() if s != world.goal
+    }
+    # the recovered Boltzmann policy's argmax action at every EXPERT-VISITED state matches the
+    # expert's own action there -- the algorithm's behavioral fidelity check.
+    for state in trajectory[:-1]:
+        assert recovered_policy[state] == expert_policy[state]
+
+
+def test_max_ent_irl_requires_at_least_one_trajectory():
+    world = GridWorld(size=3, goal=(2, 2))
+    try:
+        max_ent_irl(world, [])
+        raised = False
+    except ValueError:
+        raised = True
+    assert raised
+
+
+def test_determinism_given_same_demonstrations():
+    world = GridWorld(size=4, goal=(3, 3))
+    expert_policy = _expert_policy(world)
+    demos = [rollout_states(world, expert_policy)]
+
+    result_a = max_ent_irl(world, demos, iterations=100, lr=0.5)
+    result_b = max_ent_irl(world, demos, iterations=100, lr=0.5)
+    np.testing.assert_array_equal(result_a.reward_weights, result_b.reward_weights)

--- a/mixle/tests/task_rl_test.py
+++ b/mixle/tests/task_rl_test.py
@@ -1,0 +1,68 @@
+"""Tabular Q-learning over GridWorld: known-optimum recovery, beats-random, determinism."""
+
+import numpy as np
+
+from mixle.task.rl import GridWorld, random_policy, rollout, tabular_q_learning
+
+
+def test_optimal_path_length_matches_manual_bfs_with_obstacles():
+    world = GridWorld(size=4, goal=(3, 3), obstacles=frozenset({(1, 1), (2, 1), (1, 2)}))
+    assert world.optimal_path_length() == 6
+
+
+def test_optimal_path_length_no_obstacles_is_manhattan_distance():
+    world = GridWorld(size=5, goal=(4, 4))
+    assert world.optimal_path_length() == 8
+
+
+def test_q_learning_recovers_the_optimal_policy():
+    world = GridWorld(size=5, goal=(4, 4))
+    result = tabular_q_learning(world, episodes=800, seed=0)
+    policy = result.greedy_policy(world)
+    trace = rollout(world, policy)
+    assert len(trace) == world.optimal_path_length()
+
+
+def test_q_learning_recovers_the_optimal_policy_with_obstacles():
+    world = GridWorld(size=5, goal=(4, 4), obstacles=frozenset({(1, 1), (2, 1), (3, 1), (1, 2)}))
+    result = tabular_q_learning(world, episodes=1500, seed=1)
+    policy = result.greedy_policy(world)
+    trace = rollout(world, policy)
+    assert len(trace) == world.optimal_path_length()
+
+
+def _episode_return(world: GridWorld, policy: dict) -> float:
+    state = world.reset()
+    total = 0.0
+    for _ in range(world.max_steps):
+        state, reward, done = world.step(policy[state])
+        total += reward
+        if done:
+            break
+    return total
+
+
+def test_q_learning_beats_random_on_average_return():
+    world = GridWorld(size=5, goal=(4, 4))
+    result = tabular_q_learning(world, episodes=500, seed=2)
+    learned_policy = result.greedy_policy(world)
+    learned_return = _episode_return(world, learned_policy)
+
+    random_returns = [_episode_return(world, random_policy(world, np.random.RandomState(seed))) for seed in range(20)]
+    assert learned_return > float(np.mean(random_returns))
+
+
+def test_q_learning_is_deterministic_given_seed():
+    world_a = GridWorld(size=5, goal=(4, 4))
+    world_b = GridWorld(size=5, goal=(4, 4))
+    result_a = tabular_q_learning(world_a, episodes=200, seed=7)
+    result_b = tabular_q_learning(world_b, episodes=200, seed=7)
+    np.testing.assert_array_equal(result_a.q_table, result_b.q_table)
+    assert result_a.rewards_per_episode == result_b.rewards_per_episode
+
+
+def test_greedy_policy_covers_every_non_goal_state():
+    world = GridWorld(size=3, goal=(2, 2))
+    result = tabular_q_learning(world, episodes=200, seed=0)
+    policy = result.greedy_policy(world)
+    assert set(policy.keys()) == set(world.states()) - {world.goal}


### PR DESCRIPTION
## Summary
- Adds the two classical directions mixle didn't have: policy-from-known-reward and
  reward-from-demonstrations. Deliberately distinct from the plan's expert-iteration cards
  (`outcome_decomposer`, `probe_policy`), which optimize a whole verified sequence's terminal
  score with no per-step value estimate -- this is the per-step Bellman backup / MaxEnt IRL
  machinery, for problems naturally modeled as an MDP with a known (or, for IRL, inferable) reward.
- **`mixle/task/rl.py`**: `GridWorld` (a deterministic grid MDP with a BFS-computed
  `optimal_path_length` as an independent ground truth) and `tabular_q_learning` (epsilon-greedy
  Q-learning). `QLearningResult.greedy_policy()` recovers the learned optimal policy.
- **`mixle/task/irl.py`**: `max_ent_irl` (Ziebart et al. 2008 maximum-entropy IRL) -- recovers
  linear reward weights from expert state trajectories via feature-expectation matching (soft
  value iteration + a forward state-visitation pass), never seeing the expert's true reward or
  actions.
- Both exported from `mixle.task`.

## Test plan
- `mixle/tests/task_rl_test.py`: `optimal_path_length` matches manual BFS (with and without
  obstacles); Q-learning recovers the exact optimal path length on two GridWorld configurations;
  beats a random-policy baseline on average return; deterministic given seed; greedy policy covers
  every non-goal state.
- `mixle/tests/task_irl_test.py`: convergence history (feature-expectation gap) decreases;
  recovered reward peaks at the goal among expert-visited states; recovered policy's argmax action
  matches the expert's actual action at every expert-visited state (the behavioral-fidelity check,
  not a proxy metric); rejects empty demonstrations; deterministic given the same demonstrations.
- `python -m pytest mixle/tests/task_rl_test.py mixle/tests/task_irl_test.py -q`: 12 passed,
  stable across 4 repeated runs (checked for flakiness given the stochastic exploration/demo
  generation).
- `python -m pytest mixle/tests -k "task_" -q`: 234 passed, 2 skipped -- no regressions.
- `ruff check` / `ruff format --check`: clean.