### PR TITLE
release process: CHANGELOG, coverage tracking, SECURITY.md, dependabot, CONTRIBUTING.md, __version__

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  # Python dependencies declared in pyproject.toml.
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      # Bundle routine version-bump PRs into one per week instead of one per dependency, so they
+      # don't flood the PR list; a dependency with a major-version bump is excluded so it still gets
+      # its own PR and its own review.
+      python-dependencies:
+        update-types: ["minor", "patch"]
+
+  # GitHub Actions used in .github/workflows/*.yml.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,43 @@
+name: Security
+
+# Scan the resolved dependency set for known vulnerabilities. Runs weekly (dependencies can go stale
+# between pushes) and on any change that could affect what gets resolved, plus manual dispatch.
+# Advisory only for now (continue-on-error) -- flip that off once the initial findings, if any, are
+# triaged and the base install is clean.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "pyproject.toml"
+      - ".github/workflows/security.yml"
+  pull_request:
+    paths:
+      - "pyproject.toml"
+  schedule:
+    - cron: "23 6 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pip-audit:
+    name: pip-audit (base install)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Install package (base extras only)
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e .
+          python -m pip install pip-audit
+      - name: Audit resolved dependencies
+        continue-on-error: true
+        run: pip-audit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,8 +76,19 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -e ".[test]"
-      - name: Run full non-optional suite
-        run: python -m pytest -m "not optional and not benchmark" -n auto
+      - name: Run full non-optional suite with coverage
+        # Reporting only for now, no --cov-fail-under gate: this base install skips every optional
+        # backend (torch/numba/spark/dask/jax/...), so line coverage here is a floor, not the real
+        # number -- a hard threshold set against this subset would misrepresent actual coverage and
+        # either block unrelated PRs or get raised past what full-extras coverage really supports.
+        # Revisit once the optional-extras job also reports and the two are combined.
+        run: python -m pytest -m "not optional and not benchmark" -n auto --cov --cov-report=xml --cov-report=term
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-xml
+          path: coverage.xml
+          retention-days: 30
 
   optional:
     name: optional extras / py3.12

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,9 @@ audit/
 mixle/engines/_dd_kernels.c
 mixle/engines/_bitpacked.c
 mixle/engines/_lns_kernel.c
+
+# coverage.py output (local runs and CI's --cov-report=xml artifact upload; never committed)
+.coverage
+.coverage.*
+coverage.xml
+htmlcov/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,112 @@
+# Changelog
+
+All notable changes to mixle are documented here. The format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and versions follow
+[Semantic Versioning](https://semver.org/).
+
+## [Unreleased] — 0.6.3
+
+Workstream: generic AI-capability platform pieces on top of the core estimation engine (task
+decomposition, cross-modal reasoning, self-improvement loops, a system facade), plus a hardening
+pass across the automatic-inference and design-of-experiments subsystems. This section is finalized
+at release time per the version release checklist in `notes/mixle-development-agent-rules.md`.
+
+### Added
+
+- New model families: `PINNRegression` (physics-informed neural network leaf), `HamiltonianNet`
+  (conservation-law-preserving dynamics), `make_deep_set` (permutation-equivariant networks),
+  monotonic MLPs and input-convex energy networks, `build_product_energy_net` (energy-based product
+  of experts), `CopulaDistribution` (arbitrary marginals + a Sklar dependence core),
+  `GatedMixtureDistribution` (input-dependent mixture-of-experts weights).
+- Task-decomposition and agent-facing workstreams: plan models fit as Markov chains over agent
+  traces, an outcome-trained decomposer, a minimal orchestrator loop, tabular Q-learning and
+  maximum-entropy inverse RL, a local model registry, `ExecutionTrace` with bit-identical replay, the
+  `Receipt` object (ledger + trace + calibration + provenance, offline re-verifiable), and the
+  `System` facade (`answer`/`ingest`/`improve`).
+- Cross-modal reasoning: `ModalityView`, per-edge conditional-transport premise checks, belief walks
+  across chains of verified transports, cycle-consistency as a self-supervised abstention signal,
+  task-sufficient projection, information-gain retrieval, and the workstream-F flagship harness.
+- Self-improvement / knowledge-accumulation loops: the collapse monitor shared across amplification
+  loops, the composition operator, `DesignModel`'s cross-round what-works prior, diagnosis-directed
+  correction, a knowledge-accumulation flywheel measurement, degradation-policy handling for fault
+  modes, and cost-aware routing threshold selection.
+- `doe`: `VerifiableOracle` + the design-test-learn loop, noise-robust incumbent selection for
+  Bayesian optimization, and a budgeted propose-verify-retrain loop over a discrete design space.
+
+### Fixed
+
+- `mixle.utils.automatic`: crashes on empty/degenerate input (`ZeroDivisionError` in the Poisson/
+  Gaussian/log-normal estimator builders), every distribution detector silently dropping its own
+  already-computed fit and the caller's `pseudo_count`, an `IndexError` on always-empty sequence
+  fields, a modality-fingerprint diagnostic that could contradict the actual estimator built, and the
+  model-suggestion logic ignoring its own held-out validation signal when it disagreed with the
+  in-sample BIC pick.
+- `mixle.data`: `Boolean.coerce` silently inverting string-typed values (`bool("False") == True`),
+  `Schema.conform_record` silently truncating mismatched records via an unchecked `zip`, an
+  inconsistent tuple-vs-list adjacency coercion in the graph data source, and `MaterializedSource`
+  silently accepting non-reiterable one-shot iterators.
+- `mixle.doe`: an unguarded Cholesky decomposition crashing on singular/near-singular input
+  covariance, a Morris-screening `ZeroDivisionError` on a degenerate grid, a silent-`NaN` Gaussian
+  Process surrogate when fit with zero observations, an infinite loop given a zero-cost fidelity in
+  multi-fidelity optimization, several proposal functions crashing instead of validating
+  `n_candidates`, TuRBO overshooting its evaluation budget on trust-region restart, silent
+  batch-truncation/duplication under an oversized batch request, and `BayesianOptimizer.ask()`
+  re-dispensing duplicate initial-design points in async/parallel ask-before-tell campaigns.
+- A circular import that broke `mixle.inference` entirely; a mixture-correction term error in
+  `explain()`'s decision-margin ledger; a stale `capacity.py` embedding-head rung mismatch; CI
+  flakiness in EM's log-likelihood computation and a de-flaked mixture-of-trees test; Python
+  3.10-specific abstention timing in the oracle-timeout path.
+
+### Changed
+
+- `pinn_leaf.py` renamed to `pinn.py`; the "leaf" suffix dropped from PINN naming throughout.
+- Default `pytest` worker count capped (`-n 4` instead of `-n auto`) to stop individual test runs
+  from oversubscribing shared CI/dev machines when many run concurrently.
+- Several `mixle/doe` tests re-marked `slow` (heavy Monte Carlo / neural-density fits) so the default
+  fast test gate stays fast; a real duplicate-training bug (an estimator refit once per test instead
+  of once per class) fixed alongside the re-marking.
+
+## [0.6.2]
+
+- Test-suite hardening: skip embedder-path `Budget` cases when torch is absent.
+
+## [0.6.1]
+
+- Maintenance release.
+
+## [0.6.0] — First release under the `mixle` name
+
+Renamed from `pysparkplug`. Highlights since 0.5.2:
+
+- PPL language core: deterministic-expression slots, `potential()` custom factors,
+  `.each(by=)` indexed-flat hierarchical models, data-indexed latents (`theta[Field]`), non-Normal
+  GLMMs, R-hat/ESS in `summary()`.
+- Automatic-inference `fit` API: prototype/data coercion, `fit` forwards all `optimize` kwargs.
+- Categorical/Dirichlet free-dimension inference.
+- Streaming-estimator unification.
+
+## [0.5.2]
+
+- Maintenance release.
+
+## [0.5.1]
+
+- Added lower bounds to every optional-dependency extra (not just the always-installed core), so a
+  user selecting an extra with a too-old version gets a clear resolver error instead of a broken
+  connector: `tbb>=2021.6`, `pandas>=2.0`, `pyarrow>=14`, `sqlalchemy>=2.0`, `pymongo>=4.3`,
+  `fsspec>=2023.1.0`, `networkx>=3.0`, `gmpy2>=2.1`, `pyspark>=3.4`, `dask`/`distributed>=2023.5.0`,
+  `torch>=2.0`, `mpi4py>=3.1`.
+
+## [0.5.0]
+
+- Added lower-bound pins for the always-installed core dependencies (`numpy>=1.26`, `scipy>=1.11`,
+  `mpmath>=1.3`) so users on older releases get a clear resolver error instead of obscure runtime
+  breakage.
+
+[Unreleased]: https://github.com/gmboquet/mixle/compare/v0.6.2...HEAD
+[0.6.2]: https://github.com/gmboquet/mixle/compare/v0.6.1...v0.6.2
+[0.6.1]: https://github.com/gmboquet/mixle/compare/v0.6.0...v0.6.1
+[0.6.0]: https://github.com/gmboquet/mixle/compare/v0.5.2...v0.6.0
+[0.5.2]: https://github.com/gmboquet/mixle/compare/v0.5.1...v0.5.2
+[0.5.1]: https://github.com/gmboquet/mixle/compare/v0.5.0...v0.5.1
+[0.5.0]: https://github.com/gmboquet/mixle/releases/tag/v0.5.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,83 @@
+# Contributing to mixle
+
+## Development setup
+
+```sh
+git clone https://github.com/gmboquet/mixle.git
+cd mixle
+python -m venv .venv
+source .venv/bin/activate           # or .venv\Scripts\activate on Windows
+pip install -e ".[test,lint,docs]"  # add other extras (torch, numba, spark, ...) as needed
+git config core.hooksPath .githooks # auto-format + lint-fix staged files before every commit
+```
+
+Python 3.10+ is required; CI tests against 3.10, 3.11, and 3.12.
+
+## Running tests
+
+```sh
+pytest                                        # the fast gate (default addopts): < 30s
+pytest -m "not optional and not benchmark"    # the full non-optional suite (what CI's `full` job runs)
+pytest -m "optional or torch or numba or jax" # optional-extras tests (needs the matching extras installed)
+pytest path/to/some_test.py -n0 -m ""         # a single file, serial, ignoring the fast-gate filter
+pytest --cov --cov-report=term-missing        # with coverage
+```
+
+New tests default to the `fast` gate automatically (see `mixle/tests/conftest.py`) unless they need a
+heavier tag (`slow`, `optional`, `torch`, `numba`, `jax`, `benchmark`, ...) — tag anything that takes
+more than a couple seconds or needs an optional dependency, so the default `pytest` invocation stays
+fast for everyone.
+
+## Linting and formatting
+
+```sh
+ruff format mixle    # auto-format
+ruff check mixle      # lint (enforced in CI)
+mypy                  # type check (advisory in CI, not yet enforced)
+```
+
+The pre-commit hook (once enabled via `git config core.hooksPath .githooks`) runs `ruff format` +
+`ruff check --fix` on staged Python files automatically, so most formatting/lint issues never reach a
+commit.
+
+## Pull request conventions
+
+- Keep a PR small enough that its purpose is obvious from the file list — one logical change per PR.
+- Write the commit/PR title and body around *why*, not just *what*; the diff already shows what
+  changed.
+- Include a test plan: what you ran, what passed, what you narrowed the test selection to and why.
+- Target `main` unless you're told otherwise; release branches (`release/X.Y.Z-*`) are used for
+  large in-flight bodies of work and merged back per
+  `notes/mixle-development-agent-rules.md`'s release checklist.
+- Update `CHANGELOG.md`'s `[Unreleased]` section for any user-visible change (new public API, fixed
+  bug, behavior change). Purely internal refactors with no visible effect don't need an entry.
+- CI must be green (lint, fast, full) before merge; the `optional` and `security` jobs are informative
+  but not currently required.
+
+## Deprecation policy
+
+mixle is pre-1.0 and iterates quickly, but a deprecation should still give users a chance to react
+before it becomes a hard break, not just an entry in the changelog they might not read in time:
+
+1. **Deprecate first.** Mark the old API with a `DeprecationWarning` (via `warnings.warn(...,
+   DeprecationWarning, stacklevel=2)`) that names the replacement. Document it in the docstring and in
+   `CHANGELOG.md` under `Changed` (or a `Deprecated` heading if there are several in one release).
+2. **Keep it working for one minor release.** The deprecated path should still function (not just
+   warn) for at least one full minor version after the warning is introduced, so a user pinned to a
+   slightly-behind version isn't broken by upgrading within the same minor line.
+3. **Remove in a later minor release**, with a `CHANGELOG.md` entry under `Removed` naming what was
+   removed and what replaced it, and (if the removal is significant) a one-line migration note.
+4. **Exception:** a genuine security fix or a bug fix where the "working" behavior was itself unsafe
+   (e.g. the `Boolean.coerce` / `conform_record` silent-corruption fixes in 0.6.3) does not have to
+   follow this cycle — correctness and safety win over compatibility, but the change must still be
+   called out clearly in `CHANGELOG.md` under `Fixed` so nobody is silently surprised.
+
+This project does not yet publish a formal API-stability tier (e.g. "stable" vs. "experimental"
+namespaces); until it does, treat everything under `mixle.*` as covered by this policy except names
+prefixed with a single underscore, which are implementation details and may change without notice.
+
+## Reporting bugs / requesting features
+
+Open a GitHub issue. For a bug report, include a minimal reproduction, the mixle version
+(`python -c "import mixle; print(mixle.__version__)"`), the Python version, and the full traceback.
+For a security vulnerability, see [SECURITY.md](SECURITY.md) instead — do not open a public issue.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,32 @@
+# Security Policy
+
+## Supported Versions
+
+mixle is pre-1.0 and releases frequently. Security fixes are made against the latest release only;
+please upgrade to the newest version before reporting an issue if you are not already on it.
+
+| Version | Supported |
+| ------- | --------- |
+| Latest  | ✅ |
+| Older   | ❌ |
+
+## Reporting a Vulnerability
+
+Please **do not** open a public GitHub issue for a security vulnerability. Instead, use
+[GitHub's private vulnerability reporting](https://github.com/gmboquet/mixle/security/advisories/new)
+for this repository, or email **grant.boquet@gmail.com** with:
+
+- A description of the vulnerability and its potential impact.
+- Steps to reproduce (a minimal example, if possible).
+- The mixle version and Python version affected.
+
+You should expect an initial response within **5 business days**. Once a fix is confirmed, we will
+coordinate a release and a public advisory, and credit the reporter unless anonymity is requested.
+
+## Scope
+
+mixle is a modeling/inference library, not a network service. In-scope issues include things like:
+deserialization of untrusted model artifacts leading to code execution, dependency vulnerabilities
+that affect mixle's own code paths, and unsafe handling of untrusted input data. Out of scope:
+vulnerabilities in optional third-party backends (torch, Spark, Dask, Ray, MPI, ...) that are not
+specific to how mixle uses them — please report those upstream.

--- a/mixle/__init__.py
+++ b/mixle/__init__.py
@@ -18,7 +18,15 @@ The structure (see ``docs/ARCHITECTURE.md`` and ``docs/CAPABILITIES.md``):
 Start with ``mixle.describe(x)`` to see what any object can do.
 """
 
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
+
 from mixle.capability import capabilities, catalog, describe, require, summarize, supports, what_supports
+
+try:
+    __version__ = _pkg_version("mixle")
+except PackageNotFoundError:  # running from a source tree with no installed distribution metadata
+    __version__ = "0+unknown"
 
 # Top-level namespaces resolved lazily so ``import mixle`` stays cheap and ``mixle.dist`` / ``mixle.ops``
 # / ``mixle.enumeration`` work without importing the whole tree up front.
@@ -53,6 +61,7 @@ def __dir__() -> list[str]:
 
 
 __all__ = [
+    "__version__",
     "Model",
     "propose",
     "supports",

--- a/mixle/tests/package_metadata_test.py
+++ b/mixle/tests/package_metadata_test.py
@@ -1,0 +1,22 @@
+"""mixle.__version__ resolves from installed package metadata."""
+
+import unittest
+
+import mixle
+
+
+class VersionTest(unittest.TestCase):
+    def test_version_is_a_non_empty_string(self):
+        self.assertIsInstance(mixle.__version__, str)
+        self.assertTrue(mixle.__version__)
+
+    def test_version_looks_like_a_version(self):
+        # PEP 440 is permissive; just check it starts with a numeric release segment.
+        self.assertRegex(mixle.__version__, r"^\d+(\.\d+)*")
+
+    def test_version_is_exported_from_dunder_all(self):
+        self.assertIn("__version__", mixle.__all__)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ sympy = ["sympy>=1.12"]
 # to_sage symbolic export. Full SageMath is not pip-installable; passagemath is its modular,
 # wheel-distributed fork (the symbolic subset suffices -- it provides sage.all__sagemath_symbolics).
 sage = ["passagemath-symbolics>=10.4"]
-test = ["pytest>=8", "pytest-xdist>=3.0"]
+test = ["pytest>=8", "pytest-xdist>=3.0", "pytest-cov>=5.0"]
 # ruff is pinned: a newer release could add rules and break the blocking lint check unexpectedly.
 lint = ["ruff==0.15.17", "mypy>=1.0"]
 all = ["numba>=0.59", "tbb>=2021.6", "pyspark>=3.4", "dask>=2023.5.0", "distributed>=2023.5.0", "torch>=2.0", "safetensors>=0.4", "mpi4py>=3.1", "umap-learn>=0.5.4", "pandas>=2.0", "pyarrow>=14", "sqlalchemy>=2.0", "networkx>=3.0"]
@@ -135,6 +135,24 @@ markers = [
     "pcfg: grammar and PCFG tests.",
     "latent: mixture, DPM, LDA, LLDA, and hidden-association tests.",
 ]
+
+[tool.coverage.run]
+source = ["mixle"]
+omit = ["mixle/tests/*"]
+# branch coverage catches an untested if/else arm that line coverage alone would miss.
+branch = true
+
+[tool.coverage.report]
+# Lines that are structurally unreachable in a coverage run (defensive asserts, TYPE_CHECKING blocks,
+# abstract-method bodies) are excluded rather than counted against the threshold.
+exclude_lines = [
+    "pragma: no cover",
+    "if TYPE_CHECKING:",
+    "raise NotImplementedError",
+    "^\\s*\\.\\.\\.\\s*$",
+]
+skip_covered = false
+show_missing = true
 
 [tool.ruff]
 line-length = 120


### PR DESCRIPTION
## Summary
Fills the gaps a professional package normally has that this repo was missing (surveyed against the actual current `pyproject.toml`/CI/docs state before writing any of this).

- **`CHANGELOG.md`**: Keep a Changelog format, backfilled from real tag messages for 0.5.0 through 0.6.2, plus an `Unreleased`/0.6.3 section grouped by Added/Fixed/Changed (built from this release's actual first-parent commit history). Referenced from `CONTRIBUTING.md` and from the version-release checklist in `notes/mixle-development-agent-rules.md`.
- **Coverage tracking**: `pytest-cov` added to the `test` extra; `[tool.coverage.run]`/`[tool.coverage.report]` configured (branch coverage on, `tests/` omitted); wired into CI's `full` job (`--cov --cov-report=xml`, uploaded as a workflow artifact). Deliberately **no** `--cov-fail-under` gate yet -- the `full` job's base install skips every optional backend, so its number is a floor, not the real one; a hard threshold against this subset would misrepresent actual coverage.
- **`SECURITY.md`**: private vulnerability reporting via GitHub's advisory flow + email, a response-time commitment, and explicit scope.
- **`.github/dependabot.yml`**: weekly pip + github-actions update checks, routine minor/patch bumps grouped into one PR; a major-version bump still gets its own PR.
- **`.github/workflows/security.yml`**: `pip-audit` against the resolved base-install dependency set, weekly + on `pyproject.toml` changes. Advisory (`continue-on-error`) until an initial baseline is triaged.
- **`CONTRIBUTING.md`**: dev setup, the actual test/lint commands this repo uses, PR conventions, and a deprecation policy (deprecate with a `DeprecationWarning` → keep working for ≥ 1 minor release → remove with a CHANGELOG entry; correctness/security fixes are the stated exception, matching the silent-corruption fixes already shipped this release).
- **`mixle.__version__`**: did not exist (`AttributeError`) -- only `importlib.metadata.version('mixle')` worked. Caught while fact-checking `CONTRIBUTING.md`'s own example command against the real package. Added via `importlib.metadata` with a `PackageNotFoundError` fallback.
- **`.gitignore`**: added coverage.py's own output patterns now that coverage tooling is part of the normal workflow.

Also fixed separately (not in this commit, done directly): a stray, never-pushed `v1.0.0` git tag predating the real `v0.2.0`→`v0.6.2` sequence (leftover from before this repo was renamed from its predecessor project) has been deleted locally.

## Test plan
- [x] `mixle/tests/package_metadata_test.py` (3 new tests): `__version__` is a non-empty string, matches a PEP 440-ish shape, and is exported via `__all__`.
- [x] Regression: `package_metadata_test` + `capability_test` (exercises the same `__init__.py` lazy-attribute machinery) = 32 passed.
- [x] Coverage flags smoke-tested end to end (real report produced, correct source/omit filtering).
- [x] `pyproject.toml` and all new/changed YAML parse cleanly.
- [x] `ruff check` + `ruff format --check` clean on all changed Python files.