### PR TITLE
hvis: coherent default view, streaming, embedding goals, internal UMAP engine

### DIFF
--- a/mixle/tests/hvis_barycentric_test.py
+++ b/mixle/tests/hvis_barycentric_test.py
@@ -1,0 +1,124 @@
+"""The (posterior, remainder) decomposition made first-class (mixle.utils.hvis):
+mixture_coordinates exposes both levels of the observation description, and Y='barycentric'
+initializes the embedding from the barycentric reading of the posterior -- the layout's global
+arrangement comes from the model's own component geometry instead of the random seed.
+"""
+
+import io
+import unittest
+
+import numpy as np
+
+from mixle.stats import GaussianDistribution, MixtureDistribution
+from mixle.utils.hvis import barycentric_init, component_map, htsne, mixture_coordinates
+
+# three regimes on a line: 0 and 4 are confusable, 20 is far -- the overlap geometry is unambiguous
+_MODEL3 = MixtureDistribution(
+    [GaussianDistribution(0.0, 1.0), GaussianDistribution(4.0, 1.0), GaussianDistribution(20.0, 1.0)],
+    [1.0 / 3.0] * 3,
+)
+
+
+def _data3(n_per=25, seed=0):
+    rng = np.random.RandomState(seed)
+    xs = np.concatenate([rng.normal(0.0, 1.0, n_per), rng.normal(4.0, 1.0, n_per), rng.normal(20.0, 1.0, n_per)])
+    labels = np.repeat([0, 1, 2], n_per)
+    return [float(v) for v in xs], labels
+
+
+class MixtureCoordinatesTest(unittest.TestCase):
+    def test_decomposition_exposes_both_levels(self):
+        data, _ = _data3()
+        decomp = mixture_coordinates(_MODEL3, data)
+        z = decomp["posterior"]
+        self.assertEqual(z.shape, (75, 3))
+        np.testing.assert_allclose(z.sum(axis=1), 1.0, atol=1.0e-9)  # barycentric: on the simplex
+        self.assertEqual(len(decomp["fields"]), 1)  # one scalar Gaussian leaf
+        field = decomp["fields"][0]
+        self.assertEqual(field["log_density"].shape, (75, 3))
+        self.assertTrue(field["native"])  # Gaussian leaf: native value coordinates
+        self.assertEqual(field["coords"].shape, (75, 1))
+
+    def test_field_weights_length_is_validated(self):
+        data, _ = _data3(n_per=5)
+        with self.assertRaises(ValueError):
+            mixture_coordinates(_MODEL3, data, field_weights=[1.0, 1.0])
+
+
+class ComponentMapTest(unittest.TestCase):
+    def test_vertices_reflect_overlap_geometry(self):
+        data, _ = _data3()
+        z = mixture_coordinates(_MODEL3, data)["posterior"]
+        vertices = component_map(z)
+        self.assertEqual(vertices.shape, (3, 2))
+        d01 = float(np.linalg.norm(vertices[0] - vertices[1]))
+        d02 = float(np.linalg.norm(vertices[0] - vertices[2]))
+        d12 = float(np.linalg.norm(vertices[1] - vertices[2]))
+        self.assertLess(d01, d02)  # confusable regimes (0, 4) sit closer than either does to 20
+        self.assertLess(d01, d12)
+
+    def test_single_component_degenerates_to_origin(self):
+        z = np.ones((10, 1))
+        np.testing.assert_array_equal(component_map(z), np.zeros((1, 2)))
+
+
+class BarycentricInitTest(unittest.TestCase):
+    def test_init_is_scaled_and_deterministic(self):
+        data, _ = _data3()
+        z = mixture_coordinates(_MODEL3, data)["posterior"]
+        y1 = barycentric_init(z, seed=0)
+        y2 = barycentric_init(z, seed=0)
+        np.testing.assert_array_equal(y1, y2)
+        self.assertAlmostEqual(float(y1.std()), 1.0e-4, delta=3.0e-5)  # optimizer-conventional scale
+
+    def test_global_arrangement_is_seed_independent(self):
+        # the payoff of the barycentric reading: the random seed no longer decides which clusters
+        # sit near which. Two runs with different seeds must produce the SAME centroid geometry.
+        data, labels = _data3()
+
+        def centroid_gaps(seed):
+            y = htsne(
+                data, mix_model=_MODEL3, Y="barycentric", method="exact", max_its=300, seed=seed, out=io.StringIO()
+            )
+            cents = np.stack([y[labels == c].mean(axis=0) for c in (0, 1, 2)])
+            d01 = np.linalg.norm(cents[0] - cents[1])
+            return d01 / np.linalg.norm(cents[0] - cents[2]), d01 / np.linalg.norm(cents[1] - cents[2])
+
+        r_a = centroid_gaps(seed=1)
+        r_b = centroid_gaps(seed=2)
+        for a, b in zip(r_a, r_b):
+            self.assertLess(a, 0.9)  # confusable pair closer than either is to the far regime...
+            self.assertLess(abs(a - b), 0.05)  # ...and the arrangement is reproducible across seeds
+
+    def test_mixed_membership_point_lands_between_its_clusters(self):
+        data, labels = _data3()
+        data = data + [2.0]  # posterior ~(0.5, 0.5, 0) between regimes 0 and 4
+        y = htsne(data, mix_model=_MODEL3, Y="barycentric", method="exact", max_its=300, seed=3, out=io.StringIO())
+        cents = np.stack([y[:75][labels == c].mean(axis=0) for c in (0, 1, 2)])
+        point = y[75]
+        d0, d1, d2 = (float(np.linalg.norm(point - cents[c])) for c in (0, 1, 2))
+        self.assertLess(max(d0, d1), d2)  # closer to both parent regimes than to the far one
+        midpoint = (cents[0] + cents[1]) / 2.0
+        self.assertLess(float(np.linalg.norm(point - midpoint)), float(np.linalg.norm(cents[0] - cents[1])))
+
+    def test_barnes_hut_engine_accepts_barycentric(self):
+        data, labels = _data3()
+        y = htsne(data, mix_model=_MODEL3, Y="barycentric", method="barnes_hut", max_its=300, seed=4, out=io.StringIO())
+        self.assertEqual(y.shape, (75, 2))
+        d2 = np.square(y[:, None, :] - y[None, :, :]).sum(axis=2)
+        np.fill_diagonal(d2, np.inf)
+        self.assertGreater(float(np.mean(labels[d2.argmin(axis=1)] == labels)), 0.9)
+
+    def test_unknown_string_and_prebuilt_affinity_raise(self):
+        data, _ = _data3(n_per=8)
+        with self.assertRaises(ValueError):
+            htsne(data, mix_model=_MODEL3, Y="not-a-mode", method="exact", out=io.StringIO())
+        from mixle.utils.hvis import local_factors
+
+        factors = local_factors(_MODEL3, data)
+        with self.assertRaises(ValueError):
+            htsne(data, affinity=factors, Y="barycentric", method="exact", out=io.StringIO())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mixle/tests/hvis_coherence_test.py
+++ b/mixle/tests/hvis_coherence_test.py
@@ -1,0 +1,208 @@
+"""The coherent default view (mixle.utils.hvis): the three classic "janky visualization" complaints,
+reproduced as fixtures and pinned as fixed.
+
+1. SEQUENCES THROUGH AN HMM -- a mixture of HMMs has no native leaf coordinates, so the old 'local'
+   fallback degraded to posterior overlap; sharp posteriors made every same-cluster pair an exact
+   tie and clusters rendered as tiny structureless points. Typicality coordinates (per-token
+   log-density rate per component + a log-length axis) give every HMM observation real
+   within-cluster geometry.
+2. VARIABLE-LENGTH FIELDS -- total sequence evidence grows with length, so unnormalized views let
+   length masquerade as all the structure. Per-token rates keep content primary; length stays one
+   honest axis.
+3. MIXED CONTINUOUS + DISCRETE -- a sharp continuous field dominates the joint posterior and the
+   discrete field's relationships become invisible under joint-posterior affinities. Per-field
+   factors with component-local whitening make the fields commensurate.
+
+Plus affinity_health: the degeneracies above are measurable properties of the AFFINITY, reported in
+milliseconds with plain-language diagnosis -- not something to discover after a thousand t-SNE
+iterations.
+"""
+
+import io
+import unittest
+
+import numpy as np
+
+from mixle.stats import (
+    CategoricalDistribution,
+    CompositeDistribution,
+    GaussianDistribution,
+    HiddenMarkovModelDistribution,
+    IntegerCategoricalDistribution,
+    MixtureDistribution,
+    SequenceDistribution,
+)
+from mixle.utils.hvis import affinity_health, htsne, local_factors, model_log_affinity
+
+# medium lengths: posteriors sharp enough to cluster, soft enough that geometry is graded
+_LEN_MED = IntegerCategoricalDistribution(18, [1.0 / 9.0] * 9)  # lengths 18..26
+# long lengths: posterior sharpness underflows into EXACT ties -- the hard-collapse regime
+_LEN_LONG = IntegerCategoricalDistribution(40, [1.0 / 21.0] * 21)  # lengths 40..60
+
+
+def _hmm(trans, emit_a, len_dist):
+    return HiddenMarkovModelDistribution(
+        [CategoricalDistribution({"a": emit_a, "b": 1.0 - emit_a}), CategoricalDistribution({"a": 0.5, "b": 0.5})],
+        [0.5, 0.5],
+        trans,
+        len_dist=len_dist,
+    )
+
+
+def _hmm_mixture_fixture(n_per=35, seed=0, len_dist=_LEN_MED):
+    """Two HMM regimes with different dynamics over the SAME alphabet, variable lengths."""
+    comps = [_hmm([[0.9, 0.1], [0.1, 0.9]], 0.9, len_dist), _hmm([[0.2, 0.8], [0.8, 0.2]], 0.1, len_dist)]
+    model = MixtureDistribution(comps, [0.5, 0.5])
+    data, labels = [], []
+    for k, comp in enumerate(comps):
+        data.extend(comp.sampler(seed=seed + k).sample(size=n_per))
+        labels.extend([k] * n_per)
+    return data, np.asarray(labels), model
+
+
+def _embedding_shape_stats(y, labels):
+    cents = np.stack([y[labels == c].mean(axis=0) for c in np.unique(labels)])
+    within = np.mean(
+        [np.linalg.norm(y[labels == c] - cents[i], axis=1).mean() for i, c in enumerate(np.unique(labels))]
+    )
+    between = np.mean(
+        [np.linalg.norm(cents[i] - cents[j]) for i in range(len(cents)) for j in range(i + 1, len(cents))]
+    )
+    d2 = np.square(y[:, None, :] - y[None, :, :]).sum(axis=2)
+    np.fill_diagonal(d2, np.inf)
+    purity = float(np.mean(labels[d2.argmin(axis=1)] == labels))
+    return purity, float(within), float(between)
+
+
+class HmmSequenceCoherenceTest(unittest.TestCase):
+    """Complaint 1: 'sequences through an HMM ... collapse into tiny points'."""
+
+    def test_posterior_only_view_is_measurably_degenerate(self):
+        # long sequences: posterior sharpness underflows into exact within-cluster ties -- the
+        # affinity literally cannot rank a point's same-regime neighbors.
+        data, _, model = _hmm_mixture_fixture(len_dist=_LEN_LONG)
+        report = affinity_health(model, data, affinity="bhattacharyya")
+        self.assertGreater(report["top_tie_fraction"], 0.05)
+        self.assertTrue(report["diagnosis"])
+        # ...while the local view on the SAME data stays rankable
+        report_auto = affinity_health(model, data, affinity="auto")
+        self.assertLess(report_auto["top_tie_fraction"], 0.05)
+
+    def test_auto_view_is_healthy_and_structured(self):
+        data, labels, model = _hmm_mixture_fixture()
+        report = affinity_health(model, data, affinity="auto")
+        self.assertLess(report["top_tie_fraction"], 0.05)
+        self.assertTrue(all(f["geometry"] == "local" for f in report["fields"]))
+
+        y = htsne(data, mix_model=model, perplexity=12.0, method="exact", max_its=300, seed=0, out=io.StringIO())
+        purity, within, between = _embedding_shape_stats(y, labels)
+        self.assertGreater(purity, 0.85)  # regimes separate (short sequences stay honestly ambiguous)...
+        self.assertGreater(within, 0.10 * between)  # ...and clusters are clouds, not tiny points
+
+    def test_hmm_leaf_gets_local_geometry_not_posterior_fallback(self):
+        data, _, model = _hmm_mixture_fixture(n_per=15)
+        factors = local_factors(model, data)
+        self.assertTrue(all(isinstance(f, dict) and f.get("kind") == "local" for f in factors))
+        # sequence-valued leaf: per-component rate columns + one log-length axis, scored per dof
+        self.assertEqual(factors[0]["x"].shape[1], 3)  # K=2 rates + log-length
+        self.assertEqual(factors[0]["delta_scale"], 3.0)
+
+
+class VariableLengthCoherenceTest(unittest.TestCase):
+    """Complaint 2: 'stuff with variable length fields' -- length must not masquerade as content."""
+
+    def _fixture(self, n_per=35, seed=3):
+        comps = [
+            SequenceDistribution(CategoricalDistribution({"a": 0.85, "b": 0.15}), len_dist=_LEN_MED),
+            SequenceDistribution(CategoricalDistribution({"a": 0.15, "b": 0.85}), len_dist=_LEN_MED),
+        ]
+        model = MixtureDistribution(comps, [0.5, 0.5])
+        data, labels = [], []
+        for k, comp in enumerate(comps):
+            data.extend(comp.sampler(seed=seed + k).sample(size=n_per))
+            labels.extend([k] * n_per)
+        return data, np.asarray(labels), model
+
+    def test_content_organizes_the_embedding_not_length(self):
+        data, content, model = self._fixture()
+
+        lengths = np.asarray([len(x) for x in data])
+        length_split = (lengths > np.median(lengths)).astype(int)
+
+        y = htsne(data, mix_model=model, perplexity=12.0, method="exact", max_its=300, seed=1, out=io.StringIO())
+        content_purity, _, _ = _embedding_shape_stats(y, content)
+        length_purity, _, _ = _embedding_shape_stats(y, length_split)
+        self.assertGreater(content_purity, 0.85)
+        # both regimes share the SAME length distribution: content must organize the layout, with
+        # length visible at most as secondary structure, never the dominant axis
+        self.assertGreater(content_purity, length_purity)
+
+
+class MixedFieldCoherenceTest(unittest.TestCase):
+    """Complaint 3: 'mixed continuous and discrete data' -- a sharp continuous field must not make
+    the discrete field's relationships invisible."""
+
+    def _fixture(self, n_per=35, seed=6):
+        # cluster-independent discrete field. NON-uniform on purpose: a model-based view can only
+        # show structure the model encodes -- under a uniform categorical every category has the
+        # same probability and there is genuinely nothing to visualize.
+        cat = {"x": 0.6, "y": 0.3, "z": 0.1}
+        comps = [
+            CompositeDistribution((GaussianDistribution(-4.0, 0.01), CategoricalDistribution(cat))),
+            CompositeDistribution((GaussianDistribution(4.0, 0.01), CategoricalDistribution(cat))),
+        ]
+        model = MixtureDistribution(comps, [0.5, 0.5])
+        data, labels = [], []
+        for k, comp in enumerate(comps):
+            data.extend(comp.sampler(seed=seed + k).sample(size=n_per))
+            labels.extend([k] * n_per)
+        return data, np.asarray(labels), model
+
+    def _within_cluster_category_contrast(self, log_s, data, labels):
+        """Mean within-cluster affinity gap: same-category pairs minus cross-category pairs."""
+        cats = np.array([x[1] for x in data])
+        same, cross = [], []
+        for c in np.unique(labels):
+            idx = np.where(labels == c)[0]
+            for a_pos, i in enumerate(idx):
+                for j in idx[a_pos + 1 :]:
+                    (same if cats[i] == cats[j] else cross).append(log_s[i, j])
+        return float(np.mean(same) - np.mean(cross))
+
+    def test_discrete_relationships_visible_under_local_invisible_under_joint_posterior(self):
+        data, labels, model = self._fixture()
+        from mixle.utils.hvis import _posteriors_and_loglikes
+
+        z, ll = _posteriors_and_loglikes(model, data=data)
+        log_s_joint = model_log_affinity(z, ll, affinity="bhattacharyya")
+        factors = local_factors(model, data)
+        log_s_local = model_log_affinity(None, None, affinity=factors, evidence_cap=1.0)
+
+        contrast_joint = self._within_cluster_category_contrast(log_s_joint, data, labels)
+        contrast_local = self._within_cluster_category_contrast(log_s_local, data, labels)
+        # under the joint posterior the razor-sharp Gaussian owns the posterior and the categorical
+        # contributes ~nothing within a cluster; the per-field local view makes it visible.
+        self.assertLess(abs(contrast_joint), 1.0e-6)
+        self.assertGreater(contrast_local, 0.05)
+
+
+class AffinityHealthTest(unittest.TestCase):
+    def test_healthy_local_view_has_empty_diagnosis(self):
+        rng = np.random.RandomState(0)
+        data = [float(v) for v in np.concatenate([rng.normal(0, 1, 30), rng.normal(8, 1, 30)])]
+        model = MixtureDistribution([GaussianDistribution(0.0, 1.0), GaussianDistribution(8.0, 1.0)], [0.5, 0.5])
+        report = affinity_health(model, data, affinity="auto")
+        self.assertLess(report["top_tie_fraction"], 0.05)
+        self.assertEqual(report["diagnosis"], [])
+
+    def test_subsampling_caps_the_diagnostic_cost(self):
+        rng = np.random.RandomState(1)
+        data = [float(v) for v in rng.normal(0, 1, 900)]
+        model = MixtureDistribution([GaussianDistribution(0.0, 1.0), GaussianDistribution(8.0, 1.0)], [0.5, 0.5])
+        report = affinity_health(model, data, affinity="auto", max_rows=100)
+        self.assertEqual(report["n"], 900)
+        self.assertEqual(report["n_sampled"], 100)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mixle/tests/hvis_front_test.py
+++ b/mixle/tests/hvis_front_test.py
@@ -1,0 +1,220 @@
+"""The front door (mixle.utils.hvis.front): one call -> coordinates + every receipt.
+
+Also covers the roadmap items it composes: model_fit_health (merged / shattered / clean), the
+occlusion invariant (no model overlap => no screen overlap), quadratic charts (mechanics + exact
+placement), the merge tree, and zoom with measured alignment.
+"""
+
+import unittest
+
+import numpy as np
+import pytest
+
+import mixle.utils.hvis as hvis
+from mixle.stats import GaussianDistribution, MixtureDistribution
+from mixle.utils.hvis import component_tree, fuzzy_nerve, hvis_map, model_fit_health, model_map
+
+_MODEL3 = MixtureDistribution(
+    [GaussianDistribution(0.0, 1.0), GaussianDistribution(4.0, 1.0), GaussianDistribution(20.0, 1.0)],
+    [1.0 / 3.0] * 3,
+)
+
+
+def _data3(n_per=25, seed=0):
+    rng = np.random.RandomState(seed)
+    xs = np.concatenate([rng.normal(0.0, 1.0, n_per), rng.normal(4.0, 1.0, n_per), rng.normal(20.0, 1.0, n_per)])
+    return [float(v) for v in xs], np.repeat([0, 1, 2], n_per)
+
+
+class FrontDoorTest(unittest.TestCase):
+    def test_one_call_returns_coords_and_all_receipts(self):
+        data, _ = _data3()
+        m = hvis_map(data, _MODEL3)
+        self.assertEqual(m.coords.shape, (75, 2))
+        self.assertEqual(m.posterior_entropy.shape, (75,))
+        self.assertEqual(m.typicality.shape, (75,))
+        self.assertIn("trustworthiness", m.render_health)
+        self.assertIn("components", m.fit_health)
+        self.assertIn("holes", m.nerve_health)
+        self.assertIsInstance(m.summary(), str)
+        self.assertIn("findings", m.summary())
+
+    def test_hvis_map_alias_is_the_promised_name(self):
+        self.assertIs(hvis.map, hvis_map)
+
+    def test_uncertainty_channels_mean_what_they_claim(self):
+        data, _ = _data3()
+        data = data + [2.0, 60.0]  # a mixed-membership point and an outlier
+        m = hvis_map(data, _MODEL3, health=False)
+        self.assertGreater(m.posterior_entropy[75], np.median(m.posterior_entropy[:75]))  # mixed = high entropy
+        self.assertLess(m.typicality[76], 0.05)  # the outlier sits in the lowest typicality percentiles
+
+    def test_goals_imply_refine(self):
+        from mixle.utils.hvis import Anchor
+
+        data, _ = _data3()
+        pins = np.array([[-5.0, 0.0]])
+        m = hvis_map(data, _MODEL3, goals=[Anchor([0], pins)], health=False, seed=0, refine_kwargs={"max_its": 150})
+        np.testing.assert_array_equal(m.coords[0], pins[0])  # the hard anchor proves the optimizer ran
+
+
+class FitHealthTest(unittest.TestCase):
+    def test_merged_regimes_are_flagged_on_the_right_component(self):
+        rng = np.random.RandomState(0)
+        data = [float(v) for v in np.concatenate([rng.normal(0, 1, 40), rng.normal(4, 1, 40), rng.normal(20, 1, 40)])]
+        underfit = MixtureDistribution(
+            [GaussianDistribution(2.0, 5.0), GaussianDistribution(20.0, 1.0)], [2.0 / 3.0, 1.0 / 3.0]
+        )  # one wide component covering what the data treats as TWO regimes
+        report = model_fit_health(underfit, data)
+        self.assertTrue(any("component 0" in d and "merged" in d for d in report["diagnosis"]))
+        self.assertGreater(report["components"][0]["merged_separation"], 3.4)
+
+    def test_shattered_duplicates_are_flagged(self):
+        rng = np.random.RandomState(1)
+        data = [float(v) for v in rng.normal(0, 1, 80)]
+        shattered = MixtureDistribution([GaussianDistribution(0.0, 1.0), GaussianDistribution(0.0, 1.0)], [0.5, 0.5])
+        report = model_fit_health(shattered, data)
+        self.assertTrue(any("near-duplicates" in d for d in report["diagnosis"]))
+        self.assertEqual(report["shattered_pairs"][0][0], [0, 1])
+
+    def test_well_specified_model_is_clean(self):
+        data, _ = _data3(n_per=40)
+        report = model_fit_health(_MODEL3, data)
+        self.assertEqual(report["diagnosis"], [])
+
+    def test_holdout_drop_is_reported(self):
+        data, _ = _data3(n_per=40)
+        rng = np.random.RandomState(5)
+        shifted_holdout = [float(v) for v in rng.normal(40.0, 1.0, 30)]  # nothing like the training data
+        report = model_fit_health(_MODEL3, data, holdout=shifted_holdout)
+        self.assertGreater(report["holdout_drop_nats"], 1.0)
+        self.assertTrue(any("held-out" in d for d in report["diagnosis"]))
+
+
+class OcclusionTest(unittest.TestCase):
+    def _radii_and_dists(self, fitted):
+        z = fitted.responsibilities
+        dominant = z.argmax(axis=1)
+        radii = []
+        for k in range(z.shape[1]):
+            mine = fitted.coords[dominant == k]
+            radii.append(
+                float(np.percentile(np.linalg.norm(mine - fitted.vertices[k], axis=1), 90)) if len(mine) else 0.0
+            )
+        return np.asarray(radii)
+
+    def test_no_model_overlap_means_no_screen_overlap(self):
+        # big fibers (spread=1.2) + a disconnected far regime: without the occlusion pass, the
+        # rendering gap between nerve pieces is smaller than the fiber clouds it separates.
+        data, _ = _data3(n_per=30)
+        loose = model_map(data, mix_model=_MODEL3, spread=1.2, occlusion=False)
+        tight = model_map(data, mix_model=_MODEL3, spread=1.2, occlusion=True)
+
+        def violation(fitted, a, b):
+            radii = self._radii_and_dists(fitted)
+            dist = float(np.linalg.norm(fitted.vertices[a] - fitted.vertices[b]))
+            return dist - 1.05 * (radii[a] + radii[b])
+
+        # component 2 overlaps neither 0 nor 1 in the model: the invariant applies to both pairs
+        self.assertLess(min(violation(loose, 0, 2), violation(loose, 1, 2)), 0.0)  # fixture is adversarial
+        self.assertGreaterEqual(violation(tight, 0, 2), -1.0e-9)
+        self.assertGreaterEqual(violation(tight, 1, 2), -1.0e-9)
+
+    def test_occlusion_preserves_determinism_and_placement(self):
+        data, _ = _data3()
+        a = model_map(data, mix_model=_MODEL3, spread=1.2)
+        b = model_map(data, mix_model=_MODEL3, spread=1.2)
+        np.testing.assert_array_equal(a.coords, b.coords)
+        np.testing.assert_allclose(a.place(data), a.coords, atol=1.0e-10)
+
+
+class QuadraticChartTest(unittest.TestCase):
+    def test_quadratic_chart_mechanics(self):
+        data, labels = _data3()
+        fitted = model_map(data, mix_model=_MODEL3, chart="quadratic")
+        self.assertEqual(fitted.chart, "quadratic")
+        self.assertEqual(fitted.coords.shape, (75, 2))
+        self.assertEqual(len(fitted.coord_labels), fitted.loadings[0].shape[0])  # labels track the lift
+        np.testing.assert_allclose(fitted.place(data), fitted.coords, atol=1.0e-9)  # still closed-form
+        d2 = np.square(fitted.coords[:, None, :] - fitted.coords[None, :, :]).sum(axis=2)
+        np.fill_diagonal(d2, np.inf)
+        self.assertGreater(float(np.mean(labels[d2.argmin(axis=1)] == labels)), 0.85)
+
+    def test_chart_residuals_are_reported_and_bounded(self):
+        data, _ = _data3()
+        fitted = model_map(data, mix_model=_MODEL3)
+        self.assertEqual(fitted.chart_residuals.shape, (3,))
+        self.assertTrue(np.all((fitted.chart_residuals >= 0.0) & (fitted.chart_residuals <= 1.0)))
+        # 1-D fibers in a 2-D chart leave nothing behind
+        np.testing.assert_allclose(fitted.chart_residuals, 0.0, atol=1.0e-9)
+
+    def test_bad_chart_name_raises(self):
+        data, _ = _data3(n_per=5)
+        with self.assertRaises(ValueError):
+            model_map(data, mix_model=_MODEL3, chart="cubic")
+
+
+class HierarchyTest(unittest.TestCase):
+    _MODEL4 = MixtureDistribution(
+        [
+            GaussianDistribution(0.0, 1.0),
+            GaussianDistribution(3.0, 1.0),
+            GaussianDistribution(40.0, 1.0),
+            GaussianDistribution(43.0, 1.0),
+        ],
+        [0.25] * 4,
+    )
+
+    def _data4(self, n_per=30, seed=0):
+        rng = np.random.RandomState(seed)
+        xs = np.concatenate([rng.normal(mu, 1.0, n_per) for mu in (0.0, 3.0, 40.0, 43.0)])
+        return [float(v) for v in xs], np.repeat([0, 1, 2, 3], n_per)
+
+    def test_merge_tree_joins_the_adjacent_pairs_first(self):
+        data, _ = self._data4()
+        from mixle.utils.hvis import _posteriors_and_loglikes
+
+        z, _ = _posteriors_and_loglikes(self._MODEL4, data=data)
+        merges = component_tree(fuzzy_nerve(z))
+        first_two = [m["merged"] for m in merges[:2]]
+        self.assertIn(frozenset({0, 1}), first_two)
+        self.assertIn(frozenset({2, 3}), first_two)
+
+    def test_zoom_recharts_a_group_and_measures_alignment(self):
+        data, labels = self._data4()
+        parent = hvis_map(data, self._MODEL4, health=False)
+        child = parent.zoom([0, 1])
+        self.assertEqual(child.coords.shape[0], int(np.sum(labels <= 1)))
+        self.assertIsNotNone(child.zoom_alignment_rms)
+        parent_spread = float(parent.coords[labels <= 1].std())
+        self.assertLess(child.zoom_alignment_rms, parent_spread)  # continuity measured, not assumed
+        # the child still separates its two regimes
+        child_labels = labels[labels <= 1]
+        d2 = np.square(child.coords[:, None, :] - child.coords[None, :, :]).sum(axis=2)
+        np.fill_diagonal(d2, np.inf)
+        self.assertGreaterEqual(float(np.mean(child_labels[d2.argmin(axis=1)] == child_labels)), 0.85)
+
+    def test_zoom_on_too_few_points_raises(self):
+        data, _ = _data3(n_per=2)
+        parent = hvis_map(data, _MODEL3, health=False)
+        with self.assertRaises(ValueError):
+            parent.zoom([2])
+
+
+@pytest.mark.slow
+class ScalingSmokeTest(unittest.TestCase):
+    def test_twenty_thousand_points_complete(self):
+        import time
+
+        rng = np.random.RandomState(0)
+        data = [float(v) for v in np.concatenate([rng.normal(0, 1, 10000), rng.normal(8, 1, 10000)])]
+        model = MixtureDistribution([GaussianDistribution(0.0, 1.0), GaussianDistribution(8.0, 1.0)], [0.5, 0.5])
+        start = time.time()
+        m = hvis_map(data, model, health=True)
+        elapsed = time.time() - start
+        self.assertEqual(m.coords.shape, (20000, 2))
+        self.assertLess(elapsed, 300.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mixle/tests/hvis_goals_test.py
+++ b/mixle/tests/hvis_goals_test.py
@@ -1,0 +1,177 @@
+"""Embedding goals (mixle.utils.hvis.goals) + the internal UMAP engine (mixle.utils.hvis.umap_np).
+
+Same deterministic known-model fixture as hvis_stream_test: a two-component 1-D Gaussian mixture --
+the affinity machinery only needs a model, so no fitting. The load-bearing claims: hard anchors are
+EXACT (projection, not a strong suggestion); partial labels measurably tighten labeled groups
+without dictating unlabeled points; AxisAlign makes a chosen scalar actually run along the chosen
+axis; and the internal UMAP produces a usable layout (cluster separation) with zero optional
+dependencies, honoring goals that umap-learn structurally cannot.
+"""
+
+import sys
+import unittest
+from unittest import mock
+
+import numpy as np
+
+from mixle.stats import GaussianDistribution, MixtureDistribution
+from mixle.utils.hvis import Anchor, AxisAlign, LabelCohesion, htsne, humap
+
+_MODEL = MixtureDistribution([GaussianDistribution(0.0, 1.0), GaussianDistribution(8.0, 1.0)], [0.5, 0.5])
+
+
+def _data(n_per_cluster=25, seed=0):
+    rng = np.random.RandomState(seed)
+    xs = np.concatenate([rng.normal(0.0, 1.0, n_per_cluster), rng.normal(8.0, 1.0, n_per_cluster)])
+    labels = np.array([0] * n_per_cluster + [1] * n_per_cluster)
+    return [float(v) for v in xs], labels
+
+
+def _cluster_separation(coords, labels):
+    """Mean nearest-neighbor label agreement -- the layout keeps clusters coherent."""
+    d2 = np.square(coords[:, None, :] - coords[None, :, :]).sum(axis=2)
+    np.fill_diagonal(d2, np.inf)
+    return float(np.mean(labels[d2.argmin(axis=1)] == labels))
+
+
+class AnchorTest(unittest.TestCase):
+    def test_hard_anchors_are_exact_on_the_exact_engine(self):
+        data, labels = _data(seed=0)
+        pins = np.array([[-5.0, -5.0], [5.0, 5.0]])
+        anchor = Anchor([0, 25], pins)  # one point from each cluster
+        coords = htsne(data, mix_model=_MODEL, method="exact", seed=0, max_its=300, goals=[anchor], out=None)
+        np.testing.assert_array_equal(coords[[0, 25]], pins)  # projection: exact, not approximately
+        self.assertGreater(_cluster_separation(coords, labels), 0.9)
+
+    def test_hard_anchors_are_exact_on_the_barnes_hut_engine(self):
+        data, _ = _data(seed=1)
+        pins = np.array([[-3.0, 0.0], [3.0, 0.0]])
+        anchor = Anchor([0, 25], pins)
+        coords = htsne(data, mix_model=_MODEL, method="barnes_hut", seed=1, max_its=300, goals=[anchor], out=None)
+        np.testing.assert_array_equal(coords[[0, 25]], pins)
+
+    def test_soft_anchor_equilibrium_gap_shrinks_with_the_rate(self):
+        # a soft anchor reaches equilibrium where the data force balances the relaxation pull, so
+        # (a) the point sits near the pin but NOT exactly on it, and (b) a faster rate sits closer.
+        # (Comparing against a free run would be unsound: unaligned layouts have rotation freedom.)
+        data, _ = _data(seed=2)
+        pin = np.array([[4.0, 4.0]])
+
+        def dist_at(weight):
+            coords = htsne(
+                data,
+                mix_model=_MODEL,
+                method="exact",
+                seed=2,
+                max_its=300,
+                goals=[Anchor([0], pin, weight=weight)],
+                out=None,
+            )
+            return float(np.linalg.norm(coords[0] - pin[0])), float(coords.std())
+
+        dist_slow, _ = dist_at(0.1)
+        dist_fast, spread = dist_at(0.5)
+        self.assertGreater(dist_fast, 0.0)  # soft: never an exact projection
+        self.assertLess(dist_fast, 0.25 * spread)  # but the pull is real: well inside the layout scale
+        self.assertLess(dist_fast, dist_slow)  # and monotone in the rate, as the equilibrium predicts
+
+    def test_anchor_shape_mismatch_raises(self):
+        with self.assertRaises(ValueError):
+            Anchor([0, 1], np.zeros((3, 2)))
+        with self.assertRaises(ValueError):
+            Anchor([0], np.zeros((1, 2)), weight=-1.0)
+        with self.assertRaises(ValueError):
+            Anchor([0], np.zeros((1, 2)), weight=2.0)  # rate semantics: weights live in (0, 1]
+
+
+class LabelCohesionTest(unittest.TestCase):
+    def test_partial_labels_tighten_labeled_groups(self):
+        data, labels = _data(seed=3)
+        # PARTIAL labeling: only 40% of points labeled, the rest None
+        rng = np.random.RandomState(3)
+        partial = [int(lab) if rng.rand() < 0.4 else None for lab in labels]
+        goal = LabelCohesion(partial, weight=0.3)
+
+        coords_free = htsne(data, mix_model=_MODEL, method="exact", seed=3, max_its=300, out=None)
+        coords_goal = htsne(data, mix_model=_MODEL, method="exact", seed=3, max_its=300, goals=[goal], out=None)
+
+        def within_spread(coords):
+            spread = 0.0
+            for lab in (0, 1):
+                idx = [i for i, p in enumerate(partial) if p == lab]
+                spread += float(np.linalg.norm(coords[idx] - coords[idx].mean(axis=0, keepdims=True), axis=1).mean())
+            return spread / (2.0 * float(np.abs(coords).std()))  # scale-normalized: t-SNE spreads differ
+
+        self.assertLess(within_spread(coords_goal), within_spread(coords_free))
+        # semi-supervision, not relabeling: unlabeled points still sit with their true cluster
+        self.assertGreater(_cluster_separation(coords_goal, labels), 0.9)
+
+    def test_margin_pushes_centroids_apart(self):
+        data, labels = _data(seed=4)
+        margin = 40.0
+        goal = LabelCohesion([int(lab) for lab in labels], weight=0.3, margin=margin)
+        coords = htsne(data, mix_model=_MODEL, method="exact", seed=4, max_its=400, goals=[goal], out=None)
+        c0 = coords[labels == 0].mean(axis=0)
+        c1 = coords[labels == 1].mean(axis=0)
+        self.assertGreater(float(np.linalg.norm(c0 - c1)), 0.8 * margin)
+
+    def test_all_unlabeled_raises(self):
+        with self.assertRaises(ValueError):
+            LabelCohesion([None, None, None])
+
+
+class AxisAlignTest(unittest.TestCase):
+    def test_values_run_along_the_chosen_axis(self):
+        data, _ = _data(seed=5)
+        goal = AxisAlign(data, axis=0, weight=0.5)  # the raw 1-D value should order embedding axis 0
+        coords = htsne(data, mix_model=_MODEL, method="exact", seed=5, max_its=400, goals=[goal], out=None)
+        r = float(np.corrcoef(coords[:, 0], np.asarray(data))[0, 1])
+        self.assertGreater(r, 0.8)
+
+    def test_constant_values_raise(self):
+        with self.assertRaises(ValueError):
+            AxisAlign([1.0, 1.0, 1.0])
+
+
+class InternalUmapTest(unittest.TestCase):
+    def test_internal_engine_separates_clusters(self):
+        data, labels = _data(seed=6)
+        coords = humap(data, mix_model=_MODEL, engine="internal", seed=6, n_epochs=150, out=None)
+        self.assertEqual(coords.shape, (50, 2))
+        self.assertGreater(_cluster_separation(coords, labels), 0.9)
+
+    def test_internal_engine_is_deterministic_given_seed(self):
+        data, _ = _data(seed=7)
+        a = humap(data, mix_model=_MODEL, engine="internal", seed=7, n_epochs=100, out=None)
+        b = humap(data, mix_model=_MODEL, engine="internal", seed=7, n_epochs=100, out=None)
+        np.testing.assert_array_equal(a, b)
+
+    def test_auto_engine_with_goals_uses_internal_and_honors_hard_anchors(self):
+        data, _ = _data(seed=8)
+        pins = np.array([[-9.0, 0.0], [9.0, 0.0]])
+        coords = humap(
+            data, mix_model=_MODEL, engine="auto", seed=8, n_epochs=100, goals=[Anchor([0, 25], pins)], out=None
+        )
+        # umap-learn structurally cannot pin points, so exact pins prove the internal engine ran
+        np.testing.assert_array_equal(coords[[0, 25]], pins)
+
+    def test_umap_learn_engine_with_goals_refuses_rather_than_dropping_them(self):
+        data, _ = _data(seed=9)
+        with self.assertRaises(ValueError):
+            humap(data, mix_model=_MODEL, engine="umap-learn", goals=[Anchor([0], [[0.0, 0.0]])], out=None)
+
+    def test_auto_engine_falls_back_to_internal_when_umap_learn_is_missing(self):
+        data, labels = _data(seed=10)
+        with mock.patch.dict(sys.modules, {"umap": None}):  # import umap -> ImportError
+            coords = humap(data, mix_model=_MODEL, engine="auto", seed=10, n_epochs=100, out=None)
+        self.assertEqual(coords.shape, (50, 2))
+        self.assertGreater(_cluster_separation(coords, labels), 0.85)
+
+    def test_bad_engine_raises(self):
+        data, _ = _data(seed=11)
+        with self.assertRaises(ValueError):
+            humap(data, mix_model=_MODEL, engine="not-an-engine", out=None)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mixle/tests/hvis_model_map_test.py
+++ b/mixle/tests/hvis_model_map_test.py
@@ -1,0 +1,163 @@
+"""The direct compositional layout (mixle.utils.hvis.direct): read the map off the model.
+
+The claims that distinguish it from the neighbor-optimizer path, each pinned: bit-determinism with
+NO seed; closed-form out-of-sample placement that reproduces the training coordinates exactly;
+nameable within-regime axes (the fiber loadings recover the generative field); model-decided global
+arrangement (confusable regimes adjacent); and the complaint fixtures (HMM sequences) rendering as
+structured clouds. refine=True only polishes -- the global arrangement stays the skeleton's.
+"""
+
+import unittest
+
+import numpy as np
+
+from mixle.stats import (
+    CategoricalDistribution,
+    CompositeDistribution,
+    GaussianDistribution,
+    HiddenMarkovModelDistribution,
+    IntegerCategoricalDistribution,
+    MixtureDistribution,
+)
+from mixle.utils.hvis import model_map
+
+_MODEL3 = MixtureDistribution(
+    [GaussianDistribution(0.0, 1.0), GaussianDistribution(4.0, 1.0), GaussianDistribution(20.0, 1.0)],
+    [1.0 / 3.0] * 3,
+)
+
+
+def _data3(n_per=25, seed=0):
+    rng = np.random.RandomState(seed)
+    xs = np.concatenate([rng.normal(0.0, 1.0, n_per), rng.normal(4.0, 1.0, n_per), rng.normal(20.0, 1.0, n_per)])
+    return [float(v) for v in xs], np.repeat([0, 1, 2], n_per)
+
+
+def _purity(coords, labels):
+    d2 = np.square(coords[:, None, :] - coords[None, :, :]).sum(axis=2)
+    np.fill_diagonal(d2, np.inf)
+    return float(np.mean(labels[d2.argmin(axis=1)] == labels))
+
+
+class DeterminismAndPlacementTest(unittest.TestCase):
+    def test_bit_deterministic_with_no_seed_at_all(self):
+        data, _ = _data3()
+        a = model_map(data, mix_model=_MODEL3)
+        b = model_map(data, mix_model=_MODEL3)
+        np.testing.assert_array_equal(a.coords, b.coords)
+        np.testing.assert_array_equal(a.vertices, b.vertices)
+
+    def test_place_reproduces_training_coordinates_exactly(self):
+        data, _ = _data3()
+        fitted = model_map(data, mix_model=_MODEL3)
+        np.testing.assert_allclose(fitted.place(data), fitted.coords, atol=1.0e-10)
+
+    def test_place_streams_new_points_to_the_right_regime(self):
+        data, labels = _data3()
+        fitted = model_map(data, mix_model=_MODEL3)
+        rng = np.random.RandomState(7)
+        new = [float(v) for v in np.concatenate([rng.normal(0, 1, 10), rng.normal(20, 1, 10)])]
+        placed = fitted.place(new)
+        d2 = np.square(placed[:, None, :] - fitted.coords[None, :, :]).sum(axis=2)
+        nearest_labels = labels[d2.argmin(axis=1)]
+        self.assertGreater(float(np.mean(nearest_labels == np.repeat([0, 2], 10))), 0.9)
+
+    def test_place_rejects_a_different_field_shape(self):
+        data, _ = _data3()
+        fitted = model_map(data, mix_model=_MODEL3)
+        comp_model = MixtureDistribution(
+            [CompositeDistribution((GaussianDistribution(0.0, 1.0), CategoricalDistribution({"a": 1.0})))], [1.0]
+        )
+        fitted._model = comp_model  # simulate a model/data mismatch at placement time
+        with self.assertRaises(ValueError):
+            fitted.place([(0.0, "a"), (1.0, "a")])
+
+
+class GeometryAndInterpretabilityTest(unittest.TestCase):
+    def test_confusable_regimes_sit_adjacent_and_clusters_separate(self):
+        data, labels = _data3()
+        fitted = model_map(data, mix_model=_MODEL3)
+        v = fitted.vertices
+        d01 = float(np.linalg.norm(v[0] - v[1]))
+        self.assertLess(d01, float(np.linalg.norm(v[0] - v[2])))
+        self.assertLess(d01, float(np.linalg.norm(v[1] - v[2])))
+        self.assertGreater(_purity(fitted.coords, labels), 0.9)
+
+    def test_mixed_membership_point_sits_between_its_regimes(self):
+        data, labels = _data3()
+        fitted = model_map(data, mix_model=_MODEL3)
+        point = fitted.place([2.0])[0]  # posterior ~(0.5, 0.5, 0)
+        cents = np.stack([fitted.coords[labels == c].mean(axis=0) for c in (0, 1, 2)])
+        d0, d1, d2 = (float(np.linalg.norm(point - cents[c])) for c in (0, 1, 2))
+        self.assertLess(max(d0, d1), d2)
+
+    def test_fiber_axes_are_nameable_and_recover_the_generative_field(self):
+        # two regimes over (Gaussian value, sharp categorical): within a regime, the leading fiber
+        # axis should BE the Gaussian value -- the "axes mean something" claim, checked.
+        cat = {"p": 0.5, "q": 0.5}
+        comps = [
+            CompositeDistribution((GaussianDistribution(-4.0, 1.0), CategoricalDistribution(cat))),
+            CompositeDistribution((GaussianDistribution(4.0, 1.0), CategoricalDistribution(cat))),
+        ]
+        model = MixtureDistribution(comps, [0.5, 0.5])
+        data = []
+        for k, comp in enumerate(comps):
+            data.extend(comp.sampler(seed=k).sample(size=30))
+        fitted = model_map(data, mix_model=model)
+        self.assertEqual(len(fitted.coord_labels), fitted.loadings[0].shape[0])
+        values = np.array([x[0] for x in data[:30]])
+        axis_scores = fitted.coords[:30] - fitted.vertices[0][None, :]  # regime-0 chart offsets
+        r = float(np.corrcoef(axis_scores[:, 0], values)[0, 1])
+        self.assertGreater(abs(r), 0.9)
+
+
+class ComplaintFixtureTest(unittest.TestCase):
+    def test_hmm_sequences_render_as_structured_clouds(self):
+        len_dist = IntegerCategoricalDistribution(18, [1.0 / 9.0] * 9)
+
+        def hmm(trans, emit_a):
+            return HiddenMarkovModelDistribution(
+                [
+                    CategoricalDistribution({"a": emit_a, "b": 1 - emit_a}),
+                    CategoricalDistribution({"a": 0.5, "b": 0.5}),
+                ],
+                [0.5, 0.5],
+                trans,
+                len_dist=len_dist,
+            )
+
+        comps = [hmm([[0.9, 0.1], [0.1, 0.9]], 0.9), hmm([[0.2, 0.8], [0.8, 0.2]], 0.1)]
+        model = MixtureDistribution(comps, [0.5, 0.5])
+        data, labels = [], []
+        for k, comp in enumerate(comps):
+            data.extend(comp.sampler(seed=k).sample(size=35))
+            labels.extend([k] * 35)
+        labels = np.asarray(labels)
+
+        fitted = model_map(data, mix_model=model)
+        self.assertTrue(np.all(np.isfinite(fitted.coords)))
+        self.assertGreater(_purity(fitted.coords, labels), 0.85)
+        cents = np.stack([fitted.coords[labels == c].mean(axis=0) for c in (0, 1)])
+        within = np.mean(
+            [np.linalg.norm(fitted.coords[labels == c] - cents[i], axis=1).mean() for i, c in enumerate((0, 1))]
+        )
+        self.assertGreater(float(within), 0.10 * float(np.linalg.norm(cents[0] - cents[1])))
+
+
+class RefineTest(unittest.TestCase):
+    def test_refine_polishes_without_losing_the_global_arrangement(self):
+        data, labels = _data3()
+        skeleton = model_map(data, mix_model=_MODEL3)
+        refined = model_map(data, mix_model=_MODEL3, refine=True, seed=0)
+
+        def gap_ratio(coords):
+            cents = np.stack([coords[labels == c].mean(axis=0) for c in (0, 1, 2)])
+            return float(np.linalg.norm(cents[0] - cents[1]) / np.linalg.norm(cents[0] - cents[2]))
+
+        self.assertGreaterEqual(_purity(refined.coords, labels), _purity(skeleton.coords, labels) - 0.05)
+        self.assertLess(gap_ratio(refined.coords), 0.9)  # confusable pair still adjacent
+        self.assertLess(abs(gap_ratio(refined.coords) - gap_ratio(skeleton.coords)), 0.25)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mixle/tests/hvis_model_map_test.py
+++ b/mixle/tests/hvis_model_map_test.py
@@ -106,8 +106,9 @@ class GeometryAndInterpretabilityTest(unittest.TestCase):
         fitted = model_map(data, mix_model=model)
         self.assertEqual(len(fitted.coord_labels), fitted.loadings[0].shape[0])
         values = np.array([x[0] for x in data[:30]])
-        axis_scores = fitted.coords[:30] - fitted.vertices[0][None, :]  # regime-0 chart offsets
-        r = float(np.corrcoef(axis_scores[:, 0], values)[0, 1])
+        offsets = fitted.coords[:30] - fitted.vertices[0][None, :]  # regime-0 chart offsets
+        major = offsets @ fitted.frames[0][0]  # read them in the chart's own frame (row 0 = major axis)
+        r = float(np.corrcoef(major, values)[0, 1])
         self.assertGreater(abs(r), 0.9)
 
 
@@ -150,13 +151,17 @@ class RefineTest(unittest.TestCase):
         skeleton = model_map(data, mix_model=_MODEL3)
         refined = model_map(data, mix_model=_MODEL3, refine=True, seed=0)
 
-        def gap_ratio(coords):
+        def pair_dists(coords):
             cents = np.stack([coords[labels == c].mean(axis=0) for c in (0, 1, 2)])
-            return float(np.linalg.norm(cents[0] - cents[1]) / np.linalg.norm(cents[0] - cents[2]))
+            return {p: float(np.linalg.norm(cents[p[0]] - cents[p[1]])) for p in ((0, 1), (0, 2), (1, 2))}
 
         self.assertGreaterEqual(_purity(refined.coords, labels), _purity(skeleton.coords, labels) - 0.05)
-        self.assertLess(gap_ratio(refined.coords), 0.9)  # confusable pair still adjacent
-        self.assertLess(abs(gap_ratio(refined.coords) - gap_ratio(skeleton.coords)), 0.25)
+        # the invariant refine must keep is the ORDERING: the confusable pair stays the closest.
+        # A tight ratio pin would be wrong -- the skeleton's disconnected-piece gap is an explicit
+        # rendering choice that the affinity-driven polish legitimately renegotiates.
+        for dists in (pair_dists(skeleton.coords), pair_dists(refined.coords)):
+            self.assertLess(dists[(0, 1)], dists[(0, 2)])
+            self.assertLess(dists[(0, 1)], dists[(1, 2)])
 
 
 if __name__ == "__main__":

--- a/mixle/tests/hvis_stream_test.py
+++ b/mixle/tests/hvis_stream_test.py
@@ -1,0 +1,126 @@
+"""Streaming HViS (mixle.utils.hvis.stream): frozen-atlas placement, drift accounting, aligned refresh.
+
+Fixture: a KNOWN two-component 1-D Gaussian mixture (no fitting -- the affinity machinery only needs
+a model, and constructing it directly keeps the tests fast and fully deterministic). The load-bearing
+claims: placement puts arriving points with their own cluster's landmarks; the atlas never moves
+during streaming; drift trips on a genuinely shifted stream and not on an in-distribution one; a
+refresh preserves visual continuity measurably (small Procrustes residual), not by assumption.
+"""
+
+import unittest
+
+import numpy as np
+
+from mixle.stats import GaussianDistribution, MixtureDistribution
+from mixle.utils.hvis import StreamingHvis, place_in_atlas
+
+_MODEL = MixtureDistribution([GaussianDistribution(0.0, 1.0), GaussianDistribution(8.0, 1.0)], [0.5, 0.5])
+
+
+def _draw(n_per_cluster, rng):
+    xs = np.concatenate([rng.normal(0.0, 1.0, n_per_cluster), rng.normal(8.0, 1.0, n_per_cluster)])
+    labels = np.array([0] * n_per_cluster + [1] * n_per_cluster)
+    order = rng.permutation(len(xs))
+    return [float(v) for v in xs[order]], labels[order]
+
+
+def _make_stream(seed=0, n_landmarks_per_cluster=30, **kwargs):
+    rng = np.random.RandomState(seed)
+    landmarks, labels = _draw(n_landmarks_per_cluster, rng)
+    stream = StreamingHvis(_MODEL, landmarks, perplexity=10.0, seed=seed, max_its=300, **kwargs)
+    return stream, labels, rng
+
+
+class PlacementTest(unittest.TestCase):
+    def test_add_places_points_with_their_own_cluster(self):
+        stream, landmark_labels, rng = _make_stream(seed=0)
+        batch, batch_labels = _draw(20, rng)
+        coords = stream.add(batch)
+        self.assertEqual(coords.shape, (40, 2))
+
+        # each placed point's nearest LANDMARK must come from the same true cluster
+        d2 = np.square(coords[:, None, :] - stream.atlas[None, :, :]).sum(axis=2)
+        nearest = d2.argmin(axis=1)
+        agreement = float(np.mean(landmark_labels[nearest] == batch_labels))
+        self.assertGreater(agreement, 0.9)
+
+    def test_add_never_moves_the_atlas(self):
+        stream, _, rng = _make_stream(seed=1)
+        before = stream.atlas.copy()
+        batch, _ = _draw(15, rng)
+        stream.add(batch)
+        np.testing.assert_array_equal(stream.atlas, before)  # bit-identical: stability is structural
+
+    def test_determinism_given_seed(self):
+        stream_a, _, rng_a = _make_stream(seed=2)
+        stream_b, _, rng_b = _make_stream(seed=2)
+        batch_a, _ = _draw(10, rng_a)
+        batch_b, _ = _draw(10, rng_b)
+        np.testing.assert_array_equal(stream_a.add(batch_a), stream_b.add(batch_b))
+
+    def test_empty_batch(self):
+        stream, _, _ = _make_stream(seed=3)
+        self.assertEqual(stream.add([]).shape, (0, 2))
+
+    def test_place_in_atlas_one_hot_row_converges_onto_that_landmark(self):
+        atlas = np.array([[0.0, 0.0], [10.0, 0.0], [0.0, 10.0]])
+        p = np.array([[0.0, 1.0, 0.0]])
+        y = place_in_atlas(p, atlas, max_its=500)
+        self.assertLess(float(np.linalg.norm(y[0] - atlas[1])), 1.0)
+
+
+class DriftTest(unittest.TestCase):
+    def test_in_distribution_stream_does_not_trip(self):
+        stream, _, rng = _make_stream(seed=4)
+        batch, _ = _draw(25, rng)
+        stream.add(batch)
+        self.assertLess(stream.drift_score(), stream.drift_threshold_nats)
+        self.assertFalse(stream.drifted)
+
+    def test_shifted_stream_trips(self):
+        stream, _, rng = _make_stream(seed=5)
+        shifted = [float(v) for v in rng.normal(30.0, 1.0, 30)]  # far outside both components
+        stream.add(shifted)
+        self.assertTrue(stream.drifted)
+        self.assertGreater(stream.drift_score(), stream.drift_threshold_nats)
+
+    def test_refresh_resets_the_drift_accumulator(self):
+        stream, _, rng = _make_stream(seed=6)
+        stream.add([float(v) for v in rng.normal(30.0, 1.0, 20)])
+        self.assertTrue(stream.drifted)
+        stream.refresh()
+        self.assertFalse(stream.drifted)
+        self.assertEqual(stream.drift_score(), 0.0)
+
+
+class RefreshAndGrowthTest(unittest.TestCase):
+    def test_refresh_on_unchanged_data_keeps_continuity_measurably(self):
+        stream, _, _ = _make_stream(seed=7)
+        # first refresh may legitimately move things: it CONTINUES the optimization of a
+        # not-yet-converged atlas (that is real geometry refinement, not misalignment).
+        first = stream.refresh()
+        self.assertIn("alignment_scale", first)
+        # at steady state (converged atlas, unchanged data/model) a refresh must be ~identity up to
+        # rigid motion + uniform scale -- continuity is this measured claim, not an assumption.
+        second = stream.refresh()
+        self.assertLess(second["alignment_residual_rms"], 0.25 * second["atlas_spread"])
+        self.assertEqual(second["n_landmarks"], 60)
+
+    def test_extend_landmarks_grows_the_atlas_without_moving_it(self):
+        stream, _, rng = _make_stream(seed=8)
+        before = stream.atlas.copy()
+        batch, _ = _draw(5, rng)
+        stream.extend_landmarks(batch)
+        self.assertEqual(stream.atlas.shape, (70, 2))
+        np.testing.assert_array_equal(stream.atlas[:60], before)
+        self.assertEqual(len(stream.landmark_data), 70)
+
+    def test_bad_atlas_shape_raises(self):
+        rng = np.random.RandomState(9)
+        landmarks, _ = _draw(10, rng)
+        with self.assertRaises(ValueError):
+            StreamingHvis(_MODEL, landmarks, atlas=np.zeros((3, 2)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mixle/tests/hvis_stream_test.py
+++ b/mixle/tests/hvis_stream_test.py
@@ -11,8 +11,9 @@ import unittest
 
 import numpy as np
 
-from mixle.stats import GaussianDistribution, MixtureDistribution
+from mixle.stats import GaussianDistribution, GaussianEstimator, MixtureDistribution, MixtureEstimator
 from mixle.utils.hvis import StreamingHvis, place_in_atlas
+from mixle.utils.hvis.stream import _mean_log_density
 
 _MODEL = MixtureDistribution([GaussianDistribution(0.0, 1.0), GaussianDistribution(8.0, 1.0)], [0.5, 0.5])
 
@@ -120,6 +121,69 @@ class RefreshAndGrowthTest(unittest.TestCase):
         landmarks, _ = _draw(10, rng)
         with self.assertRaises(ValueError):
             StreamingHvis(_MODEL, landmarks, atlas=np.zeros((3, 2)))
+
+
+class StreamingEstimatorTest(unittest.TestCase):
+    """The model streams too (incremental EM): a NEW cluster arrives, drift trips, and refresh()
+    re-estimates the model from the arrivals' accumulated sufficient statistics -- the third,
+    broad "background" component migrates to explain the new cluster. The estimator must be
+    consistent with the model (same mixture shape), so the capacity for a new cluster is a broad
+    component, not a component count change."""
+
+    def _stream_with_estimator(self, seed=0):
+        # two sharp known clusters + one broad background component that a new cluster can claim
+        model = MixtureDistribution(
+            [GaussianDistribution(0.0, 1.0), GaussianDistribution(8.0, 1.0), GaussianDistribution(4.0, 100.0)],
+            [0.45, 0.45, 0.10],
+        )
+        estimator = MixtureEstimator([GaussianEstimator(), GaussianEstimator(), GaussianEstimator()])
+        rng = np.random.RandomState(seed)
+        landmarks, _ = _draw(30, rng)
+        stream = StreamingHvis(model, landmarks, perplexity=10.0, seed=seed, estimator=estimator, max_its=300)
+        return stream, rng
+
+    def test_refresh_absorbs_a_new_cluster_via_stream_em(self):
+        stream, rng = self._stream_with_estimator(seed=10)
+        new_cluster = [float(v) for v in rng.normal(20.0, 1.0, 40)]
+        stream.add(new_cluster)
+        self.assertTrue(stream.drifted)  # the frozen model cannot explain the arrivals
+        ll_before = _mean_log_density(stream.mix_model, new_cluster)
+
+        report = stream.refresh()
+        self.assertEqual(report["model_updated"], "stream_em")
+        self.assertEqual(report["n_stream_obs_consumed"], 40.0)
+
+        # the M-step moved the broad component onto the new cluster: same data, much higher density
+        ll_after = _mean_log_density(stream.mix_model, new_cluster)
+        self.assertGreater(ll_after, ll_before + 2.0)
+
+        # and the stream no longer reads as drifted under the updated model
+        fresh = [float(v) for v in rng.normal(20.0, 1.0, 25)]
+        stream.add(fresh)
+        self.assertFalse(stream.drifted)
+
+    def test_explicit_model_wins_and_discards_pending_stream_stats(self):
+        stream, rng = self._stream_with_estimator(seed=11)
+        stream.add([float(v) for v in rng.normal(20.0, 1.0, 20)])
+        replacement = MixtureDistribution(
+            [GaussianDistribution(0.0, 1.0), GaussianDistribution(8.0, 1.0), GaussianDistribution(20.0, 1.0)],
+            [0.4, 0.4, 0.2],
+        )
+        report = stream.refresh(mix_model=replacement)
+        self.assertEqual(report["model_updated"], "explicit")
+        self.assertEqual(report["n_stream_obs_consumed"], 0.0)
+        self.assertIs(stream.mix_model, replacement)
+        # the pending statistics were discarded: a follow-up refresh has nothing to consume
+        follow_up = stream.refresh()
+        self.assertIsNone(follow_up["model_updated"])
+
+    def test_no_estimator_means_the_model_never_changes(self):
+        stream, _, rng = _make_stream(seed=12)
+        model_before = stream.mix_model
+        stream.add([float(v) for v in rng.normal(30.0, 1.0, 15)])
+        report = stream.refresh()
+        self.assertIs(stream.mix_model, model_before)
+        self.assertIsNone(report["model_updated"])
 
 
 if __name__ == "__main__":

--- a/mixle/tests/hvis_test.py
+++ b/mixle/tests/hvis_test.py
@@ -838,7 +838,21 @@ class HTSNETestCase(unittest.TestCase):
         y = htsne(data, mix_model=self.model, perplexity=10.0, method="exact", max_its=300, seed=3, out=io.StringIO())
         self.assertEqual(y.shape, (len(data), 2))
         self.assertTrue(np.all(np.isfinite(y)))
-        self.assertGreater(separation_ratio(y, labels), 1.5)
+        # the old 1.5 bar encoded the categorical field contributing NOTHING within a cluster; the
+        # universal typicality coordinates now surface real within-cluster substructure (a cluster's
+        # minority-category points genuinely differ), which legitimately widens clusters...
+        self.assertGreater(separation_ratio(y, labels), 1.25)
+        # ...and that substructure is the new claim worth pinning: within a cluster, cross-category
+        # pairs sit measurably farther apart than same-category pairs.
+        cats = np.array([x[1] for x in data])
+        same_d, cross_d = [], []
+        for c in np.unique(labels):
+            idx = np.where(labels == c)[0]
+            for a_pos, i in enumerate(idx):
+                for j in idx[a_pos + 1 :]:
+                    d = float(np.linalg.norm(y[i] - y[j]))
+                    (same_d if cats[i] == cats[j] else cross_d).append(d)
+        self.assertGreater(np.mean(cross_d) / np.mean(same_d), 1.1)
 
     def test_exact_kl_decreases(self):
         p = get_pmat(self.z, self.l, targ_perplexity=20.0)
@@ -1117,7 +1131,11 @@ class HTSNETestCase(unittest.TestCase):
         data, labels, model = self._complex_heterogeneous_data_and_model()
         factors = local_factors(model, data)
         self.assertEqual(len(factors), 7)
-        self.assertEqual(sum(isinstance(f, dict) and f.get("kind") == "local" for f in factors), 3)
+        # every non-Optional field now carries local geometry: native coordinates where the leaf
+        # has them, universal typicality coordinates otherwise (the old pin of 3 documented the
+        # posterior-only fallback gap that collapsed discrete/sequence fields into ties). The two
+        # Optional-derived fields (missingness gate + gated inner scores) remain posterior-only.
+        self.assertEqual(sum(isinstance(f, dict) and f.get("kind") == "local" for f in factors), 5)
 
         log_s = model_log_affinity(None, None, affinity=factors, evidence_cap=1.0)
         self.assertGreater(affinity_neighbor_purity(log_s, labels, k=12), 0.95)

--- a/mixle/tests/hvis_test.py
+++ b/mixle/tests/hvis_test.py
@@ -1131,11 +1131,13 @@ class HTSNETestCase(unittest.TestCase):
         data, labels, model = self._complex_heterogeneous_data_and_model()
         factors = local_factors(model, data)
         self.assertEqual(len(factors), 7)
-        # every non-Optional field now carries local geometry: native coordinates where the leaf
-        # has them, universal typicality coordinates otherwise (the old pin of 3 documented the
-        # posterior-only fallback gap that collapsed discrete/sequence fields into ties). The two
-        # Optional-derived fields (missingness gate + gated inner scores) remain posterior-only.
-        self.assertEqual(sum(isinstance(f, dict) and f.get("kind") == "local" for f in factors), 5)
+        # every field except gated-inner scores now carries local geometry: native coordinates
+        # where the leaf has them, universal typicality coordinates otherwise, and the Optional
+        # missingness gate carries its presence indicator (the missing/present pattern is real
+        # within-cluster structure). Only the Optional INNER field (scores gated to present rows)
+        # remains posterior-only. Earlier pins (3, then 5) documented the fallback gaps as they
+        # were successively closed.
+        self.assertEqual(sum(isinstance(f, dict) and f.get("kind") == "local" for f in factors), 6)
 
         log_s = model_log_affinity(None, None, affinity=factors, evidence_cap=1.0)
         self.assertGreater(affinity_neighbor_purity(log_s, labels, k=12), 0.95)

--- a/mixle/tests/hvis_topology_test.py
+++ b/mixle/tests/hvis_topology_test.py
@@ -83,6 +83,21 @@ class FuzzyNerveTest(unittest.TestCase):
         self.assertEqual(report["n_components"], 2)
         self.assertTrue(any("disconnected" in d for d in report["diagnosis"]))
 
+    def test_ring_cover_renders_as_a_ring_not_a_line(self):
+        # the R3 acceptance: the geodesic nerve layout must realize the loop geometrically --
+        # vertices near-equidistant from their centroid, every vertex's nearest a true ring
+        # neighbor. Bare MDS on the clipped dense distance matrix cannot promise this.
+        from mixle.utils.hvis import component_map
+
+        z = _ring_fixture()
+        v = component_map(z)
+        radial = np.linalg.norm(v - v.mean(axis=0, keepdims=True), axis=1)
+        self.assertLess(float(radial.std() / radial.mean()), 0.2)  # a ring, not a smear
+        for k in range(8):
+            d = np.linalg.norm(v - v[k], axis=1)
+            d[k] = np.inf
+            self.assertIn(int(np.argmin(d)), ((k - 1) % 8, (k + 1) % 8))  # adjacency survives
+
     def test_nerve_is_deterministic(self):
         z = _ring_fixture()
         a, b = fuzzy_nerve(z), fuzzy_nerve(z)

--- a/mixle/tests/hvis_topology_test.py
+++ b/mixle/tests/hvis_topology_test.py
@@ -1,0 +1,130 @@
+"""The fuzzy nerve + map-fidelity receipts (mixle.utils.hvis.topology).
+
+The topology framing made checkable: a ring of overlapping components IS a loop in the data's
+topology and the nerve detects it from posteriors alone; a chain has none; a mutually-overlapping
+triple is a FILLED cycle, not a hole; a disconnected cover is reported. embedding_health separates
+"the layout misrepresents the model" from "the map is fine" -- and says exactly which it audits.
+"""
+
+import unittest
+
+import numpy as np
+
+from mixle.stats import DiagonalGaussianDistribution, GaussianDistribution, MixtureDistribution
+from mixle.utils.hvis import (
+    _posteriors_and_loglikes,
+    embedding_health,
+    fuzzy_nerve,
+    model_map,
+    nerve_report,
+)
+
+
+def _ring_fixture(k=8, radius=5.0, n_per=30, seed=0):
+    angles = 2.0 * np.pi * np.arange(k) / k
+    comps = [DiagonalGaussianDistribution([radius * np.cos(a), radius * np.sin(a)], [1.0, 1.0]) for a in angles]
+    model = MixtureDistribution(comps, [1.0 / k] * k)
+    rng = np.random.RandomState(seed)
+    data = [
+        list(np.array([radius * np.cos(a), radius * np.sin(a)]) + rng.normal(0, 1, 2))
+        for a in angles
+        for _ in range(n_per)
+    ]
+    z, _ = _posteriors_and_loglikes(model, data=data)
+    return z
+
+
+class FuzzyNerveTest(unittest.TestCase):
+    def test_ring_cover_reports_an_unfilled_cycle(self):
+        z = _ring_fixture()
+        nerve = fuzzy_nerve(z)
+        report = nerve_report(nerve)
+        self.assertEqual(report["n_components"], 1)
+        self.assertEqual(report["n_strong_edges"], 8)  # exactly the ring adjacencies
+        self.assertEqual(len(report["holes"]), 1)  # one independent loop, unfilled
+        self.assertEqual(sorted(report["holes"][0]), list(range(8)))
+        self.assertTrue(any("loop" in d for d in report["diagnosis"]))
+
+    def test_chain_cover_has_no_cycles(self):
+        model = MixtureDistribution(
+            [GaussianDistribution(0.0, 1.0), GaussianDistribution(3.0, 1.0), GaussianDistribution(6.0, 1.0)],
+            [1.0 / 3.0] * 3,
+        )
+        rng = np.random.RandomState(1)
+        data = [float(v) for mu in (0.0, 3.0, 6.0) for v in rng.normal(mu, 1.0, 40)]
+        z, _ = _posteriors_and_loglikes(model, data=data)
+        report = nerve_report(fuzzy_nerve(z))
+        self.assertEqual(report["n_components"], 1)
+        self.assertEqual(report["cycles"], [])
+        self.assertEqual(report["holes"], [])
+        self.assertEqual(report["diagnosis"], [])
+
+    def test_mutually_overlapping_triple_is_a_filled_cycle_not_a_hole(self):
+        angles = 2.0 * np.pi * np.arange(3) / 3
+        comps = [DiagonalGaussianDistribution([np.cos(a), np.sin(a)], [1.5, 1.5]) for a in angles]
+        model = MixtureDistribution(comps, [1.0 / 3.0] * 3)
+        rng = np.random.RandomState(2)
+        data = [list(rng.normal(0, 1.4, 2)) for _ in range(120)]
+        z, _ = _posteriors_and_loglikes(model, data=data)
+        report = nerve_report(fuzzy_nerve(z))
+        self.assertEqual(len(report["cycles"]), 1)  # the triangle is a cycle of the 1-skeleton...
+        self.assertEqual(report["holes"], [])  # ...but its strong 2-simplex fills it: no hole
+        self.assertEqual(report["diagnosis"], [])
+
+    def test_disconnected_cover_is_reported(self):
+        model = MixtureDistribution(
+            [GaussianDistribution(0.0, 1.0), GaussianDistribution(3.0, 1.0), GaussianDistribution(100.0, 1.0)],
+            [1.0 / 3.0] * 3,
+        )
+        rng = np.random.RandomState(3)
+        data = [float(v) for mu in (0.0, 3.0, 100.0) for v in rng.normal(mu, 1.0, 40)]
+        z, _ = _posteriors_and_loglikes(model, data=data)
+        report = nerve_report(fuzzy_nerve(z))
+        self.assertEqual(report["n_components"], 2)
+        self.assertTrue(any("disconnected" in d for d in report["diagnosis"]))
+
+    def test_nerve_is_deterministic(self):
+        z = _ring_fixture()
+        a, b = fuzzy_nerve(z), fuzzy_nerve(z)
+        self.assertEqual(a["edges"], b["edges"])
+        self.assertEqual(a["triangles"], b["triangles"])
+
+
+class EmbeddingHealthTest(unittest.TestCase):
+    _MODEL3 = MixtureDistribution(
+        [GaussianDistribution(0.0, 1.0), GaussianDistribution(4.0, 1.0), GaussianDistribution(20.0, 1.0)],
+        [1.0 / 3.0] * 3,
+    )
+
+    def _data(self, n_per=25, seed=0):
+        rng = np.random.RandomState(seed)
+        xs = np.concatenate([rng.normal(0, 1, n_per), rng.normal(4, 1, n_per), rng.normal(20, 1, n_per)])
+        return [float(v) for v in xs]
+
+    def test_faithful_map_scores_high_with_empty_diagnosis(self):
+        data = self._data()
+        fitted = model_map(data, mix_model=self._MODEL3)
+        report = embedding_health(fitted.coords, self._MODEL3, data)
+        self.assertGreater(report["trustworthiness"], 0.85)
+        self.assertGreater(report["continuity"], 0.85)
+        self.assertEqual(report["diagnosis"], [])
+
+    def test_scrambled_map_is_flagged(self):
+        data = self._data()
+        fitted = model_map(data, mix_model=self._MODEL3)
+        rng = np.random.RandomState(9)
+        scrambled = fitted.coords[rng.permutation(len(data))]
+        report = embedding_health(scrambled, self._MODEL3, data)
+        self.assertLess(report["trustworthiness"], 0.7)
+        self.assertTrue(report["diagnosis"])
+
+    def test_subsampling_caps_cost(self):
+        data = self._data(n_per=200, seed=1)
+        fitted = model_map(data, mix_model=self._MODEL3)
+        report = embedding_health(fitted.coords, self._MODEL3, data, max_rows=100)
+        self.assertEqual(report["n_sampled"], 100)
+        self.assertEqual(len(report["per_point_trust_penalty"]), 100)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mixle/utils/hvis/__init__.py
+++ b/mixle/utils/hvis/__init__.py
@@ -245,6 +245,15 @@ from mixle.utils.hvis.stream import (
 from mixle.utils.hvis.stream import (
     place_in_atlas as place_in_atlas,
 )
+from mixle.utils.hvis.topology import (
+    embedding_health as embedding_health,
+)
+from mixle.utils.hvis.topology import (
+    fuzzy_nerve as fuzzy_nerve,
+)
+from mixle.utils.hvis.topology import (
+    nerve_report as nerve_report,
+)
 from mixle.utils.hvis.tsne import (
     _barnes_hut_negative_forces as _barnes_hut_negative_forces,
 )
@@ -338,6 +347,9 @@ __all__ = [
     "barycentric_init",
     "model_map",
     "ModelMap",
+    "fuzzy_nerve",
+    "nerve_report",
+    "embedding_health",
     "sparse_model_distances",
     "approx_sparse_model_distances",
     "model_knn",

--- a/mixle/utils/hvis/__init__.py
+++ b/mixle/utils/hvis/__init__.py
@@ -188,6 +188,12 @@ from mixle.utils.hvis.affinity import (
 from mixle.utils.hvis.affinity import (
     model_log_affinity as model_log_affinity,
 )
+from mixle.utils.hvis.direct import (
+    ModelMap as ModelMap,
+)
+from mixle.utils.hvis.direct import (
+    model_map as model_map,
+)
 from mixle.utils.hvis.embed import (
     dpmsne as dpmsne,
 )
@@ -330,6 +336,8 @@ __all__ = [
     "mixture_coordinates",
     "component_map",
     "barycentric_init",
+    "model_map",
+    "ModelMap",
     "sparse_model_distances",
     "approx_sparse_model_distances",
     "model_knn",

--- a/mixle/utils/hvis/__init__.py
+++ b/mixle/utils/hvis/__init__.py
@@ -203,6 +203,12 @@ from mixle.utils.hvis.neighbors import (
 from mixle.utils.hvis.neighbors import (
     sparse_model_distances as sparse_model_distances,
 )
+from mixle.utils.hvis.stream import (
+    StreamingHvis as StreamingHvis,
+)
+from mixle.utils.hvis.stream import (
+    place_in_atlas as place_in_atlas,
+)
 from mixle.utils.hvis.tsne import (
     _barnes_hut_negative_forces as _barnes_hut_negative_forces,
 )
@@ -281,6 +287,8 @@ from mixle.utils.hvis.tsne import (
 
 __all__ = [
     "htsne",
+    "StreamingHvis",
+    "place_in_atlas",
     "humap",
     "dpmsne",
     "model_log_affinity",

--- a/mixle/utils/hvis/__init__.py
+++ b/mixle/utils/hvis/__init__.py
@@ -162,6 +162,12 @@ from mixle.utils.hvis.affinity import (
     balanced_factors as balanced_factors,
 )
 from mixle.utils.hvis.affinity import (
+    barycentric_init as barycentric_init,
+)
+from mixle.utils.hvis.affinity import (
+    component_map as component_map,
+)
+from mixle.utils.hvis.affinity import (
     conditional_pmat as conditional_pmat,
 )
 from mixle.utils.hvis.affinity import (
@@ -175,6 +181,9 @@ from mixle.utils.hvis.affinity import (
 )
 from mixle.utils.hvis.affinity import (
     log_affinity_block as log_affinity_block,
+)
+from mixle.utils.hvis.affinity import (
+    mixture_coordinates as mixture_coordinates,
 )
 from mixle.utils.hvis.affinity import (
     model_log_affinity as model_log_affinity,
@@ -318,6 +327,9 @@ __all__ = [
     "model_log_affinity",
     "affinity_health",
     "log_affinity_block",
+    "mixture_coordinates",
+    "component_map",
+    "barycentric_init",
     "sparse_model_distances",
     "approx_sparse_model_distances",
     "model_knn",

--- a/mixle/utils/hvis/__init__.py
+++ b/mixle/utils/hvis/__init__.py
@@ -176,6 +176,15 @@ from mixle.utils.hvis.embed import (
 from mixle.utils.hvis.embed import (
     humap as humap,
 )
+from mixle.utils.hvis.goals import (
+    Anchor as Anchor,
+)
+from mixle.utils.hvis.goals import (
+    AxisAlign as AxisAlign,
+)
+from mixle.utils.hvis.goals import (
+    LabelCohesion as LabelCohesion,
+)
 from mixle.utils.hvis.neighbors import (
     _augment_candidates as _augment_candidates,
 )
@@ -289,6 +298,9 @@ __all__ = [
     "htsne",
     "StreamingHvis",
     "place_in_atlas",
+    "Anchor",
+    "LabelCohesion",
+    "AxisAlign",
     "humap",
     "dpmsne",
     "model_log_affinity",

--- a/mixle/utils/hvis/__init__.py
+++ b/mixle/utils/hvis/__init__.py
@@ -7,12 +7,18 @@ are supported (the `affinity` argument):
 
 - 'local' (the 'auto' default whenever raw data is available): the model is
   flattened into leaf fields and each field contributes a local statistical
-  affinity. Discrete fields use the per-field posterior Bhattacharyya
-  geometry; continuous/count fields additionally use a component-local
-  Mahalanobis metric in sufficient-statistic-like coordinates learned from
-  the realized data. Thus the same component is no longer a zero-distance
-  quotient: within-component neighborhoods are resolved when the field has
-  actual local structure.
+  affinity combining the per-field posterior (between-cluster structure)
+  with a component-local Mahalanobis metric (within-cluster structure).
+  Continuous/count fields use their native coordinates; every other leaf --
+  HMMs, Markov chains, categoricals, sequence-of-discrete element fields --
+  uses typicality coordinates (per-component log-density; per-token rate
+  plus a log-length axis for sequence-valued leaves), so no field type
+  degrades to posterior-only geometry. Thus the same component is never a
+  zero-distance quotient: sharp posteriors stop collapsing clusters into
+  tiny structureless points, variable-length fields keep length as one
+  honest axis instead of the dominant one, and mixed continuous/discrete
+  fields are made commensurate by the per-component whitening. See
+  affinity_health() for measurable receipts of these degeneracies.
 
 - 'balanced': the model
   is flattened into its leaf fields (nested composites, sequence
@@ -150,6 +156,9 @@ from mixle.utils.hvis.affinity import (
     _resolve_affinity as _resolve_affinity,
 )
 from mixle.utils.hvis.affinity import (
+    affinity_health as affinity_health,
+)
+from mixle.utils.hvis.affinity import (
     balanced_factors as balanced_factors,
 )
 from mixle.utils.hvis.affinity import (
@@ -163,6 +172,9 @@ from mixle.utils.hvis.affinity import (
 )
 from mixle.utils.hvis.affinity import (
     local_factors as local_factors,
+)
+from mixle.utils.hvis.affinity import (
+    log_affinity_block as log_affinity_block,
 )
 from mixle.utils.hvis.affinity import (
     model_log_affinity as model_log_affinity,
@@ -304,6 +316,8 @@ __all__ = [
     "humap",
     "dpmsne",
     "model_log_affinity",
+    "affinity_health",
+    "log_affinity_block",
     "sparse_model_distances",
     "approx_sparse_model_distances",
     "model_knn",

--- a/mixle/utils/hvis/__init__.py
+++ b/mixle/utils/hvis/__init__.py
@@ -203,6 +203,12 @@ from mixle.utils.hvis.embed import (
 from mixle.utils.hvis.embed import (
     humap as humap,
 )
+from mixle.utils.hvis.front import (
+    Map as Map,
+)
+from mixle.utils.hvis.front import (
+    hvis_map as hvis_map,
+)
 from mixle.utils.hvis.goals import (
     Anchor as Anchor,
 )
@@ -246,10 +252,16 @@ from mixle.utils.hvis.stream import (
     place_in_atlas as place_in_atlas,
 )
 from mixle.utils.hvis.topology import (
+    component_tree as component_tree,
+)
+from mixle.utils.hvis.topology import (
     embedding_health as embedding_health,
 )
 from mixle.utils.hvis.topology import (
     fuzzy_nerve as fuzzy_nerve,
+)
+from mixle.utils.hvis.topology import (
+    model_fit_health as model_fit_health,
 )
 from mixle.utils.hvis.topology import (
     nerve_report as nerve_report,
@@ -350,6 +362,11 @@ __all__ = [
     "fuzzy_nerve",
     "nerve_report",
     "embedding_health",
+    "model_fit_health",
+    "component_tree",
+    "hvis_map",
+    "Map",
+    "map",
     "sparse_model_distances",
     "approx_sparse_model_distances",
     "model_knn",
@@ -359,3 +376,6 @@ __all__ = [
     "fisher_factors",
     "tsne_barnes_hut",
 ]
+
+# the design review promised hvis.map(); hvis_map is the shadow-safe import name.
+map = hvis_map  # noqa: A001

--- a/mixle/utils/hvis/affinity.py
+++ b/mixle/utils/hvis/affinity.py
@@ -83,8 +83,56 @@ def _leaf_feature_matrix(dists, items):
     return None
 
 
+def _typicality_coordinates(l, items):
+    """Universal within-component coordinates for leaves with NO native vector coordinates.
+
+    Every leaf -- an HMM, a Markov chain, a categorical, anything with seq_log_density -- already
+    yields the per-component log-density matrix ``l`` (n x K). Its columns are a real, continuous
+    "how typical is this observation under regime k" coordinate: exactly the within-component
+    structure a posterior-overlap factor throws away (sharp posteriors make same-component pairs
+    indistinguishable, which is what renders clusters as tiny structureless points). The component-
+    local Mahalanobis machinery downstream whitens per component, so these coordinates are made
+    dimensionless there -- no manual scale tuning, and continuous/discrete/sequence fields become
+    commensurate for free.
+
+    Sequence-valued leaves (list/tuple/ndarray items) use the PER-TOKEN log-density rate plus one
+    explicit log-length column: total sequence evidence grows with length, so unnormalized columns
+    would all reduce to a single length axis -- length stays visible, but as one honest coordinate
+    among K+1 rather than as all of them. Non-finite entries (impossible categories score -inf) are
+    floored a little below the finite range so they read as "maximally atypical", never as NaN.
+    """
+    l = np.asarray(l, dtype=np.float64)
+    first = items[0]
+    if isinstance(first, (list, tuple, np.ndarray)):
+        lens = np.asarray([len(x) for x in items], dtype=np.float64)
+        coords = np.column_stack([l / np.maximum(lens, 1.0)[:, None], np.log1p(lens)])
+    else:
+        coords = l.copy()
+    return _floor_nonfinite(coords)
+
+
+def _floor_nonfinite(coords: np.ndarray) -> np.ndarray:
+    """Replace non-finite coordinate entries with a value a little below the column's finite range
+    -- "maximally atypical", never NaN (a -inf score would otherwise poison the Mahalanobis block)."""
+    finite = np.isfinite(coords)
+    if not finite.all():
+        for j in range(coords.shape[1]):
+            col_finite = coords[finite[:, j], j]
+            if len(col_finite):
+                lo = float(col_finite.min())
+                spread = float(col_finite.std()) or 1.0
+                coords[~finite[:, j], j] = lo - 3.0 * spread
+            else:
+                coords[:, j] = 0.0
+    return coords
+
+
 def _field_log_density_features(dists, items):
-    """Yield (log_density_matrix, feature_matrix_or_None) for leaf fields.
+    """Yield (log_density_matrix, feature_matrix_or_None, native_coords) for leaf fields.
+
+    ``native_coords`` records whether the feature matrix came from the leaf's own value coordinates
+    (True) or from universal typicality coordinates (False) -- the latter are scored per degree of
+    freedom downstream, and guessing the origin from array shapes would be fragile.
 
     - composite records recurse into their child fields (nested composites
       flatten all the way down),
@@ -114,21 +162,32 @@ def _field_log_density_features(dists, items):
         elems = [e for x in items for e in x]
         if elems:
             seg = np.repeat(np.arange(n), lens)
-            for l_e, x_e in _field_log_density_features([d.dist for d in dists], elems):
+            for l_e, x_e, native_e in _field_log_density_features([d.dist for d in dists], elems):
                 l_f = np.zeros((n, K))
                 np.add.at(l_f, seg, l_e)
                 if getattr(dists[0], "len_normalized", False):
                     denom = np.asarray(lens, dtype=np.float64)
                     mask = denom > 0
                     l_f[mask] /= denom[mask, None]
-                x_f = None
                 if x_e is not None:
                     x_f = np.zeros((n, x_e.shape[1]), dtype=np.float64)
                     np.add.at(x_f, seg, x_e)
                     denom = np.asarray(lens, dtype=np.float64)
                     mask = denom > 0
                     x_f[mask] /= denom[mask, None]
-                yield l_f, x_f
+                    native_f = native_e
+                else:
+                    # element leaves without native coordinates (categorical/Markov tokens): the
+                    # per-token typicality rate is still a real within-component coordinate. The
+                    # separate length field carries length, so no log-length column here.
+                    x_f = np.zeros((n, l_e.shape[1]), dtype=np.float64)
+                    np.add.at(x_f, seg, l_e)
+                    denom = np.asarray(lens, dtype=np.float64)
+                    mask = denom > 0
+                    x_f[mask] /= denom[mask, None]
+                    x_f = _floor_nonfinite(x_f)
+                    native_f = False
+                yield l_f, x_f, native_f
         len_dists = [d.len_dist for d in dists]
         if len_dists[0] is not None:
             yield from _field_log_density_features(len_dists, lens)
@@ -151,13 +210,13 @@ def _field_log_density_features(dists, items):
                 ],
                 dtype=np.float64,
             )  # log P(present)
-            yield np.where(miss[:, None], lp0[None, :], lp1[None, :]), None
+            yield np.where(miss[:, None], lp0[None, :], lp1[None, :]), None, True
         if (~miss).any():
             fill = items[int(np.argmax(~miss))]
             sub = [fill if m else x for x, m in zip(items, miss)]
             keep = (~miss).astype(np.float64)[:, None]
-            for l_in, _ in _field_log_density_features([d.dist for d in dists], sub):
-                yield np.where(keep > 0.0, l_in, 0.0), None
+            for l_in, _x, _nat in _field_log_density_features([d.dist for d in dists], sub):
+                yield np.where(keep > 0.0, l_in, 0.0), None, True
         return
 
     if hasattr(dists[0], "dist_to_encoder"):
@@ -173,11 +232,15 @@ def _field_log_density_features(dists, items):
             l[:, k] = np.asarray(d.seq_log_density(enc), dtype=np.float64)
         else:
             l[:, k] = [d.log_density(x) for x in items]
-    yield l, _leaf_feature_matrix(dists, items)
+    x_native = _leaf_feature_matrix(dists, items)
+    if x_native is not None:
+        yield l, x_native, True
+    else:
+        yield l, _typicality_coordinates(l, items), False
 
 
 def _field_log_densities(dists, items):
-    for l_f, _ in _field_log_density_features(dists, items):
+    for l_f, _x, _native in _field_log_density_features(dists, items):
         yield l_f
 
 
@@ -279,10 +342,19 @@ def local_factors(mix_model, data, field_weights=None):
     """Per-field local statistical affinity factors.
 
     Each leaf field is first represented by its field-restricted component
-    posterior. If the leaf has meaningful local coordinates (continuous/count
-    leaves, and averages of such leaves inside sequences), the factor also
-    carries component-local inverse covariances estimated from the realized
-    data. Pair affinities then use
+    posterior, and EVERY field also carries within-component local geometry:
+    continuous/count leaves (and averages of such leaves inside sequences) use
+    their native coordinates; every other leaf -- HMMs, Markov chains,
+    categoricals, sequence-of-discrete element fields -- uses typicality
+    coordinates (per-component log-density; per-token rate plus a log-length
+    axis for sequence-valued leaves, see _typicality_coordinates). Without
+    that universal fallback, sharp posteriors make all same-component pairs
+    exact ties and clusters render as tiny structureless points -- the
+    collapse this affinity exists to prevent. The factor carries
+    component-local inverse covariances estimated from the realized data
+    (which also makes heterogeneous fields dimensionless, so continuous,
+    discrete, and sequence evidence are commensurate). Pair affinities then
+    use
 
         sum_k sqrt(z_ik z_jk) exp(-delta_ijk / 8),
 
@@ -305,7 +377,7 @@ def local_factors(mix_model, data, field_weights=None):
         )
 
     factors = []
-    for (l_f, x_f), w_f in zip(terms, field_weights):
+    for (l_f, x_f, native_f), w_f in zip(terms, field_weights):
         if w_f < 0:
             raise ValueError("field_weights must be non-negative.")
         z_f = np.asarray(l_f, dtype=np.float64) + log_w
@@ -321,6 +393,11 @@ def local_factors(mix_model, data, field_weights=None):
             factors.append((sq, sq) if w_f == 1.0 else (sq, sq, float(w_f)))
         else:
             x_f = np.asarray(x_f, dtype=np.float64)
+            # typicality coordinates span one column per component (+ length), so a whitened
+            # Mahalanobis delta averages ~dim and would saturate the evidence cap as K grows,
+            # making far-within-cluster pairs indistinguishable from cross-cluster pairs.
+            # Score them per degree of freedom; native low-dim coordinates keep the exact
+            # behavior the /8 exponent was tuned on.
             factors.append(
                 {
                     "kind": "local",
@@ -328,6 +405,7 @@ def local_factors(mix_model, data, field_weights=None):
                     "x": x_f,
                     "inv_cov": _component_inv_covariances(x_f, z_f),
                     "weight": float(w_f),
+                    "delta_scale": 1.0 if native_f else float(x_f.shape[1]),
                 }
             )
 
@@ -429,6 +507,7 @@ def _local_similarity_block(factor, row_idx: np.ndarray, col_idx: np.ndarray) ->
     sq = np.asarray(factor["sqrt_z"], dtype=np.float64)
     x = np.asarray(factor["x"], dtype=np.float64)
     inv_cov = np.asarray(factor["inv_cov"], dtype=np.float64)
+    delta_scale = float(factor.get("delta_scale", 1.0))
 
     zr, zc = sq[row_idx], sq[col_idx]
     xr, xc = x[row_idx], x[col_idx]
@@ -444,7 +523,7 @@ def _local_similarity_block(factor, row_idx: np.ndarray, col_idx: np.ndarray) ->
             delta = np.einsum("...d,de,...e->...", diff, inv_cov[k], diff)
         else:
             delta = sqdiff1 * inv_cov[k, 0, 0]
-        delta = np.maximum(delta, 0.0)
+        delta = np.maximum(delta, 0.0) / delta_scale
         sim += gate * np.exp(-0.125 * np.minimum(delta, 80.0))
 
     return sim
@@ -618,6 +697,139 @@ def model_log_affinity(
     log_s[np.arange(n), np.arange(n)] = -np.inf
 
     return log_s
+
+
+def log_affinity_block(
+    factors, row_idx: np.ndarray, col_idx: np.ndarray, evidence_cap: float | None = None
+) -> np.ndarray:
+    """Rectangular (rows x cols) log-affinity block -- :func:`model_log_affinity` for a sub-block.
+
+    Mirrors the square path exactly: per-factor similarity blocks, log, per-factor evidence cap
+    (multi-factor affinities only), weighted sum. Used by streaming placement (new points x
+    landmarks) and by :func:`affinity_health` (subsampled diagnostics).
+    """
+    row_idx = np.asarray(row_idx, dtype=np.int64)
+    col_idx = np.asarray(col_idx, dtype=np.int64)
+    cap = evidence_cap if (evidence_cap is not None and len(factors) > 1) else None
+    log_s = np.zeros((len(row_idx), len(col_idx)))
+    with np.errstate(divide="ignore"):
+        for factor in factors:
+            weight = _factor_weight(factor)
+            if weight == 0.0:
+                continue
+            term = np.log(np.maximum(_factor_similarity_block(factor, row_idx, col_idx), 1.0e-300))
+            if cap is not None:
+                np.maximum(term, -cap, out=term)
+            log_s += weight * term
+    return log_s
+
+
+def affinity_health(
+    mix_model,
+    data,
+    *,
+    affinity="auto",
+    perplexity: float | None = 30.0,
+    field_weights=None,
+    evidence_cap: float | None = 1.0,
+    max_rows: int = 400,
+    seed: int = 0,
+) -> dict:
+    """Receipts for "why does my embedding look like this": measure the affinity's degeneracies
+    BEFORE spending an optimization on them.
+
+    The classic failure this catches is posterior collapse: sharp posteriors make every
+    same-component pair an exact tie, rows cannot reach the requested perplexity, and t-SNE renders
+    each cluster as a tiny structureless point. That is a property of the AFFINITY, measurable in
+    milliseconds -- not a property of the optimizer, discoverable after a thousand iterations.
+
+    Returns a dict with per-field entries (``geometry``: ``'local'``/``'fisher'``/
+    ``'posterior-only'``; ``posterior_sharpness``: mean max field-posterior, 1.0 = fully hard) and
+    overall numbers on a row subsample of at most ``max_rows``:
+
+    * ``top_tie_fraction`` -- mean fraction of each row's neighbors tied (within 1e-9) with its
+      best neighbor. Near 0 is healthy; large means nearest-neighbor structure is degenerate.
+    * ``row_entropy_deficit_nats`` -- mean shortfall between the requested ``log(perplexity)`` and
+      the entropy each row can actually reach (ties saturate the calibration). 0 is healthy.
+    * ``diagnosis`` -- plain-language findings, empty when healthy.
+    """
+    data = list(data)
+    resolved = _resolve_affinity(affinity, mix_model, data, field_weights)
+    if isinstance(resolved, str):
+        z, ll = _posteriors_and_loglikes(mix_model, data=data)
+        factors = _affinity_factors(z, ll, resolved)
+        mode = resolved
+    else:
+        factors = _affinity_factors(None, None, resolved)
+        mode = "local" if any(_is_local_factor(f) for f in resolved) else "prebuilt"
+
+    fields = []
+    for factor in factors:
+        if _is_local_factor(factor):
+            geometry, sq = "local", np.asarray(factor["sqrt_z"], dtype=np.float64)
+        elif _is_fisher_factor(factor):
+            geometry, sq = "fisher", None
+        else:
+            geometry, sq = "posterior-only", np.asarray(_factor_parts(factor)[0], dtype=np.float64)
+        sharpness = float(np.mean(np.max(sq**2, axis=1))) if sq is not None else None
+        fields.append({"geometry": geometry, "posterior_sharpness": sharpness})
+
+    n = _factor_n(factors[0])
+    rng = np.random.RandomState(seed)
+    idx = np.arange(n) if n <= max_rows else np.sort(rng.choice(n, size=max_rows, replace=False))
+    log_s = log_affinity_block(factors, idx, idx, evidence_cap)
+    np.fill_diagonal(log_s, -np.inf)
+
+    tie_fracs = np.empty(len(idx))
+    deficits = np.empty(len(idx))
+    target = None if perplexity is None else np.log(min(float(perplexity), max(1.0, len(idx) - 1.0)))
+    for i in range(len(idx)):
+        row = log_s[i]
+        finite = np.isfinite(row)
+        if not np.any(finite):
+            tie_fracs[i], deficits[i] = 1.0, 0.0
+            continue
+        vals = row[finite]
+        tie_fracs[i] = float(np.mean(vals >= vals.max() - 1.0e-9))
+        if target is None:
+            deficits[i] = 0.0
+        else:
+            p = _calibrate_row(vals.copy(), target)
+            h = -float(np.dot(p, np.log(np.maximum(p, 1.0e-300))))
+            deficits[i] = max(0.0, target - h)
+
+    top_tie = float(tie_fracs.mean())
+    deficit = float(deficits.mean())
+
+    diagnosis = []
+    if top_tie > 0.05:
+        diagnosis.append(
+            f"degenerate neighborhoods: on average {top_tie:.0%} of a row's neighbors are exact ties with its "
+            "nearest -- pairs the affinity cannot rank. Expect collapsed blobs; prefer affinity='local' "
+            "(every field carries within-component geometry) over posterior-only modes."
+        )
+    if deficit > 0.25:
+        diagnosis.append(
+            f"rows fall {deficit:.2f} nats short of the requested perplexity (tie groups saturate the "
+            "calibration) -- clusters will render smaller and denser than the perplexity asks for."
+        )
+    for f_pos, field in enumerate(fields):
+        if field["geometry"] == "posterior-only" and (field["posterior_sharpness"] or 0.0) > 0.9:
+            diagnosis.append(
+                f"field {f_pos} is posterior-only with near-hard posteriors (sharpness "
+                f"{field['posterior_sharpness']:.3f}): it contributes cluster identity but no within-cluster "
+                "geometry."
+            )
+
+    return {
+        "mode": mode,
+        "n": n,
+        "n_sampled": len(idx),
+        "fields": fields,
+        "top_tie_fraction": top_tie,
+        "row_entropy_deficit_nats": deficit,
+        "diagnosis": diagnosis,
+    }
 
 
 def _hbeta(neg_d: np.ndarray, beta: float) -> tuple[float, np.ndarray]:

--- a/mixle/utils/hvis/affinity.py
+++ b/mixle/utils/hvis/affinity.py
@@ -699,6 +699,94 @@ def model_log_affinity(
     return log_s
 
 
+def mixture_coordinates(mix_model, data, field_weights=None) -> dict:
+    """The observation decomposition made first-class: ``x -> (posterior, remainder per field)``.
+
+    The mixture describes every observation at two levels, and this returns both explicitly:
+    ``"posterior"`` -- the (n, K) component posterior, literally barycentric coordinates on the
+    simplex whose vertices are the components (the between-cluster geometry); ``"fields"`` -- one
+    entry per flattened leaf field with its per-component log-densities, its within-component
+    coordinates (``"coords"``: native value coordinates where the leaf has them, universal
+    typicality coordinates otherwise), and ``"native"`` recording which. This is exactly the
+    decomposition the 'local' affinity is built from; exposing it lets a caller inspect or plot the
+    two levels directly (e.g. a ternary plot of the posterior for K=3) instead of trusting the
+    embedding blindly.
+    """
+    data = list(data)
+    z, _ = _posteriors_and_loglikes(mix_model, data=data)
+    fields = []
+    for l_f, x_f, native_f in _field_log_density_features(list(mix_model.components), data):
+        fields.append({"log_density": np.asarray(l_f, dtype=np.float64), "coords": x_f, "native": bool(native_f)})
+    if field_weights is not None and len(field_weights) != len(fields):
+        raise ValueError(f"field_weights has {len(field_weights)} entries but the model flattens to {len(fields)}.")
+    return {"posterior": z, "fields": fields}
+
+
+def component_map(z: np.ndarray, emb_dim: int = 2) -> np.ndarray:
+    """Lay out the K components as simplex vertices by their overlap geometry on the data.
+
+    Component confusability is measured from the posteriors alone: the Bhattacharyya coefficient
+    between the components' responsibility profiles, ``BC(k, l) = sum_i sqrt(z_ik z_il) /
+    sqrt(sum_i z_ik * sum_i z_il)`` -- 1 when two components claim exactly the same observations,
+    0 when they never co-claim. Classical MDS on ``-log BC`` gives vertex coordinates in which
+    confusable components sit close. These vertices anchor :func:`barycentric_init`.
+    """
+    z = np.asarray(z, dtype=np.float64)
+    k = z.shape[1]
+    if k == 1:
+        return np.zeros((1, emb_dim))
+    sq = np.sqrt(z)
+    overlap = sq.T @ sq
+    mass = np.sqrt(np.maximum(z.sum(axis=0), 1.0e-12))
+    bc = overlap / np.outer(mass, mass)
+    np.clip(bc, 1.0e-12, 1.0, out=bc)
+    d2 = np.square(-np.log(bc))
+    np.fill_diagonal(d2, 0.0)
+
+    j = np.eye(k) - np.ones((k, k)) / k  # classical MDS: double-center the squared distances
+    b = -0.5 * j @ d2 @ j
+    vals, vecs = np.linalg.eigh(b)
+    order = np.argsort(vals)[::-1][:emb_dim]
+    coords = vecs[:, order] * np.sqrt(np.maximum(vals[order], 0.0))
+    if coords.shape[1] < emb_dim:  # rank-deficient overlap geometry: pad axes with zeros
+        coords = np.column_stack([coords, np.zeros((k, emb_dim - coords.shape[1]))])
+    return coords
+
+
+def barycentric_init(z: np.ndarray, emb_dim: int = 2, *, jitter: float = 0.15, seed: int | None = None) -> np.ndarray:
+    """Initial embedding coordinates from the barycentric reading of the posterior.
+
+    Each observation starts at ``z @ vertices`` -- its posterior-weighted combination of the
+    component vertices from :func:`component_map` -- so the layout's GLOBAL arrangement (which
+    clusters sit near which, where mixed-membership points fall) is decided by the model's own
+    geometry rather than by the random seed, and t-SNE's optimization refines locally from there.
+
+    ``jitter`` is a fraction of the smallest nonzero inter-vertex distance and matters more than it
+    looks: sharp posteriors put every same-regime point EXACTLY on its vertex, and t-SNE from
+    near-coincident starts is chaotic (microscopic noise decides the layout) and slow to develop
+    local structure. The decomposition needs both levels even at init time -- the barycentric base
+    supplies the between geometry, the jitter stands in for the within spread the optimization then
+    makes real. Rescaled to the conventional 1e-4 standard deviation so optimizer dynamics (early
+    exaggeration, learning rates) match the random-init path.
+    """
+    z = np.asarray(z, dtype=np.float64)
+    vertices = component_map(z, emb_dim=emb_dim)
+    y = z @ vertices
+    gaps = [
+        float(np.linalg.norm(vertices[a] - vertices[b]))
+        for a in range(len(vertices))
+        for b in range(a + 1, len(vertices))
+    ]
+    nonzero = [g for g in gaps if g > 0]
+    scale = min(nonzero) if nonzero else 1.0
+    rng = np.random.RandomState(seed)
+    y = y + rng.randn(*y.shape) * (float(jitter) * scale)
+    spread = float(y.std())
+    if spread > 0:
+        y = y * (1.0e-4 / spread)
+    return y
+
+
 def log_affinity_block(
     factors, row_idx: np.ndarray, col_idx: np.ndarray, evidence_cap: float | None = None
 ) -> np.ndarray:

--- a/mixle/utils/hvis/affinity.py
+++ b/mixle/utils/hvis/affinity.py
@@ -210,7 +210,9 @@ def _field_log_density_features(dists, items):
                 ],
                 dtype=np.float64,
             )  # log P(present)
-            yield np.where(miss[:, None], lp0[None, :], lp1[None, :]), None, True
+            # the presence pattern is real within-cluster structure: a 0/1 coordinate lets the
+            # local machinery separate present-vs-missing neighbors instead of posterior-only ties.
+            yield np.where(miss[:, None], lp0[None, :], lp1[None, :]), (~miss).astype(np.float64)[:, None], False
         if (~miss).any():
             fill = items[int(np.argmax(~miss))]
             sub = [fill if m else x for x, m in zip(items, miss)]
@@ -722,14 +724,63 @@ def mixture_coordinates(mix_model, data, field_weights=None) -> dict:
     return {"posterior": z, "fields": fields}
 
 
-def component_map(z: np.ndarray, emb_dim: int = 2) -> np.ndarray:
-    """Lay out the K components as simplex vertices by their overlap geometry on the data.
+def _classical_mds(d2: np.ndarray, emb_dim: int) -> np.ndarray:
+    k = d2.shape[0]
+    j = np.eye(k) - np.ones((k, k)) / k
+    b = -0.5 * j @ d2 @ j
+    vals, vecs = np.linalg.eigh(b)
+    order = np.argsort(vals)[::-1][:emb_dim]
+    coords = vecs[:, order] * np.sqrt(np.maximum(vals[order], 0.0))
+    flips = np.sign(coords[np.abs(coords).argmax(axis=0), np.arange(coords.shape[1])])
+    flips[flips == 0] = 1.0
+    coords = coords * flips  # canonical eigenvector signs: determinism must not depend on LAPACK
+    if coords.shape[1] < emb_dim:
+        coords = np.column_stack([coords, np.zeros((k, emb_dim - coords.shape[1]))])
+    return coords
 
-    Component confusability is measured from the posteriors alone: the Bhattacharyya coefficient
-    between the components' responsibility profiles, ``BC(k, l) = sum_i sqrt(z_ik z_il) /
-    sqrt(sum_i z_ik * sum_i z_il)`` -- 1 when two components claim exactly the same observations,
-    0 when they never co-claim. Classical MDS on ``-log BC`` gives vertex coordinates in which
-    confusable components sit close. These vertices anchor :func:`barycentric_init`.
+
+def _smacof(d: np.ndarray, emb_dim: int, n_iter: int = 300) -> np.ndarray:
+    """Deterministic stress majorization (uniform weights, classical-MDS init) toward target
+    distances ``d`` -- the Guttman transform, no randomness anywhere."""
+    k = d.shape[0]
+    if k == 1:
+        return np.zeros((1, emb_dim))
+    x = _classical_mds(np.square(d), emb_dim)
+    for _ in range(int(n_iter)):
+        cur = np.sqrt(np.maximum(np.square(x[:, None, :] - x[None, :, :]).sum(axis=2), 1.0e-12))
+        np.fill_diagonal(cur, 1.0)
+        ratio = d / cur
+        np.fill_diagonal(ratio, 0.0)
+        b = -ratio
+        b[np.arange(k), np.arange(k)] = ratio.sum(axis=1)
+        x_new = (b @ x) / k
+        if float(np.abs(x_new - x).max()) < 1.0e-10:
+            x = x_new
+            break
+        x = x_new
+    return x - x.mean(axis=0, keepdims=True)
+
+
+def component_map(
+    z: np.ndarray, emb_dim: int = 2, *, method: str = "nerve", edge_threshold: float = 0.02
+) -> np.ndarray:
+    """Lay out the K components as vertices by their overlap geometry on the data.
+
+    ``method='nerve'`` (default): geodesic layout of the cover's nerve -- edge lengths are
+    ``-log BC`` on STRONG edges only (see :func:`mixle.utils.hvis.topology.fuzzy_nerve`), all-pairs
+    shortest paths give the target metric, and deterministic stress majorization embeds it. This is
+    Isomap on the nerve: a ring of components renders as a ring and a chain as a line, where bare
+    MDS on the clipped dense ``-log BC`` matrix (every non-overlapping pair saturating at the same
+    huge distance) distorts both -- the classic horseshoe failure. Disconnected pieces of the nerve
+    are laid out separately and placed side by side with an explicit gap; their on-screen separation
+    is a RENDERING choice, which :func:`mixle.utils.hvis.topology.nerve_report` also says outright.
+
+    ``method='mds'``: the previous behavior -- classical MDS on the dense clipped ``-log BC``
+    matrix. Kept as the fallback and for comparison.
+
+    Component confusability itself is unchanged: the Bhattacharyya coefficient between the
+    components' responsibility profiles. These vertices anchor :func:`barycentric_init` and
+    :func:`mixle.utils.hvis.direct.model_map`.
     """
     z = np.asarray(z, dtype=np.float64)
     k = z.shape[1]
@@ -740,17 +791,43 @@ def component_map(z: np.ndarray, emb_dim: int = 2) -> np.ndarray:
     mass = np.sqrt(np.maximum(z.sum(axis=0), 1.0e-12))
     bc = overlap / np.outer(mass, mass)
     np.clip(bc, 1.0e-12, 1.0, out=bc)
-    d2 = np.square(-np.log(bc))
-    np.fill_diagonal(d2, 0.0)
+    neg_log_bc = -np.log(bc)
+    np.fill_diagonal(neg_log_bc, 0.0)
 
-    j = np.eye(k) - np.ones((k, k)) / k  # classical MDS: double-center the squared distances
-    b = -0.5 * j @ d2 @ j
-    vals, vecs = np.linalg.eigh(b)
-    order = np.argsort(vals)[::-1][:emb_dim]
-    coords = vecs[:, order] * np.sqrt(np.maximum(vals[order], 0.0))
-    if coords.shape[1] < emb_dim:  # rank-deficient overlap geometry: pad axes with zeros
-        coords = np.column_stack([coords, np.zeros((k, emb_dim - coords.shape[1]))])
-    return coords
+    if method == "mds":
+        return _classical_mds(np.square(neg_log_bc), emb_dim)
+    if method != "nerve":
+        raise ValueError("method must be 'nerve' or 'mds'.")
+
+    from mixle.utils.hvis.topology import fuzzy_nerve
+
+    nerve = fuzzy_nerve(z, edge_threshold=edge_threshold)
+    strong = {e for e, w in nerve["edges"].items() if w >= edge_threshold}
+    if not strong:  # no measured overlaps at all: fall back to the dense view
+        return _classical_mds(np.square(neg_log_bc), emb_dim)
+
+    import scipy.sparse
+    import scipy.sparse.csgraph
+
+    rows = [a for a, _b in strong] + [b for _a, b in strong]
+    cols = [b for _a, b in strong] + [a for a, _b in strong]
+    lengths = [max(float(neg_log_bc[a, b]), 1.0e-6) for a, b in strong] * 2
+    graph = scipy.sparse.csr_matrix((lengths, (rows, cols)), shape=(k, k))
+    geo = scipy.sparse.csgraph.shortest_path(graph, directed=False)
+
+    n_pieces, piece_of = scipy.sparse.csgraph.connected_components(graph, directed=False)
+    coords = np.zeros((k, emb_dim))
+    offset = 0.0
+    typical = float(np.median([length for length in lengths])) if lengths else 1.0
+    for piece in range(n_pieces):
+        members = np.flatnonzero(piece_of == piece)
+        sub = _smacof(geo[np.ix_(members, members)], emb_dim)
+        half_width = float(sub[:, 0].max() - sub[:, 0].min()) / 2.0 if len(members) > 1 else 0.0
+        offset += half_width
+        sub = sub + np.array([offset] + [0.0] * (emb_dim - 1))
+        coords[members] = sub
+        offset += half_width + 1.5 * max(typical, 1.0)  # explicit rendering gap between pieces
+    return coords - coords.mean(axis=0, keepdims=True)
 
 
 def barycentric_init(z: np.ndarray, emb_dim: int = 2, *, jitter: float = 0.15, seed: int | None = None) -> np.ndarray:

--- a/mixle/utils/hvis/direct.py
+++ b/mixle/utils/hvis/direct.py
@@ -7,14 +7,22 @@ posterior simplex and component overlap geometry), and WHERE each observation si
 regime (the whitened local/typicality coordinates). This module composes those two levels directly
 -- the (posterior, remainder) decomposition as a layout:
 
-    y_i = sum_k z_ik * (vertex_k + fiber_scores_ik)
+    y_i = sum_k z_ik * (vertex_k + frame_k(fiber_scores_ik))
 
-* vertices: :func:`~mixle.utils.hvis.affinity.component_map` -- classical MDS on the components'
-  overlap geometry (confusable regimes adjacent). Deterministic.
+* vertices: :func:`~mixle.utils.hvis.affinity.component_map` -- geodesic layout of the cover's
+  nerve (confusable regimes adjacent; rings render as rings). Deterministic.
 * fibers: per component, a responsibility-weighted PCA of the per-field WHITENED local coordinates
   (native value coordinates or universal typicality coordinates -- the same geometry the 'local'
   affinity scores). Deterministic up to sign, and signs are canonicalized. The loadings are
   returned, so a fiber axis is NAMEABLE: "within regime k, axis 1 is field 2's coordinate 0".
+  ``chart='quadratic'`` lifts the fiber features with degree-2 terms (explicit polynomial kernel,
+  still closed-form and placeable) for regimes whose within-structure is curved; the per-component
+  ``chart_residuals`` report says how much variance the linear chart leaves behind either way.
+* frames: each chart gets its own on-screen frame, major axis oriented tangentially (orthogonal to
+  the nearest other vertex) so neighboring charts' fringes cannot collide head-on.
+* occlusion: components with NO measured overlap in the model must not overlap on screen -- a
+  deterministic push-apart pass enforces it, while genuinely-overlapping components are allowed to
+  overlap visually (screen overlap then MEANS model overlap).
 * composition: barycentric in the posterior, so sharp points sit in their regime's local chart and
   mixed-membership points interpolate between charts.
 
@@ -25,9 +33,9 @@ responsibility -- rebuilt here on HViS's field decomposition so it covers hetero
 variable-length, and sequence data.
 
 When to still reach for the neighbor optimizers: no trustworthy model, strongly nonlinear
-within-regime manifolds a linear fiber chart flattens, or pure exploration. ``refine=True`` runs
-t-SNE FROM this layout (informative init, exaggeration off) so the optimizer only polishes local
-neighborhoods it is actually good at -- the composition stays in charge of the global picture.
+within-regime manifolds a chart flattens, or pure exploration. ``refine=True`` runs t-SNE FROM this
+layout (informative init, exaggeration off) so the optimizer only polishes local neighborhoods it
+is actually good at -- the composition stays in charge of the global picture.
 """
 
 from __future__ import annotations
@@ -44,6 +52,8 @@ from mixle.utils.hvis.affinity import (
     local_factors,
 )
 
+_MAX_QUAD_BASE = 8  # quadratic lift caps its base at this many pre-PCA directions
+
 
 def _sqrt_psd(mat: np.ndarray) -> np.ndarray:
     vals, vecs = np.linalg.eigh(np.asarray(mat, dtype=np.float64))
@@ -58,13 +68,110 @@ def _canonical_signs(components: np.ndarray) -> np.ndarray:
     return components * flips
 
 
+def _lift_quadratic(v: np.ndarray) -> np.ndarray:
+    """Explicit degree-2 polynomial features: ``[v, v_i v_j for i <= j]`` -- a closed-form,
+    deterministic, placement-compatible nonlinear chart."""
+    n, m = v.shape
+    prods = [v[:, i] * v[:, j] for i in range(m) for j in range(i, m)]
+    return np.column_stack([v] + prods)
+
+
+def _quad_labels(base: list[str]) -> list[str]:
+    m = len(base)
+    return list(base) + [f"{base[i]}*{base[j]}" for i in range(m) for j in range(i, m)]
+
+
+def component_fiber_coords(mix_model, data, field_weights=None) -> tuple[np.ndarray, list[np.ndarray], list[str], dict]:
+    """The shared fiber machinery: posteriors, per-component whitened field coordinates, labels.
+
+    Returns ``(z, [u_k for each component], coord_labels, transforms)`` where ``u_k`` is the
+    (n, D) concatenation of every coordinate-bearing field's values, whitened by component ``k``'s
+    local inverse covariance and weighted per field. ``transforms`` carries everything needed to
+    reproduce the coordinates for NEW data (used by :meth:`ModelMap.place` and by
+    :func:`mixle.utils.hvis.topology.model_fit_health`).
+    """
+    data = list(data)
+    z, _ = _posteriors_and_loglikes(mix_model, data=data)
+    k_count = z.shape[1]
+    factors = local_factors(mix_model, data, field_weights=field_weights)
+    terms = list(_field_log_density_features(list(mix_model.components), data))
+
+    field_specs, xs, labels, keep = [], [], [], []
+    for f_pos, (factor, (_l, x_f, native_f)) in enumerate(zip(factors, terms)):
+        if x_f is None:
+            continue
+        x_f = np.asarray(x_f, dtype=np.float64)
+        if not _is_local_factor(factor):  # coordinate-bearing fields are always local factors
+            raise ValueError("internal: coordinate-bearing fields must be local factors.")
+        weight = float(factor["weight"])
+        dof = float(factor.get("delta_scale", 1.0))
+        field_specs.append({"dim": x_f.shape[1], "weight_sqrt": float(np.sqrt(weight / dof))})
+        xs.append(x_f)
+        keep.append(f_pos)
+        kind = "native" if native_f else "typicality"
+        labels.extend([f"field{f_pos}[{kind}]:{c}" for c in range(x_f.shape[1])])
+
+    inv_covs = [np.asarray(factors[i]["inv_cov"], dtype=np.float64) for i in keep]
+    whiteners = [[_sqrt_psd(inv_covs[f_pos][k]) for f_pos in range(len(keep))] for k in range(k_count)]
+    us = [
+        np.column_stack([(x @ w) * spec["weight_sqrt"] for x, w, spec in zip(xs, whiteners[k], field_specs)])
+        for k in range(k_count)
+    ]
+    transforms = {"keep": keep, "field_specs": field_specs, "whiteners": whiteners}
+    return z, us, labels, transforms
+
+
+def _resolve_overlap(
+    vertices: np.ndarray,
+    radii: np.ndarray,
+    allowed: set[tuple[int, int]],
+    *,
+    margin: float = 1.05,
+    max_sweeps: int = 200,
+) -> np.ndarray:
+    """Deterministic push-apart: components with NO measured overlap in the model must not overlap
+    on screen. Pairs in ``allowed`` (model overlap present) may overlap visually -- screen overlap
+    then MEANS model overlap. Pushes only ever grow separations, so adjacency orderings among the
+    allowed pairs are preserved."""
+    v = vertices.copy()
+    k = v.shape[0]
+    for _ in range(int(max_sweeps)):
+        moved = False
+        for a in range(k):
+            for b in range(a + 1, k):
+                if (a, b) in allowed:
+                    continue
+                need = margin * (radii[a] + radii[b])
+                diff = v[b] - v[a]
+                dist = float(np.linalg.norm(diff))
+                if dist >= need:
+                    continue
+                if dist <= 1.0e-12:  # coincident: split along a deterministic, pair-specific angle
+                    angle = 2.0 * np.pi * (a * k + b) / float(k * k)
+                    direction = np.zeros(v.shape[1])
+                    direction[0], direction[min(1, v.shape[1] - 1)] = np.cos(angle), np.sin(angle)
+                else:
+                    direction = diff / dist
+                push = (need - dist) / 2.0
+                v[a] -= push * direction
+                v[b] += push * direction
+                moved = True
+        if not moved:
+            break
+    return v
+
+
 @dataclass
 class ModelMap:
     """A fitted direct layout: coordinates plus everything needed to read and extend the map.
 
-    ``vertices`` are the component anchors; ``loadings[k]`` names what regime ``k``'s fiber axes
-    measure (rows = concatenated whitened field coordinates, see ``coord_labels``); ``place(data)``
-    maps NEW observations with the fit-time transforms -- closed form, so streaming is one call.
+    ``vertices`` are the component anchors (post occlusion resolution); ``loadings[k]`` names what
+    regime ``k``'s chart axes measure (rows = chart features, see ``coord_labels``); ``frames[k]``
+    is the chart's on-screen frame (row 0 = the major axis's direction); ``chart_residuals[k]`` is
+    the fraction of fiber variance the LINEAR chart leaves beyond ``emb_dim`` (high = this regime's
+    within-structure is not 2-D-linear -- consider ``chart='quadratic'`` or ``refine=True``);
+    ``place(data)`` maps NEW observations with the fit-time transforms -- closed form, so streaming
+    is one call.
     """
 
     coords: np.ndarray
@@ -72,43 +179,51 @@ class ModelMap:
     responsibilities: np.ndarray
     loadings: list[np.ndarray]
     coord_labels: list[str]
+    frames: list[np.ndarray] = field(default_factory=list)
+    chart: str = "linear"
+    chart_residuals: np.ndarray = field(default_factory=lambda: np.zeros(0))
     _model: object = field(repr=False, default=None)
-    _keep_fields: list[int] = field(repr=False, default_factory=list)
-    _field_specs: list[dict] = field(repr=False, default_factory=list)
+    _transforms: dict = field(repr=False, default_factory=dict)
+    _pre: list = field(repr=False, default_factory=list)  # per-k (pre_mu, pre_dirs) or None
     _fiber_means: list[np.ndarray] = field(repr=False, default_factory=list)
-    _fiber_whiteners: list[list[np.ndarray]] = field(repr=False, default_factory=list)
     _fiber_scale: float = field(repr=False, default=1.0)
     _emb_dim: int = field(repr=False, default=2)
 
+    def _chart_features(self, u: np.ndarray, k: int) -> np.ndarray:
+        if self.chart == "linear":
+            return u
+        pre = self._pre[k]
+        v = u if pre is None else (u - pre[0]) @ pre[1]
+        return _lift_quadratic(v)
+
     def place(self, data) -> np.ndarray:
         """Closed-form out-of-sample placement with the FIT-TIME transforms (means, whiteners,
-        fiber directions, scale). Placing the training data reproduces ``coords`` exactly."""
+        chart directions, frames, scale). Placing the training data reproduces ``coords`` exactly."""
         data = list(data)
         z, _ = _posteriors_and_loglikes(self._model, data=data)
         terms = list(_field_log_density_features(list(self._model.components), data))
-        if max(self._keep_fields, default=-1) >= len(terms):
+        keep = self._transforms["keep"]
+        if max(keep, default=-1) >= len(terms):
             raise ValueError("data decomposes into a different field set than the fitted map.")
         xs = []
-        for f_pos in self._keep_fields:
+        for f_pos, spec in zip(keep, self._transforms["field_specs"]):
             x_f = terms[f_pos][1]
-            if x_f is None:
+            if x_f is None or np.asarray(x_f).shape[1] != spec["dim"]:
                 raise ValueError("data decomposes into a different field set than the fitted map.")
             xs.append(np.asarray(x_f, dtype=np.float64))
         k_count = self.vertices.shape[0]
         y = np.zeros((len(data), self._emb_dim))
         for k in range(k_count):
-            u = self._whitened_block(xs, k)
-            scores = (u - self._fiber_means[k]) @ self.loadings[k] * self._fiber_scale
-            y += z[:, k : k + 1] * (self.vertices[k][None, :] + scores)
+            u = np.column_stack(
+                [
+                    (x @ w) * spec["weight_sqrt"]
+                    for x, w, spec in zip(xs, self._transforms["whiteners"][k], self._transforms["field_specs"])
+                ]
+            )
+            feats = self._chart_features(u, k)
+            scores = (feats - self._fiber_means[k]) @ self.loadings[k] * self._fiber_scale
+            y += z[:, k : k + 1] * (self.vertices[k][None, :] + scores @ self.frames[k])
         return y
-
-    def _whitened_block(self, xs: list[np.ndarray], k: int) -> np.ndarray:
-        parts = []
-        for x_f, spec, whitener in zip(xs, self._field_specs, self._fiber_whiteners[k]):
-            if x_f is None or x_f.shape[1] != spec["dim"]:
-                raise ValueError("field coordinates do not match the fitted map's field shapes.")
-            parts.append((x_f @ whitener) * spec["weight_sqrt"])
-        return np.column_stack(parts)
 
 
 def model_map(
@@ -117,6 +232,10 @@ def model_map(
     emb_dim: int = 2,
     *,
     spread: float = 0.35,
+    chart: str = "linear",
+    occlusion: bool = True,
+    occlusion_margin: float = 1.05,
+    edge_threshold: float = 0.02,
     field_weights=None,
     max_components: int = 50,
     dpm_max_its: int = 200,
@@ -128,12 +247,16 @@ def model_map(
 
     ``spread`` sets how large regime fibers render relative to the smallest inter-vertex gap --
     a LEGIBILITY choice made explicit, unlike t-SNE where cluster sizes are a meaningless artifact.
-    ``seed``/``max_components``/``dpm_max_its`` only matter when ``mix_model`` is None and a DPM
-    must be fit first; the layout itself uses no randomness. ``refine=True`` polishes local
-    neighborhoods with t-SNE initialized FROM this layout (exaggeration off), leaving the global
-    arrangement model-decided; the refined coordinates replace ``coords`` (the skeleton stays
-    available as ``vertices``).
+    ``chart`` is ``'linear'`` (default) or ``'quadratic'`` (explicit degree-2 features -- a curved
+    within-regime chart that stays closed-form and placeable); either way ``chart_residuals``
+    reports the linear chart's leftover variance per regime. ``occlusion=True`` enforces that
+    components with no measured overlap never overlap on screen. ``seed``/``max_components``/
+    ``dpm_max_its`` only matter when ``mix_model`` is None and a DPM must be fit first; the layout
+    itself uses no randomness. ``refine=True`` polishes local neighborhoods with t-SNE initialized
+    FROM this layout (exaggeration off), leaving the global arrangement model-decided.
     """
+    if chart not in ("linear", "quadratic"):
+        raise ValueError("chart must be 'linear' or 'quadratic'.")
     data = list(data)
     if mix_model is None:
         from mixle.utils.automatic import get_dpm_mixture
@@ -142,50 +265,55 @@ def model_map(
             data, rng=np.random.RandomState(seed), max_components=max_components, max_its=dpm_max_its, out=None
         )
 
-    z, _ = _posteriors_and_loglikes(mix_model, data=data)
+    z, us, base_labels, transforms = component_fiber_coords(mix_model, data, field_weights=field_weights)
     n, k_count = z.shape
-    vertices = component_map(z, emb_dim=emb_dim)
+    vertices = component_map(z, emb_dim=emb_dim, edge_threshold=edge_threshold)
 
-    factors = local_factors(mix_model, data, field_weights=field_weights)
-    terms = list(_field_log_density_features(list(mix_model.components), data))
-    field_specs, xs, labels = [], [], []
-    for f_pos, (factor, (_l, x_f, native_f)) in enumerate(zip(factors, terms)):
-        if x_f is None:
-            field_specs.append(None)
-            xs.append(None)
-            continue
-        x_f = np.asarray(x_f, dtype=np.float64)
-        weight = float(factor["weight"]) if _is_local_factor(factor) else 1.0
-        dof = float(factor.get("delta_scale", 1.0)) if _is_local_factor(factor) else 1.0
-        field_specs.append({"dim": x_f.shape[1], "weight_sqrt": np.sqrt(weight / dof)})
-        xs.append(x_f)
-        kind = "native" if native_f else "typicality"
-        labels.extend([f"field{f_pos}[{kind}]:{c}" for c in range(x_f.shape[1])])
-    keep = [i for i, spec in enumerate(field_specs) if spec is not None]
-    field_specs = [field_specs[i] for i in keep]
-    xs = [xs[i] for i in keep]
-    inv_covs = [np.asarray(factors[i]["inv_cov"], dtype=np.float64) for i in keep if _is_local_factor(factors[i])]
-    if len(inv_covs) != len(keep):  # a posterior-only tuple factor slipped through with coords: not expected
-        raise ValueError("internal: coordinate-bearing fields must be local factors.")
-
-    fiber_means, fiber_whiteners, loadings, raw_scores = [], [], [], []
+    fiber_means, loadings, raw_scores, pre_list, residuals = [], [], [], [], []
+    labels = list(base_labels)
     for k in range(k_count):
-        whiteners = [_sqrt_psd(inv_covs[f_pos][k]) for f_pos in range(len(keep))]
-        u = np.column_stack([(x @ w) * spec["weight_sqrt"] for x, w, spec in zip(xs, whiteners, field_specs)])
+        u = us[k]
         wk = z[:, k]
-        sw = float(wk.sum())
-        mu = (wk @ u) / sw if sw > 0 else u.mean(axis=0)
-        centered = u - mu
-        cov = (centered * wk[:, None]).T @ centered / max(sw, 1.0e-12)
+        sw = max(float(wk.sum()), 1.0e-12)
+
+        # linear-chart residual report: how much fiber variance emb_dim linear axes leave behind
+        mu_u = (wk @ u) / sw
+        cov_u = ((u - mu_u) * wk[:, None]).T @ (u - mu_u) / sw
+        vals_u = np.sort(np.linalg.eigvalsh(cov_u))[::-1]
+        total = float(vals_u.sum())
+        residuals.append(0.0 if total <= 0 else float(max(0.0, 1.0 - vals_u[:emb_dim].sum() / total)))
+
+        if chart == "quadratic":
+            if u.shape[1] > _MAX_QUAD_BASE:
+                vals, vecs = np.linalg.eigh(cov_u)
+                order = np.argsort(vals)[::-1][:_MAX_QUAD_BASE]
+                pre = (mu_u, _canonical_signs(vecs[:, order]))
+                feats = _lift_quadratic((u - pre[0]) @ pre[1])
+            else:
+                pre = None
+                feats = _lift_quadratic(u)
+        else:
+            pre = None
+            feats = u
+        pre_list.append(pre)
+
+        mu = (wk @ feats) / sw
+        centered = feats - mu
+        cov = (centered * wk[:, None]).T @ centered / sw
         vals, vecs = np.linalg.eigh(cov)
         order = np.argsort(vals)[::-1][:emb_dim]
         p = _canonical_signs(vecs[:, order])
         if p.shape[1] < emb_dim:
             p = np.column_stack([p, np.zeros((p.shape[0], emb_dim - p.shape[1]))])
         fiber_means.append(mu)
-        fiber_whiteners.append(whiteners)
         loadings.append(p)
         raw_scores.append(centered @ p)
+
+    if chart == "quadratic":
+        if pre_list[0] is None:
+            labels = _quad_labels(base_labels)
+        else:
+            labels = _quad_labels([f"pre_pc{i}" for i in range(_MAX_QUAD_BASE)])
 
     stds = [
         float(np.sqrt(np.average(np.sum(s**2, axis=1), weights=np.maximum(z[:, k], 1e-12))))
@@ -197,9 +325,44 @@ def model_map(
     med_std = float(np.median([s for s in stds if s > 0]) or 1.0)
     scale = (spread * ref / med_std) if med_std > 0 else 1.0
 
+    if occlusion and k_count > 1:
+        dominant = z.argmax(axis=1)
+        radii = np.zeros(k_count)
+        for k in range(k_count):
+            mine = raw_scores[k][dominant == k] * scale
+            radii[k] = float(np.percentile(np.linalg.norm(mine, axis=1), 90)) if len(mine) else 0.0
+        masses = np.maximum(z.sum(axis=0), 1.0e-12)
+        co = z.T @ z
+        allowed = {
+            (a, b)
+            for a in range(k_count)
+            for b in range(a + 1, k_count)
+            if co[a, b] / min(masses[a], masses[b]) >= edge_threshold
+        }
+        vertices = _resolve_overlap(vertices, radii, allowed, margin=occlusion_margin)
+
+    # per-chart frames: orient each chart's MAJOR axis tangentially (orthogonal to the nearest
+    # other vertex) so neighboring charts' fringes cannot collide head-on. Computed from the FINAL
+    # vertices, after occlusion.
+    frames = []
+    for k in range(k_count):
+        if emb_dim != 2 or k_count < 2:
+            frames.append(np.eye(emb_dim))
+            continue
+        others = [j for j in range(k_count) if j != k]
+        nearest = min(others, key=lambda j: float(np.linalg.norm(vertices[j] - vertices[k])))
+        radial = vertices[nearest] - vertices[k]
+        norm = float(np.linalg.norm(radial))
+        if norm <= 1.0e-12:
+            frames.append(np.eye(2))
+            continue
+        radial = radial / norm
+        tangent = np.array([-radial[1], radial[0]])
+        frames.append(np.stack([tangent, radial]))  # rows: major axis -> tangent, minor -> radial
+
     coords = np.zeros((n, emb_dim))
     for k in range(k_count):
-        coords += z[:, k : k + 1] * (vertices[k][None, :] + raw_scores[k] * scale)
+        coords += z[:, k : k + 1] * (vertices[k][None, :] + (raw_scores[k] * scale) @ frames[k])
 
     result = ModelMap(
         coords=coords,
@@ -207,11 +370,13 @@ def model_map(
         responsibilities=z,
         loadings=loadings,
         coord_labels=labels,
+        frames=frames,
+        chart=chart,
+        chart_residuals=np.asarray(residuals),
         _model=mix_model,
-        _keep_fields=keep,
-        _field_specs=field_specs,
+        _transforms=transforms,
+        _pre=pre_list,
         _fiber_means=fiber_means,
-        _fiber_whiteners=fiber_whiteners,
         _fiber_scale=scale,
         _emb_dim=emb_dim,
     )

--- a/mixle/utils/hvis/direct.py
+++ b/mixle/utils/hvis/direct.py
@@ -1,0 +1,235 @@
+"""The direct compositional layout: read the map off the model instead of re-inferring it.
+
+t-SNE/UMAP exist to DISCOVER global and local structure from raw pairwise distances when there is
+no model. HViS has a model, and the structure the neighbor optimizers spend a thousand stochastic
+iterations inferring is already known in closed form: WHICH regimes exist and how they relate (the
+posterior simplex and component overlap geometry), and WHERE each observation sits within its
+regime (the whitened local/typicality coordinates). This module composes those two levels directly
+-- the (posterior, remainder) decomposition as a layout:
+
+    y_i = sum_k z_ik * (vertex_k + fiber_scores_ik)
+
+* vertices: :func:`~mixle.utils.hvis.affinity.component_map` -- classical MDS on the components'
+  overlap geometry (confusable regimes adjacent). Deterministic.
+* fibers: per component, a responsibility-weighted PCA of the per-field WHITENED local coordinates
+  (native value coordinates or universal typicality coordinates -- the same geometry the 'local'
+  affinity scores). Deterministic up to sign, and signs are canonicalized. The loadings are
+  returned, so a fiber axis is NAMEABLE: "within regime k, axis 1 is field 2's coordinate 0".
+* composition: barycentric in the posterior, so sharp points sit in their regime's local chart and
+  mixed-membership points interpolate between charts.
+
+No perplexity, no seed, no optimizer failure modes; out-of-sample placement (:meth:`ModelMap.place`)
+is the same closed form, so streaming costs one matrix product. The precedent is Bishop & Tipping's
+hierarchical mixture visualization / GTM: per-component local projections composed by
+responsibility -- rebuilt here on HViS's field decomposition so it covers heterogeneous,
+variable-length, and sequence data.
+
+When to still reach for the neighbor optimizers: no trustworthy model, strongly nonlinear
+within-regime manifolds a linear fiber chart flattens, or pure exploration. ``refine=True`` runs
+t-SNE FROM this layout (informative init, exaggeration off) so the optimizer only polishes local
+neighborhoods it is actually good at -- the composition stays in charge of the global picture.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import numpy as np
+
+from mixle.utils.hvis.affinity import (
+    _field_log_density_features,
+    _is_local_factor,
+    _posteriors_and_loglikes,
+    component_map,
+    local_factors,
+)
+
+
+def _sqrt_psd(mat: np.ndarray) -> np.ndarray:
+    vals, vecs = np.linalg.eigh(np.asarray(mat, dtype=np.float64))
+    return vecs @ np.diag(np.sqrt(np.maximum(vals, 0.0))) @ vecs.T
+
+
+def _canonical_signs(components: np.ndarray) -> np.ndarray:
+    """Fix each principal direction's sign so its largest-magnitude loading is positive --
+    determinism must not depend on LAPACK's arbitrary eigenvector signs."""
+    flips = np.sign(components[np.abs(components).argmax(axis=0), np.arange(components.shape[1])])
+    flips[flips == 0] = 1.0
+    return components * flips
+
+
+@dataclass
+class ModelMap:
+    """A fitted direct layout: coordinates plus everything needed to read and extend the map.
+
+    ``vertices`` are the component anchors; ``loadings[k]`` names what regime ``k``'s fiber axes
+    measure (rows = concatenated whitened field coordinates, see ``coord_labels``); ``place(data)``
+    maps NEW observations with the fit-time transforms -- closed form, so streaming is one call.
+    """
+
+    coords: np.ndarray
+    vertices: np.ndarray
+    responsibilities: np.ndarray
+    loadings: list[np.ndarray]
+    coord_labels: list[str]
+    _model: object = field(repr=False, default=None)
+    _keep_fields: list[int] = field(repr=False, default_factory=list)
+    _field_specs: list[dict] = field(repr=False, default_factory=list)
+    _fiber_means: list[np.ndarray] = field(repr=False, default_factory=list)
+    _fiber_whiteners: list[list[np.ndarray]] = field(repr=False, default_factory=list)
+    _fiber_scale: float = field(repr=False, default=1.0)
+    _emb_dim: int = field(repr=False, default=2)
+
+    def place(self, data) -> np.ndarray:
+        """Closed-form out-of-sample placement with the FIT-TIME transforms (means, whiteners,
+        fiber directions, scale). Placing the training data reproduces ``coords`` exactly."""
+        data = list(data)
+        z, _ = _posteriors_and_loglikes(self._model, data=data)
+        terms = list(_field_log_density_features(list(self._model.components), data))
+        if max(self._keep_fields, default=-1) >= len(terms):
+            raise ValueError("data decomposes into a different field set than the fitted map.")
+        xs = []
+        for f_pos in self._keep_fields:
+            x_f = terms[f_pos][1]
+            if x_f is None:
+                raise ValueError("data decomposes into a different field set than the fitted map.")
+            xs.append(np.asarray(x_f, dtype=np.float64))
+        k_count = self.vertices.shape[0]
+        y = np.zeros((len(data), self._emb_dim))
+        for k in range(k_count):
+            u = self._whitened_block(xs, k)
+            scores = (u - self._fiber_means[k]) @ self.loadings[k] * self._fiber_scale
+            y += z[:, k : k + 1] * (self.vertices[k][None, :] + scores)
+        return y
+
+    def _whitened_block(self, xs: list[np.ndarray], k: int) -> np.ndarray:
+        parts = []
+        for x_f, spec, whitener in zip(xs, self._field_specs, self._fiber_whiteners[k]):
+            if x_f is None or x_f.shape[1] != spec["dim"]:
+                raise ValueError("field coordinates do not match the fitted map's field shapes.")
+            parts.append((x_f @ whitener) * spec["weight_sqrt"])
+        return np.column_stack(parts)
+
+
+def model_map(
+    data,
+    mix_model=None,
+    emb_dim: int = 2,
+    *,
+    spread: float = 0.35,
+    field_weights=None,
+    max_components: int = 50,
+    dpm_max_its: int = 200,
+    seed: int | None = None,
+    refine: bool = False,
+    refine_kwargs: dict | None = None,
+) -> ModelMap:
+    """The deterministic model-native layout (see module docstring). Returns a :class:`ModelMap`.
+
+    ``spread`` sets how large regime fibers render relative to the smallest inter-vertex gap --
+    a LEGIBILITY choice made explicit, unlike t-SNE where cluster sizes are a meaningless artifact.
+    ``seed``/``max_components``/``dpm_max_its`` only matter when ``mix_model`` is None and a DPM
+    must be fit first; the layout itself uses no randomness. ``refine=True`` polishes local
+    neighborhoods with t-SNE initialized FROM this layout (exaggeration off), leaving the global
+    arrangement model-decided; the refined coordinates replace ``coords`` (the skeleton stays
+    available as ``vertices``).
+    """
+    data = list(data)
+    if mix_model is None:
+        from mixle.utils.automatic import get_dpm_mixture
+
+        mix_model = get_dpm_mixture(
+            data, rng=np.random.RandomState(seed), max_components=max_components, max_its=dpm_max_its, out=None
+        )
+
+    z, _ = _posteriors_and_loglikes(mix_model, data=data)
+    n, k_count = z.shape
+    vertices = component_map(z, emb_dim=emb_dim)
+
+    factors = local_factors(mix_model, data, field_weights=field_weights)
+    terms = list(_field_log_density_features(list(mix_model.components), data))
+    field_specs, xs, labels = [], [], []
+    for f_pos, (factor, (_l, x_f, native_f)) in enumerate(zip(factors, terms)):
+        if x_f is None:
+            field_specs.append(None)
+            xs.append(None)
+            continue
+        x_f = np.asarray(x_f, dtype=np.float64)
+        weight = float(factor["weight"]) if _is_local_factor(factor) else 1.0
+        dof = float(factor.get("delta_scale", 1.0)) if _is_local_factor(factor) else 1.0
+        field_specs.append({"dim": x_f.shape[1], "weight_sqrt": np.sqrt(weight / dof)})
+        xs.append(x_f)
+        kind = "native" if native_f else "typicality"
+        labels.extend([f"field{f_pos}[{kind}]:{c}" for c in range(x_f.shape[1])])
+    keep = [i for i, spec in enumerate(field_specs) if spec is not None]
+    field_specs = [field_specs[i] for i in keep]
+    xs = [xs[i] for i in keep]
+    inv_covs = [np.asarray(factors[i]["inv_cov"], dtype=np.float64) for i in keep if _is_local_factor(factors[i])]
+    if len(inv_covs) != len(keep):  # a posterior-only tuple factor slipped through with coords: not expected
+        raise ValueError("internal: coordinate-bearing fields must be local factors.")
+
+    fiber_means, fiber_whiteners, loadings, raw_scores = [], [], [], []
+    for k in range(k_count):
+        whiteners = [_sqrt_psd(inv_covs[f_pos][k]) for f_pos in range(len(keep))]
+        u = np.column_stack([(x @ w) * spec["weight_sqrt"] for x, w, spec in zip(xs, whiteners, field_specs)])
+        wk = z[:, k]
+        sw = float(wk.sum())
+        mu = (wk @ u) / sw if sw > 0 else u.mean(axis=0)
+        centered = u - mu
+        cov = (centered * wk[:, None]).T @ centered / max(sw, 1.0e-12)
+        vals, vecs = np.linalg.eigh(cov)
+        order = np.argsort(vals)[::-1][:emb_dim]
+        p = _canonical_signs(vecs[:, order])
+        if p.shape[1] < emb_dim:
+            p = np.column_stack([p, np.zeros((p.shape[0], emb_dim - p.shape[1]))])
+        fiber_means.append(mu)
+        fiber_whiteners.append(whiteners)
+        loadings.append(p)
+        raw_scores.append(centered @ p)
+
+    stds = [
+        float(np.sqrt(np.average(np.sum(s**2, axis=1), weights=np.maximum(z[:, k], 1e-12))))
+        for k, s in enumerate(raw_scores)
+    ]
+    gaps = [float(np.linalg.norm(vertices[a] - vertices[b])) for a in range(k_count) for b in range(a + 1, k_count)]
+    nonzero_gaps = [g for g in gaps if g > 0]
+    ref = min(nonzero_gaps) if nonzero_gaps else 1.0
+    med_std = float(np.median([s for s in stds if s > 0]) or 1.0)
+    scale = (spread * ref / med_std) if med_std > 0 else 1.0
+
+    coords = np.zeros((n, emb_dim))
+    for k in range(k_count):
+        coords += z[:, k : k + 1] * (vertices[k][None, :] + raw_scores[k] * scale)
+
+    result = ModelMap(
+        coords=coords,
+        vertices=vertices,
+        responsibilities=z,
+        loadings=loadings,
+        coord_labels=labels,
+        _model=mix_model,
+        _keep_fields=keep,
+        _field_specs=field_specs,
+        _fiber_means=fiber_means,
+        _fiber_whiteners=fiber_whiteners,
+        _fiber_scale=scale,
+        _emb_dim=emb_dim,
+    )
+
+    if refine:
+        import io
+
+        from mixle.utils.hvis.embed import htsne
+
+        kwargs = dict(refine_kwargs or {})
+        kwargs.setdefault("max_its", 400)
+        kwargs.setdefault("out", io.StringIO())
+        y0 = coords.copy()
+        y_std = float(y0.std())
+        if y_std > 0:  # optimizer-conventional init scale; the arrangement, not the size, is the information
+            y0 = y0 * (1.0e-4 / y_std)
+        result.coords = np.asarray(
+            htsne(data, mix_model=mix_model, emb_dim=emb_dim, Y=y0, seed=seed, **kwargs), dtype=np.float64
+        )
+
+    return result

--- a/mixle/utils/hvis/embed.py
+++ b/mixle/utils/hvis/embed.py
@@ -65,8 +65,14 @@ def htsne(
     candidate_multiplier: int = 8,
     repulsion_method: str = "auto",
     exact_repulsion_threshold: int = 5000,
+    goals=None,
 ):
     """Embed heterogeneous data with model-based t-SNE.
+
+    goals: optional sequence of embedding goals (mixle.utils.hvis.goals) -- Anchor pins for
+    anchoring, LabelCohesion for partial labeling, AxisAlign for layout objectives. Goal gradients
+    join the data gradient every iteration on BOTH engines; hard anchors are re-projected exactly
+    after every step.
 
     A mixture model is fit to the data (a Dirichlet process mixture with
     automatically typed components by default, or pass mix_model), pairwise
@@ -213,6 +219,7 @@ def htsne(
             leaf_size=barnes_hut_leaf_size,
             repulsion_method=repulsion_method,
             exact_repulsion_threshold=exact_repulsion_threshold,
+            goals=goals,
         )
 
     P = get_pmat(z_ij, l_ij, targ_perplexity=perplexity, affinity=affinity, evidence_cap=evidence_cap)
@@ -234,6 +241,7 @@ def htsne(
         print_iter=print_iter,
         seed=seed,
         out=out,
+        goals=goals,
     )
 
 
@@ -256,6 +264,8 @@ def humap(
     fisher_information: str = "observed",
     n_epochs: int | None = None,
     out=None,
+    engine: str = "auto",
+    goals=None,
     **umap_kwargs,
 ):
     """Embed heterogeneous data with model-based UMAP.
@@ -263,24 +273,54 @@ def humap(
     The same mixture-model affinities as htsne (see the affinity and
     evidence_cap arguments there), but the k-nearest-neighbor graph of model
     distances -log s_ij is handed to UMAP's fuzzy simplicial set construction
-    and layout (umap-learn) instead of t-SNE. Scales like UMAP: the dense
-    affinity matrix is never built.
+    and layout instead of t-SNE. Scales like UMAP: the dense affinity matrix
+    is never built.
 
-    Extra keyword arguments are passed to umap.UMAP. Returns the n x emb_dim
-    embedding.
+    engine selects the layout backend:
+        'umap-learn' - the optional umap-learn package (extra keyword
+            arguments are passed to umap.UMAP). Cannot honor goals: its numba
+            SGD loop takes no external gradients, so goals raise rather than
+            being silently dropped.
+        'internal'   - mixle.utils.hvis.umap_np, a dependency-free UMAP core
+            (same construction: smoothed-kNN fuzzy graph, fitted a/b curve,
+            epochs-per-sample SGD with negative sampling). Slower than the
+            numba path but always available, and the only engine that can
+            steer the layout with goals.
+        'auto'       - umap-learn when it is installed AND no goals were
+            given; the internal engine otherwise.
+
+    goals: optional sequence of embedding goals (mixle.utils.hvis.goals) --
+    Anchor / LabelCohesion / AxisAlign, as in htsne. Requires the internal
+    engine (auto selects it when goals are present).
     """
-    try:
-        import warnings
+    if engine not in ("auto", "umap-learn", "internal"):
+        raise ValueError("engine must be 'auto', 'umap-learn', or 'internal'.")
 
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                "ignore", message="Tensorflow not installed; ParametricUMAP will be unavailable", category=ImportWarning
-            )
-            import umap
-    except ImportError:
-        from mixle.utils.optional_deps import require
+    umap = None
+    if engine in ("auto", "umap-learn"):
+        try:
+            import warnings
 
-        require("umap-learn", "umap")
+            with warnings.catch_warnings():
+                warnings.filterwarnings(
+                    "ignore",
+                    message="Tensorflow not installed; ParametricUMAP will be unavailable",
+                    category=ImportWarning,
+                )
+                import umap
+        except ImportError:
+            if engine == "umap-learn":
+                from mixle.utils.optional_deps import require
+
+                require("umap-learn", "umap")
+
+    if engine == "umap-learn" and goals:
+        raise ValueError(
+            "goals require engine='internal' (or 'auto'): umap-learn's layout loop cannot honor them, "
+            "and silently dropping a stated goal would be worse than refusing."
+        )
+    if engine == "auto":
+        engine = "umap-learn" if (umap is not None and not goals) else "internal"
 
     if out is None:
         out = sys.stdout
@@ -320,6 +360,20 @@ def humap(
     k = min(n_neighbors, n - 1)
 
     knn_idx, knn_dist = model_knn(z_ij, l_ij, k=k, affinity=affinity, evidence_cap=evidence_cap)
+
+    if engine == "internal":
+        from mixle.utils.hvis.umap_np import internal_umap
+
+        return internal_umap(
+            knn_idx,
+            knn_dist,
+            emb_dim=emb_dim,
+            min_dist=min_dist,
+            n_epochs=n_epochs,
+            seed=seed,
+            goals=goals,
+            **umap_kwargs,
+        )
 
     reducer = umap.UMAP(
         n_components=emb_dim,

--- a/mixle/utils/hvis/embed.py
+++ b/mixle/utils/hvis/embed.py
@@ -45,7 +45,7 @@ def htsne(
     mix_model=None,
     enc_data=None,
     method: str = "auto",
-    early_exaggeration: float = 12.0,
+    early_exaggeration: float | None = None,
     tol: float = 1.0e-7,
     dpm_max_its: int = 200,
     affinity="auto",
@@ -73,6 +73,18 @@ def htsne(
     anchoring, LabelCohesion for partial labeling, AxisAlign for layout objectives. Goal gradients
     join the data gradient every iteration on BOTH engines; hard anchors are re-projected exactly
     after every step.
+
+    Y='barycentric' initializes every observation at its posterior-weighted combination of
+    component vertices laid out by overlap geometry (see affinity.barycentric_init): the layout's
+    global arrangement comes from the model instead of the random seed, so runs are globally
+    consistent and mixed-membership points start (and tend to stay) between their clusters.
+
+    early_exaggeration=None (the default) resolves to 12.0 for a random init and 1.0 for an
+    informative one (Y='barycentric' or a supplied array): exaggeration exists to FORM global
+    structure from randomness, and given a meaningful init it does the opposite -- crushes
+    confusable clusters together before the refine phase can save them (measured: 0.71-0.89
+    purity and seed-dependent arrangements at 12.0, a seed-stable 0.96 at 1.0). Pass a number to
+    override.
 
     A mixture model is fit to the data (a Dirichlet process mixture with
     automatically typed components by default, or pass mix_model), pairwise
@@ -174,6 +186,27 @@ def htsne(
     else:
         z_ij, l_ij = _posteriors_and_loglikes(mix_model, data=data, enc_data=enc_data)
         n = z_ij.shape[0]
+
+    informative_init = Y is not None
+    if isinstance(Y, str):
+        if Y != "barycentric":
+            raise ValueError("Y accepts an (n, emb_dim) array, None, or the string 'barycentric'.")
+        if z_ij is not None:
+            z_bary = z_ij
+        elif mix_model is not None:  # 'auto'/'local' resolve to factor lists before posteriors exist
+            z_bary, _ = _posteriors_and_loglikes(mix_model, data=data, enc_data=enc_data)
+        else:
+            raise ValueError(
+                "Y='barycentric' needs mixture posteriors (a mix_model, or data to fit one); "
+                "a pre-built affinity factor list without a model carries no posterior to take "
+                "barycentric coordinates of."
+            )
+        from mixle.utils.hvis.affinity import barycentric_init
+
+        Y = barycentric_init(z_bary, emb_dim=emb_dim, seed=seed)
+
+    if early_exaggeration is None:
+        early_exaggeration = 1.0 if informative_init else 12.0
 
     if method == "auto":
         method = "exact" if (optimize_alpha or n <= 10) else "barnes_hut"

--- a/mixle/utils/hvis/front.py
+++ b/mixle/utils/hvis/front.py
@@ -1,0 +1,212 @@
+"""The one front door (design review R1): call one thing, get coordinates + receipts.
+
+``hvis.map(data)`` runs the whole pipeline the package's pieces add up to: fit or accept a model,
+compose the direct layout (:func:`~mixle.utils.hvis.direct.model_map` -- deterministic, occlusion-
+resolved, optionally refined by t-SNE from the model-decided arrangement), and attach every receipt
+so "make it make sense" is a property of the RETURNED OBJECT, not of the user's diligence:
+
+* per-point uncertainty channels a plot can encode directly: ``posterior_entropy`` (mixed
+  membership) and ``typicality`` (log-density percentile; low = the model finds this point odd);
+* ``nerve`` + ``nerve_health`` -- the learned cover's topology (loops, disconnection);
+* ``fit_health`` -- does the MODEL describe the DATA (merged/shattered regimes, fiber calibration);
+* ``render_health`` -- does the MAP describe the MODEL (trustworthiness/continuity);
+* ``zoom(components)`` -- the hierarchy: re-chart a regime group with its own fibers, aligned back
+  to the parent (residual reported, never silently rotated);
+* ``summary()`` -- every diagnosis in one plain-text block.
+
+``htsne``/``humap`` remain the optimizer-flavored escape hatches; this is the default reading.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+
+from mixle.utils.hvis.direct import ModelMap, model_map
+from mixle.utils.hvis.topology import component_tree, embedding_health, fuzzy_nerve, model_fit_health, nerve_report
+
+__all__ = ["Map", "hvis_map"]
+
+
+@dataclass
+class Map:
+    """A finished map: coordinates, anchors, per-point uncertainty, and every receipt."""
+
+    base: ModelMap
+    posterior_entropy: np.ndarray = field(default_factory=lambda: np.zeros(0))
+    typicality: np.ndarray = field(default_factory=lambda: np.zeros(0))
+    nerve: dict = field(default_factory=dict)
+    nerve_health: dict = field(default_factory=dict)
+    fit_health: dict = field(default_factory=dict)
+    render_health: dict = field(default_factory=dict)
+    merge_tree: list = field(default_factory=list)
+    zoom_alignment_rms: float | None = None
+    _data: list = field(repr=False, default_factory=list)
+    _params: dict = field(repr=False, default_factory=dict)
+
+    # -- the readable surface (delegating to the underlying layout) --------------------------------
+
+    @property
+    def coords(self) -> np.ndarray:
+        return self.base.coords
+
+    @property
+    def vertices(self) -> np.ndarray:
+        return self.base.vertices
+
+    @property
+    def responsibilities(self) -> np.ndarray:
+        return self.base.responsibilities
+
+    @property
+    def model(self) -> Any:
+        return self.base._model  # noqa: SLF001 - the Map owns its layout
+
+    def place(self, data) -> np.ndarray:
+        return self.base.place(data)
+
+    @property
+    def diagnosis(self) -> list[str]:
+        """Every receipt's findings, one flat list -- empty means no receipt has a complaint."""
+        out: list[str] = []
+        for report in (self.nerve_health, self.fit_health, self.render_health):
+            out.extend(report.get("diagnosis", []))
+        return out
+
+    def summary(self) -> str:
+        z = self.responsibilities
+        lines = [
+            f"map: {len(self._data)} observations, {z.shape[1]} components, chart={self.base.chart}",
+            f"render: trustworthiness={self.render_health.get('trustworthiness', float('nan')):.2f} "
+            f"continuity={self.render_health.get('continuity', float('nan')):.2f}",
+            f"topology: {self.nerve_health.get('n_components', '?')} piece(s), "
+            f"{len(self.nerve_health.get('holes', []))} hole(s)",
+        ]
+        if self.zoom_alignment_rms is not None:
+            lines.append(f"zoom alignment rms vs parent: {self.zoom_alignment_rms:.3f}")
+        findings = self.diagnosis
+        lines.append("findings: none" if not findings else "findings:")
+        lines.extend(f"  - {d}" for d in findings)
+        return "\n".join(lines)
+
+    # -- hierarchy ----------------------------------------------------------------------------------
+
+    def zoom(self, components: list[int]) -> Map:
+        """Re-chart one regime group with its own fibers: the sub-mixture over ``components`` maps
+        the points they dominate, then the child layout is rigidly aligned (rotation/translation +
+        uniform scale) onto those points' PARENT positions -- continuity is measured
+        (``zoom_alignment_rms``), never assumed. Component indices in the child are positional
+        within ``components``."""
+        from mixle.stats import MixtureDistribution
+        from mixle.utils.hvis.stream import _procrustes_align
+
+        components = sorted(set(int(c) for c in components))
+        if len(components) < 1:
+            raise ValueError("zoom needs at least one component index.")
+        z = self.responsibilities
+        dominant = z.argmax(axis=1)
+        member_idx = [i for i in range(len(self._data)) if int(dominant[i]) in components]
+        if len(member_idx) < 5:
+            raise ValueError(f"components {components} dominate only {len(member_idx)} points -- nothing to zoom into.")
+
+        comps = list(self.model.components)
+        w = np.asarray(self.model.w, dtype=np.float64)[components]
+        sub_model = MixtureDistribution([comps[c] for c in components], w / w.sum())
+        sub_data = [self._data[i] for i in member_idx]
+
+        child = hvis_map(sub_data, sub_model, **self._params)
+        if len(components) > 1 and len(member_idx) >= 3:
+            aligned, rms, _scale = _procrustes_align(child.base.coords, self.coords[member_idx])
+            child.base.coords = aligned
+            child.zoom_alignment_rms = rms
+        return child
+
+
+def hvis_map(
+    data,
+    mix_model=None,
+    emb_dim: int = 2,
+    *,
+    spread: float = 0.35,
+    chart: str = "linear",
+    occlusion: bool = True,
+    refine: bool = False,
+    goals=None,
+    health: bool = True,
+    holdout=None,
+    field_weights=None,
+    max_components: int = 50,
+    dpm_max_its: int = 200,
+    seed: int | None = None,
+    refine_kwargs: dict | None = None,
+) -> Map:
+    """One call, one finished map (see module docstring). Deterministic unless a DPM must be fit.
+
+    ``goals`` (anchoring / partial labels / axis objectives) require the optimizer pass, so passing
+    them implies ``refine=True``. ``health=False`` skips the receipt computations (they are cheap
+    and subsampled; skip only in tight loops).
+    """
+    data = list(data)
+    kwargs = dict(refine_kwargs or {})
+    if goals:
+        refine = True
+        kwargs.setdefault("goals", goals)
+
+    base = model_map(
+        data,
+        mix_model=mix_model,
+        emb_dim=emb_dim,
+        spread=spread,
+        chart=chart,
+        occlusion=occlusion,
+        field_weights=field_weights,
+        max_components=max_components,
+        dpm_max_its=dpm_max_its,
+        seed=seed,
+        refine=refine,
+        refine_kwargs=kwargs if refine else None,
+    )
+    model = base._model  # noqa: SLF001 - the front door owns the layout it just built
+
+    z = base.responsibilities
+    with np.errstate(divide="ignore", invalid="ignore"):
+        entropy = -np.sum(np.where(z > 0, z * np.log(z), 0.0), axis=1)
+
+    if hasattr(model, "dist_to_encoder") and hasattr(model, "seq_log_density"):
+        enc = model.dist_to_encoder().seq_encode(data)
+        ll = np.asarray(model.seq_log_density(enc), dtype=np.float64)
+    else:
+        from mixle.utils.hvis.affinity import _posteriors_and_loglikes
+
+        _, ll_mat = _posteriors_and_loglikes(model, data=data)
+        log_w = np.asarray(model.log_w, dtype=np.float64).reshape(1, -1)
+        joint = ll_mat + log_w
+        mx = joint.max(axis=1, keepdims=True)
+        ll = mx[:, 0] + np.log(np.exp(joint - mx).sum(axis=1))
+    typicality = np.argsort(np.argsort(ll)).astype(np.float64) / max(len(ll) - 1, 1)  # percentile: low = odd
+
+    nerve = fuzzy_nerve(z)
+    result = Map(
+        base=base,
+        posterior_entropy=entropy,
+        typicality=typicality,
+        nerve=nerve,
+        nerve_health=nerve_report(nerve),
+        merge_tree=component_tree(nerve),
+        _data=data,
+        _params={
+            "emb_dim": emb_dim,
+            "spread": spread,
+            "chart": chart,
+            "occlusion": occlusion,
+            "refine": refine,
+            "health": health,
+            "seed": seed,
+        },
+    )
+    if health:
+        result.fit_health = model_fit_health(model, data, holdout=holdout, field_weights=field_weights)
+        result.render_health = embedding_health(base.coords, model, data, field_weights=field_weights)
+    return result

--- a/mixle/utils/hvis/goals.py
+++ b/mixle/utils/hvis/goals.py
@@ -1,0 +1,179 @@
+"""Embedding goals: declarative objectives layered onto an HViS embedding.
+
+The data term (t-SNE row-KL / UMAP cross-entropy) says "preserve the model's neighborhood
+structure"; a goal says what else the layout is FOR. Goals steer the same optimization -- they are
+not a post-hoc warp of a finished layout, which would break exactly the neighborhood structure the
+embedding exists to show.
+
+**Rate semantics (the stability contract).** A goal's ``gradient(Y)`` returns a bounded
+per-iteration DISPLACEMENT, applied as ``Y -= gradient`` once per optimizer iteration -- decoupled
+from the data optimizer's learning rate and adaptive gains on purpose. t-SNE's data gradient lives
+on probability scale and is driven with ``eta ~ n/12`` and delta-bar-delta gains; a raw quadratic
+penalty routed through that machinery is amplified by orders of magnitude and diverges. Under rate
+semantics every goal's weight is a fraction-per-step in ``(0, 1]``, contraction-stable by
+construction regardless of the optimizer it rides along with.
+
+Three goals, and two headline features are special cases:
+
+* :class:`Anchor` -- ANCHORING: pin chosen points to given coordinates. Hard (``weight=None``) is
+  an exact projection every step; soft (``weight`` in ``(0, 1]``) closes that fraction of the
+  remaining gap per step -- unconditionally stable exponential relaxation. Anchors fix the
+  translational gauge, so the optimizers skip their usual mean-centering (they would fight).
+* :class:`LabelCohesion` -- PARTIAL LABELING: labels for any subset of points (``None`` =
+  unlabeled). Labeled points move toward their label centroid at ``weight`` per step; an optional
+  ``margin`` hinge pushes centroid pairs apart. Unlabeled points are shaped only by the data term
+  -- semi-supervision, not relabeling.
+* :class:`AxisAlign` -- a layout GOAL: a per-point scalar (time, depth, severity, ...) should run
+  along a chosen embedding axis, ascending the Pearson correlation along its scale-normalized
+  direction (translation/scale invariant, so it orders the axis without dictating layout scale).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+import numpy as np
+
+__all__ = ["Anchor", "AxisAlign", "LabelCohesion", "apply_projections", "goals_fix_gauge", "total_goal_gradient"]
+
+
+class Anchor:
+    """Pin ``indices`` to ``coordinates``: hard when ``weight`` is None (exact projection each
+    step), soft for ``weight`` in ``(0, 1]`` (close that fraction of the remaining gap per step)."""
+
+    fixes_gauge = True
+
+    def __init__(self, indices: Sequence[int], coordinates: Any, weight: float | None = None) -> None:
+        self.indices = np.asarray(indices, dtype=np.int64)
+        self.coordinates = np.atleast_2d(np.asarray(coordinates, dtype=np.float64))
+        if self.coordinates.shape[0] != len(self.indices):
+            raise ValueError(f"coordinates must have one row per index ({len(self.indices)}).")
+        if weight is not None and not 0.0 < weight <= 1.0:
+            raise ValueError("soft anchor weight is a per-step fraction in (0, 1] (None = hard pin).")
+        self.weight = None if weight is None else float(weight)
+
+    @property
+    def hard(self) -> bool:
+        return self.weight is None
+
+    def gradient(self, y: np.ndarray) -> np.ndarray:
+        return np.zeros_like(y)  # both anchor kinds act in project(): relaxation is already a step
+
+    def project(self, y: np.ndarray) -> np.ndarray:
+        if self.hard:
+            y[self.indices] = self.coordinates
+        else:
+            y[self.indices] += self.weight * (self.coordinates - y[self.indices])
+        return y
+
+
+class LabelCohesion:
+    """Partial labels shape the layout: each labeled point moves toward its label's centroid at
+    ``weight`` (a per-step fraction in ``(0, 1]``); with ``margin``, centroid pairs closer than
+    ``margin`` are pushed apart (every member displaced alike, which moves the centroid by exactly
+    the intended amount). ``labels`` has one entry per point; ``None`` marks a point unlabeled."""
+
+    fixes_gauge = False
+
+    def __init__(self, labels: Sequence[Any], weight: float = 0.1, margin: float | None = None) -> None:
+        if not 0.0 < weight <= 1.0:
+            raise ValueError("weight is a per-step fraction in (0, 1].")
+        self.labels = list(labels)
+        self.weight = float(weight)
+        self.margin = None if margin is None else float(margin)
+        self._groups: dict[Any, np.ndarray] = {}
+        for label in sorted({lab for lab in self.labels if lab is not None}, key=str):
+            self._groups[label] = np.asarray([i for i, lab in enumerate(self.labels) if lab == label], dtype=np.int64)
+        if not self._groups:
+            raise ValueError("LabelCohesion needs at least one labeled point.")
+
+    def gradient(self, y: np.ndarray) -> np.ndarray:
+        if len(self.labels) != y.shape[0]:
+            raise ValueError(f"labels cover {len(self.labels)} points but the embedding has {y.shape[0]}.")
+        grad = np.zeros_like(y)
+        centroids = {label: y[idx].mean(axis=0) for label, idx in self._groups.items()}
+        for label, idx in self._groups.items():
+            grad[idx] += self.weight * (y[idx] - centroids[label])  # Y -= grad: move toward the centroid
+        if self.margin is not None and len(self._groups) > 1:
+            labels = list(self._groups)
+            n_pairs = len(labels) * (len(labels) - 1) // 2
+            for a_pos, a in enumerate(labels):
+                for b in labels[a_pos + 1 :]:
+                    diff = centroids[a] - centroids[b]
+                    dist = float(np.linalg.norm(diff))
+                    gap = self.margin - dist
+                    if gap <= 0:
+                        continue
+                    push = (self.weight * gap / n_pairs) * (diff / max(dist, 1.0e-12))
+                    grad[self._groups[a]] -= push  # Y -= grad: a-members move +push (apart), b-members -push
+                    grad[self._groups[b]] += push
+        return grad
+
+
+class AxisAlign:
+    """A per-point scalar should run along embedding axis ``axis``: each step ascends the Pearson
+    correlation ``r(y[:, axis], values)`` along its scale-normalized direction (bounded norm <= 2,
+    so ``weight`` -- recommended at most ~1 -- is a stable per-step rate in embedding units). Pass
+    ``-values`` to reverse direction."""
+
+    fixes_gauge = False
+
+    def __init__(self, values: Sequence[float], axis: int = 0, weight: float = 0.5) -> None:
+        if weight <= 0.0:
+            raise ValueError("weight must be positive.")
+        self.values = np.asarray(values, dtype=np.float64)
+        self.axis = int(axis)
+        self.weight = float(weight)
+        centered = self.values - self.values.mean()
+        norm = float(np.linalg.norm(centered))
+        if norm <= 0:
+            raise ValueError("AxisAlign values must not be constant.")
+        self._v_unit = centered / norm
+
+    def gradient(self, y: np.ndarray) -> np.ndarray:
+        if len(self.values) != y.shape[0]:
+            raise ValueError(f"values cover {len(self.values)} points but the embedding has {y.shape[0]}.")
+        grad = np.zeros_like(y)
+        u = y[:, self.axis]
+        u_centered = u - u.mean()
+        u_norm = float(np.linalg.norm(u_centered))
+        if u_norm <= 1.0e-12:  # degenerate axis (e.g. the first init steps): no direction to prefer yet
+            return grad
+        u_unit = u_centered / u_norm
+        r = float(u_unit @ self._v_unit)
+        direction = self._v_unit - r * u_unit  # the ascent direction on r, normalized to scale-free units
+        grad[:, self.axis] = -self.weight * direction  # Y -= grad ascends the correlation
+        return grad
+
+
+def total_goal_gradient(goals: Sequence[Any] | None, y: np.ndarray) -> np.ndarray | None:
+    """Summed per-step goal displacement at ``y`` (applied as ``Y -= result``), or None when there
+    are no goals so the optimizers skip the add entirely."""
+    if not goals:
+        return None
+    total = np.zeros_like(y)
+    for goal in goals:
+        total += goal.gradient(y)
+    return total
+
+
+def apply_projections(goals: Sequence[Any] | None, y: np.ndarray, velocity: np.ndarray | None = None) -> np.ndarray:
+    """Apply anchor projections/relaxations after a step; zero the velocity of hard-pinned rows so
+    momentum cannot accumulate against the pin."""
+    if not goals:
+        return y
+    for goal in goals:
+        project = getattr(goal, "project", None)
+        if project is None:
+            continue
+        y = project(y)
+        if velocity is not None and getattr(goal, "hard", False):
+            velocity[goal.indices] = 0.0
+    return y
+
+
+def goals_fix_gauge(goals: Sequence[Any] | None) -> bool:
+    """True when any goal pins absolute coordinates -- the optimizers must then skip mean-centering
+    (centering re-translates the cloud every step, which would fight the pins)."""
+    return bool(goals) and any(getattr(goal, "fixes_gauge", False) for goal in goals)

--- a/mixle/utils/hvis/stream.py
+++ b/mixle/utils/hvis/stream.py
@@ -44,33 +44,18 @@ import numpy as np
 from mixle.utils.hvis.affinity import (
     _affinity_factors,
     _calibrate_row,
-    _factor_similarity_block,
-    _factor_weight,
     _posteriors_and_loglikes,
     _resolve_affinity,
+    log_affinity_block,
 )
 
 __all__ = ["StreamingHvis", "place_in_atlas"]
 
 
 def _cross_log_affinity(factors, row_idx: np.ndarray, col_idx: np.ndarray, evidence_cap: float | None) -> np.ndarray:
-    """Rectangular (rows x cols) log-affinity block -- :func:`model_log_affinity` for a sub-block.
-
-    Mirrors the square path exactly: per-factor similarity blocks, log, per-factor evidence cap
-    (multi-factor affinities only), weighted sum.
-    """
-    cap = evidence_cap if (evidence_cap is not None and len(factors) > 1) else None
-    log_s = np.zeros((len(row_idx), len(col_idx)))
-    with np.errstate(divide="ignore"):
-        for factor in factors:
-            weight = _factor_weight(factor)
-            if weight == 0.0:
-                continue
-            term = np.log(np.maximum(_factor_similarity_block(factor, row_idx, col_idx), 1.0e-300))
-            if cap is not None:
-                np.maximum(term, -cap, out=term)
-            log_s += weight * term
-    return log_s
+    """Rectangular log-affinity block; the shared implementation lives in
+    :func:`mixle.utils.hvis.affinity.log_affinity_block` (also used by ``affinity_health``)."""
+    return log_affinity_block(factors, row_idx, col_idx, evidence_cap)
 
 
 def _row_probabilities(log_aff: np.ndarray, perplexity: float | None) -> np.ndarray:

--- a/mixle/utils/hvis/stream.py
+++ b/mixle/utils/hvis/stream.py
@@ -23,6 +23,12 @@ required. That turns streaming into three separable, individually-checkable piec
    and Procrustes-aligns the result back onto the old atlas -- and REPORTS the alignment residual,
    so a genuine geometry change is surfaced instead of being animated away.
 
+With an ``estimator``, the MODEL streams too, closing the loop with mixle's native
+sufficient-statistic machinery: each arriving batch is E-stepped once at arrival time under the
+then-current model (``accumulator.seq_update``), and :meth:`StreamingHvis.refresh` performs the
+M-step over reservoir + accumulated stream statistics before re-embedding -- incremental EM
+(Neal & Hinton 1998), one honest sweep per refresh, never a silent full re-fit.
+
 The one thing this deliberately does not promise: a placement is a projection into the atlas's
 geometry. A point unlike anything in the reservoir gets a low-affinity row (and drags the drift
 score down) rather than a secretly-wrong confident position -- check :meth:`drift_score` before
@@ -174,6 +180,15 @@ class StreamingHvis:
             data the factors are built over, which during streaming is ``landmarks + batch`` -- with
             a reasonably sized reservoir the landmarks dominate, but ``'balanced'`` (the default) is
             a pure per-point function of the model and has no such coupling.
+        estimator: optional ``ParameterEstimator`` consistent with ``mix_model``. When given, the
+            MODEL streams too, by incremental EM (Neal & Hinton 1998): every :meth:`add` batch is
+            E-stepped once, at arrival time, under the model current at that moment, and its
+            sufficient statistics accumulate; :meth:`refresh` then performs one M-step over the
+            reservoir's statistics (E-stepped under the current model) combined with the accumulated
+            stream statistics, adopting the re-estimated model before re-embedding. One honest EM
+            sweep per refresh -- NOT full-batch EM to convergence; pass ``refresh(mix_model=...)``
+            with your own fully re-fit model when that is what you want (an explicit model always
+            wins, and discards the pending stream statistics).
         drift_threshold_nats: how far (in nats) the arrivals' mean log-density may fall below the
             landmark reference before :attr:`drifted` trips.
         htsne_kwargs: forwarded to :func:`htsne` for atlas builds and :meth:`refresh`.
@@ -191,6 +206,7 @@ class StreamingHvis:
         affinity: str = "balanced",
         evidence_cap: float | None = 1.0,
         field_weights=None,
+        estimator: Any = None,
         drift_threshold_nats: float = 2.0,
         seed: int | None = None,
         **htsne_kwargs: Any,
@@ -206,6 +222,9 @@ class StreamingHvis:
         self.drift_threshold_nats = float(drift_threshold_nats)
         self.seed = seed
         self._htsne_kwargs = dict(htsne_kwargs)
+        self.estimator = estimator
+        self._stream_acc = estimator.accumulator_factory().make() if estimator is not None else None
+        self._stream_nobs = 0.0
 
         if atlas is not None:
             atlas = np.asarray(atlas, dtype=np.float64)
@@ -278,6 +297,10 @@ class StreamingHvis:
             self._recent_log_density = batch_ll
         else:  # EWMA so one odd batch informs but does not own the verdict
             self._recent_log_density = 0.7 * self._recent_log_density + 0.3 * batch_ll
+        if self._stream_acc is not None:  # incremental EM: E-step now, under the model of this moment
+            enc = self.mix_model.dist_to_encoder().seq_encode(batch)
+            self._stream_acc.seq_update(enc, np.ones(len(batch)), self.mix_model)
+            self._stream_nobs += len(batch)
         return coords
 
     def extend_landmarks(self, data: list, coords: np.ndarray | None = None) -> None:
@@ -312,13 +335,40 @@ class StreamingHvis:
         """Re-embed the landmark reservoir (optionally under an updated model), warm-started from
         the current coordinates and rigidly aligned back onto them.
 
-        Returns ``{"alignment_residual_rms", "atlas_spread", "n_landmarks"}``. A residual small
-        relative to the spread means visual continuity is real; a large one means the embedding
-        geometry genuinely changed and the report says so rather than hiding it in the alignment.
-        Resets the drift accumulator (a refresh is the response to drift, so scoring restarts).
+        With an ``estimator`` configured and stream statistics pending, the model is re-estimated
+        first (one incremental-EM M-step over reservoir + stream statistics) and the re-embed runs
+        under the NEW model. An explicit ``mix_model`` argument always wins and discards the pending
+        stream statistics -- passing both a stream-updated posture and an external model would make
+        the vintage of the statistics unaccountable.
+
+        Returns ``{"alignment_residual_rms", "alignment_scale", "atlas_spread", "n_landmarks",
+        "model_updated", "n_stream_obs_consumed"}``. A residual small relative to the spread means
+        visual continuity is real; a large one means the embedding geometry genuinely changed and
+        the report says so rather than hiding it in the alignment. Resets the drift accumulator
+        (a refresh is the response to drift, so scoring restarts).
         """
+        model_updated = None
+        n_consumed = 0.0
         if mix_model is not None:
             self.mix_model = mix_model
+            model_updated = "explicit"
+            if self._stream_acc is not None:  # stale-vintage stats must not survive an external model
+                n_consumed = 0.0
+                self._stream_acc = self.estimator.accumulator_factory().make()
+                self._stream_nobs = 0.0
+        elif self._stream_acc is not None and self._stream_nobs > 0:
+            acc = self.estimator.accumulator_factory().make()
+            enc = self.mix_model.dist_to_encoder().seq_encode(self.landmark_data)
+            acc.seq_update(enc, np.ones(len(self.landmark_data)), self.mix_model)
+            acc.combine(self._stream_acc.value())
+            stats_dict: dict[Any, Any] = {}
+            acc.key_merge(stats_dict)
+            acc.key_replace(stats_dict)
+            self.mix_model = self.estimator.estimate(None, acc.value())
+            model_updated = "stream_em"
+            n_consumed = self._stream_nobs
+            self._stream_acc = self.estimator.accumulator_factory().make()
+            self._stream_nobs = 0.0
         old = self.atlas
         new = self._embed_landmarks(Y=old.copy())
         aligned, residual, scale = _procrustes_align(new, old)
@@ -330,4 +380,6 @@ class StreamingHvis:
             "alignment_scale": scale,
             "atlas_spread": float(old.std()),
             "n_landmarks": len(self.landmark_data),
+            "model_updated": model_updated,
+            "n_stream_obs_consumed": float(n_consumed),
         }

--- a/mixle/utils/hvis/stream.py
+++ b/mixle/utils/hvis/stream.py
@@ -1,0 +1,333 @@
+"""Streaming HViS: place arriving points into a frozen model-based embedding, honestly.
+
+Classic t-SNE/UMAP cannot stream: they are transductive (no out-of-sample map), their input
+probabilities are normalized over the whole dataset, and re-running on n+1 points produces an
+arbitrarily rotated/rearranged layout -- the picture "jumps" and a monitoring view is useless.
+
+HViS escapes all three because its affinities come from a FITTED MODEL, not from raw pairwise
+distances: every observation has a fixed encoder (``x -> posterior / field evidence``), so a new
+point's affinity row against a frozen set of landmarks is self-contained -- no other stream data
+required. That turns streaming into three separable, individually-checkable pieces:
+
+1. **Atlas** -- embed a landmark reservoir once (:func:`~mixle.utils.hvis.embed.htsne`, or any
+   coordinates you supply, e.g. a ``humap`` layout). The atlas is FROZEN: existing coordinates never
+   move while streaming, so the view is stable by construction rather than by hope.
+2. **Placement** -- each arriving point gets its perplexity-calibrated affinity row over the
+   landmarks only (reusing the exact factor/calibration machinery of the batch path), then minimizes
+   its OWN row-KL against the frozen atlas under the same heavy-tailed kernel. One moving point per
+   objective (the out-of-sample "transform" trick), O(landmarks) per point, vectorized across the
+   whole batch since placed points do not interact.
+3. **Drift** -- placement is only trustworthy while the model still fits the stream. The model gives
+   a free, principled drift signal: the mean log-density of arrivals versus the landmark reference.
+   When it trips, :meth:`StreamingHvis.refresh` re-embeds warm-started from the current coordinates
+   and Procrustes-aligns the result back onto the old atlas -- and REPORTS the alignment residual,
+   so a genuine geometry change is surfaced instead of being animated away.
+
+The one thing this deliberately does not promise: a placement is a projection into the atlas's
+geometry. A point unlike anything in the reservoir gets a low-affinity row (and drags the drift
+score down) rather than a secretly-wrong confident position -- check :meth:`drift_score` before
+trusting a batch of placements.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from mixle.utils.hvis.affinity import (
+    _affinity_factors,
+    _calibrate_row,
+    _factor_similarity_block,
+    _factor_weight,
+    _posteriors_and_loglikes,
+    _resolve_affinity,
+)
+
+__all__ = ["StreamingHvis", "place_in_atlas"]
+
+
+def _cross_log_affinity(factors, row_idx: np.ndarray, col_idx: np.ndarray, evidence_cap: float | None) -> np.ndarray:
+    """Rectangular (rows x cols) log-affinity block -- :func:`model_log_affinity` for a sub-block.
+
+    Mirrors the square path exactly: per-factor similarity blocks, log, per-factor evidence cap
+    (multi-factor affinities only), weighted sum.
+    """
+    cap = evidence_cap if (evidence_cap is not None and len(factors) > 1) else None
+    log_s = np.zeros((len(row_idx), len(col_idx)))
+    with np.errstate(divide="ignore"):
+        for factor in factors:
+            weight = _factor_weight(factor)
+            if weight == 0.0:
+                continue
+            term = np.log(np.maximum(_factor_similarity_block(factor, row_idx, col_idx), 1.0e-300))
+            if cap is not None:
+                np.maximum(term, -cap, out=term)
+            log_s += weight * term
+    return log_s
+
+
+def _row_probabilities(log_aff: np.ndarray, perplexity: float | None) -> np.ndarray:
+    """Per-row conditional probabilities over the landmark columns (calibrated when perplexity set).
+
+    Row calibration only ever needs the row itself -- this is precisely why out-of-sample placement
+    is well-posed here while global t-SNE symmetrization is not.
+    """
+    b, n_landmarks = log_aff.shape
+    p = np.zeros_like(log_aff)
+    target = None if perplexity is None else np.log(min(float(perplexity), max(1.0, n_landmarks - 1.0)))
+    for i in range(b):
+        row = log_aff[i]
+        finite = np.isfinite(row)
+        if not np.any(finite):
+            p[i] = 1.0 / n_landmarks  # the model offers no information: honest uniform, not a crash
+            continue
+        if target is None:
+            shifted = row[finite] - row[finite].max()
+            q = np.exp(shifted)
+            p[i, finite] = q / q.sum()
+        else:
+            p[i, finite] = _calibrate_row(row[finite].copy(), target)
+    return p
+
+
+def place_in_atlas(
+    p_rows: np.ndarray,
+    atlas: np.ndarray,
+    *,
+    alpha: float = 1.0,
+    max_its: int = 250,
+    eta: float | None = None,
+    momentum: float = 0.8,
+    tol: float = 1.0e-7,
+) -> np.ndarray:
+    """Place each row's point into a FROZEN atlas by minimizing its own row-KL under the t-kernel.
+
+    ``p_rows`` is ``(B, L)`` row-stochastic (each arriving point's calibrated affinities over the
+    ``L`` landmarks); ``atlas`` is ``(L, d)``. Each point's objective involves only itself and the
+    frozen landmarks, so the whole batch optimizes as one vectorized gradient descent. Initialized
+    at the affinity-weighted barycenter of landmark coordinates.
+    """
+    p_rows = np.asarray(p_rows, dtype=np.float64)
+    atlas = np.asarray(atlas, dtype=np.float64)
+    y = p_rows @ atlas  # barycentric init: already in the right neighborhood for sharp rows
+    if eta is None:
+        spread = float(atlas.std())
+        eta = 0.5 * (spread if spread > 0 else 1.0)
+    velocity = np.zeros_like(y)
+    c = (alpha + 1.0) / alpha
+
+    for _ in range(int(max_its)):
+        d2 = np.square(y[:, None, :] - atlas[None, :, :]).sum(axis=2)  # (B, L)
+        u = 1.0 / (1.0 + d2 / alpha)
+        w = u ** ((alpha + 1.0) / 2.0)
+        q = w / np.maximum(w.sum(axis=1, keepdims=True), 1.0e-300)
+        coeff = (p_rows - q) * u  # (B, L)
+        grad = c * (y * coeff.sum(axis=1, keepdims=True) - coeff @ atlas)
+        velocity = momentum * velocity - eta * grad
+        y = y + velocity
+        if float(np.abs(grad).max()) < tol:
+            break
+    return y
+
+
+def _procrustes_align(source: np.ndarray, target: np.ndarray) -> tuple[np.ndarray, float, float]:
+    """Align ``source`` onto ``target`` by rotation/reflection + translation + UNIFORM scale (full
+    Procrustes). A t-SNE layout expands globally as it converges, so isotropic scale is nuisance for
+    the continuity question; what the residual measures is SHAPE change. The scale factor is returned
+    (and reported) rather than hidden -- a large one says the layout re-expanded even if the shape
+    held. Returns ``(aligned, rms_residual, scale)``."""
+    from scipy.linalg import orthogonal_procrustes
+
+    mu_s, mu_t = source.mean(axis=0), target.mean(axis=0)
+    src, tgt = source - mu_s, target - mu_t
+    rotation, trace = orthogonal_procrustes(src, tgt)
+    denom = float(np.sum(src * src))
+    scale = float(trace) / denom if denom > 0 else 1.0
+    aligned = scale * (src @ rotation) + mu_t
+    residual = float(np.sqrt(np.mean(np.sum((aligned - target) ** 2, axis=1))))
+    return aligned, residual, scale
+
+
+def _mean_log_density(mix_model, data) -> float:
+    """Mean per-observation log-density under the mixture -- the drift reference/score input."""
+    if hasattr(mix_model, "dist_to_encoder") and hasattr(mix_model, "seq_log_density"):
+        enc = mix_model.dist_to_encoder().seq_encode(list(data))
+        return float(np.mean(np.asarray(mix_model.seq_log_density(enc), dtype=np.float64)))
+    _, ll_mat = _posteriors_and_loglikes(mix_model, data=list(data))
+    log_w = np.asarray(mix_model.log_w, dtype=np.float64).reshape(1, -1)
+    joint = ll_mat + log_w
+    mx = joint.max(axis=1, keepdims=True)
+    return float(np.mean(mx[:, 0] + np.log(np.exp(joint - mx).sum(axis=1))))
+
+
+class StreamingHvis:
+    """A frozen model-based atlas that arriving points are placed into, with drift accounting.
+
+    Args:
+        mix_model: the fitted mixture the affinities come from (any model ``htsne`` accepts).
+        landmark_data: the reservoir the atlas is built over. The model's components make this easy
+            to keep representative -- e.g. sample a quota per component.
+        atlas: optional precomputed ``(len(landmark_data), emb_dim)`` coordinates (e.g. a ``humap``
+            layout). When omitted, the atlas is built here with :func:`htsne`.
+        affinity: any named HViS affinity. Note ``'local'`` learns component-local metrics from the
+            data the factors are built over, which during streaming is ``landmarks + batch`` -- with
+            a reasonably sized reservoir the landmarks dominate, but ``'balanced'`` (the default) is
+            a pure per-point function of the model and has no such coupling.
+        drift_threshold_nats: how far (in nats) the arrivals' mean log-density may fall below the
+            landmark reference before :attr:`drifted` trips.
+        htsne_kwargs: forwarded to :func:`htsne` for atlas builds and :meth:`refresh`.
+    """
+
+    def __init__(
+        self,
+        mix_model: Any,
+        landmark_data: list,
+        *,
+        atlas: np.ndarray | None = None,
+        emb_dim: int = 2,
+        alpha: float = 1.0,
+        perplexity: float | None = 30.0,
+        affinity: str = "balanced",
+        evidence_cap: float | None = 1.0,
+        field_weights=None,
+        drift_threshold_nats: float = 2.0,
+        seed: int | None = None,
+        **htsne_kwargs: Any,
+    ) -> None:
+        self.mix_model = mix_model
+        self.landmark_data = list(landmark_data)
+        self.emb_dim = int(emb_dim)
+        self.alpha = float(alpha)
+        self.perplexity = perplexity
+        self.affinity = affinity
+        self.evidence_cap = evidence_cap
+        self.field_weights = field_weights
+        self.drift_threshold_nats = float(drift_threshold_nats)
+        self.seed = seed
+        self._htsne_kwargs = dict(htsne_kwargs)
+
+        if atlas is not None:
+            atlas = np.asarray(atlas, dtype=np.float64)
+            if atlas.shape != (len(self.landmark_data), self.emb_dim):
+                raise ValueError(f"atlas must have shape ({len(self.landmark_data)}, {self.emb_dim}).")
+            self.atlas = atlas.copy()
+        else:
+            self.atlas = self._embed_landmarks(Y=None)
+
+        self._reference_log_density = _mean_log_density(self.mix_model, self.landmark_data)
+        self._recent_log_density: float | None = None
+
+    # -- atlas ------------------------------------------------------------------------------------
+
+    def _embed_landmarks(self, Y: np.ndarray | None) -> np.ndarray:
+        import io
+
+        from mixle.utils.hvis.embed import htsne
+
+        kwargs = dict(self._htsne_kwargs)
+        kwargs.setdefault("out", io.StringIO())  # quiet by default; pass out=sys.stdout for progress
+        if Y is not None:  # warm start: continuity comes from here, exaggeration would wreck it
+            kwargs.setdefault("early_exaggeration", 1.0)
+        return np.asarray(
+            htsne(
+                self.landmark_data,
+                emb_dim=self.emb_dim,
+                alpha=self.alpha,
+                perplexity=self.perplexity,
+                mix_model=self.mix_model,
+                affinity=self.affinity,
+                evidence_cap=self.evidence_cap,
+                field_weights=self.field_weights,
+                seed=self.seed,
+                Y=Y,
+                **kwargs,
+            ),
+            dtype=np.float64,
+        )
+
+    def _placement_rows(self, batch: list) -> np.ndarray:
+        combined = self.landmark_data + list(batch)
+        n_landmarks = len(self.landmark_data)
+        resolved = _resolve_affinity(self.affinity, self.mix_model, combined, self.field_weights)
+        if isinstance(resolved, str):
+            z, ll = _posteriors_and_loglikes(self.mix_model, data=combined)
+            factors = _affinity_factors(z, ll, resolved)
+        else:
+            factors = _affinity_factors(None, None, resolved)
+        row_idx = np.arange(n_landmarks, n_landmarks + len(batch), dtype=np.int64)
+        col_idx = np.arange(n_landmarks, dtype=np.int64)
+        log_aff = _cross_log_affinity(factors, row_idx, col_idx, self.evidence_cap)
+        return _row_probabilities(log_aff, self.perplexity)
+
+    # -- streaming --------------------------------------------------------------------------------
+
+    def add(self, batch: list, *, max_its: int = 250, eta: float | None = None) -> np.ndarray:
+        """Place a batch of arriving observations into the frozen atlas; returns ``(B, emb_dim)``.
+
+        Landmark coordinates are guaranteed unchanged by this call -- stability is structural, not
+        a tuning outcome. Also updates the running drift score from the batch's log-density.
+        """
+        batch = list(batch)
+        if not batch:
+            return np.zeros((0, self.emb_dim))
+        p_rows = self._placement_rows(batch)
+        coords = place_in_atlas(p_rows, self.atlas, alpha=self.alpha, max_its=max_its, eta=eta)
+        batch_ll = _mean_log_density(self.mix_model, batch)
+        if self._recent_log_density is None:
+            self._recent_log_density = batch_ll
+        else:  # EWMA so one odd batch informs but does not own the verdict
+            self._recent_log_density = 0.7 * self._recent_log_density + 0.3 * batch_ll
+        return coords
+
+    def extend_landmarks(self, data: list, coords: np.ndarray | None = None) -> None:
+        """Promote observations into the landmark reservoir (typically recent arrivals), placing
+        them first if coordinates are not supplied. Grows the atlas without moving anything."""
+        data = list(data)
+        if coords is None:
+            coords = self.add(data)
+        coords = np.asarray(coords, dtype=np.float64)
+        if coords.shape != (len(data), self.emb_dim):
+            raise ValueError(f"coords must have shape ({len(data)}, {self.emb_dim}).")
+        self.landmark_data.extend(data)
+        self.atlas = np.vstack([self.atlas, coords])
+        self._reference_log_density = _mean_log_density(self.mix_model, self.landmark_data)
+
+    # -- drift ------------------------------------------------------------------------------------
+
+    def drift_score(self) -> float:
+        """Nats of mean log-density the recent stream sits BELOW the landmark reference (>=0-ish;
+        near zero or negative means the stream fits the model at least as well as the reservoir)."""
+        if self._recent_log_density is None:
+            return 0.0
+        return self._reference_log_density - self._recent_log_density
+
+    @property
+    def drifted(self) -> bool:
+        return self.drift_score() > self.drift_threshold_nats
+
+    # -- refresh ----------------------------------------------------------------------------------
+
+    def refresh(self, mix_model: Any = None) -> dict[str, Any]:
+        """Re-embed the landmark reservoir (optionally under an updated model), warm-started from
+        the current coordinates and rigidly aligned back onto them.
+
+        Returns ``{"alignment_residual_rms", "atlas_spread", "n_landmarks"}``. A residual small
+        relative to the spread means visual continuity is real; a large one means the embedding
+        geometry genuinely changed and the report says so rather than hiding it in the alignment.
+        Resets the drift accumulator (a refresh is the response to drift, so scoring restarts).
+        """
+        if mix_model is not None:
+            self.mix_model = mix_model
+        old = self.atlas
+        new = self._embed_landmarks(Y=old.copy())
+        aligned, residual, scale = _procrustes_align(new, old)
+        self.atlas = aligned
+        self._reference_log_density = _mean_log_density(self.mix_model, self.landmark_data)
+        self._recent_log_density = None
+        return {
+            "alignment_residual_rms": residual,
+            "alignment_scale": scale,
+            "atlas_spread": float(old.std()),
+            "n_landmarks": len(self.landmark_data),
+        }

--- a/mixle/utils/hvis/topology.py
+++ b/mixle/utils/hvis/topology.py
@@ -1,0 +1,247 @@
+"""The fuzzy nerve of the learned cover, and map-fidelity receipts (design review R3/R2, partial).
+
+The fitted mixture is a parametrized cover of the data manifold: components are cover elements and
+the posterior is a partition of unity subordinate to it. By the nerve theorem, the topology of the
+data (for a good cover) is the homotopy type of the cover's NERVE -- the simplicial complex whose
+k-simplices are (k+1)-wise overlapping components. :func:`fuzzy_nerve` computes its weighted 1- and
+2-skeleton directly from the posteriors (this is soft Mapper with an EM-learned cover), and
+:func:`nerve_report` turns it into receipts a 2-D map cannot give on its own:
+
+* **holes** -- an unfilled cycle of strongly-overlapping components (e.g. a ring-shaped manifold)
+  is a loop in the data's topology. A plane embedding may render it faithfully or may distort it;
+  either way the user should KNOW the loop exists rather than infer it from blob positions.
+* **disconnection** -- a cover that splits into multiple connected pieces.
+
+Cycle classification is deliberately conservative: a 3-cycle is "filled" exactly when its triple
+overlap is strong (the 2-simplex is present); longer cycles are reported as candidate holes without
+attempting a full triangulation check (exact filling is a combinatorial problem; the honest output
+is "here is a cycle no strong triple fills directly").
+
+:func:`embedding_health` is the RENDERING-fidelity receipt: trustworthiness/continuity of the map's
+neighborhoods against the model affinity that produced it. Note precisely what this does and does
+not audit -- it catches a layout that misrepresents the model (rendering failure), NOT a model that
+misrepresents the data (model misfit, which remains the design review's open R2 item).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+__all__ = ["embedding_health", "fuzzy_nerve", "nerve_report"]
+
+
+def fuzzy_nerve(z: np.ndarray, *, edge_threshold: float = 0.02, triangle_threshold: float = 0.02) -> dict:
+    """Weighted 1- and 2-skeleton of the cover's nerve, from the posteriors alone.
+
+    Edge weight ``w(k,l) = sum_i z_ik z_il / min(mass_k, mass_l)`` -- the co-claimed fraction of the
+    smaller component's mass (1 when one component's points are entirely co-claimed by the other,
+    0 when they never co-claim). Triangle weight is the same with a triple product. Simplices at or
+    above their threshold are "strong" and drive :func:`nerve_report`; all nonzero weights are
+    returned so thresholds are inspectable choices, not hidden ones.
+    """
+    z = np.asarray(z, dtype=np.float64)
+    k_count = z.shape[1]
+    masses = z.sum(axis=0)
+    safe = np.maximum(masses, 1.0e-12)
+
+    co = z.T @ z
+    edges: dict[tuple[int, int], float] = {}
+    for a in range(k_count):
+        for b in range(a + 1, k_count):
+            w = float(co[a, b] / min(safe[a], safe[b]))
+            if w > 0.0:
+                edges[(a, b)] = w
+
+    triangles: dict[tuple[int, int, int], float] = {}
+    strong_pairs = {e for e, w in edges.items() if w >= edge_threshold}
+    for a in range(k_count):
+        for b in range(a + 1, k_count):
+            if (a, b) not in strong_pairs:
+                continue  # a strong triangle needs strong faces; skip the O(K^3) full sweep
+            for c in range(b + 1, k_count):
+                if (a, c) not in strong_pairs or (b, c) not in strong_pairs:
+                    continue
+                w = float(np.einsum("i,i,i->", z[:, a], z[:, b], z[:, c]) / min(safe[a], safe[b], safe[c]))
+                if w > 0.0:
+                    triangles[(a, b, c)] = w
+
+    return {
+        "masses": masses,
+        "edges": edges,
+        "triangles": triangles,
+        "edge_threshold": float(edge_threshold),
+        "triangle_threshold": float(triangle_threshold),
+    }
+
+
+def _independent_cycles(nodes: list[int], edges: list[tuple[int, int]]) -> tuple[int, list[list[int]]]:
+    """Connected-component count and one representative cycle per independent loop (spanning-forest
+    construction: every non-tree edge closes exactly one cycle, recovered through tree parents)."""
+    adj: dict[int, list[int]] = {v: [] for v in nodes}
+    tree_edges = set()
+    parent: dict[int, int | None] = {}
+    n_components = 0
+    for a, b in edges:
+        adj[a].append(b)
+        adj[b].append(a)
+    for root in nodes:
+        if root in parent:
+            continue
+        n_components += 1
+        parent[root] = None
+        stack = [root]
+        while stack:
+            v = stack.pop()
+            for u in adj[v]:
+                if u not in parent:
+                    parent[u] = v
+                    tree_edges.add((min(v, u), max(v, u)))
+                    stack.append(u)
+
+    def path_to_root(v: int) -> list[int]:
+        path = [v]
+        while parent[path[-1]] is not None:
+            path.append(parent[path[-1]])
+        return path
+
+    cycles = []
+    for a, b in edges:
+        if (min(a, b), max(a, b)) in tree_edges:
+            continue
+        pa, pb = path_to_root(a), path_to_root(b)
+        common = set(pa) & set(pb)
+        cut_a = next(i for i, v in enumerate(pa) if v in common)
+        anchor = pa[cut_a]
+        cut_b = pb.index(anchor)
+        cycles.append(pa[: cut_a + 1] + pb[:cut_b][::-1])
+    return n_components, cycles
+
+
+def nerve_report(nerve: dict) -> dict:
+    """Topology receipts from a :func:`fuzzy_nerve`: connected pieces, cycles, and candidate holes.
+
+    A hole is an independent cycle of strong edges not directly filled by a strong 2-simplex
+    (3-cycles are checked exactly; longer cycles are conservatively reported as candidates). The
+    ``diagnosis`` strings are the user-facing half: a loop in the cover is real data topology that
+    a 2-D layout may distort silently.
+    """
+    strong_edges = [e for e, w in nerve["edges"].items() if w >= nerve["edge_threshold"]]
+    strong_triangles = {t for t, w in nerve["triangles"].items() if w >= nerve["triangle_threshold"]}
+    k_count = len(nerve["masses"])
+    n_components, cycles = _independent_cycles(list(range(k_count)), strong_edges)
+
+    holes = []
+    for cycle in cycles:
+        filled = len(cycle) == 3 and tuple(sorted(cycle)) in strong_triangles
+        if not filled:
+            holes.append(sorted(cycle))
+
+    diagnosis = []
+    if n_components > 1:
+        diagnosis.append(
+            f"the component cover is disconnected into {n_components} pieces: inter-piece distances in the "
+            "map reflect only the layout, not measured overlap."
+        )
+    for hole in holes:
+        diagnosis.append(
+            f"the cover contains an unfilled cycle through components {hole}: the data topology has a loop "
+            "(ring/period-like structure) that a 2-D layout may distort -- verify it deliberately rather "
+            "than reading it off blob positions."
+        )
+
+    return {
+        "n_components": n_components,
+        "n_strong_edges": len(strong_edges),
+        "cycles": [sorted(c) for c in cycles],
+        "holes": holes,
+        "diagnosis": diagnosis,
+    }
+
+
+def embedding_health(
+    coords: np.ndarray,
+    mix_model,
+    data,
+    *,
+    affinity="auto",
+    k: int = 10,
+    field_weights=None,
+    evidence_cap: float | None = 1.0,
+    max_rows: int = 400,
+    seed: int = 0,
+) -> dict:
+    """Rendering-fidelity receipt: do the map's neighborhoods agree with the model affinity?
+
+    Standard trustworthiness (are map-neighbors genuinely close under the model?) and continuity
+    (are model-neighbors kept close in the map?), computed on a row subsample. This audits the
+    LAYOUT against the MODEL -- a low score means the picture misrepresents the affinities that
+    produced it (bad init, unconverged optimizer, non-embeddable topology). It does NOT audit the
+    model against the raw data; that receipt is still open (design review R2).
+    """
+    from mixle.utils.hvis.affinity import (
+        _affinity_factors,
+        _posteriors_and_loglikes,
+        _resolve_affinity,
+        log_affinity_block,
+    )
+
+    coords = np.asarray(coords, dtype=np.float64)
+    data = list(data)
+    resolved = _resolve_affinity(affinity, mix_model, data, field_weights)
+    if isinstance(resolved, str):
+        z, ll = _posteriors_and_loglikes(mix_model, data=data)
+        factors = _affinity_factors(z, ll, resolved)
+    else:
+        factors = _affinity_factors(None, None, resolved)
+
+    n = coords.shape[0]
+    rng = np.random.RandomState(seed)
+    idx = np.arange(n) if n <= max_rows else np.sort(rng.choice(n, size=max_rows, replace=False))
+    m = len(idx)
+    k = min(int(k), m - 2)
+
+    log_s = log_affinity_block(factors, idx, idx, evidence_cap)
+    np.fill_diagonal(log_s, -np.inf)
+    d2 = np.square(coords[idx][:, None, :] - coords[idx][None, :, :]).sum(axis=2)
+    np.fill_diagonal(d2, np.inf)
+
+    # rank matrices: rank_data[i, j] = position of j in i's model-affinity ordering (1 = nearest)
+    order_data = np.argsort(-log_s, axis=1, kind="stable")
+    order_map = np.argsort(d2, axis=1, kind="stable")
+    rank_data = np.empty((m, m), dtype=np.int64)
+    rank_map = np.empty((m, m), dtype=np.int64)
+    rows = np.arange(m)[:, None]
+    rank_data[rows, order_data] = np.arange(m)[None, :] + 1
+    rank_map[rows, order_map] = np.arange(m)[None, :] + 1
+
+    knn_data = rank_data <= k
+    knn_map = rank_map <= k
+    norm = 2.0 / (m * k * (2.0 * m - 3.0 * k - 1.0))
+
+    trust_pen = np.where(knn_map & ~knn_data, rank_data - k, 0).sum(axis=1).astype(np.float64)
+    cont_pen = np.where(knn_data & ~knn_map, rank_map - k, 0).sum(axis=1).astype(np.float64)
+    trustworthiness = float(1.0 - norm * trust_pen.sum())
+    continuity = float(1.0 - norm * cont_pen.sum())
+
+    diagnosis = []
+    if trustworthiness < 0.85:
+        diagnosis.append(
+            f"trustworthiness {trustworthiness:.2f}: the map shows neighbor pairs the model does not "
+            "support -- treat visual proximity with suspicion (bad init, unconverged refine, or a "
+            "topology 2-D cannot hold)."
+        )
+    if continuity < 0.85:
+        diagnosis.append(
+            f"continuity {continuity:.2f}: genuinely-close pairs (under the model) were torn apart in the "
+            "map -- clusters or fibers may be split visually that the model considers one region."
+        )
+
+    return {
+        "trustworthiness": trustworthiness,
+        "continuity": continuity,
+        "per_point_trust_penalty": trust_pen,
+        "per_point_continuity_penalty": cont_pen,
+        "k": k,
+        "n_sampled": m,
+        "diagnosis": diagnosis,
+    }

--- a/mixle/utils/hvis/topology.py
+++ b/mixle/utils/hvis/topology.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 
 import numpy as np
 
-__all__ = ["embedding_health", "fuzzy_nerve", "nerve_report"]
+__all__ = ["component_tree", "embedding_health", "fuzzy_nerve", "model_fit_health", "nerve_report"]
 
 
 def fuzzy_nerve(z: np.ndarray, *, edge_threshold: float = 0.02, triangle_threshold: float = 0.02) -> dict:
@@ -154,6 +154,155 @@ def nerve_report(nerve: dict) -> dict:
         "n_strong_edges": len(strong_edges),
         "cycles": [sorted(c) for c in cycles],
         "holes": holes,
+        "diagnosis": diagnosis,
+    }
+
+
+def component_tree(nerve: dict) -> list[dict]:
+    """Single-linkage merge tree over components by nerve edge weight -- the hierarchy skeleton.
+
+    Merges are emitted strongest-overlap-first: ``[{"a": frozenset, "b": frozenset, "weight": w,
+    "merged": frozenset}, ...]``. Cutting the tree at any weight gives coarse super-components
+    (:class:`mixle.utils.hvis.front.Map` uses it for zoom groups); the merge order is itself a
+    receipt -- which regimes are almost one regime.
+    """
+    k_count = len(nerve["masses"])
+    parent = list(range(k_count))
+
+    def find(v: int) -> int:
+        while parent[v] != v:
+            parent[v] = parent[parent[v]]
+            v = parent[v]
+        return v
+
+    merges = []
+    for (a, b), w in sorted(nerve["edges"].items(), key=lambda item: (-item[1], item[0])):
+        ra, rb = find(a), find(b)
+        if ra == rb:
+            continue
+        group_a = frozenset(v for v in range(k_count) if find(v) == ra)
+        group_b = frozenset(v for v in range(k_count) if find(v) == rb)
+        parent[ra] = rb
+        merges.append({"a": group_a, "b": group_b, "weight": float(w), "merged": group_a | group_b})
+    return merges
+
+
+def model_fit_health(
+    mix_model,
+    data,
+    *,
+    holdout=None,
+    field_weights=None,
+    coverage_q: float = 0.9,
+    merged_sep_threshold: float | None = None,
+    shattered_weight: float = 0.5,
+    min_component_points: int = 20,
+) -> dict:
+    """The model<->data receipt (design review R2, second half): does the FITTED MODEL describe the
+    data it is about to be a map of? Measured from the model's own residual structure -- no raw
+    feature space is assumed, which is the whole point of HViS.
+
+    * **fiber calibration** -- per component, the squared Mahalanobis of its dominant points'
+      whitened fiber coordinates should look chi-squared: the fraction inside the ``coverage_q``
+      ball is compared against ``coverage_q``. A large gap means the component's shape claim is
+      wrong (too wide, too narrow, or mis-shaped).
+    * **merged-regime detector** -- a deterministic 2-means split (top-PC sign init) of each
+      component's dominant fiber coordinates; a separation ratio above the threshold with a
+      non-trivial minority says one component is covering what the data treats as two regimes
+      (K too small). The threshold has a derivation plus a measured finite-sample correction: for
+      a UNIMODAL normal the population statistic is ``2 E|x| / sqrt(1 - 2/pi) ~ 2.65`` regardless
+      of scale, but at n=40 sample noise inflates it to ~3.4 (observed), so the default threshold
+      is ``2.65 + 6/sqrt(n)`` -- ~3.6 at n=40, tightening toward the population value as n grows.
+      Two unit-variance regimes 4 sigma apart score ~4.0 either way. Pass an explicit
+      ``merged_sep_threshold`` to pin it.
+    * **shattered detector** -- nerve edges with weight >= ``shattered_weight`` are near-duplicate
+      components claiming largely the same points (K too large).
+    * **held-out check** -- with ``holdout`` data, a mean log-density drop > 1 nat vs training is
+      flagged (memorization / drift).
+    """
+    from scipy.stats import chi2
+
+    from mixle.utils.hvis.direct import component_fiber_coords
+
+    data = list(data)
+    z, us, _labels, _t = component_fiber_coords(mix_model, data, field_weights=field_weights)
+    k_count = z.shape[1]
+    dominant = z.argmax(axis=1)
+
+    components = []
+    diagnosis = []
+    for k in range(k_count):
+        mine = us[k][dominant == k]
+        entry: dict = {"n_points": int(len(mine)), "coverage": None, "merged_separation": None}
+        if len(mine) >= min_component_points:
+            mu = mine.mean(axis=0)
+            centered = mine - mu
+            dim = mine.shape[1]
+            cov = centered.T @ centered / max(len(mine) - 1, 1) + 1.0e-9 * np.eye(dim)
+            m2 = np.einsum("ij,jk,ik->i", centered, np.linalg.pinv(cov), centered)
+            coverage = float(np.mean(m2 <= chi2.ppf(coverage_q, df=dim)))
+            entry["coverage"] = coverage
+            if abs(coverage - coverage_q) > 0.15:
+                diagnosis.append(
+                    f"component {k}: fiber calibration off (coverage {coverage:.2f} vs nominal {coverage_q}) -- "
+                    "its shape claim does not match its points."
+                )
+
+            # deterministic 2-means on the top principal axis: split by sign, then Lloyd iterations
+            vals, vecs = np.linalg.eigh(cov)
+            axis = vecs[:, np.argmax(vals)]
+            proj = centered @ axis
+            assign = proj > 0.0
+            for _ in range(15):
+                if assign.all() or (~assign).all():
+                    break
+                c1, c0 = float(proj[assign].mean()), float(proj[~assign].mean())
+                new_assign = np.abs(proj - c1) < np.abs(proj - c0)
+                if bool(np.all(new_assign == assign)):
+                    break
+                assign = new_assign
+            if 0 < int(assign.sum()) < len(proj):
+                minority = min(float(assign.mean()), float(1.0 - assign.mean()))
+                within_var = float(
+                    np.average([proj[assign].var(), proj[~assign].var()], weights=[assign.mean(), 1 - assign.mean()])
+                )
+                sep = abs(float(proj[assign].mean() - proj[~assign].mean())) / max(np.sqrt(within_var), 1.0e-12)
+                entry["merged_separation"] = sep
+                threshold = (
+                    merged_sep_threshold if merged_sep_threshold is not None else 2.65 + 6.0 / np.sqrt(float(len(mine)))
+                )
+                if sep > threshold and minority >= 0.2:
+                    diagnosis.append(
+                        f"component {k}: looks like TWO merged regimes (2-means separation {sep:.1f}, minority "
+                        f"{minority:.0%}) -- the mixture may need more components here."
+                    )
+        components.append(entry)
+
+    nerve = fuzzy_nerve(z)
+    shattered = [(list(e), float(w)) for e, w in nerve["edges"].items() if w >= shattered_weight]
+    for pair, w in shattered:
+        diagnosis.append(
+            f"components {pair}: near-duplicates (overlap weight {w:.2f}) -- they claim largely the same "
+            "points; the mixture may have too many components here."
+        )
+
+    holdout_drop = None
+    if holdout is not None:
+        from mixle.utils.hvis.stream import _mean_log_density
+
+        train_ll = _mean_log_density(mix_model, data)
+        hold_ll = _mean_log_density(mix_model, list(holdout))
+        holdout_drop = float(train_ll - hold_ll)
+        if holdout_drop > 1.0:
+            diagnosis.append(
+                f"held-out mean log-density is {holdout_drop:.2f} nats below training -- the fit does not "
+                "generalize to the data the map will be read against."
+            )
+
+    return {
+        "components": components,
+        "shattered_pairs": shattered,
+        "holdout_drop_nats": holdout_drop,
         "diagnosis": diagnosis,
     }
 

--- a/mixle/utils/hvis/tsne.py
+++ b/mixle/utils/hvis/tsne.py
@@ -60,12 +60,15 @@ def update_embed(
     alpha: float,
     min_gain: float,
     min_value: float = 1.0e-128,
+    center: bool = True,
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
     """One delta-bar-delta gradient step of KL(P || Q) on the embedding Y.
 
     Gradient of the heavy-tailed kernel:
         dC/dy_i = (2(alpha+1)/alpha) * sum_j (p_ij - q_ij) num_ij (y_i - y_j),
-    computed in matrix form (no per-row Python loop).
+    computed in matrix form (no per-row Python loop). ``center=False`` skips the mean-centering
+    for gauge-fixing goals (anchors, see :mod:`mixle.utils.hvis.goals`), which centering would
+    otherwise undo each step.
     """
     dC, Q = _exact_tsne_gradient(P, Y, alpha, min_value=min_value)
 
@@ -75,7 +78,8 @@ def update_embed(
 
     iY = momentum * iY - eta * (gains * dC)
     Y = Y + iY
-    Y -= np.mean(Y, axis=0, keepdims=True)
+    if center:
+        Y -= np.mean(Y, axis=0, keepdims=True)
 
     return Y, iY, gains, Q
 
@@ -153,8 +157,17 @@ def tsne_exact(
     print_iter: int = 100,
     seed: int | None = None,
     out=None,
+    goals=None,
 ) -> np.ndarray:
-    """Full-matrix t-SNE on symmetrized probabilities P with convergence stopping."""
+    """Full-matrix t-SNE on symmetrized probabilities P with convergence stopping.
+
+    ``goals`` is an optional sequence of embedding goals (:mod:`mixle.utils.hvis.goals`): their
+    gradients join the data gradient every iteration and hard constraints are re-projected after
+    every step.
+    """
+    from mixle.utils.hvis.goals import apply_projections, goals_fix_gauge, total_goal_gradient
+
+    center = not goals_fix_gauge(goals)
     if out is None:
         out = sys.stdout
 
@@ -185,7 +198,11 @@ def tsne_exact(
             np.maximum(P, min_value, out=P)
 
         mom = 0.5 if i <= early_its else momentum
-        Y, iY, gains, Q = update_embed(P, Y, iY, gains, mom, eta, alpha, min_gain, min_value)
+        Y, iY, gains, Q = update_embed(P, Y, iY, gains, mom, eta, alpha, min_gain, min_value, center=center)
+        step = total_goal_gradient(goals, Y)
+        if step is not None:  # goals apply as their own bounded step: rate semantics, no eta/gains coupling
+            Y = Y - step
+        Y = apply_projections(goals, Y, iY)
 
         if optimize_alpha and i > early_its:
             alpha = update_alpha(P, Y, alpha, min_alpha, min_value, max_alpha_its)
@@ -630,8 +647,14 @@ def _tsne_barnes_hut_from_p(
     seed: int | None = None,
     Y: np.ndarray | None = None,
     out=None,
+    goals=None,
 ) -> np.ndarray:
-    """Barnes-Hut t-SNE on a sparse symmetric probability matrix."""
+    """Barnes-Hut t-SNE on a sparse symmetric probability matrix. ``goals`` as in
+    :func:`tsne_exact`: goal gradients join the data gradient each iteration, hard constraints are
+    re-projected each step, and mean-centering is skipped when a goal fixes the gauge."""
+    from mixle.utils.hvis.goals import apply_projections, goals_fix_gauge, total_goal_gradient
+
+    center = not goals_fix_gauge(goals)
     if out is None:
         out = sys.stdout
 
@@ -653,7 +676,8 @@ def _tsne_barnes_hut_from_p(
         if Y.shape[0] != n:
             raise ValueError("initial embedding Y has the wrong number of rows.")
         emb_dim = Y.shape[1]
-    Y -= np.mean(Y, axis=0, keepdims=True)
+    if center:
+        Y -= np.mean(Y, axis=0, keepdims=True)
 
     iY = np.zeros_like(Y)
     gains = np.ones_like(Y)
@@ -684,7 +708,12 @@ def _tsne_barnes_hut_from_p(
         mom = 0.5 if it <= early_its else momentum
         iY = mom * iY - eta * gains * dC
         Y = Y + iY
-        Y -= np.mean(Y, axis=0, keepdims=True)
+        if center:
+            Y -= np.mean(Y, axis=0, keepdims=True)
+        step = total_goal_gradient(goals, Y)
+        if step is not None:  # bounded rate semantics, decoupled from eta/gains (see goals module)
+            Y = Y - step
+        Y = apply_projections(goals, Y, iY)
 
         if (it % print_iter) == 0:
             _, kl_z_sum = _dispatch_negative_forces(
@@ -731,6 +760,7 @@ def _tsne_barnes_hut(
     leaf_size: int = 16,
     repulsion_method: str = "auto",
     exact_repulsion_threshold: int = 5000,
+    goals=None,
 ) -> np.ndarray:
     P = _sparse_joint_pmat(dist_csr, perplexity)
     return _tsne_barnes_hut_from_p(
@@ -750,6 +780,7 @@ def _tsne_barnes_hut(
         seed=seed,
         Y=Y,
         out=out,
+        goals=goals,
     )
 
 

--- a/mixle/utils/hvis/umap_np.py
+++ b/mixle/utils/hvis/umap_np.py
@@ -1,0 +1,216 @@
+"""A dependency-free UMAP core (numpy/scipy only) -- the fallback engine behind ``humap``.
+
+``humap`` prefers umap-learn when it is installed; this module exists so a missing optional
+dependency degrades to a slower-but-correct layout instead of an ImportError, and so embedding
+goals (:mod:`mixle.utils.hvis.goals`) have an optimizer they can actually steer -- umap-learn's
+numba SGD loop cannot take per-iteration external gradients.
+
+It is the standard UMAP construction (McInnes, Healy & Melville 2018), deliberately minimal:
+
+1. :func:`fuzzy_simplicial_set` -- per-row smoothed-kNN calibration (``rho`` = nearest distance,
+   ``sigma`` binary-searched so the row's total membership is ``log2(k)``), then probabilistic
+   t-conorm symmetrization ``W + W^T - W o W^T``.
+2. :func:`fit_ab` -- least-squares fit of the low-dimensional curve ``1/(1 + a d^(2b))`` to the
+   ``min_dist``/``spread`` target, exactly as umap-learn does.
+3. :func:`simplicial_set_layout` -- spectral initialization (normalized-Laplacian eigenvectors,
+   random fallback) and the epochs-per-sample SGD with negative sampling and per-component +-4
+   move clipping, vectorized per epoch over the due edges rather than numba-jitted per edge.
+
+The knn graph comes from the caller (``humap`` hands in MODEL distances), so nothing here embeds
+raw vectors -- it lays out whatever graph the model-based affinity machinery produced.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import scipy.sparse
+
+__all__ = ["fit_ab", "fuzzy_simplicial_set", "internal_umap", "simplicial_set_layout"]
+
+_SMOOTH_K_TOLERANCE = 1.0e-5
+_MOVE_CLIP = 4.0
+
+
+def fit_ab(min_dist: float, spread: float = 1.0) -> tuple[float, float]:
+    """Fit ``(a, b)`` of the low-dimensional membership curve ``1/(1 + a d^(2b))`` to the target
+    ``exp(-(d - min_dist)/spread)`` (1 inside ``min_dist``) -- umap-learn's own calibration."""
+    from scipy.optimize import curve_fit
+
+    grid = np.linspace(0.0, 3.0 * spread, 300)
+    target = np.where(grid < min_dist, 1.0, np.exp(-(grid - min_dist) / spread))
+
+    def curve(d, a, b):
+        return 1.0 / (1.0 + a * d ** (2.0 * b))
+
+    (a, b), _ = curve_fit(curve, grid, target, p0=(1.0, 1.0), maxfev=10000)
+    return float(a), float(b)
+
+
+def _smooth_knn_row(dists: np.ndarray, target: float, n_iter: int = 64) -> tuple[float, float]:
+    """UMAP's per-row calibration: rho = nearest positive distance; binary-search sigma so
+    ``sum_j exp(-max(0, d_j - rho)/sigma) = target``."""
+    positive = dists[dists > 0.0]
+    rho = float(positive.min()) if len(positive) else 0.0
+    lo, hi, sigma = 0.0, np.inf, 1.0
+    for _ in range(n_iter):
+        val = float(np.sum(np.exp(-np.maximum(dists - rho, 0.0) / sigma)))
+        if abs(val - target) < _SMOOTH_K_TOLERANCE:
+            break
+        if val > target:
+            hi = sigma
+            sigma = (lo + hi) / 2.0
+        else:
+            lo = sigma
+            sigma = sigma * 2.0 if np.isinf(hi) else (lo + hi) / 2.0
+    return rho, max(sigma, 1.0e-12)
+
+
+def fuzzy_simplicial_set(knn_idx: np.ndarray, knn_dist: np.ndarray) -> scipy.sparse.coo_matrix:
+    """Symmetric fuzzy graph from a kNN graph of (model) distances.
+
+    Per-row memberships ``exp(-(d - rho)/sigma)`` with the smoothed-kNN calibration, then the
+    probabilistic t-conorm ``W + W^T - W o W^T`` -- an undirected membership strength that is high
+    when EITHER direction considers the edge close.
+    """
+    knn_idx = np.asarray(knn_idx, dtype=np.int64)
+    knn_dist = np.asarray(knn_dist, dtype=np.float64)
+    n, k = knn_idx.shape
+    target = np.log2(max(k, 2))
+
+    rows = np.repeat(np.arange(n, dtype=np.int64), k)
+    cols = knn_idx.ravel()
+    vals = np.empty(n * k, dtype=np.float64)
+    for i in range(n):
+        rho, sigma = _smooth_knn_row(knn_dist[i], target)
+        vals[i * k : (i + 1) * k] = np.exp(-np.maximum(knn_dist[i] - rho, 0.0) / sigma)
+
+    w = scipy.sparse.coo_matrix((vals, (rows, cols)), shape=(n, n)).tocsr()
+    w_t = w.T.tocsr()
+    prod = w.multiply(w_t)
+    return (w + w_t - prod).tocoo()
+
+
+def _spectral_init(graph: scipy.sparse.coo_matrix, emb_dim: int, rng: np.random.RandomState) -> np.ndarray:
+    """Normalized-Laplacian eigenvector initialization, with a random fallback when the eigensolver
+    does not converge (small/disconnected graphs) -- a fallback engine must never hard-fail on init."""
+    n = graph.shape[0]
+    try:
+        from scipy.sparse.linalg import eigsh
+
+        w = graph.tocsr()
+        deg = np.asarray(w.sum(axis=1)).ravel()
+        d_inv_sqrt = scipy.sparse.diags(1.0 / np.sqrt(np.maximum(deg, 1.0e-12)))
+        lap = scipy.sparse.identity(n) - d_inv_sqrt @ w @ d_inv_sqrt
+        k = min(emb_dim + 1, n - 1)
+        v0 = rng.uniform(-1.0, 1.0, size=n)  # ARPACK's default start vector uses the GLOBAL rng
+        _, vecs = eigsh(lap, k=k, sigma=0.0, which="LM", maxiter=n * 50, v0=v0)
+        y = vecs[:, 1 : emb_dim + 1]
+        if y.shape[1] < emb_dim:
+            raise ValueError("not enough eigenvectors")
+        y = y / max(float(np.abs(y).max()), 1.0e-12) * 10.0
+        return y + rng.normal(0.0, 1.0e-4, size=(n, emb_dim))
+    except Exception:
+        return rng.uniform(-10.0, 10.0, size=(n, emb_dim))
+
+
+def simplicial_set_layout(
+    graph: scipy.sparse.coo_matrix,
+    emb_dim: int = 2,
+    n_epochs: int | None = None,
+    a: float = 1.577,
+    b: float = 0.8951,
+    *,
+    seed: int | None = None,
+    Y: np.ndarray | None = None,
+    negative_sample_rate: int = 5,
+    learning_rate: float = 1.0,
+    goals=None,
+) -> np.ndarray:
+    """UMAP's epochs-per-sample SGD on a fuzzy graph, vectorized per epoch over the due edges.
+
+    Attractive moves apply to both endpoints, repulsive (negative-sampled) moves to the head only,
+    every per-component move clipped to +-4 and the learning rate annealed linearly to zero -- the
+    reference algorithm's behavior, minus numba. ``goals`` gradients are applied once per epoch at
+    the same annealed rate, followed by hard-constraint projection.
+    """
+    from mixle.utils.hvis.goals import apply_projections, total_goal_gradient
+
+    graph = graph.tocoo()
+    n = graph.shape[0]
+    keep = graph.data > graph.data.max() / max(float(n_epochs or 500), 1.0)
+    heads, tails, weights = graph.row[keep], graph.col[keep], graph.data[keep]
+    if n_epochs is None:
+        n_epochs = 500 if n < 10000 else 200
+    rng = np.random.RandomState(seed)
+
+    if Y is None:
+        y = _spectral_init(graph, emb_dim, rng)
+    else:
+        y = np.array(Y, dtype=np.float64)
+        if y.shape != (n, emb_dim):
+            raise ValueError(f"initial Y must have shape ({n}, {emb_dim}).")
+
+    epochs_per_sample = weights.max() / weights
+    next_due = epochs_per_sample.copy()
+
+    for epoch in range(1, int(n_epochs) + 1):
+        lr = learning_rate * (1.0 - epoch / float(n_epochs))
+        due = next_due <= epoch
+        if np.any(due):
+            h, t = heads[due], tails[due]
+            diff = y[h] - y[t]
+            d2 = np.sum(diff * diff, axis=1)
+            pos = d2 > 0.0
+            coeff = np.zeros_like(d2)
+            coeff[pos] = (-2.0 * a * b * d2[pos] ** (b - 1.0)) / (1.0 + a * d2[pos] ** b)
+            move = np.clip(coeff[:, None] * diff, -_MOVE_CLIP, _MOVE_CLIP) * lr
+            np.add.at(y, h, move)
+            np.add.at(y, t, -move)
+
+            neg = rng.randint(0, n, size=(len(h), int(negative_sample_rate)))
+            diff_n = y[h][:, None, :] - y[neg]
+            d2_n = np.sum(diff_n * diff_n, axis=2)
+            coeff_n = (2.0 * b) / ((0.001 + d2_n) * (1.0 + a * d2_n**b))
+            coeff_n[neg == h[:, None]] = 0.0  # a point is not its own negative
+            move_n = np.clip(coeff_n[:, :, None] * diff_n, -_MOVE_CLIP, _MOVE_CLIP) * lr
+            np.add.at(y, h, move_n.sum(axis=1))
+
+            next_due[due] += epochs_per_sample[due]
+
+        extra = total_goal_gradient(goals, y)
+        if extra is not None:  # bounded rate semantics: applied as-is, not annealed away with the SGD rate
+            y -= extra
+        y = apply_projections(goals, y)
+
+    return y
+
+
+def internal_umap(
+    knn_idx: np.ndarray,
+    knn_dist: np.ndarray,
+    emb_dim: int = 2,
+    *,
+    min_dist: float = 0.1,
+    spread: float = 1.0,
+    n_epochs: int | None = None,
+    seed: int | None = None,
+    negative_sample_rate: int = 5,
+    learning_rate: float = 1.0,
+    goals: Any = None,
+) -> np.ndarray:
+    """kNN graph in, embedding out: the dependency-free ``humap`` engine, end to end."""
+    a, b = fit_ab(min_dist, spread)
+    graph = fuzzy_simplicial_set(knn_idx, knn_dist)
+    return simplicial_set_layout(
+        graph,
+        emb_dim=emb_dim,
+        n_epochs=n_epochs,
+        a=a,
+        b=b,
+        seed=seed,
+        negative_sample_rate=negative_sample_rate,
+        learning_rate=learning_rate,
+        goals=goals,
+    )


### PR DESCRIPTION
## Summary
Owner-requested HViS overhaul, four commits on this branch:

### 1. The coherent default view (the "janky visualization" fix)
The complaint -- HMM sequences, variable-length fields, and mixed continuous/discrete data collapsing into tiny points or showing no structure, with posterior/log-density/fisher views all disagreeing -- has ONE root cause: the model describes every observation at two levels (WHICH regime: posterior, between-cluster; WHERE within it: continuous, within-cluster), and each affinity mode captured only one. Posterior modes collapse clusters exactly when the model fits well (sharp posteriors = exact ties); likelihood lets sequence length masquerade as structure; a sharp continuous field makes discrete relationships invisible. \`'local'\` (the \`'auto'\` default) had the right shape but silently degraded to posterior-only for any leaf without native coordinates -- HMMs, Markov chains, categoricals, sequence-of-discrete fields: precisely the named data.

Fix: **universal typicality coordinates** -- every leaf already yields per-component log-densities; their columns are a real "how typical under regime k" within-cluster coordinate (per-token rate + explicit log-length axis for sequence-valued leaves), made dimensionless by the existing component-local Mahalanobis whitening, **scored per degree of freedom** (unscaled, typicality deltas grow with K and saturate the evidence cap, making far-within-cluster pairs look cross-cluster: measured 1.09 -> 1.41 separation). Plus **\`affinity_health()\`**: collapse is a measurable property of the affinity, reported in milliseconds with plain-language diagnosis (\`top_tie_fraction\`, \`row_entropy_deficit_nats\`, per-field geometry/sharpness) -- not something to discover after a thousand t-SNE iterations. A prototyped Jaccard "neighborhood degeneracy" metric was measured indistinguishable on healthy vs degenerate data and dropped rather than shipped.

### 2. Streaming (\`StreamingHvis\`)
Frozen landmark atlas + per-point row-KL placement (bit-identical existing coordinates across \`add()\`), model-priced drift detection, Procrustes-aligned \`refresh()\` reporting residual + scale.

### 3. The model streams too
\`estimator=\` wires incremental EM through mixle's accumulator machinery: E-step at arrival, M-step at refresh, receipted (\`model_updated\`, \`n_stream_obs_consumed\`).

### 4. Embedding goals + internal UMAP engine
\`Anchor\` (hard = exact projection; soft = stable relaxation), \`LabelCohesion\` (partial labels; margin hinge), \`AxisAlign\` (scalar runs along an axis) -- rate semantics (bounded per-step displacement, decoupled from optimizer gains; the naive gradient coupling measurably diverges). \`humap(engine=)\`: dependency-free internal UMAP core used when umap-learn is missing or goals are present (umap-learn refuses goals rather than dropping them).

## Test plan
- [x] 103/103 hvis tests: 67 existing (2 pins updated: the 7-field fixture now has 5 local-geometry fields, was 3 -- the old pin documented the gap; separation bar 1.5 -> 1.25 WITH a stronger new claim pinned: within-cluster cross-category pairs sit measurably farther than same-category pairs), 14 streaming, 13 goals, 7 coherence (the three complaints as fixtures: HMM exact-tie collapse detected + healthy under auto; content organizes variable-length layouts, not length; discrete relationships visible under local, provably invisible under joint posterior), plus \`affinity_health\` receipts.
- [x] \`ruff check\` / \`ruff format --check\` clean.

### 5. The (posterior, remainder) decomposition, first-class + barycentric init
The owner's framing made explicit: `mixture_coordinates(model, data)` returns both levels (posterior = barycentric coordinates on the component simplex; per-field within-component coordinates). `component_map` lays components out as vertices by overlap geometry (MDS on -log Bhattacharyya of responsibility profiles); `htsne(Y='barycentric')` starts every point at `z @ vertices`, so the layout's global arrangement comes from the model, not the seed (measured: centroid-geometry ratios identical to 3 decimals across seeds, purity 0.96). Two measured lessons folded in: the init needs BOTH levels (jitter = 0.15 of the smallest vertex gap stands in for within-spread; coincident starts are chaotic), and `early_exaggeration=None` now resolves to 1.0 for informative inits / 12.0 for random -- exaggeration forms global structure from randomness and destroys an informative init (0.71-0.89 seed-dependent purity at 12.0 vs seed-stable 0.96 at 1.0). 9 new tests; 112/112 hvis tests green.

### 6. model_map: the direct compositional layout
Design-review outcome ("are we doing the right thing?"): the model-based affinity idea is right; routing everything through a stochastic neighbor optimizer is the questionable part -- every measured improvement on this branch came from taking work AWAY from the optimizer. `model_map()` reads the layout off the model directly: `y_i = sum_k z_ik (vertex_k + fiber_ik)` -- component vertices by overlap geometry, per-regime fibers by responsibility-weighted PCA of the whitened local coordinates (signs canonicalized), barycentric composition. No perplexity, no seed, bit-deterministic; `ModelMap.place()` is closed-form out-of-sample placement (reproduces training coords to 1e-10 -- streaming is one matrix product); `loadings`/`coord_labels` make within-regime axes nameable; `spread=` makes cluster size an explicit legibility choice instead of a t-SNE artifact; `refine=True` demotes t-SNE to an optional local polish from this init. Precedent: Bishop & Tipping hierarchical mixture visualization / GTM, rebuilt on the HViS field decomposition. 9 new tests; 121/121 hvis tests green.

### 7. topology.py: fuzzy nerve + fidelity receipts (design-review R3/R2, partial)
The mixture is a parametrized cover; by the nerve theorem the data's topology is the cover's nerve. `fuzzy_nerve(z)` computes its weighted 1-/2-skeleton from posteriors alone (soft Mapper with an EM-learned cover; thresholds explicit, empirically calibrated); `nerve_report` emits topology receipts no 2-D map can give -- an 8-component ring cover reports exactly one unfilled cycle (a real loop in the data), a chain reports none, a mutually-overlapping triple is a cycle but NOT a hole (its 2-simplex fills it), a disconnected cover names its pieces. `embedding_health` adds the rendering-fidelity receipt (trustworthiness/continuity of the map vs the model affinity, per-point penalties; scrambled maps flagged, faithful maps clean) -- precisely scoped: it audits layout-vs-model, NOT model-vs-data (that half of R2 stays open, and the design-review doc's status annotations say so). 8 new tests; 129/129 hvis tests green.

### 8. The design-review roadmap, implemented end to end (R1-R7)
- **R1 `hvis.map()`**: one call -> a `Map` with coords, per-point `posterior_entropy` + `typicality` percentile (tested to mean what they claim), nerve + all three healths, `merge_tree`, `place()`, `zoom()`, `summary()`, flat `diagnosis`.
- **R2 both halves**: `model_fit_health` (model<->data from the model's own residuals: chi-squared fiber calibration; a merged-regime detector whose threshold is DERIVED (2.65 unimodal population statistic) plus a measured finite-sample correction `+6/sqrt(n)` after the population value false-positived at n=40; shattered near-duplicates; held-out drop). Underfit K flags the right component.
- **R3**: `component_map` now defaults to geodesic SMACOF on the strong-edge nerve — an 8-component ring cover *renders as a ring* (radial CV < 0.2, adjacency preserved); `method='mds'` kept as fallback.
- **R4**: per-chart tangential frames (found organically: 1-D fibers collided head-on with the vertex axis) + a deterministic push-apart pass — components with NO measured model overlap never overlap on screen, so screen overlap now MEANS model overlap. Adversarial fixture violates pre-pass; determinism + exact placement preserved.
- **R5**: `component_tree` (adjacent pairs merge first) + `Map.zoom()` with measured `zoom_alignment_rms`.
- **R6, scope-corrected**: the automatic residual trigger was REJECTED at design time (linear residual is not chart self-overlap); shipped `chart_residuals` (report) + explicit `chart='quadratic'` (closed-form, placeable).
- **R7 item-by-item**: level/contrast orthogonalization MEASURED AND REJECTED (purity 0.946->0.933 — the redundancy is load-bearing; recorded); Optional missingness gate now carries its presence indicator; 20k-point `hvis_map` with full health completes in seconds (slow smoke pins < 300 s); affinity-zoo shims decided against (the modes are pinned negative baselines).

18 new tests; **147/147 hvis tests green including slow**. Design-review doc updated with final per-item statuses and the remaining honest tail. (Branch note: remote was rebased onto the newer release tip mid-work; the roadmap commit was cherry-picked onto it — no force pushes.)