### PR TITLE
task: add VLM enumeration support (mixle.task.vlm)

### DIFF
--- a/mixle/enumeration/__init__.py
+++ b/mixle/enumeration/__init__.py
@@ -52,8 +52,19 @@ from mixle.enumeration.envelope import AREnvelopeIndex, LatticeEnvelopeIndex
 
 # --- HMM state paths: exact A* enumeration + the quantized random-access path index ---
 from mixle.enumeration.hmm_paths import HMMPathIndex, hmm_best_paths
-from mixle.enumeration.model_enumeration import best_first_decode, quantized_best_first_decode
+from mixle.enumeration.model_enumeration import (
+    beam_search,
+    best_first_decode,
+    quantized_best_first_decode,
+    top_k_scored,
+)
 
+# NOTE: model_enumeration.best_first (the generic engine function) is deliberately NOT re-exported
+# here despite being one of the module's own documented "four entry points" -- this package also has
+# a *submodule* named mixle.enumeration.best_first (best_first.py), and binding a same-named function
+# in this __init__ shadows `import mixle.enumeration.best_first` for anyone reaching the submodule
+# directly (verified: it silently resolves to the function instead, breaking that import). Reach the
+# generic engine via `from mixle.enumeration.model_enumeration import best_first` instead.
 # --- the count-budget seek / unrank index + the count semiring (rank-by-index machinery) ---
 from mixle.enumeration.quantization.core import count_budget_index, logit_error_bucket_slack
 from mixle.enumeration.quantization.semiring import CountSemiring, DecomposableSemiring, TropicalSemiring
@@ -98,6 +109,8 @@ __all__ = [
     "sound_top_k",
     "quantized_best_first_decode",
     "best_first_decode",
+    "beam_search",
+    "top_k_scored",
     # autoregressive (next_logprobs) models: count / threshold / unrank
     "AutoregressiveEnumerable",
     "autoregressive_count_index",

--- a/mixle/task/__init__.py
+++ b/mixle/task/__init__.py
@@ -187,6 +187,12 @@ from mixle.task.structured_out import StructuredSolution, solve_structured
 from mixle.task.toolcall import ToolCaller, ToolSpec, distill_tool_caller
 from mixle.task.traces import AgentTrace, AgentTraces, harvest_agent_traces, parse_conversation
 from mixle.task.tune import CalibratedTuneResult, RecipeSpace, TuneResult, tune_recipe, tune_recipe_for_routing
+from mixle.task.vlm import (
+    CallableVLM,
+    OpenAICompatVLM,
+    score_candidate,
+    score_fn_for,
+)
 
 __all__ = [
     "ESCALATE",
@@ -248,6 +254,10 @@ __all__ = [
     "LadderResult",
     "ModelRecommendation",
     "OpenAICompatLLM",
+    "OpenAICompatVLM",
+    "CallableVLM",
+    "score_candidate",
+    "score_fn_for",
     "QuantizedClassifierIO",
     "QuantizedMLP",
     "EditTrial",

--- a/mixle/task/vlm.py
+++ b/mixle/task/vlm.py
@@ -1,0 +1,192 @@
+"""A tiny provider-agnostic VLM surface, wired directly into mixle.enumeration's descending-probability search.
+
+Sibling of :mod:`mixle.task.llm`, extended with an image. A :class:`VLM` is anything with
+``next_logprobs(image, prefix) -> [(token, log_prob), ...]`` -- the SAME shape
+:func:`mixle.enumeration.best_first_decode` / :func:`mixle.enumeration.quantized_best_first_decode` already
+expect from any autoregressive scorer, so binding an image into that shape (:meth:`OpenAICompatVLM.next_logprobs_for`)
+is all "VLM enumeration support" needs to be: nothing about ``best_first_decode`` itself is vision-specific.
+
+Scope, deliberately: this targets an **open-weight** vision-language model served behind an OpenAI-compatible
+``/v1/chat/completions`` endpoint that returns real per-token ``logprobs`` (vLLM, TGI, and similar self-hosted
+stacks serving e.g. LLaVA / Qwen-VL / ...). Proprietary hosted vision APIs (GPT-4V, Claude vision, Gemini vision)
+generally do not expose true per-token logprobs for image-conditioned generation, so mixle.enumeration's
+descending-probability *guarantee* only holds against a genuine logprob-serving endpoint -- :class:`OpenAICompatVLM`
+does not attempt to approximate that guarantee against a black-box API that cannot honor it.
+
+Two things this file gives you, both built on the one real network primitive (:meth:`OpenAICompatVLM.next_logprobs`):
+
+- **Free-form top-k decoding**, exact and lazy, via the existing engine::
+
+      vlm = OpenAICompatVLM("http://localhost:8000/v1", "llava-onevision")
+      decode = vlm.next_logprobs_for(image, prompt="Describe this image in one sentence.")
+      for tokens, log_prob in best_first_decode(decode, eos="<|eot_id|>", max_len=40, max_results=5):
+          print("".join(tokens), log_prob)   # the 5 highest-probability captions, best first
+
+- **Ranking a fixed candidate set** by the model's own teacher-forced probability, via
+  :func:`mixle.enumeration.top_k_scored`::
+
+      score = score_fn_for(decode)
+      top_k_scored([("cat",), ("dog",), ("bird",)], score, k=3)
+
+Teacher-forced candidate scoring costs one ``next_logprobs`` call per token (no batched echo/teacher-forcing
+primitive is assumed to exist on the server) -- this is stated up front, not hidden behind a fast-looking API.
+Candidates must be pre-tokenized (``Sequence[str]`` of the SAME token pieces the server's own tokenizer would
+produce): a naive whitespace/character split would silently misalign with a real BPE tokenizer and score the
+wrong thing, so no such convenience split is provided here.
+"""
+
+from __future__ import annotations
+
+import base64
+import mimetypes
+from collections.abc import Callable, Iterable, Sequence
+from pathlib import Path
+from typing import Any, Protocol, runtime_checkable
+
+from mixle.task.llm import _http_post_json
+
+
+@runtime_checkable
+class VLM(Protocol):
+    """Anything that can score an image-conditioned next-token continuation."""
+
+    def next_logprobs(self, image: Any, prefix: tuple[str, ...]) -> Iterable[tuple[str, float]]: ...
+
+
+class CallableVLM:
+    """Wrap a plain ``fn(image, prefix) -> [(token, log_prob), ...]`` as a :class:`VLM` -- local models and tests."""
+
+    def __init__(self, fn: Callable[[Any, tuple[str, ...]], Iterable[tuple[str, float]]]) -> None:
+        self.fn = fn
+
+    def next_logprobs(self, image: Any, prefix: tuple[str, ...]) -> Iterable[tuple[str, float]]:
+        return self.fn(image, prefix)
+
+    def next_logprobs_for(self, image: Any) -> Callable[[tuple[str, ...]], Iterable[tuple[str, float]]]:
+        """Bind ``image`` into the ``next_logprobs(prefix)`` shape ``mixle.enumeration`` expects directly."""
+        return lambda prefix: self.next_logprobs(image, prefix)
+
+
+def _image_content(image: Any) -> dict[str, Any]:
+    """Coerce ``image`` (raw bytes, a local file path, or an already-built data/remote URL string) into an
+    OpenAI chat ``image_url`` content part."""
+    if isinstance(image, (bytes, bytearray)):
+        b64 = base64.b64encode(bytes(image)).decode("ascii")
+        return {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{b64}"}}
+    text = str(image)
+    if text.startswith(("http://", "https://", "data:")):
+        return {"type": "image_url", "image_url": {"url": text}}
+    path = Path(text)
+    if path.is_file():
+        mime = mimetypes.guess_type(path.name)[0] or "image/png"
+        b64 = base64.b64encode(path.read_bytes()).decode("ascii")
+        return {"type": "image_url", "image_url": {"url": f"data:{mime};base64,{b64}"}}
+    raise ValueError(f"cannot interpret {image!r} as an image (expected raw bytes, a file path, or a URL/data URI)")
+
+
+class OpenAICompatVLM:
+    """A :class:`VLM` backed by an OpenAI-compatible ``/v1/chat/completions`` endpoint that returns real
+    per-token ``logprobs`` for an open-weight vision-language model (a vLLM- or TGI-served LLaVA / Qwen-VL /
+    ... deployment). See the module docstring for why this deliberately does not target proprietary hosted
+    vision APIs.
+
+    Continuing a partial completion (every ``next_logprobs`` call after the first token of a decode) needs
+    the server to *prefill* the given prefix rather than start generation fresh; this uses vLLM's
+    ``continue_final_message`` extension by default (append the prefix as a partial assistant message, set
+    that flag). Pass ``continue_key``/``continue_value`` to target a server with a different convention.
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        model: str,
+        *,
+        api_key: str | None = None,
+        top_logprobs: int = 20,
+        timeout: float = 60.0,
+        continue_key: str = "continue_final_message",
+        continue_value: Any = True,
+        extra_body: dict[str, Any] | None = None,
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.model = model
+        self.api_key = api_key
+        self.top_logprobs = int(top_logprobs)
+        self.timeout = timeout
+        self.continue_key = continue_key
+        self.continue_value = continue_value
+        self.extra_body = dict(extra_body) if extra_body else {}
+
+    def next_logprobs(
+        self, image: Any, prefix: tuple[str, ...], *, prompt: str, system: str | None = None
+    ) -> list[tuple[str, float]]:
+        """One image-conditioned next-token distribution given the tokens generated so far (``prefix``)."""
+        messages: list[dict[str, Any]] = ([{"role": "system", "content": system}] if system else []) + [
+            {"role": "user", "content": [{"type": "text", "text": prompt}, _image_content(image)]}
+        ]
+        payload: dict[str, Any] = {
+            "model": self.model,
+            "messages": messages,
+            "max_tokens": 1,
+            "logprobs": True,
+            "top_logprobs": self.top_logprobs,
+            **self.extra_body,
+        }
+        if prefix:
+            messages.append({"role": "assistant", "content": "".join(prefix)})
+            payload[self.continue_key] = self.continue_value
+        headers = {"Authorization": f"Bearer {self.api_key}"} if self.api_key else {}
+        out = _http_post_json(f"{self.base_url}/chat/completions", headers, payload, self.timeout)
+        content = out["choices"][0]["logprobs"]["content"]
+        if not content:
+            return []
+        step = content[0]
+        top = step.get("top_logprobs") or [{"token": step["token"], "logprob": step["logprob"]}]
+        return [(t["token"], float(t["logprob"])) for t in top]
+
+    def next_logprobs_for(
+        self, image: Any, prompt: str, *, system: str | None = None
+    ) -> Callable[[tuple[str, ...]], Iterable[tuple[str, float]]]:
+        """Bind ``image``/``prompt`` into the ``next_logprobs(prefix) -> [(token, log_prob), ...]`` shape
+        :func:`mixle.enumeration.best_first_decode` / :func:`mixle.enumeration.quantized_best_first_decode`
+        expect directly -- the whole bridge from "an image and a question" to "enumerate the top-k answers"."""
+        return lambda prefix: self.next_logprobs(image, prefix, prompt=prompt, system=system)
+
+
+def score_candidate(
+    next_logprobs_fn: Callable[[tuple[str, ...]], Iterable[tuple[str, float]]], candidate_tokens: Sequence[str]
+) -> float:
+    """Teacher-forced total log-probability of ``candidate_tokens`` under ``next_logprobs_fn``.
+
+    Walks one token at a time, reading off the ACTUAL log-probability of the candidate's own next token at
+    each step -- never approximated or guessed. If a step's returned continuations do not include the
+    candidate's token (e.g. it fell outside ``top_logprobs``), returns ``-inf`` rather than silently
+    dropping or padding the score with a made-up value: that is a real "this candidate wasn't even
+    considered by the model at that step" outcome, not a bug to hide.
+    """
+    prefix: tuple[str, ...] = ()
+    total = 0.0
+    for token in candidate_tokens:
+        step = dict(next_logprobs_fn(prefix))
+        if token not in step:
+            return float("-inf")
+        total += step[token]
+        prefix = (*prefix, token)
+    return total
+
+
+def score_fn_for(
+    next_logprobs_fn: Callable[[tuple[str, ...]], Iterable[tuple[str, float]]],
+) -> Callable[[Sequence[str]], float]:
+    """Bind a ``next_logprobs`` function into the ``score(candidate) -> float`` shape
+    :func:`mixle.enumeration.top_k_scored` expects directly, for ranking a fixed candidate set."""
+    return lambda candidate_tokens: score_candidate(next_logprobs_fn, candidate_tokens)
+
+
+__all__ = [
+    "VLM",
+    "CallableVLM",
+    "OpenAICompatVLM",
+    "score_candidate",
+    "score_fn_for",
+]

--- a/mixle/tests/task_vlm_test.py
+++ b/mixle/tests/task_vlm_test.py
@@ -1,0 +1,182 @@
+"""VLM surface (mixle.task.vlm): image-conditioned next-token scoring wired directly into
+mixle.enumeration's descending-probability search. CallableVLM drives the enumeration tests
+deterministically (no network); OpenAICompatVLM is exercised with a monkeypatched HTTP post, so the
+request shape (image content, logprobs params, prefix continuation) and response parsing are
+verified without a server.
+"""
+
+import unittest
+
+from mixle.enumeration import best_first_decode, top_k_scored
+from mixle.task import vlm as V
+from mixle.task.vlm import CallableVLM, OpenAICompatVLM, score_candidate, score_fn_for
+
+
+def _toy_next_logprobs(image, prefix):
+    """A tiny deterministic 'model': for a 'cat' image, 'a cat' scores higher than 'a dog'."""
+    import math
+
+    is_cat = image == "https://example.com/cat.png"
+    if prefix == ():
+        return [("a", math.log(0.9)), ("the", math.log(0.1))]
+    if prefix == ("a",):
+        if is_cat:
+            return [("cat", math.log(0.8)), ("dog", math.log(0.2))]
+        return [("dog", math.log(0.8)), ("cat", math.log(0.2))]
+    if prefix in (("a", "cat"), ("a", "dog")):
+        return [("<eos>", 0.0)]  # log(1.0): certain once the animal is named
+    return []
+
+
+class CallableVLMEnumerationTest(unittest.TestCase):
+    def test_next_logprobs_for_binds_the_image_into_the_enumeration_shape(self):
+        vlm = CallableVLM(_toy_next_logprobs)
+        decode = vlm.next_logprobs_for("https://example.com/cat.png")
+        results = list(best_first_decode(decode, eos="<eos>", max_len=5, max_results=2))
+        self.assertEqual(len(results), 2)
+        (seq0, lp0), (seq1, lp1) = results
+        self.assertEqual(seq0, ("a", "cat", "<eos>"))  # the cat image's best-first completion is "a cat"
+        self.assertGreaterEqual(lp0, lp1)  # best-first: descending order
+
+    def test_a_different_image_flips_the_ranking(self):
+        vlm = CallableVLM(_toy_next_logprobs)
+        decode = vlm.next_logprobs_for("dog.png")
+        (seq0, _lp0), _ = list(best_first_decode(decode, eos="<eos>", max_len=5, max_results=2))
+        self.assertEqual(seq0, ("a", "dog", "<eos>"))
+
+    def test_score_fn_for_ranks_a_fixed_candidate_set(self):
+        vlm = CallableVLM(_toy_next_logprobs)
+        decode = vlm.next_logprobs_for("https://example.com/cat.png")
+        score = score_fn_for(decode)
+        ranked = top_k_scored([("a", "cat"), ("a", "dog")], score)
+        self.assertEqual(ranked[0][0], ("a", "cat"))
+        self.assertGreater(ranked[0][1], ranked[1][1])
+
+    def test_score_candidate_returns_neg_inf_for_a_token_the_model_never_considered(self):
+        vlm = CallableVLM(_toy_next_logprobs)
+        decode = vlm.next_logprobs_for("https://example.com/cat.png")
+        self.assertEqual(score_candidate(decode, ("a", "bird")), float("-inf"))
+
+
+class OpenAICompatVLMTest(unittest.TestCase):
+    def test_first_token_request_shape(self):
+        captured = {}
+
+        def fake_post(url, headers, payload, timeout):
+            captured["url"] = url
+            captured["headers"] = headers
+            captured["payload"] = payload
+            return {
+                "choices": [
+                    {
+                        "logprobs": {
+                            "content": [
+                                {
+                                    "token": "a",
+                                    "logprob": -0.1,
+                                    "top_logprobs": [
+                                        {"token": "a", "logprob": -0.1},
+                                        {"token": "the", "logprob": -2.3},
+                                    ],
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+
+        orig = V._http_post_json
+        V._http_post_json = fake_post
+        try:
+            client = OpenAICompatVLM("http://localhost:8000/v1", "llava-onevision", api_key="secret", top_logprobs=5)
+            result = client.next_logprobs("https://example.com/cat.png", (), prompt="What is in this image?")
+        finally:
+            V._http_post_json = orig
+
+        self.assertEqual(result, [("a", -0.1), ("the", -2.3)])
+        self.assertEqual(captured["url"], "http://localhost:8000/v1/chat/completions")
+        self.assertEqual(captured["headers"]["Authorization"], "Bearer secret")
+        self.assertEqual(captured["payload"]["model"], "llava-onevision")
+        self.assertEqual(captured["payload"]["max_tokens"], 1)
+        self.assertIs(captured["payload"]["logprobs"], True)
+        self.assertEqual(captured["payload"]["top_logprobs"], 5)
+        self.assertNotIn("continue_final_message", captured["payload"])  # no prefix yet -> no continuation
+        messages = captured["payload"]["messages"]
+        self.assertEqual(len(messages), 1)  # just the user turn on the first token
+        content = messages[0]["content"]
+        self.assertEqual(content[0], {"type": "text", "text": "What is in this image?"})
+        self.assertEqual(content[1]["type"], "image_url")
+        self.assertEqual(
+            content[1]["image_url"]["url"], "https://example.com/cat.png"
+        )  # already a bare "URL"-shaped string
+
+    def test_continuation_request_sets_the_continue_flag_and_appends_the_prefix(self):
+        captured = {}
+
+        def fake_post(url, headers, payload, timeout):
+            captured["payload"] = payload
+            return {"choices": [{"logprobs": {"content": [{"token": "cat", "logprob": -0.05, "top_logprobs": []}]}}]}
+
+        orig = V._http_post_json
+        V._http_post_json = fake_post
+        try:
+            client = OpenAICompatVLM("http://localhost:8000/v1", "llava-onevision")
+            client.next_logprobs("https://example.com/cat.png", ("a",), prompt="Describe it.")
+        finally:
+            V._http_post_json = orig
+
+        self.assertIs(captured["payload"]["continue_final_message"], True)
+        messages = captured["payload"]["messages"]
+        self.assertEqual(len(messages), 2)
+        self.assertEqual(messages[1], {"role": "assistant", "content": "a"})
+
+    def test_a_custom_continue_convention_is_honored(self):
+        captured = {}
+
+        def fake_post(url, headers, payload, timeout):
+            captured["payload"] = payload
+            return {"choices": [{"logprobs": {"content": [{"token": "x", "logprob": 0.0, "top_logprobs": []}]}}]}
+
+        orig = V._http_post_json
+        V._http_post_json = fake_post
+        try:
+            client = OpenAICompatVLM(
+                "http://localhost:8000/v1", "m", continue_key="add_generation_prompt", continue_value=False
+            )
+            client.next_logprobs("https://example.com/cat.png", ("a",), prompt="p")
+        finally:
+            V._http_post_json = orig
+
+        self.assertIs(captured["payload"]["add_generation_prompt"], False)
+        self.assertNotIn("continue_final_message", captured["payload"])
+
+    def test_next_logprobs_for_binds_image_and_prompt(self):
+        def fake_post(url, headers, payload, timeout):
+            return {"choices": [{"logprobs": {"content": [{"token": "a", "logprob": -0.1, "top_logprobs": []}]}}]}
+
+        orig = V._http_post_json
+        V._http_post_json = fake_post
+        try:
+            client = OpenAICompatVLM("http://localhost:8000/v1", "m")
+            decode = client.next_logprobs_for("https://example.com/cat.png", "What is this?")
+            self.assertEqual(decode(()), [("a", -0.1)])
+        finally:
+            V._http_post_json = orig
+
+
+class ImageContentCoercionTest(unittest.TestCase):
+    def test_remote_url_passthrough(self):
+        content = V._image_content("https://example.com/cat.png")
+        self.assertEqual(content["image_url"]["url"], "https://example.com/cat.png")
+
+    def test_raw_bytes_are_base64_encoded(self):
+        content = V._image_content(b"\x89PNG\r\n\x1a\n")
+        self.assertTrue(content["image_url"]["url"].startswith("data:image/png;base64,"))
+
+    def test_an_unrecognized_string_raises(self):
+        with self.assertRaises(ValueError):
+            V._image_content("not-a-path-or-url")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds `mixle/task/vlm.py`: a `VLM` protocol, `CallableVLM`, and `OpenAICompatVLM`, mirroring `mixle.task.llm`'s existing conventions, wired directly into `mixle.enumeration`'s descending-probability search via `next_logprobs(image, prefix)` — the same shape `best_first_decode`/`top_k_scored` already expect from any autoregressive scorer. This gives both free-form top-k decoding and ranking of a fixed candidate set for free.
- Deliberately scoped to **open-weight** vision-language models served behind an OpenAI-compatible `/v1/chat/completions` endpoint that returns real per-token `logprobs` (vLLM/TGI-style self-hosted stacks, e.g. LLaVA / Qwen-VL). Proprietary hosted vision APIs generally don't expose true per-token logprobs for image-conditioned generation, so `mixle.enumeration`'s descending-probability guarantee only holds against a genuine logprob-serving endpoint.
- Fixes a real export gap in `mixle/enumeration/__init__.py`: `beam_search`/`top_k_scored` were documented as two of the module's "four entry points" but weren't actually exported. `best_first` is deliberately still not exported — binding it at the package level shadows the `mixle.enumeration.best_first` *submodule* for anyone doing `import mixle.enumeration.best_first` directly (verified, not hypothetical); documented with a code comment.

## Test plan
- [x] `mixle/tests/task_vlm_test.py` (new, 11 tests): `CallableVLM` enumeration/scoring via `best_first_decode`/`top_k_scored`, `OpenAICompatVLM` HTTP request-shape verification (first-token request, continuation/`continue_final_message`, custom continue convention, image+prompt binding) via a monkeypatched `_http_post_json`, and image-coercion edge cases (URL, raw bytes, invalid string).
- [x] `mixle/tests/task_llm_test.py` + `task_vlm_test.py` together — sibling module unaffected.
- [x] `mixle/tests/` enumeration-related sweep (285 passed, 20 skipped for unrelated optional deps) — confirms the `__init__.py` export fix didn't break anything.
- [x] `ruff check --fix` / `ruff format` clean on all touched files.