### PR TITLE
test: widen the AxisAlign correlation pin for BLAS-dependent trajectories

### DIFF
--- a/mixle/tests/hvis_goals_test.py
+++ b/mixle/tests/hvis_goals_test.py
@@ -126,7 +126,9 @@ class AxisAlignTest(unittest.TestCase):
         goal = AxisAlign(data, axis=0, weight=0.5)  # the raw 1-D value should order embedding axis 0
         coords = htsne(data, mix_model=_MODEL, method="exact", seed=5, max_its=400, goals=[goal], out=None)
         r = float(np.corrcoef(coords[:, 0], np.asarray(data))[0, 1])
-        self.assertGreater(r, 0.8)
+        # without the goal this seed lands at r=-0.79 (sign is arbitrary); the goal forces positive
+        # alignment at 0.75-0.98 depending on the BLAS/numpy build, so pin the sign with margin
+        self.assertGreater(r, 0.6)
 
     def test_constant_values_raise(self):
         with self.assertRaises(ValueError):


### PR DESCRIPTION
The fast py3.10/py3.11 jobs on the #105 merge run failed `AxisAlignTest::test_values_run_along_the_chosen_axis` at r=0.7506 against a 0.8 pin, while the same seed gives r=0.9748 locally on py3.12 — the exact-t-SNE trajectory under a goal is BLAS/numpy-build dependent and the final layout's Pearson r is bimodal across builds (0.75–0.98 observed).

What the goal actually guarantees is the **sign**: without the goal this seed converges to r=-0.79 (axis orientation is arbitrary), and across seeds the no-goal baseline is ±0.5–0.8 with random sign. With the goal every observed run is strongly positive. The new pin of 0.6 sits decisively above every failure mode (a no-op goal fails at -0.79) and 0.15 below the weakest observed goal-on value.

The other failure on that run (`sampler_seed_test` missing the three copula samplers from #106) is already fixed on #109 and is untouched here.