### PR TITLE
task/distill: parallel teacher labeling (n_jobs) on every teacher entry point

### DIFF
--- a/mixle/task/distill.py
+++ b/mixle/task/distill.py
@@ -47,6 +47,28 @@ def _as_batched(teacher: Callable[..., Any]) -> Callable[[list[str]], list[Any]]
     return batched
 
 
+def _teacher_labels(teacher: Callable[..., Any], items: list, n_jobs: int = 1) -> list[Any]:
+    """Label ``items`` with ``teacher``, fanning contiguous blocks across ``n_jobs`` THREADS.
+
+    Threads, not processes: teachers are typically network-bound LM calls (:mod:`mixle.task.llm`),
+    where parallel in-flight requests are the whole win and the GIL never bites; a CPU-bound Python
+    teacher gains nothing here and should batch internally instead. Labels come back in input
+    order, and ``n_jobs=1`` is byte-for-byte the sequential batched call. Blocks are ~4 per worker
+    so one slow straggler cannot idle the pool.
+    """
+    if n_jobs <= 1 or len(items) <= 1:
+        return _as_batched(teacher)(items)
+    from concurrent.futures import ThreadPoolExecutor
+
+    n_blocks = min(len(items), 4 * n_jobs)
+    edges = [round(i * len(items) / n_blocks) for i in range(n_blocks + 1)]
+    blocks = [items[a:b] for a, b in zip(edges[:-1], edges[1:]) if b > a]
+    batched = _as_batched(teacher)
+    with ThreadPoolExecutor(max_workers=n_jobs) as pool:
+        parts = list(pool.map(batched, blocks))
+    return [label for part in parts for label in part]
+
+
 def distill(
     teacher: Callable[..., Any],
     texts: Sequence[str],
@@ -60,15 +82,18 @@ def distill(
     seed: int = 0,
     task: str = "",
     device: str = "cpu",
+    n_jobs: int = 1,
 ) -> TaskModel:
     """Label ``texts`` with ``teacher``, fit a small student to match, and return a callable :class:`TaskModel`.
 
     ``n``/``dim`` size the hashed n-gram featurizer; ``hidden`` the student MLP. ``labels`` fixes the label set
     (else inferred from the teacher's outputs). The student's train-set agreement with the teacher is recorded
-    in ``meta``.
+    in ``meta``. ``n_jobs > 1`` fans teacher labeling across that many threads (order-preserving; the win is
+    parallel in-flight requests against a network-bound teacher) -- every ``distill_*`` teacher entry point
+    takes the same knob.
     """
     texts = [str(t) for t in texts]
-    teacher_labels = _as_batched(teacher)(texts)
+    teacher_labels = _teacher_labels(teacher, texts, n_jobs=n_jobs)
     return distill_from_labels(
         texts,
         teacher_labels,
@@ -138,6 +163,7 @@ def distill_for_routing(
     device: str = "cpu",
     density_gate: bool = False,
     density_gate_alpha: float = 0.05,
+    n_jobs: int = 1,
 ) -> CalibratedTaskModel:
     """Label ``texts`` with ``teacher``, fit a student, and calibrate it for routing -- all in one call.
 
@@ -152,7 +178,7 @@ def distill_for_routing(
     :func:`distill_from_labels_for_routing`.
     """
     texts = [str(t) for t in texts]
-    teacher_labels = _as_batched(teacher)(texts)
+    teacher_labels = _teacher_labels(teacher, texts, n_jobs=n_jobs)
     return distill_from_labels_for_routing(
         texts,
         teacher_labels,
@@ -241,6 +267,7 @@ def distill_records(
     seed: int = 0,
     task: str = "",
     device: str = "cpu",
+    n_jobs: int = 1,
 ) -> TaskModel:
     """Distill a teacher into a record classifier (``record -> label`` over tuples/dicts of mixed fields).
 
@@ -248,7 +275,7 @@ def distill_records(
     Uses the hashing-trick :class:`~mixle.task.model.HashedRecord` featurizer, so it needs no fitted encoder.
     """
     records = list(records)
-    teacher_labels = _as_batched(teacher)(records)
+    teacher_labels = _teacher_labels(teacher, records, n_jobs=n_jobs)
     return distill_records_from_labels(
         records,
         teacher_labels,
@@ -310,11 +337,12 @@ def distill_records_for_routing(
     device: str = "cpu",
     density_gate: bool = False,
     density_gate_alpha: float = 0.05,
+    n_jobs: int = 1,
 ) -> CalibratedTaskModel:
     """The structured-record sibling of :func:`distill_for_routing`: fit + calibrate a record classifier
     in one call, returning a routing-ready :class:`~mixle.task.calibrate.CalibratedTaskModel`."""
     records = list(records)
-    teacher_labels = _as_batched(teacher)(records)
+    teacher_labels = _teacher_labels(teacher, records, n_jobs=n_jobs)
     return distill_records_from_labels_for_routing(
         records,
         teacher_labels,
@@ -388,6 +416,7 @@ def distill_structured(
     max_its: int = 30,
     seed: int = 0,
     task: str = "",
+    n_jobs: int = 1,
 ) -> TaskModel:
     """Distill a teacher into a tiny **structured probabilistic** classifier -- a learned Bayesian network, not an MLP.
 
@@ -402,7 +431,7 @@ def distill_structured(
     student whose sub-structures differ by regime. Assumes a fixed record schema (see :class:`StructuredClassifierIO`).
     """
     records = list(records)
-    teacher_labels = [str(t) for t in _as_batched(teacher)(records)]
+    teacher_labels = [str(t) for t in _teacher_labels(teacher, records, n_jobs=n_jobs)]
     return distill_structured_from_labels(
         records,
         teacher_labels,

--- a/mixle/tests/distill_parallel_test.py
+++ b/mixle/tests/distill_parallel_test.py
@@ -1,0 +1,77 @@
+"""Parallel teacher labeling (mixle.task.distill._teacher_labels and the n_jobs knob).
+
+The claims: n_jobs=1 is byte-for-byte the sequential batched call; n_jobs>1 preserves input order
+for BOTH per-item and batched teachers; requests genuinely overlap in flight (measured, not
+assumed); and the knob reaches the torch-free structured entry point end to end.
+"""
+
+import threading
+import time
+import unittest
+
+from mixle.task.distill import _as_batched, _teacher_labels
+
+
+def _label(text: str) -> str:
+    return "long" if len(str(text)) > 5 else "short"
+
+
+class TeacherLabelsTest(unittest.TestCase):
+    TEXTS = [f"item-{i}" * (1 + i % 3) for i in range(23)]
+
+    def test_sequential_path_is_exactly_as_batched(self):
+        want = _as_batched(_label)(list(self.TEXTS))
+        self.assertEqual(_teacher_labels(_label, list(self.TEXTS), n_jobs=1), want)
+
+    def test_per_item_teacher_keeps_order_across_threads(self):
+        want = [_label(t) for t in self.TEXTS]
+        self.assertEqual(_teacher_labels(_label, list(self.TEXTS), n_jobs=4), want)
+
+    def test_batched_teacher_keeps_order_across_threads(self):
+        def batched_teacher(texts):
+            return [_label(t) for t in texts]
+
+        want = [_label(t) for t in self.TEXTS]
+        self.assertEqual(_teacher_labels(batched_teacher, list(self.TEXTS), n_jobs=3), want)
+
+    def test_requests_actually_overlap(self):
+        lock = threading.Lock()
+        state = {"in_flight": 0, "max_in_flight": 0}
+
+        def slow_teacher(text):
+            with lock:
+                state["in_flight"] += 1
+                state["max_in_flight"] = max(state["max_in_flight"], state["in_flight"])
+            time.sleep(0.02)
+            with lock:
+                state["in_flight"] -= 1
+            return _label(text)
+
+        want = [_label(t) for t in self.TEXTS]
+        self.assertEqual(_teacher_labels(slow_teacher, list(self.TEXTS), n_jobs=4), want)
+        self.assertGreaterEqual(state["max_in_flight"], 2)  # concurrency observed, not assumed
+
+    def test_single_item_short_circuits(self):
+        self.assertEqual(_teacher_labels(_label, ["ab"], n_jobs=8), ["short"])
+
+
+class EndToEndTest(unittest.TestCase):
+    def test_structured_distill_accepts_n_jobs(self):
+        # distill_structured is torch-free: the full path from parallel teacher labels to a fitted
+        # student, with the parallel and sequential labelings producing the same student decisions.
+        from mixle.task.distill import distill_structured
+
+        records = [(float(i % 7), ("a", "b", "c")[i % 3]) for i in range(60)]
+
+        def teacher(rec):
+            if isinstance(rec, list):  # the batched-probe protocol hands the whole list first
+                return [teacher(r) for r in rec]
+            return "big" if rec[0] >= 3.0 else "small"
+
+        seq = distill_structured(teacher, records, seed=0)
+        par = distill_structured(teacher, records, seed=0, n_jobs=4)
+        self.assertEqual([seq(r) for r in records], [par(r) for r in records])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Answers "does mixle support distributed distillation?" with the honest decomposition:

- **Teacher labeling** — the actual wall-clock wall (one serial batched pass over the corpus against a network-bound LM) — now fans out: `_teacher_labels` splits the corpus into contiguous, order-preserving blocks (~4 per worker so a straggler can't idle the pool) across `n_jobs` **threads**. Threads are the right tool here: the win is parallel in-flight requests against an I/O-bound teacher, and the GIL never bites; a CPU-bound Python teacher gains nothing and should batch internally (the docstring says so). `n_jobs=1` is byte-for-byte the previous sequential call.
- **Student fitting** stays local by design: the MLP student is one small torch fit, and structured/mixture students already distribute through the estimator machinery (`seq_estimate`'s Spark/multiprocessing/MPI paths) when the data demands it — that half of "distributed distillation" has existed all along.

All five teacher-calling entry points take the knob (`distill`, `distill_for_routing`, `distill_records`, `distill_records_for_routing`, `distill_structured`); the `*_from_labels` cores are untouched since they never call the teacher.

Tests: `n_jobs=1` equals the sequential batched call exactly; order preservation for both per-item and batched teachers across threads; concurrency **measured** (max in-flight ≥ 2 under a slow teacher), not assumed; and a torch-free end-to-end through `distill_structured` where parallel and sequential labeling produce identical student decisions. The existing routing-distill suite passes unchanged.