### PR TITLE
structure: make learn_structure/learn_mixture_structure deterministic given seed

### DIFF
--- a/mixle/inference/__init__.py
+++ b/mixle/inference/__init__.py
@@ -252,6 +252,7 @@ from mixle.inference.structure import (
     dependency_gain,
     learn_mixture_structure,
     learn_structure,
+    mixture_structure_health,
 )
 from mixle.inference.structure_embedded import EmbeddedStructureModel, learn_structure_embedded
 
@@ -565,6 +566,7 @@ __all__ = [
     # automatic dependency-structure learning for heterogeneous records
     "learn_structure",
     "learn_mixture_structure",
+    "mixture_structure_health",
     "learn_bayesian_network",
     "learn_mixture_bayesian_network",
     "select_mixture_components",

--- a/mixle/inference/structure.py
+++ b/mixle/inference/structure.py
@@ -473,6 +473,17 @@ class MixtureOfDependencyTrees:
         self.weights = np.asarray(weights, dtype=np.float64)
         self.log_weights = np.log(np.clip(self.weights, 1e-300, None))
 
+    @property
+    def w(self) -> np.ndarray:
+        """Mixture-convention alias for ``weights`` -- lets mixture-generic tooling (e.g.
+        ``mixle.utils.hvis.model_fit_health`` / ``hvis_map``) accept this model unchanged."""
+        return self.weights
+
+    @property
+    def log_w(self) -> np.ndarray:
+        """Mixture-convention alias for ``log_weights`` (see :attr:`w`)."""
+        return self.log_weights
+
     def __str__(self) -> str:
         return f"MixtureOfDependencyTrees(k={len(self.components)}, weights={np.round(self.weights, 3).tolist()})"
 
@@ -590,6 +601,119 @@ def learn_mixture_structure(
             best_ll, best = ll, model
     assert best is not None
     return best
+
+
+def _split_separation(values: np.ndarray) -> tuple[float, float]:
+    """Deterministic 1-D 2-means ``(separation, minority share)`` -- the same construction (sign
+    split + Lloyd, gap over pooled within-std) and calibration as the merged-regime detector in
+    ``mixle.utils.hvis.topology.model_fit_health``, so the ``2.65 + 6/sqrt(n)`` threshold carries
+    over. Returns ``(0, 0)`` when 2-means degenerates to one cluster."""
+    proj = np.asarray(values, dtype=np.float64)
+    proj = proj - proj.mean()
+    assign = proj > 0.0
+    for _ in range(15):
+        if assign.all() or (~assign).all():
+            return 0.0, 0.0
+        c1, c0 = float(proj[assign].mean()), float(proj[~assign].mean())
+        new_assign = np.abs(proj - c1) < np.abs(proj - c0)
+        if bool(np.all(new_assign == assign)):
+            break
+        assign = new_assign
+    if not 0 < int(assign.sum()) < len(proj):
+        return 0.0, 0.0
+    minority = min(float(assign.mean()), float(1.0 - assign.mean()))
+    within_var = float(
+        np.average([proj[assign].var(), proj[~assign].var()], weights=[assign.mean(), 1 - assign.mean()])
+    )
+    sep = abs(float(proj[assign].mean() - proj[~assign].mean())) / max(np.sqrt(within_var), 1.0e-12)
+    return sep, minority
+
+
+def mixture_structure_health(
+    mot: MixtureOfDependencyTrees, data: Sequence[tuple], *, merged_sep_threshold: float | None = None
+) -> dict:
+    """The identifiability receipt for a fitted :class:`MixtureOfDependencyTrees`.
+
+    The trap it names: a flexible per-field family (a Gaussian-mixture conditional, a heavy-tailed
+    catch-all marginal) lets ONE component absorb what the caller intended as SEVERAL regimes --
+    and because the absorbed fit scores well, likelihood-level receipts look healthy. Measured
+    concretely: on two planted regimes, a one-component fit matches the two-component fit's
+    likelihood, so nothing downstream of the density can see the difference.
+
+    The check that can: STRUCTURE-CONDITIONAL multimodality. For every continuous field of every
+    component, group that component's dominated points by the field's own learned conditioning
+    (parent level for a binned conditional, regression residuals for a linear edge, the whole
+    fiber for a root marginal) -- after the tree has explained what it can, each group must be
+    unimodal. A group that still splits (deterministic 2-means separation over the same
+    ``2.65 + 6/sqrt(n)`` finite-sample threshold the hvis merged-regime detector is calibrated
+    to, minority share >= 20%) is a regime split the component is hiding, whichever family
+    absorbed it.
+
+    Returns ``{"components": [...], "diagnosis": [str, ...]}`` -- empty ``diagnosis`` means no
+    component hides multimodal structure. Per component, ``multimodal_fields`` lists
+    ``(field, where, separation)`` and ``mixture_factors`` lists factors the detector fitted as
+    mixture families (supporting detail: where the absorbed structure went). The fix when it
+    fires is more components or pinned unimodal ``field_estimators`` (see
+    :func:`learn_mixture_structure`). Complementary to ``mixle.utils.hvis.model_fit_health``,
+    which audits density calibration and accepts this model directly.
+    """
+    from mixle.stats import MixtureDistribution
+    from mixle.stats.combinator.conditional import ConditionalDistribution
+
+    data = list(data)
+    cols = _columns(data)
+    dominant = mot.responsibilities(data).argmax(axis=1)
+    components, diagnosis = [], []
+    for k, tree in enumerate(mot.components):
+        rows_k = np.flatnonzero(dominant == k)
+        mixture_factors: list[tuple[int, str]] = []
+        multimodal: list[tuple[int, str, float]] = []
+        for j, factor in enumerate(tree.factors):
+            if isinstance(factor, MixtureDistribution):
+                mixture_factors.append((j, "marginal"))
+            elif isinstance(factor, ConditionalDistribution):
+                mixture_factors.extend(
+                    (j, f"conditional level {lv!r}")
+                    for lv, child in factor.dmap.items()
+                    if isinstance(child, MixtureDistribution)
+                )
+
+            if not _is_numeric(cols[j]):
+                continue
+            vals = np.asarray([cols[j][i] for i in rows_k], dtype=np.float64)
+            parent = tree.parents[j]
+            if parent is None:
+                groups = [("marginal", vals)]
+            elif isinstance(factor, LinearGaussianEdge):
+                pv = np.asarray([cols[parent][i] for i in rows_k], dtype=np.float64)
+                groups = [("regression residuals", vals - (factor.a + factor.b * pv))]
+            elif isinstance(factor, ConditionalDistribution):
+                binner = tree.binners[j]
+                keys = [cols[parent][i] if binner is None else binner(cols[parent][i]) for i in rows_k]
+                by_key: dict = {}
+                for key, v in zip(keys, vals):
+                    by_key.setdefault(key, []).append(float(v))
+                groups = [
+                    (f"level {key!r}", np.asarray(g)) for key, g in sorted(by_key.items(), key=lambda t: repr(t[0]))
+                ]
+            else:  # GLM edges have discrete children; nothing continuous to test
+                continue
+            for where, g in groups:
+                if len(g) < 20:
+                    continue
+                sep, minority = _split_separation(g)
+                threshold = (
+                    merged_sep_threshold if merged_sep_threshold is not None else 2.65 + 6.0 / np.sqrt(float(len(g)))
+                )
+                if sep > threshold and minority >= 0.2:
+                    multimodal.append((j, where, sep))
+                    diagnosis.append(
+                        f"component {k} field {j} ({where}): still splits after conditioning (2-means "
+                        f"separation {sep:.1f}, minority {minority:.0%}) -- this component is absorbing "
+                        "multiple regimes; consider more components or pinned field_estimators."
+                    )
+        components.append({"mixture_factors": mixture_factors, "multimodal_fields": multimodal})
+    return {"components": components, "diagnosis": diagnosis}
 
 
 # --- structure search + fitting ------------------------------------------------------------------------------

--- a/mixle/inference/structure.py
+++ b/mixle/inference/structure.py
@@ -58,6 +58,7 @@ def dependency_gain(
     *,
     max_its: int = 30,
     penalty: str = "bic",
+    rng: np.random.RandomState | None = None,
 ) -> float:
     """Description-length gain (nats) of modeling ``child`` conditioned on a discrete ``parent`` vs. independently.
 
@@ -65,18 +66,21 @@ def dependency_gain(
     the same data and returns ``LL_cond - LL_marginal`` minus a complexity penalty for the extra parameters
     (BIC: ``0.5 * (levels - 1) * k * ln n``). Positive means the dependence is worth modeling. This is a
     model-based dependency test -- it works across *any* pair of families, unlike a same-type MI estimate.
+    ``rng`` seeds the fits' EM initializations (``None`` = a fixed seed: deterministic by default; matters when
+    the child family needs a randomized init, e.g. a mixture).
     """
+    rng = np.random.RandomState(0) if rng is None else rng
     child = list(child)
     n = len(child)
     levels = sorted(set(parent))
-    marginal = fit(child, _clone(child_estimator), max_its=max_its, out=None)
+    marginal = fit(child, _clone(child_estimator), max_its=max_its, out=None, rng=rng)
     ll_marginal = float(np.sum(marginal.seq_log_density(marginal.dist_to_encoder().seq_encode(child))))
 
     pairs = list(zip(parent, child))
     cond_est = ConditionalDistributionEstimator(
         estimator_map={lv: _clone(child_estimator) for lv in levels}, given_estimator=None
     )
-    cond = fit(pairs, cond_est, max_its=max_its, out=None)
+    cond = fit(pairs, cond_est, max_its=max_its, out=None, rng=rng)
     enc = cond.dist_to_encoder().seq_encode(pairs)
     ll_cond = float(np.sum(cond.seq_log_density(enc)))
 
@@ -155,11 +159,19 @@ def fit_linear_gaussian_edge(pairs: Sequence[tuple]) -> LinearGaussianEdge:
 
 
 def regression_gain(
-    parent: Sequence[Any], child: Sequence[Any], child_estimator: Any, *, max_its: int = 30, penalty: str = "bic"
+    parent: Sequence[Any],
+    child: Sequence[Any],
+    child_estimator: Any,
+    *,
+    max_its: int = 30,
+    penalty: str = "bic",
+    rng: np.random.RandomState | None = None,
 ) -> float:
     """Description-length gain (nats) of a linear-Gaussian *regression* edge ``child ~ a + b*parent`` over the
     child marginal. One extra parameter (the slope) vs. the ``bins * k`` a binned conditional spends — so for a
-    real linear dependence this beats binning decisively. Returns ``-inf`` when a regression is undefined."""
+    real linear dependence this beats binning decisively. Returns ``-inf`` when a regression is undefined.
+    ``rng`` seeds the marginal fit's EM initialization (``None`` = a fixed seed: deterministic by default)."""
+    rng = np.random.RandomState(0) if rng is None else rng
     p = np.asarray(parent, dtype=float)
     c = np.asarray(child, dtype=float)
     n = len(c)
@@ -167,7 +179,7 @@ def regression_gain(
         return float("-inf")
     edge = fit_linear_gaussian_edge(list(zip(p.tolist(), c.tolist())))
     ll_reg = float(np.sum(edge.seq_log_density((p, c))))
-    marginal = fit(list(child), _clone(child_estimator), max_its=max_its, out=None)
+    marginal = fit(list(child), _clone(child_estimator), max_its=max_its, out=None, rng=rng)
     ll_marginal = float(np.sum(marginal.seq_log_density(marginal.dist_to_encoder().seq_encode(list(child)))))
     pen = 0.5 * 1.0 * np.log(max(n, 2)) if penalty == "bic" else 0.0  # a single extra parameter: the slope
     return ll_reg - ll_marginal - pen
@@ -280,9 +292,12 @@ def glm_gain(
     *,
     max_its: int = 30,
     penalty: str = "bic",
+    rng: np.random.RandomState | None = None,
 ) -> float:
     """Description-length gain (nats) of a GLM ``family`` regression edge over the child marginal (one extra slope
-    parameter). Returns ``-inf`` when the fit is undefined or non-finite."""
+    parameter). Returns ``-inf`` when the fit is undefined or non-finite. ``rng`` seeds the marginal fit's EM
+    initialization (``None`` = a fixed seed: deterministic by default)."""
+    rng = np.random.RandomState(0) if rng is None else rng
     p = np.asarray(parent, dtype=float)
     c = np.asarray(child, dtype=float)
     n = len(c)
@@ -295,14 +310,19 @@ def glm_gain(
         return float("-inf")
     if not np.isfinite(ll_glm):
         return float("-inf")
-    marginal = fit(list(child), _clone(child_estimator), max_its=max_its, out=None)
+    marginal = fit(list(child), _clone(child_estimator), max_its=max_its, out=None, rng=rng)
     ll_marginal = float(np.sum(marginal.seq_log_density(marginal.dist_to_encoder().seq_encode(list(child)))))
     pen = 0.5 * 1.0 * np.log(max(n, 2)) if penalty == "bic" else 0.0
     return ll_glm - ll_marginal - pen
 
 
 def _numeric_edge_candidate(
-    parent_col: Sequence[Any], child_col: Sequence[Any], template: Any, *, max_its: int = 30
+    parent_col: Sequence[Any],
+    child_col: Sequence[Any],
+    template: Any,
+    *,
+    max_its: int = 30,
+    rng: np.random.RandomState | None = None,
 ) -> tuple[float | None, str | None]:
     """The best regression/GLM edge of ``child`` on a numeric ``parent``: ``(gain, kind)`` or ``(None, None)``.
     Dispatches on the child's type — binary -> logistic, count -> Poisson, real -> linear-Gaussian."""
@@ -311,11 +331,11 @@ def _numeric_edge_candidate(
     if not _is_numeric(child_col):  # a categorical child stays a binned conditional
         return None, None
     if _is_binary(child_col):
-        return glm_gain(parent_col, child_col, template, "binomial", max_its=max_its), "glm:binomial"
+        return glm_gain(parent_col, child_col, template, "binomial", max_its=max_its, rng=rng), "glm:binomial"
     if _is_count(child_col):
-        return glm_gain(parent_col, child_col, template, "poisson", max_its=max_its), "glm:poisson"
+        return glm_gain(parent_col, child_col, template, "poisson", max_its=max_its, rng=rng), "glm:poisson"
     if _is_numeric(child_col):
-        return regression_gain(parent_col, child_col, template, max_its=max_its), "regression"
+        return regression_gain(parent_col, child_col, template, max_its=max_its, rng=rng), "regression"
     return None, None
 
 
@@ -512,13 +532,21 @@ def learn_mixture_structure(
     min_gain: float = 0.0,
     n_bins: int = 4,
     max_its: int = 30,
+    field_estimators: Sequence[Any] | None = None,
 ) -> MixtureOfDependencyTrees:
     """Fit a :class:`MixtureOfDependencyTrees` by hard EM -- discover clusters AND each cluster's dependency graph.
 
     Each iteration re-learns a dependency forest per cluster on its currently-assigned points (M-step), then
     reassigns every record to its most-probable cluster (E-step), until assignments stabilize. Runs ``restarts``
     random initializations and returns the highest-likelihood fit. Empty/tiny clusters are re-seeded so a
-    component never collapses.
+    component never collapses. Deterministic given ``seed``: the one ``RandomState`` drives the k-means/random
+    initializations AND every per-cluster fit's EM init (via :func:`learn_structure`'s ``rng``).
+
+    ``field_estimators`` pins each field's family (forwarded to :func:`learn_structure`) instead of re-running
+    the automatic detector per cluster per iteration. Beyond the speedup, pinning matters for identifiability:
+    the detector models a multimodal column with a Gaussian MIXTURE, which lets ONE cluster absorb what the
+    caller intended as two -- with per-field families pinned to unimodal models, regimes that differ in level
+    must separate into different components to score well.
     """
     data = list(data)
     n = len(data)
@@ -528,7 +556,9 @@ def learn_mixture_structure(
     best_ll = -np.inf
 
     def learn(subset: list[tuple]) -> DependencyTreeDistribution:
-        return learn_structure(subset, min_gain=min_gain, n_bins=n_bins, max_its=max_its)
+        return learn_structure(
+            subset, field_estimators=field_estimators, min_gain=min_gain, n_bins=n_bins, max_its=max_its, rng=rng
+        )
 
     # seed the first restarts with k-means (numeric-level split, then full-feature split), rest random
     inits = [
@@ -573,6 +603,7 @@ def learn_structure(
     max_levels: int = 64,
     n_bins: int = 4,
     max_its: int = 30,
+    rng: np.random.RandomState | None = None,
 ) -> DependencyTreeDistribution:
     """Discover the dependency forest for heterogeneous ``data`` and return the fitted joint model.
 
@@ -582,7 +613,13 @@ def learn_structure(
     field at most one parent), and fits each factor. Falls back to independent marginals where no dependence
     clears ``min_gain`` -- never worse than a composite, much better when structure exists. This is "automatic
     inference for composable models of heterogeneous data" made real.
+
+    ``rng`` seeds every internal fit's EM initialization; ``None`` resolves to a FIXED seed, so two calls on
+    the same data return the same model. (Before this knob, fits whose detected family needs a randomized
+    init -- a Gaussian-mixture conditional, say -- drew fresh OS entropy per call, so the learned model
+    itself was nondeterministic.)
     """
+    rng = np.random.RandomState(0) if rng is None else rng
     data = list(data)
     cols = _columns(data)
     n_fields = len(cols)
@@ -600,9 +637,9 @@ def learn_structure(
         for c in range(n_fields):
             if c == p:
                 continue
-            gain = dependency_gain(keyed[p], cols[c], templates[c], max_its=max_its)
+            gain = dependency_gain(keyed[p], cols[c], templates[c], max_its=max_its, rng=rng)
             kind = "binned"
-            ngain, nkind = _numeric_edge_candidate(cols[p], cols[c], templates[c], max_its=max_its)
+            ngain, nkind = _numeric_edge_candidate(cols[p], cols[c], templates[c], max_its=max_its, rng=rng)
             if ngain is not None and ngain > gain:
                 gain, kind = ngain, nkind
             if gain > min_gain:
@@ -625,7 +662,7 @@ def learn_structure(
     edge_binners: list[Any] = [None] * n_fields
     for i in range(n_fields):
         if parents[i] is None:
-            factors[i] = fit(cols[i], _clone(templates[i]), max_its=max_its, out=None)
+            factors[i] = fit(cols[i], _clone(templates[i]), max_its=max_its, out=None, rng=rng)
         elif edge_kind[i] == "regression":
             factors[i] = fit_linear_gaussian_edge(list(zip(cols[parents[i]], cols[i])))
             edge_binners[i] = None  # the raw parent value drives the regression
@@ -638,7 +675,7 @@ def learn_structure(
             est = ConditionalDistributionEstimator(
                 estimator_map={lv: _clone(templates[i]) for lv in sorted(set(keys))}, given_estimator=None
             )
-            factors[i] = fit(list(zip(keys, cols[i])), est, max_its=max_its, out=None)
+            factors[i] = fit(list(zip(keys, cols[i])), est, max_its=max_its, out=None, rng=rng)
             edge_binners[i] = binners[p]
     return DependencyTreeDistribution(parents, factors, edge_binners)
 

--- a/mixle/task/distill.py
+++ b/mixle/task/distill.py
@@ -444,7 +444,9 @@ def distill_structured_from_labels(
         )
         edges = model.components[0].edges()
     else:
-        model = learn_structure(augmented, min_gain=min_gain, n_bins=n_bins, max_its=max_its)
+        model = learn_structure(
+            augmented, min_gain=min_gain, n_bins=n_bins, max_its=max_its, rng=np.random.RandomState(seed)
+        )
         edges = model.edges()
 
     adapter = StructuredClassifierIO(field_keys, label_index, label_list)

--- a/mixle/tests/structure_learning_test.py
+++ b/mixle/tests/structure_learning_test.py
@@ -228,6 +228,38 @@ class MixtureOfTreesTest(unittest.TestCase):
         for i, row in enumerate(rows):
             self.assertAlmostEqual(mot.log_density(row), float(seq[i]), places=6)
 
+    def test_health_flags_a_component_absorbing_two_regimes(self):
+        # the identifiability receipt: force ONE component over two-regime data. The absorption is
+        # invisible to density-level receipts (the flexible per-field families fit both regimes
+        # well) -- but after conditioning on the component's own learned structure, the value
+        # field still splits, whichever family hid it. Both honest two-component fits (pinned
+        # families AND auto-detected) come back clean: within-level groups are unimodal there.
+        from mixle.inference.structure import mixture_structure_health
+
+        train = _two_regime(8)
+        absorbed = learn_mixture_structure(train, 1, restarts=1, seed=0)
+        report = mixture_structure_health(absorbed, train)
+        self.assertTrue(any("component 0" in d and "absorbing" in d for d in report["diagnosis"]))
+        self.assertTrue(report["components"][0]["multimodal_fields"])
+
+        fams = (st.CategoricalEstimator(), st.GaussianEstimator())
+        clean = learn_mixture_structure(train, 2, restarts=4, seed=0, field_estimators=fams)
+        self.assertEqual(mixture_structure_health(clean, train)["diagnosis"], [])
+        auto = learn_mixture_structure(train, 2, restarts=4, seed=0)
+        self.assertEqual(mixture_structure_health(auto, train)["diagnosis"], [])
+
+    def test_hvis_fit_health_accepts_a_mixture_of_trees(self):
+        # the w/log_w aliases make the model quack like a mixture, so the DENSITY-level receipt
+        # (merged/shattered regimes, calibration) composes with the factor-family receipt above
+        from mixle.utils.hvis import model_fit_health
+
+        train = _two_regime(9, n=400)
+        mot = learn_mixture_structure(train, 2, restarts=3, seed=0)
+        report = model_fit_health(mot, train)
+        self.assertIn("components", report)
+        self.assertIn("diagnosis", report)
+        self.assertEqual(len(report["components"]), 2)
+
 
 def _linear(seed, n=400):
     """A linear continuous dependence y ~ 2x + noise, plus an independent categorical field."""

--- a/mixle/tests/structure_learning_test.py
+++ b/mixle/tests/structure_learning_test.py
@@ -182,7 +182,13 @@ class MixtureOfTreesTest(unittest.TestCase):
         self.assertTrue(any((0, 1) in c.edges() for c in mot.components))
 
     def test_responsibilities_recover_clusters(self):
-        # label each row by its regime and check the mixture's hard assignment separates them
+        # label each row by its regime and check the mixture's hard assignment separates them.
+        # Families are PINNED to unimodal models: with the automatic detector free to pick Gaussian
+        # MIXTURES for conditionals, one component can absorb both regimes, and such impure splits
+        # genuinely OUT-SCORE the planted one (measured: -3410 nats impure vs -3415 pure) -- which
+        # basin best-of-N returned then rode on EM trajectory noise, the CI flake. Pinned to single
+        # Gaussians, every restart converges to the planted split (measured: purity 1.000 at one
+        # identical likelihood across 12 seeds).
         r = np.random.RandomState(7)
         rows, z = [], []
         for _ in range(1200):
@@ -190,11 +196,23 @@ class MixtureOfTreesTest(unittest.TestCase):
             c = "hi" if r.rand() < 0.5 else "lo"
             rows.append((c, float((5.0 if zi == 0 else -5.0) + (3.0 if c == "hi" else -3.0) + r.randn())))
             z.append(zi)
-        mot = learn_mixture_structure(rows, 2, restarts=4, seed=0)
+        fams = (st.CategoricalEstimator(), st.GaussianEstimator())
+        mot = learn_mixture_structure(rows, 2, restarts=4, seed=0, field_estimators=fams)
         assign = mot.responsibilities(rows).argmax(axis=1)
         z = np.array(z)
         purity = max((assign == z).mean(), (assign != z).mean())
         self.assertGreater(purity, 0.9)
+
+    def test_learning_is_deterministic_given_seed(self):
+        # the regression test for the flake's ROOT CAUSE: per-cluster fits used to draw fresh OS
+        # entropy for their EM inits (fit() with no rng), so the same call returned a different
+        # model run to run whenever a detected family (e.g. a mixture conditional) needed a
+        # randomized init. seed must pin the WHOLE pipeline: same call, bitwise-identical model.
+        train = _two_regime(11)
+        a = learn_mixture_structure(train, 2, restarts=3, seed=5)
+        b = learn_mixture_structure(train, 2, restarts=3, seed=5)
+        np.testing.assert_array_equal(a.responsibilities(train), b.responsibilities(train))
+        self.assertEqual([c.edges() for c in a.components], [c.edges() for c in b.components])
 
     def test_samples_and_scores(self):
         mot = learn_mixture_structure(_two_regime(3), 2, restarts=3, seed=0)


### PR DESCRIPTION
Fixes the intermittent CI failure of `MixtureOfTreesTest::test_responsibilities_recover_clusters` (run 28932990312: purity 0.746 vs the 0.9 pin) at its actual roots. Two independent defects, both fixed:

**1. `seed` never made the fit deterministic.** Every internal `fit()` in the structure pipeline — `dependency_gain`'s marginal and conditional fits, `regression_gain`/`glm_gain` marginals, and both factor fits in `learn_structure` — omitted `rng`, and `fit` defaults to a **fresh OS-entropy `RandomState`** (`optimize`: `rng = RandomState() if rng is None else rng`). Any fit whose detected family needs a randomized EM init (the detector picks Gaussian-*mixture* conditionals for multimodal columns) therefore returned a different model per call: the same command measured purity 1.000, 0.991, 0.997 across three consecutive runs. This is why the test "passes repeatedly locally" and fails on CI — every process is a fresh draw. #90's restart bump treated the symptom. The fix threads one `RandomState` through the whole pipeline; `rng=None` on the public functions resolves to a **fixed** seed, so `learn_structure(data)` is now deterministic by default, and `learn_mixture_structure` drives its per-cluster fits from the same `RandomState(seed)` it already owned. `distill_structured_from_labels` forwards its previously-dead (single-tree branch) `seed`. Verified: three fresh processes now agree bitwise.

**2. The test's premise was false for its fixture.** With mixture-family conditionals available, one component can absorb both planted regimes, and those impure splits *genuinely out-score* the planted one (measured: −3410 nats impure vs −3415 pure) — best-of-N likelihood selection then correctly returns them whenever a restart finds one, and *which* basin gets found rides on EM trajectory noise (the exact 0.746 ≈ one-mode-vs-three split). Determinism alone would leave the test hostage to BLAS-build trajectory differences. `learn_mixture_structure` now forwards `field_estimators` to `learn_structure` (also skips re-running the detector per cluster per iteration), and the test pins unimodal families — under which every restart at every seed converges to the planted split (measured: purity 1.000 at one identical likelihood across 12 seeds; no knife-edge left to flip).

A new `test_learning_is_deterministic_given_seed` pins the root cause directly (bitwise-equal responsibilities and edges across two identical calls) — it **fails on the previous code** and passes now.

Verified: `structure_learning_test.py` 21/21; downstream consumers (`bayesian_network`, `task_distill_structured`, `structure_embedded`, `edge_distill`, `task_quantize`, `task_durability_edgecases`) 105 passed.