### PR TITLE
estimation: un-seeded fits are deterministic by default + fit-seed catalog test

### DIFF
--- a/mixle/inference/estimation.py
+++ b/mixle/inference/estimation.py
@@ -628,7 +628,9 @@ def optimize(
         init_estimator (Optional[ParameterEstimator]): ParameterEstimator to used to initialize EM algorithm parameters.
             If None, estimator is used. Must be consistent with estimator.
         init_p (float): Value in (0.0,1.0] for randomizing the proportion of data points used in initialization.
-        rng (RandomState): RandomState used to set seed for initializing EM algorithm.
+        rng (RandomState): RandomState used to set seed for initializing EM algorithm. ``None`` resolves to
+            a FIXED seed, so an un-seeded ``optimize``/``fit`` is deterministic by default; pass your own
+            RandomState when you WANT different initializations across calls (e.g. hand-rolled restarts).
         vdata (Optional[Sequence[T]]): Optional validation set.
         prev_estimate (Optional[SeqeuenceEncodableProbabilityDistribution]): Optional model estimate used from prior
             fitting. Must be consistent with estimator.
@@ -719,7 +721,7 @@ def optimize(
     estimator = _coerce_estimator(estimator, data)
     if init_estimator is not None:
         init_estimator = _coerce_estimator(init_estimator, data)
-    rng = RandomState() if rng is None else rng
+    rng = RandomState(0) if rng is None else rng  # fixed default: an un-seeded fit is deterministic
     if precision == "minimal":
         # Data-aware allocation: inspect the data + model and run the reduced-precision fused kernel only
         # where it is verified safe; else stay float64. The accumulation is float64 either way.
@@ -1135,7 +1137,7 @@ class BayesianStreamingEstimator:
             raise ValueError("mode must be 'posterior_carry' or 'forgetting'.")
         self.model = model
         self.init_p = init_p
-        self.rng = RandomState() if rng is None else rng
+        self.rng = RandomState(0) if rng is None else rng  # fixed default: an un-seeded fit is deterministic
         self.num_chunks = num_chunks
         self.step = 0
         self.nobs = 0.0

--- a/mixle/inference/streaming.py
+++ b/mixle/inference/streaming.py
@@ -80,7 +80,7 @@ class _StreamingBase:
         self.init_estimator = estimator if init_estimator is None else init_estimator
         self.model = model
         self.init_p = init_p
-        self.rng = RandomState() if rng is None else rng
+        self.rng = RandomState(0) if rng is None else rng  # fixed default: an un-seeded fit is deterministic
         self.encoder = encoder if encoder is not None else (model.dist_to_encoder() if model is not None else None)
         self.num_chunks = num_chunks
         self.running_accumulator = None

--- a/mixle/ppl/core.py
+++ b/mixle/ppl/core.py
@@ -2016,7 +2016,7 @@ class RandomVariable:
         ):
             import numpy as _np
 
-            rng = kw.get("rng") or _np.random.RandomState()
+            rng = kw.get("rng") or _np.random.RandomState(0)  # fixed default: an un-seeded fit is deterministic
             seed = self._family.seed_fn(self._args, data, rng, seed_child)
             if seed is not None:
                 kw["prev_estimate"] = seed

--- a/mixle/stats/compute/fused_kernels.py
+++ b/mixle/stats/compute/fused_kernels.py
@@ -1399,7 +1399,7 @@ class CompiledMixture:
         if max_iter is not None:
             max_its = max_iter
         if model is None:
-            model = self.initialize(enc, estimator, rng or np.random.RandomState(), p=init_p)
+            model = self.initialize(enc, estimator, rng or np.random.RandomState(0), p=init_p)
 
         old_ll = self.seq_log_density(enc, model).sum()
         for it in range(max_its):

--- a/mixle/stats/compute/torch_mixture.py
+++ b/mixle/stats/compute/torch_mixture.py
@@ -161,7 +161,7 @@ class TorchMixture:
         out: Any | None = None,
     ) -> tuple[Any, float]:
         """Run local EM to convergence and return ``(model, log_likelihood)``."""
-        model = self.initialize(enc, estimator, rng or np.random.RandomState(), p=init_p) if model is None else model
+        model = self.initialize(enc, estimator, rng or np.random.RandomState(0), p=init_p) if model is None else model
         old_ll = float(self.seq_log_density(enc, model=model).sum())
         for i in range(max(1, int(max_its))):
             model = self.em_step(enc, estimator, model=model)

--- a/mixle/tests/fit_seed_test.py
+++ b/mixle/tests/fit_seed_test.py
@@ -1,0 +1,110 @@
+"""Fit determinism: the estimation twin of sampler_seed_test.
+
+sampler_seed_test pins that SAMPLING is seed-repeatable; nothing pinned that FITTING is. The gap
+bit in practice: ``optimize``/``fit`` resolved ``rng=None`` to a fresh OS-entropy RandomState, so
+any un-seeded fit whose family needs a randomized EM init (mixtures, HMMs, anything with latent
+structure) returned a different model per call -- the root cause behind the structure-learning CI
+flakes. The contract pinned here: an UN-SEEDED fit is deterministic (fixed default seed), a seeded
+fit is repeatable, and the same holds through the ``fit`` wrapper. The catalog is representative
+(closed-form leaves plus the randomized-init families that actually exercise the rng), not an
+auto-discovered sweep -- entries are cheap and the point is the engine contract, not family
+coverage.
+"""
+
+import unittest
+
+import numpy as np
+
+import mixle.stats as st
+from mixle.inference import fit
+from mixle.inference.estimation import optimize
+
+
+def _catalog():
+    """(name, distribution) pairs; the estimator comes from dist.estimator(), data from its sampler."""
+    return [
+        ("gaussian", st.GaussianDistribution(1.0, 2.0)),
+        ("gamma", st.GammaDistribution(2.0, 1.5)),
+        ("poisson", st.PoissonDistribution(3.0)),
+        ("categorical", st.CategoricalDistribution({"a": 0.5, "b": 0.3, "c": 0.2})),
+        ("diagonal_gaussian", st.DiagonalGaussianDistribution([0.0, 2.0], [1.0, 1.5])),
+        (
+            "composite",
+            st.CompositeDistribution(
+                [st.CategoricalDistribution({"x": 0.7, "y": 0.3}), st.GaussianDistribution(0.0, 1.0)]
+            ),
+        ),
+        (
+            "mixture",  # the family whose randomized init made un-seeded fits nondeterministic
+            st.MixtureDistribution([st.GaussianDistribution(0.0, 1.0), st.GaussianDistribution(5.0, 1.0)], [0.5, 0.5]),
+        ),
+        (
+            "hmm",
+            st.HiddenMarkovModelDistribution(
+                [
+                    st.CategoricalDistribution({"a": 0.8, "b": 0.2}),
+                    st.CategoricalDistribution({"a": 0.1, "b": 0.9}),
+                ],
+                [0.6, 0.4],
+                [[0.7, 0.3], [0.2, 0.8]],
+                len_dist=st.CategoricalDistribution({4: 1.0}),
+                use_numba=False,
+            ),
+        ),
+    ]
+
+
+def _fingerprint(model, data):
+    """The behavioral identity of a fit: its per-row log-densities on the training data."""
+    enc = model.dist_to_encoder().seq_encode(data)
+    return np.asarray(model.seq_log_density(enc), dtype=np.float64)
+
+
+class FitSeedTest(unittest.TestCase):
+    def test_unseeded_fit_is_deterministic(self):
+        # rng=None must resolve to a FIXED seed: two identical un-seeded calls, bitwise-equal fits.
+        # Before the fixed default this failed for 'mixture' and 'hmm' (fresh OS entropy per call).
+        for name, dist in _catalog():
+            with self.subTest(family=name):
+                data = dist.sampler(seed=1).sample(150)
+                a = optimize(data, dist.estimator(), max_its=8, out=None)
+                b = optimize(data, dist.estimator(), max_its=8, out=None)
+                np.testing.assert_array_equal(_fingerprint(a, data), _fingerprint(b, data))
+
+    def test_seeded_fit_is_repeatable(self):
+        for name, dist in _catalog():
+            with self.subTest(family=name):
+                data = dist.sampler(seed=2).sample(150)
+                a = optimize(data, dist.estimator(), max_its=8, out=None, rng=np.random.RandomState(7))
+                b = optimize(data, dist.estimator(), max_its=8, out=None, rng=np.random.RandomState(7))
+                np.testing.assert_array_equal(_fingerprint(a, data), _fingerprint(b, data))
+
+    def test_fit_wrapper_shares_the_contract(self):
+        # fit() forwards rng to the same loop; pin it on the randomized-init family specifically
+        dist = st.MixtureDistribution(
+            [st.GaussianDistribution(0.0, 1.0), st.GaussianDistribution(5.0, 1.0)], [0.5, 0.5]
+        )
+        data = dist.sampler(seed=3).sample(150)
+        a = fit(data, dist.estimator(), max_its=8, out=None)
+        b = fit(data, dist.estimator(), max_its=8, out=None)
+        np.testing.assert_array_equal(_fingerprint(a, data), _fingerprint(b, data))
+
+    def test_distinct_seeds_still_diversify_restarts(self):
+        # the fixed default must NOT collapse deliberate restart diversity: explicit distinct rngs
+        # keep producing distinct initializations (they may or may not converge to the same optimum,
+        # so assert on the INITIALIZATION path: one EM step from each seed differs on a fixture with
+        # symmetric components, where init is the only symmetry breaker).
+        dist = st.MixtureDistribution(
+            [st.GaussianDistribution(-2.0, 1.0), st.GaussianDistribution(2.0, 1.0)], [0.5, 0.5]
+        )
+        data = dist.sampler(seed=4).sample(200)
+        fits = [
+            _fingerprint(optimize(data, dist.estimator(), max_its=1, out=None, rng=np.random.RandomState(s)), data)
+            for s in range(6)
+        ]
+        distinct = {arr.tobytes() for arr in fits}
+        self.assertGreater(len(distinct), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mixle/utils/automatic/factories.py
+++ b/mixle/utils/automatic/factories.py
@@ -498,7 +498,7 @@ def get_dpm_mixture(
     from .profiling import get_estimator
 
     if rng is None:
-        rng = np.random.RandomState()
+        rng = np.random.RandomState(0)  # fixed default: an un-seeded fit is deterministic
     if out is None:
         out = sys.stdout
 


### PR DESCRIPTION
The systemic follow-up to #114. The root cause there — `fit()` without `rng` drawing fresh OS entropy — is an engine default, and the audit found the same latent nondeterminism at every un-threaded call site: `lifecycle.Model.fit`, evolve's refit/family-swap operators, the automatic mixture factory, `ppl`'s `RV.fit` seed draw (the `prev_estimate=` warm-start sites are fine — no random init — and the `mpi`/`multiprocessing`/`neural_families` hits are docstring examples).

**Fix at the engine, not per site:** `optimize` (and the streaming fit classes, the fused-kernel/torch-mixture `initialize` fallbacks, ppl's `seed_fn` draw, the automatic factory) now resolve `rng=None` to a **fixed seed**. Every un-threaded call site — current and future, internal and external — becomes deterministic by default. Code that *wants* different inits across calls passes its own `RandomState`, which is exactly what `best_of` and the lifecycle symmetry-breaking restarts already do (their diversity comes through data rotation and an explicit shared rng, so restart behavior is unchanged).

**The line drawn:** sampling keeps the numpy convention — samplers, posterior-predictive draws, VMP/regression `samples()`, MCMC chains, conjugate draws, and blackbox/DOE optimizers still default to entropy. A fixed default there would make two unseeded MCMC chains *identical* and quietly break multi-chain diagnostics; randomness-on-request is the correct API for sampling, determinism-by-default is the correct API for estimation.

**The guard that was missing:** `fit_seed_test` is the estimation twin of `sampler_seed_test` — a representative catalog (closed-form leaves + the randomized-init families) asserting: un-seeded fits are bitwise-deterministic (**fails on the old default**, precisely on `mixture` and `hmm`), seeded fits are repeatable, the `fit()` wrapper shares the contract, and distinct explicit seeds still produce distinct initializations (the default must not collapse deliberate restart diversity). This test would have caught the structure-learning flake the day it was written, and catches any future regression to entropy defaults anywhere in the engine path.

Blast radius verified: lifecycle, evolve (improve/operators/search/verify), streaming, fused-EM, automatic, ppl (core/engine/density/inference/predictive/lda/semimix), and structure suites — 126 tests — all pass.