### PR TITLE
test: cut real full-suite runtime 2-17x across ~48 slow test files

### DIFF
--- a/mixle/tests/anchor_harness_test.py
+++ b/mixle/tests/anchor_harness_test.py
@@ -13,18 +13,28 @@ from mixle.reason.anchor_harness import AnchorHarnessReport, run_anchor_harness 
 
 
 class AnchorHarnessTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        # The 6 test methods below all called run_anchor_harness with these EXACT SAME arguments,
+        # independently, each refitting the same two MDNs (torch training) from scratch --
+        # run_anchor_harness is a pure function of (n_train, n_test, seed) with no shared mutable
+        # state across calls (test_deterministic_given_seed below proves two calls with the same
+        # seed produce byte-identical reports), so the 6 redundant recomputations were pure waste:
+        # fit once here and let every test method below assert against the shared result instead.
+        cls.report = run_anchor_harness(n_train=1200, n_test=80, seed=0)
+
     def test_runs_end_to_end_and_produces_a_full_report(self):
-        report = run_anchor_harness(n_train=1200, n_test=80, seed=0)
+        report = self.report
         self.assertIsInstance(report, AnchorHarnessReport)
 
     def test_at_least_two_structured_belief_modalities_no_shared_vector(self):
-        report = run_anchor_harness(n_train=1200, n_test=80, seed=0)
+        report = self.report
         self.assertGreaterEqual(len(report.modalities), 2)
         self.assertIn("geochem", report.modalities)
         self.assertIn("gravity", report.modalities)
 
     def test_at_least_two_hops_with_measured_compounding_calibration(self):
-        report = run_anchor_harness(n_train=1200, n_test=80, seed=0)
+        report = self.report
         self.assertEqual(report.hop_names, ["gravity_to_density", "density_to_grade"])
         self.assertEqual(set(report.coverage_by_hop), {1, 2})
         for k, stats in report.coverage_by_hop.items():
@@ -34,18 +44,18 @@ class AnchorHarnessTest(unittest.TestCase):
         self.assertIsInstance(report.walk_is_calibrated, bool)
 
     def test_two_receivers_get_genuinely_different_projections_of_the_same_belief(self):
-        report = run_anchor_harness(n_train=1200, n_test=80, seed=0)
+        report = self.report
         self.assertNotEqual(report.driller_projection_components, report.scout_projection_components)
         self.assertGreater(report.driller_projection_components, report.scout_projection_components)
         self.assertNotEqual(report.driller_readout, report.scout_readout)
 
     def test_cycle_consistency_gates_some_abstention(self):
-        report = run_anchor_harness(n_train=1200, n_test=80, seed=0)
+        report = self.report
         self.assertGreater(len(report.abstained_site_ids), 0)
         self.assertLess(report.abstain_rate, 0.5)  # abstention is a minority flag, not most of the traffic
 
     def test_frontier_comparison_is_reported_honestly_both_ways(self):
-        report = run_anchor_harness(n_train=1200, n_test=80, seed=0)
+        report = self.report
         self.assertIsInstance(report.frontier_mae, float)
         self.assertIsInstance(report.walk_mae, float)
         self.assertFalse(report.frontier_is_calibrated)  # the frontier baseline reports no interval at all

--- a/mixle/tests/base_dist_test.py
+++ b/mixle/tests/base_dist_test.py
@@ -184,8 +184,14 @@ def _build_dists():
     w = np.ones(num_states) / num_states
     len_dist = IntegerCategoricalDistribution(min_val=0, p_vec=len_probs)
 
+    # terminal_level=2 (rather than the previously used 4) trims this fixture back down: with
+    # len_probs favoring >1 child on average, tree size (and the non-vectorized per-tree cost
+    # paid by the plain `estimate()` E-step used in estimation_test) grows quickly with depth.
+    # terminal_level=2 was verified to keep the KLD-decreases-with-more-data recovery property
+    # (checked in estimation_test/seq_estimation_test) robust across 10 seeds (1-10), not just
+    # the 4 seeds asserted here.
     d = TreeHiddenMarkovModelDistribution(
-        topics=topics, w=w, transitions=trans_mat, len_dist=len_dist, terminal_level=4
+        topics=topics, w=w, transitions=trans_mat, len_dist=len_dist, terminal_level=2
     )
     dists.append(d)
 

--- a/mixle/tests/belief_walk_test.py
+++ b/mixle/tests/belief_walk_test.py
@@ -107,7 +107,12 @@ class ComposedWalkBeatsDirectEndToEndTest(unittest.TestCase):
         n_test = len(_X0_TEST)
         covered_direct = covered_walk = 0
         for i in range(n_test):
-            direct_draws = np.asarray([_DIRECT_SAMPLER.sample_given(_X0_TEST[i]) for _ in range(150)])
+            # batched, not 150 individual sample_given calls -- statistically identical (each row of
+            # the batch draws its own independent mixture component + Gaussian noise, see
+            # NeuralConditionalDensitySampler.sample_given_batch's docstring) but avoids paying
+            # per-call torch dispatch overhead 150*n_test times over.
+            x_batch = np.repeat(np.atleast_2d(_X0_TEST[i]), 150, axis=0)
+            direct_draws = np.asarray(_DIRECT_SAMPLER.sample_given_batch(x_batch))
             lo, hi = np.quantile(direct_draws, 0.05), np.quantile(direct_draws, 0.95)
             covered_direct += lo <= _TRUE_BY_HOP[3][i, 0] <= hi
 

--- a/mixle/tests/bingham_test.py
+++ b/mixle/tests/bingham_test.py
@@ -13,7 +13,11 @@ class BinghamTest(unittest.TestCase):
     def test_normalizer_integrates_to_one_mpmath(self):
         import mpmath as mp
 
-        mp.mp.dps = 20
+        # dps=10 keeps a large margin below the assertion tolerance (1e-9): the true numerical
+        # error at this precision is ~1.5e-11 (verified against a correct formula) vs the ~4e-16
+        # floor at dps=20, and an injected 0.1% normalization bug is still caught cleanly at this
+        # precision. This cuts the double-nested sphere quadrature's runtime by roughly 3.5x.
+        mp.mp.dps = 10
         m = np.eye(3)
         for z in [[-4.0, -2.0, 0.0], [-8.0, -1.0, 0.0], [-1.0, -1.0, 0.0]]:
             d = B(m, z)

--- a/mixle/tests/chained_attention_test.py
+++ b/mixle/tests/chained_attention_test.py
@@ -102,7 +102,13 @@ class ForwardBackwardTest(unittest.TestCase):
 class LearningTest(unittest.TestCase):
     def test_two_hop_solves_transitive_lookup_one_hop_cannot(self):
         rng = np.random.RandomState(2)
-        tr = _transitive(rng, 6000)
+        # 2000 training examples and 12 EM iterations are plenty here: the closed-form
+        # forward-backward EM plateaus (ll unchanged to 4 decimals) by iteration ~9-10 for
+        # both n_hops=1 and n_hops=2 on this task, so max_its=60 was pure overrun. Verified
+        # robust across dozens of independent (data, model) seeds -- two-hop accuracy stays
+        # >=0.88 and one-hop stays <=0.17 (vs the 0.8/0.2 assertions below), preserving the
+        # comparative margin at a fraction of the runtime.
+        tr = _transitive(rng, 2000)
         te = _transitive(rng, 2000)
         ck = np.array([x[0] for x in te])
         cv = np.array([x[1] for x in te])
@@ -112,7 +118,7 @@ class LearningTest(unittest.TestCase):
         m2 = optimize(
             tr,
             ChainedAttentionEstimator(n_hops=2, num_symbols=S, num_targets=S, sigma2=0.1),
-            max_its=60,
+            max_its=12,
             delta=None,
             rng=np.random.RandomState(3),
             out=io.StringIO(),
@@ -121,7 +127,7 @@ class LearningTest(unittest.TestCase):
         m1 = optimize(
             tr,
             ChainedAttentionEstimator(n_hops=1, num_symbols=S, num_targets=S, sigma2=0.1),
-            max_its=60,
+            max_its=12,
             delta=None,
             rng=np.random.RandomState(4),
             out=io.StringIO(),

--- a/mixle/tests/conftest.py
+++ b/mixle/tests/conftest.py
@@ -171,7 +171,7 @@ FILE_MARKERS: dict[str, MarkerTuple] = {
     "ewens_test.py": ("distribution", "numba", "stochastic"),
     "generalized_mallows_test.py": ("distribution", "numba", "stochastic"),
     "generalized_mallows_model_test.py": ("distribution", "numba", "stochastic"),
-    "survival_regression_test.py": ("distribution", "stochastic"),
+    "survival_regression_test.py": ("distribution", "stochastic", "slow"),
     "scoring_rules_test.py": ("distribution",),
     "calibration_diagnostics_test.py": ("distribution",),
     "multiple_testing_test.py": ("distribution",),
@@ -190,9 +190,9 @@ FILE_MARKERS: dict[str, MarkerTuple] = {
     "ppl_separation_test.py": ("ppl",),
     "random_graph_models_test.py": ("graph",),
     "quantized_hmm_test.py": ("hmm", "integration", "slow"),
-    "quantized_triangular_hmm_test.py": ("hmm", "enumeration", "integration"),
+    "quantized_triangular_hmm_test.py": ("hmm", "enumeration", "integration", "slow"),
     "hmm_determinize_test.py": ("hmm", "enumeration", "integration"),
-    "missing_data_test.py": ("distribution", "hmm", "ppl", "integration"),
+    "missing_data_test.py": ("distribution", "hmm", "ppl", "integration", "slow"),
     "provenance_test.py": ("distribution", "serialization"),
     "drift_test.py": ("distribution", "doe", "stochastic"),
     "serving_test.py": ("distribution", "serialization"),
@@ -207,6 +207,8 @@ FILE_MARKERS: dict[str, MarkerTuple] = {
     "sparse_markov_transform_test.py": ("latent",),
     "spearman_rho_test.py": ("distribution",),
     "spark_encoded_data_test.py": ("spark", "optional", "parallel", "slow"),
+    "spark_executor_test.py": ("spark", "optional", "parallel", "slow"),
+    "ray_encoded_data_test.py": ("ray", "optional", "parallel", "slow"),
     "torchrun_encoded_data_test.py": ("torchrun", "torch", "optional", "parallel", "slow"),
     "torch_neural_test.py": ("torchrun", "torch", "optional", "parallel", "slow"),
     "torch_engine_ext_test.py": ("torch", "optional", "integration", "slow"),
@@ -224,6 +226,25 @@ FILE_MARKERS: dict[str, MarkerTuple] = {
     "wave_select_test.py": ("distribution", "enumeration", "latent"),
     "wave_setdist_test.py": ("distribution", "enumeration"),
     "zero_count_estimate_test.py": ("distribution",),
+    # Newer files never triaged into this registry: each floors well above the ~1s/test the fast gate
+    # is built around (profiled via `pytest -m fast --durations=40`, individual calls 8-105s), so the
+    # fast gate silently regressed by ~9 minutes of wall time across all three of them as these landed.
+    # Tagged the same way their nearest existing sibling already is.
+    "doe_robust_test.py": ("doe", "stochastic", "slow"),  # 10-seed BO loop averaged for a noise claim
+    "quotient_leaf_test.py": ("torch", "integration", "slow"),  # conv+pool leaf, fits/compares real nets
+    "ppl_guide_test.py": ("ppl", "stochastic", "slow"),  # structured VI, admixture/LDA recovery
+    "structure_learning_test.py": ("integration", "slow"),  # multi-restart EM structure search
+    "task_traces_test.py": ("integration", "slow"),
+    "temporal_graph_grammar_test.py": ("graph", "stochastic", "slow"),
+    "anchor_harness_test.py": ("torch", "stochastic", "slow"),  # neural conditional-transport + calibration
+    "edge_distill_test.py": ("torch", "integration", "slow"),
+    "structured_hmm_test.py": ("hmm", "integration", "slow"),
+    "task_realteacher_smoke_test.py": ("integration", "slow"),
+    "task_model_test.py": ("integration", "slow"),  # fresh-process save/load round trip
+    "symbolic_export_test.py": ("integration", "slow"),
+    "task_tune_test.py": ("doe", "stochastic", "slow"),  # BO over student recipes via mixle.doe
+    "task_plan_test.py": ("integration", "slow"),
+    "task_distill_structured_test.py": ("integration", "slow"),
 }
 
 

--- a/mixle/tests/doe_robust_test.py
+++ b/mixle/tests/doe_robust_test.py
@@ -44,11 +44,11 @@ class PosteriorIncumbentTest(unittest.TestCase):
 
 class NoisyIncumbentBeatsArgminTest(unittest.TestCase):
     def test_posterior_incumbent_is_closer_to_the_true_optimum_under_noise(self):
-        seeds = range(10)
+        seeds = range(6)
         noise_std = 1.5  # comparable to the objective's spread -> argmin-of-observed gets fooled
         argmin_err, robust_err = [], []
         for s in seeds:
-            res = minimize(_noisy_bowl(noise_std, seed=100 + s), _BOUNDS, n_init=6, n_iter=14, seed=s)
+            res = minimize(_noisy_bowl(noise_std, seed=100 + s), _BOUNDS, n_init=6, n_iter=10, seed=s)
             argmin_x = res.x[int(np.argmin(res.y))]  # what plain minimize reports
             robust_x = posterior_incumbent(res.x, res.y, maximize=False).best_x  # the robust rule
             argmin_err.append(float(np.linalg.norm(argmin_x - _TARGET)))

--- a/mixle/tests/doe_turbo_test.py
+++ b/mixle/tests/doe_turbo_test.py
@@ -40,6 +40,11 @@ class TurboOptimizeTest(unittest.TestCase):
         opt = np.array([0.3, -0.7, 1.2, -1.5, 0.0, 0.9])
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
+            # The GP-hyperparameter refit (Adam, default max_its=500) dominates runtime: profiling
+            # showed ~54 refits x 500 Adam steps for ~25s of a ~26s run. Capping max_its=50 here
+            # only shortens that inner fit -- the TuRBO loop, n_init/max_evals/batch_size budget, and
+            # candidate set are unchanged. Verified across 30 seeds: recovered error stays <=0.165
+            # (well under the 0.5 threshold) with no failures.
             res = turbo_minimize(
                 lambda x: float(np.sum((x - opt) ** 2)),
                 [(-2.0, 2.0)] * 6,
@@ -47,6 +52,7 @@ class TurboOptimizeTest(unittest.TestCase):
                 max_evals=120,
                 batch_size=2,
                 seed=0,
+                fit_kwargs={"max_its": 50},
             )
         self.assertLess(np.linalg.norm(res["x"] - opt), 0.5)
         self.assertEqual(res["X"].shape[1], 6)
@@ -59,7 +65,19 @@ class TurboOptimizeTest(unittest.TestCase):
 
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            res = turbo_minimize(sphere, [(-3.0, 3.0)] * 10, n_init=20, max_evals=200, batch_size=4, seed=1)
+            # Same rationale as test_finds_quadratic_optimum: cap the GP refit's max_its instead of
+            # touching the search budget. Verified across 25 seeds (0-14, 20-29): turbo's best value
+            # stayed in [0.37, 2.70], comfortably beating the fixed rand_best=5.64 baseline every
+            # time (>2x margin even in the worst observed case).
+            res = turbo_minimize(
+                sphere,
+                [(-3.0, 3.0)] * 10,
+                n_init=20,
+                max_evals=200,
+                batch_size=4,
+                seed=1,
+                fit_kwargs={"max_its": 50},
+            )
         rand_best = min(sphere(np.random.RandomState(s).uniform(-3, 3, 10)) for s in range(200))
         self.assertLess(res["y"], rand_best)
 

--- a/mixle/tests/edge_distill_test.py
+++ b/mixle/tests/edge_distill_test.py
@@ -53,6 +53,22 @@ def _tiny_space():
     )
 
 
+def _fast_edge_space():
+    """Same cube as :func:`_tiny_space`, minus the mixture-of-dependency-trees arm.
+
+    ``components_range=(1, 2)`` lets ``distill_for_edge`` propose a 2-component structured student,
+    whose fit (hard EM: multiple restarts x iterations, each relearning a dependency forest per
+    cluster) costs an order of magnitude more than every other candidate in this space combined --
+    profiling a single search call showed >75% of wall time inside that one fit. None of the
+    `DistillForEdgeTest` searches below assert anything about mixture components specifically (they
+    check feasibility, agreement, Pareto validity, warm-start parity, and cross-task transfer), so
+    pinning ``components_range=(1, 1)`` removes the expensive arm without touching what's verified.
+    """
+    sp = _tiny_space()
+    sp.components_range = (1, 1)
+    return sp
+
+
 class FootprintTest(unittest.TestCase):
     def test_mlp_footprint_matches_closed_form(self):
         from mixle.task import distill_records_from_labels
@@ -297,7 +313,7 @@ class DistillForEdgeTest(unittest.TestCase):
     def test_search_returns_feasible_student_and_valid_pareto(self):
         dev = DeviceSpec(max_bytes=200_000)  # generous: both families fit; search optimizes quality
         res = distill_for_edge(
-            self.teacher, self.train, self.val, dev, space=_tiny_space(), n_init=3, n_iter=2, promote=2, seed=0
+            self.teacher, self.train, self.val, dev, space=_fast_edge_space(), n_init=3, n_iter=2, promote=2, seed=0
         )
         self.assertTrue(res.feasible)
         self.assertTrue(dev.feasible(res.footprint))
@@ -319,7 +335,7 @@ class DistillForEdgeTest(unittest.TestCase):
         # whichever wins, the deployed artifact must carry no torch dependence.
         dev = DeviceSpec(torch_free=True)
         res = distill_for_edge(
-            self.teacher, self.train, self.val, dev, space=_tiny_space(), n_init=3, n_iter=2, promote=2, seed=0
+            self.teacher, self.train, self.val, dev, space=_fast_edge_space(), n_init=3, n_iter=2, promote=2, seed=0
         )
         self.assertTrue(res.footprint.torch_free)
         if res.family == "mlp":
@@ -364,7 +380,7 @@ class DistillForEdgeTest(unittest.TestCase):
     def test_design_model_warm_start_accumulates_and_matches_cold(self):
         dev = DeviceSpec(max_bytes=200_000)
         cold = distill_for_edge(
-            self.teacher, self.train, self.val, dev, space=_tiny_space(), n_init=3, n_iter=2, promote=1, seed=0
+            self.teacher, self.train, self.val, dev, space=_fast_edge_space(), n_init=3, n_iter=2, promote=1, seed=0
         )
         n_ledger = len(cold.design)
         warm = distill_for_edge(
@@ -372,10 +388,11 @@ class DistillForEdgeTest(unittest.TestCase):
             self.train,
             self.val,
             dev,
-            space=_tiny_space(),
+            space=_fast_edge_space(),
             design=cold.design,
             n_init=2,  # halved seeding: the warm surrogate already covers the space
-            n_iter=2,
+            n_iter=3,  # one extra BO iteration: without the mixture arm's extra candidate diversity,
+            # this keeps the warm search's promoted finalists as reliably good as the cold baseline
             promote=2,
             seed=1,
         )
@@ -425,7 +442,7 @@ class DistillForEdgeTest(unittest.TestCase):
         # serves both: no compatibility error, rows accumulate, and B's search still succeeds.
         dev = DeviceSpec(max_bytes=200_000)
         a = distill_for_edge(
-            self.teacher, self.train, self.val, dev, space=_tiny_space(), n_init=2, n_iter=1, promote=1, seed=0
+            self.teacher, self.train, self.val, dev, space=_fast_edge_space(), n_init=2, n_iter=1, promote=1, seed=0
         )
         rng = np.random.RandomState(5)
         recs3 = [(float(rng.normal()), float(rng.normal()), "p" if rng.random() < 0.5 else "q") for _ in range(200)]
@@ -443,11 +460,14 @@ class DistillForEdgeTest(unittest.TestCase):
             recs3[:140],
             recs3[140:],
             dev,
-            space=_tiny_space(),
+            space=_fast_edge_space(),
             design=a.design,
-            n_init=2,
+            n_init=16,  # more LHS seeds (cheap: no surrogate fit) so a good candidate for this
+            # harder 3-field task is reliably among the screens, without paying for extra BO
+            # iterations (each of which fits a Gaussian-process surrogate -- the expensive step)
             n_iter=1,
-            promote=1,
+            promote=6,  # promote more of those screens to full fidelity so the winner is picked
+            # from a wide field rather than gambling on the single top screen
             seed=1,
         )
         self.assertGreater(len(b.design), n_after_a)  # shared ledger keeps growing across tasks

--- a/mixle/tests/fused_em_hmm_family_test.py
+++ b/mixle/tests/fused_em_hmm_family_test.py
@@ -85,7 +85,12 @@ class FusedEMHmmFamilyTestCase(unittest.TestCase):
     def test_segmental(self):
         dist, est, data = self._segmental()
         self._parity(dist, est, data)
-        self._fused(est, data)
+        # max_its=200 never actually reaches the delta=1e-8 stopping criterion on this fixture (still
+        # improving by ~2e-4/iteration at 200), so the standard/fused comparison is really "same fixed
+        # iteration count", not "same converged optimum" -- verified the fused/standard log-likelihoods
+        # stay bit-identical (not just within tolerance) all the way down to max_its=15; 50 keeps a large
+        # margin above that floor while cutting this EM loop's cost ~4x.
+        self._fused(est, data, max_its=50)
         self._default_off(est)
 
     # (the semi-supervised HMM is numpy-only and has no fused-EM fast path; see semi_supervised_hmm_test.py)

--- a/mixle/tests/graph_distribution_test.py
+++ b/mixle/tests/graph_distribution_test.py
@@ -117,12 +117,19 @@ class GraphDistributionTestCase(unittest.TestCase):
                     if not directed:
                         adj[j, i] = v
                 brute.append((adj, dist.log_density(adj)))
+            # Every adjacency the enumerator can emit is already present (with its log_density) in
+            # `brute`, since both walk the same `_edge_indices` edge set over the full 2**|edges|
+            # space. Reuse those already-computed values instead of calling dist.log_density(v) again
+            # per item -- log_density is the dominant cost here, and recomputing it for every one of
+            # the (up to tens of thousands of) enumerated graphs was pure redundant work.
+            brute_by_bytes = {a.tobytes(): lp for a, lp in brute}
             brute.sort(key=lambda t: -t[1])
             items = list(dist.enumerator())
             self.assertEqual(len(items), len(brute))
             np.testing.assert_allclose([lp for _, lp in items], [lp for _, lp in brute], atol=1e-9)
             for v, lp in items:
-                self.assertAlmostEqual(lp, dist.log_density(v), places=9)
+                self.assertIn(v.tobytes(), brute_by_bytes)
+                self.assertAlmostEqual(lp, brute_by_bytes[v.tobytes()], places=9)
 
         with self.assertRaises(EnumerationError):
             stats.StochasticBlockGraphDistribution(bp).enumerator()  # no fixed assignments

--- a/mixle/tests/hawkes_process_test.py
+++ b/mixle/tests/hawkes_process_test.py
@@ -109,8 +109,12 @@ class HawkesEMTest(unittest.TestCase):
     def test_single_long_sequence_with_full_init(self):
         truth = HawkesProcessDistribution(mu=0.5, alpha=0.8, beta=1.6, window=2000.0)
         big = [np.sort(truth.sampler(seed=7).sample())]
+        # Log-likelihood is already flat to 4 decimal places by ~iteration 55-60, and the mu/branching-ratio
+        # deltas below have converged well within their thresholds by iteration 45 (mu delta ~0.06 vs. the
+        # 0.15 budget here, and checked across many alternate data seeds to stay <=0.09 with the branching
+        # ratio staying >0.4), so 45 iterations gives the same recovery claim as 100 for a fraction of the cost.
         fit = optimize(
-            big, HawkesProcessEstimator(window=2000.0), max_its=100, rng=np.random.RandomState(0), print_iter=0
+            big, HawkesProcessEstimator(window=2000.0), max_its=45, rng=np.random.RandomState(0), print_iter=0
         )
         # the branching-floor lets EM escape the alpha=0 Poisson absorbing state even from a sparse init
         self.assertGreater(fit.branching_ratio, 0.3)

--- a/mixle/tests/hmm_terminal_states_test.py
+++ b/mixle/tests/hmm_terminal_states_test.py
@@ -37,10 +37,10 @@ class HmmTerminalStatesTest(unittest.TestCase):
     def test_normalizes_over_sequences(self):
         total = sum(
             np.exp(self.d.log_density(list(x)))
-            for length in range(1, 13)
+            for length in range(1, 11)
             for x in itertools.product("ab", repeat=length)
         )
-        self.assertAlmostEqual(total, 1.0, delta=0.01)  # remaining mass is in sequences longer than 12
+        self.assertAlmostEqual(total, 1.0, delta=0.01)  # remaining mass is in sequences longer than 10
 
     def test_seq_log_density_matches_scalar(self):
         seqs = [["b"], ["a", "b"], ["a", "a", "b"], ["b", "a", "a", "b"]]
@@ -115,7 +115,7 @@ class HmmTerminalStatesEMTest(unittest.TestCase):
             [[0.5, 0.4, 0.1], [0.4, 0.5, 0.1], [0.0, 0.0, 1.0]],
             terminal_states={2},  # state 2 absorbing
         )
-        data = true.sampler(seed=0).sample(400)
+        data = true.sampler(seed=0).sample(250)
         init = HiddenMarkovModelDistribution(
             [GaussianDistribution(-3, 2.0), GaussianDistribution(1, 2.0), GaussianDistribution(4, 2.0)],
             [0.4, 0.4, 0.2],
@@ -123,7 +123,7 @@ class HmmTerminalStatesEMTest(unittest.TestCase):
             terminal_states={2},
         )
         m = init
-        for _ in range(30):  # terminal-aware Baum-Welch, iterated by the standard estimate() driver
+        for _ in range(20):  # terminal-aware Baum-Welch, iterated by the standard estimate() driver
             m = estimate(data, init.estimator(), m)
         self.assertEqual(m.terminal_states, {2})  # stays a terminal-states model
         np.testing.assert_allclose(sorted(t.mu for t in m.topics), [-5.0, 0.0, 5.0], atol=0.2)

--- a/mixle/tests/infer_parallel_chains_test.py
+++ b/mixle/tests/infer_parallel_chains_test.py
@@ -30,17 +30,21 @@ class ParallelChainsTest(unittest.TestCase):
 
     def test_process_parallel_runs_with_picklable_target(self):
         # `_std_normal_value_and_grad` is module-level (picklable), so the process pool works.
+        # Wall time here is dominated by the per-subprocess import of mixle.inference (~15-20s,
+        # unavoidable without touching library code), not by num_samples/warmup -- the actual
+        # sampling is <1s either way. draws are trimmed anyway (verified the mean stays well
+        # under the 0.3 tolerance across 10 seeds) since it does shrink the sampling work itself.
         res = nuts(
             _std_normal_value_and_grad,
             dim=2,
-            num_samples=300,
-            warmup=300,
+            num_samples=150,
+            warmup=150,
             chains=2,
             backend="numpy",
             parallel=True,
             rng=1,
         )
-        self.assertEqual(res.chains.shape, (2, 300, 2))
+        self.assertEqual(res.chains.shape, (2, 150, 2))
         self.assertTrue(np.all(np.abs(res.samples.mean(axis=0)) < 0.3))
 
     def test_invalid_parallel_mode_raises(self):

--- a/mixle/tests/kde_test.py
+++ b/mixle/tests/kde_test.py
@@ -68,7 +68,7 @@ class ModeTest(unittest.TestCase):
     def test_bootstrap_ci_brackets_mode(self):
         rng = np.random.RandomState(2)
         x = rng.normal(0.0, 1.0, 3000)
-        out = kde_mode(x, ci=True, n_boot=200, seed=0)
+        out = kde_mode(x, ci=True, n_boot=40, seed=0)
         self.assertLessEqual(out["ci_low"], out["mode"])
         self.assertLessEqual(out["mode"], out["ci_high"])
 

--- a/mixle/tests/kent_test.py
+++ b/mixle/tests/kent_test.py
@@ -14,7 +14,11 @@ class KentTest(unittest.TestCase):
     def test_normalizer_integrates_to_one_mpmath(self):
         import mpmath as mp
 
-        mp.mp.dps = 20
+        # dps=10 keeps a comfortable margin below the assertion tolerance (1e-9): the true
+        # numerical error at this precision is ~4.4e-11 (verified against a correct formula,
+        # ~23x margin), and an injected 0.1% normalization bug is still caught cleanly at this
+        # precision. This cuts the double-nested sphere quadrature's runtime by roughly 3x.
+        mp.mp.dps = 10
         g = np.eye(3)
         for kappa, beta in [(5.0, 1.0), (10.0, 3.0), (2.0, 0.5)]:
             d = Kent(g, kappa, beta)

--- a/mixle/tests/knowledge_graph_test.py
+++ b/mixle/tests/knowledge_graph_test.py
@@ -97,8 +97,10 @@ class KnowledgeGraphRecommendTestCase(unittest.TestCase):
         self.assertTrue(all(0 in (a, c) for a, b, c, _ in sg))
 
     def test_ensemble_epistemic_uncertainty(self):
+        # epochs=15 (down from 30) still gives well-separated members: verified min/max epistemic
+        # uncertainty across 8 independent truth/train/seed configs all pass comfortably.
         ens = fit_knowledge_graph_ensemble(
-            self.train, self.nE, self.nR, dim=self.d, members=3, epochs=30, rng=np.random.RandomState(0)
+            self.train, self.nE, self.nR, dim=self.d, members=3, epochs=15, rng=np.random.RandomState(0)
         )
         u = [ens.epistemic_tail_uncertainty(h, r) for h, r, _ in self.train[:100]]
         self.assertGreaterEqual(min(u), 0.0)  # mutual information is nonnegative
@@ -163,7 +165,9 @@ class KnowledgeGraphNegativeSamplingTestCase(unittest.TestCase):
         test = _sample(ent, rel, 1500, seed=2)
         m = optimize(
             train,
-            KnowledgeGraphEstimator(nE, nR, dim=d, epochs=150, lr=1.0, negatives=20, seed=1),
+            # epochs=50 (down from 150) is enough for sampled softmax to converge here: verified acc
+            # stays ~0.55-0.75, far above the 0.3 bar, across 8 independent truth/sample/seed configs.
+            KnowledgeGraphEstimator(nE, nR, dim=d, epochs=50, lr=1.0, negatives=20, seed=1),
             max_its=1,
             rng=np.random.RandomState(0),
             print_iter=10**9,

--- a/mixle/tests/lkj_test.py
+++ b/mixle/tests/lkj_test.py
@@ -31,6 +31,13 @@ class LKJTest(unittest.TestCase):
 
             return mp.quad(lambda a: mp.quad(lambda b: inner(a, b), [-1, 1]), [-1, 1])
 
+        # This triple-nested quadrature dominates the test's runtime. Its assertion tolerance
+        # (1e-8) is far looser than the d=2 check above (1e-12), so it doesn't need the same
+        # working precision: at dps=10 the true numerical error is ~7e-12 (verified against a
+        # correct formula), a >1000x margin below the 1e-8 tolerance, and an injected 0.1%
+        # normalization bug is still caught cleanly (fails almosteq) at this precision -- while
+        # cutting this quadrature's runtime by roughly 4x versus dps=16.
+        mp.mp.dps = 10
         self.assertTrue(mp.almosteq(mp.e ** mp.mpf(LKJ(3, 2.0)._log_c) * z3(2.0), 1, 1e-8))
 
     def test_sampler_valid_and_marginal_beta(self):

--- a/mixle/tests/matching_test.py
+++ b/mixle/tests/matching_test.py
@@ -53,7 +53,10 @@ class MatchingTestCase(unittest.TestCase):
 
     def test_sampler_matches_density(self):
         dist = MatchingDistribution(_W)
-        n = 60000
+        # n=20000 keeps a comfortable margin under the delta=0.01 tolerance (worst observed
+        # |empirical - expected| ~0.006-0.007 across many seeds, vs. the 0.01 threshold) while
+        # cutting sampling cost ~3x relative to the original n=60000.
+        n = 20000
         samples = dist.sampler(seed=0).sample(n)
         empirical = Counter(tuple(s) for s in samples)
         perms = _perms(3)

--- a/mixle/tests/max_stable_test.py
+++ b/mixle/tests/max_stable_test.py
@@ -26,12 +26,19 @@ class SmithMaxStableTest(unittest.TestCase):
         self.assertTrue(0.0 < self.ms.bivariate_cdf(1.0, 1.0, [2, 0]) < 1.0)
 
     def test_sampler_has_unit_frechet_margins(self):
-        s = self.ms.sampler(np.array([[0, 0], [1, 0]]), seed=0).sample(4000, n_storms=150)
+        # n=1500 (down from 4000) keeps a comfortable safety margin on the atol=0.2 check: across
+        # 20 seeds the worst-case median deviation observed was ~0.135 (a ~1.5x margin), with mean
+        # deviation ~0.064 -- 0/20 failures. n_storms (the Schlather-algorithm storm count, which
+        # controls approximation fidelity rather than Monte Carlo replication count) is left
+        # unchanged since it governs bias, not just variance.
+        s = self.ms.sampler(np.array([[0, 0], [1, 0]]), seed=0).sample(1500, n_storms=150)
         np.testing.assert_allclose(np.median(s, axis=0), 1.0 / np.log(2), atol=0.2)  # unit-Frechet median
 
     def test_short_range_extremes_are_more_dependent(self):
+        # n=1000 (down from 3000) still leaves a wide margin on the near>far comparison: across 10
+        # seeds the smallest observed gap (near - far Spearman correlation) was ~0.90, far above 0.
         loc = np.array([[0, 0], [0.5, 0], [8, 0]])
-        s = self.ms.sampler(loc, seed=0).sample(3000, n_storms=150)
+        s = self.ms.sampler(loc, seed=0).sample(1000, n_storms=150)
         near = spearmanr(s[:, 0], s[:, 1]).correlation
         far = spearmanr(s[:, 0], s[:, 2]).correlation
         self.assertGreater(near, far)

--- a/mixle/tests/neural_leaf_test.py
+++ b/mixle/tests/neural_leaf_test.py
@@ -54,14 +54,20 @@ class NeuralLeafTest(unittest.TestCase):
         # init -- and a single torch init is not reproducible across platforms (CPU vs MPS, Linux vs mac).
         # So, as in real mixture-EM practice, take the best of a few *seeded* restarts: at least one escapes
         # the saddle and the two experts split into the +2x / -2x regimes.
+        #
+        # m_steps/em-iters below are the minimum that reliably converges: whether a restart lands in the
+        # good basin is decided by the weight init, not by extra training past this point -- a sweep across
+        # seeds 0-20 (and several alternate data draws) showed identical pass/fail-by-seed membership and a
+        # >=9x margin under the 0.2 threshold for every restart that escapes the saddle at these settings,
+        # so shortening training doesn't erode the specialization claim (only wastes time re-confirming it).
         best = float("inf")
         for seed in range(6):
             torch.manual_seed(seed)
-            la = NeuralLeaf(_mlp([1, 16, 1]), noise=1.0, m_steps=40, lr=0.02)
-            lb = NeuralLeaf(_mlp([1, 16, 1]), noise=1.0, m_steps=40, lr=0.02)
+            la = NeuralLeaf(_mlp([1, 16, 1]), noise=1.0, m_steps=12, lr=0.02)
+            lb = NeuralLeaf(_mlp([1, 16, 1]), noise=1.0, m_steps=12, lr=0.02)
             est = MixtureEstimator([la.estimator(), lb.estimator()])
             model = MixtureDistribution([la, lb], [0.5, 0.5])
-            for _ in range(15):  # EM: responsibilities (E) + per-expert weighted-NLL gradient (M)
+            for _ in range(6):  # EM: responsibilities (E) + per-expert weighted-NLL gradient (M)
                 model = estimate(data, est, model)
             pa = model.components[0]._forward(x[:, None])[:, 0]
             pb = model.components[1]._forward(x[:, None])[:, 0]

--- a/mixle/tests/neural_ppl_test.py
+++ b/mixle/tests/neural_ppl_test.py
@@ -98,8 +98,11 @@ class NeuralPPLTest(unittest.TestCase):
         b = 16
         ctx = np.stack([ids[i : i + b] for i in range(len(ids) - b)]).astype("float32")
         nxt = ids[b:]
+        # epochs=15 already drives nll to ~0.0001 on this highly repetitive corpus (verified empirically;
+        # the pass/fail boundary is between epochs=7 and 8), a large margin under the < 0.5 threshold
+        # while cutting training cost ~3x vs. the original epochs=40.
         fit = Categorical(logits=Transformer(out=v, d_model=64, n_layer=2, n_head=4)).fit(
-            nxt, given={"x": ctx}, epochs=40, batch_size=128, lr=0.003
+            nxt, given={"x": ctx}, epochs=15, batch_size=128, lr=0.003
         )
         nll = -np.mean(fit.dist.seq_log_density((ctx, nxt)))
         self.assertLess(nll, 0.5)  # learned next-token prediction (random would be ~log(v) ~ 2.8 nats)
@@ -118,7 +121,10 @@ class NeuralPPLTest(unittest.TestCase):
         ids = np.array([stoi[c] for c in text])
         b = 16
         module = build_causal_lm(v, d_model=64, n_layer=2, n_head=4, block=b)
-        src = stream_token_source(ids, block=b, batch_size=128, epochs=30, seed=0)  # a generator, not a buffered list
+        # epochs=10 already drives nll to ~0.0001 on this highly repetitive corpus (verified empirically;
+        # the pass/fail boundary is between epochs=5 and 6), a large margin under the < 0.5 threshold
+        # while cutting training cost ~3x vs. the original epochs=30.
+        src = stream_token_source(ids, block=b, batch_size=128, epochs=10, seed=0)  # a generator, not a buffered list
         leaf, payload = stream_fit(module, src, lr=3e-3)
         self.assertEqual(len(payload), 2)  # (loss_sum, tokens) -- the accumulator never held the corpus
         ctx = np.stack([ids[i : i + b] for i in range(64)]).astype("float32")
@@ -195,7 +201,10 @@ class NeuralPPLTest(unittest.TestCase):
         stoi = {c: i for i, c in enumerate(chars)}
         ids = np.array([stoi[c] for c in text])
         lm = LM(len(chars), d_model=64, n_layer=2, n_head=4, block=16)
-        lm.fit(ids, epochs=30, batch_size=128, lr=3e-3)
+        # epochs=10 already drives nll to ~0.0001 on this highly repetitive corpus (verified empirically;
+        # the pass/fail boundary is between epochs=5 and 6), a large margin under the < 0.5 threshold
+        # while cutting training cost ~3x vs. the original epochs=30.
+        lm.fit(ids, epochs=10, batch_size=128, lr=3e-3)
         self.assertLess(lm.nll(ids), 0.5)  # learned next-token prediction
         gen = lm.generate(ids[:16].tolist(), n=20, greedy=True)
         self.assertEqual(len(gen), 36)  # generation extends the 16-token prompt by 20

--- a/mixle/tests/nuts_mass_adaptation_test.py
+++ b/mixle/tests/nuts_mass_adaptation_test.py
@@ -56,7 +56,9 @@ class NutsMassAdaptationTest(unittest.TestCase):
 
     def test_adaptation_improves_mixing(self):
         var = np.array([100.0, 1.0, 0.01])
-        common = dict(initial=np.zeros(3), num_samples=2000, warmup=2000)
+        # The adapted/fixed ESS gap is large (adapted ~2-3x fixed on this 10000:1 ill-conditioned
+        # target) and holds reliably at a much shorter chain -- verified across 10 seeds.
+        common = dict(initial=np.zeros(3), num_samples=600, warmup=600)
         fixed = nuts(value_and_grad=_ill_scaled(var), rng=RandomState(1), **common)
         adapted = nuts(value_and_grad=_ill_scaled(var), adapt_mass=True, rng=RandomState(1), **common)
         # Adapted metric mixes at least as well on the worst-conditioned dimension.

--- a/mixle/tests/parallel_test.py
+++ b/mixle/tests/parallel_test.py
@@ -137,9 +137,14 @@ class MultiprocessingBackendTestCase(unittest.TestCase):
         serial.update(batch2)
 
         parallel = StreamingEstimator(estimator, schedule=constant(0.4), model=start)
-        with encoded_data(batch1, estimator=estimator, model=start, backend="mp", num_workers=2) as enc:
+        # num_workers=1 is enough to exercise the real subprocess/pickling path for
+        # this handle; each `with` block still pays the fixed spawn+import cost of a
+        # fresh worker process (the dominant cost here, not data volume or worker
+        # count), so keep worker count minimal rather than paying for parallelism
+        # this tiny batch doesn't need.
+        with encoded_data(batch1, estimator=estimator, model=start, backend="mp", num_workers=1) as enc:
             model1 = parallel.update(enc_data=enc)
-        with encoded_data(batch2, estimator=estimator, model=model1, backend="mp", num_workers=2) as enc:
+        with encoded_data(batch2, estimator=estimator, model=model1, backend="mp", num_workers=1) as enc:
             parallel.update(enc_data=enc)
 
         np.testing.assert_allclose(

--- a/mixle/tests/ppl_composite_sampling_test.py
+++ b/mixle/tests/ppl_composite_sampling_test.py
@@ -38,7 +38,7 @@ class HMMStructuralParameterTestCase(unittest.TestCase):
         seqs = self._sequences()
         m0, m1 = Normal(0, 10, name="m0"), Normal(0, 10, name="m1")
         fit = Markov([Normal(m0, 1.0), Normal(m1, 1.0)], transitions=free, initial=free).fit(
-            seqs, how="ensemble", constraints=m0 < m1, draws=800, burn=300, rng=np.random.RandomState(1)
+            seqs, how="ensemble", constraints=m0 < m1, draws=600, burn=250, rng=np.random.RandomState(1)
         )
         t = fit.params["transitions"]
         self.assertEqual(t.shape, (2, 2))
@@ -71,7 +71,7 @@ class MixtureWeightsAsParameterTestCase(unittest.TestCase):
         m0, m1 = Normal(0, 10, name="m0"), Normal(0, 10, name="m1")
         w = Dirichlet([1.0, 1.0], name="w")
         fit = Mix([Normal(m0, 1.0), Normal(m1, 1.0)], w).fit(
-            self.data, how="ensemble", constraints=m0 < m1, draws=1000, burn=400, rng=np.random.RandomState(1)
+            self.data, how="ensemble", constraints=m0 < m1, draws=600, burn=250, rng=np.random.RandomState(1)
         )
         wts = fit.params["weights"]
         self.assertAlmostEqual(wts[0], 0.7, delta=0.05)
@@ -81,7 +81,7 @@ class MixtureWeightsAsParameterTestCase(unittest.TestCase):
     def test_free_weights(self):
         m0, m1 = Normal(0, 10, name="m0"), Normal(0, 10, name="m1")
         fit = Mix([Normal(m0, 1.0), Normal(m1, 1.0)], free).fit(
-            self.data, how="ensemble", constraints=m0 < m1, draws=1000, burn=400, rng=np.random.RandomState(2)
+            self.data, how="ensemble", constraints=m0 < m1, draws=600, burn=250, rng=np.random.RandomState(2)
         )
         wts = fit.params["weights"]
         self.assertAlmostEqual(wts[0], 0.7, delta=0.05)
@@ -97,8 +97,8 @@ class MixtureWeightsAsParameterTestCase(unittest.TestCase):
             list(x),
             how="ensemble",
             constraints=(m0 < m1) & (m1 < m2),
-            draws=2000,
-            burn=800,
+            draws=1500,
+            burn=650,
             walkers=40,  # 3-component posterior needs a larger ensemble to mix reliably
             rng=np.random.RandomState(4),
         )
@@ -134,7 +134,7 @@ class MixtureAutogradTestCase(unittest.TestCase):
     def test_nuts_on_mixture(self):
         m0, m1 = Normal(0, 10, name="m0"), Normal(0, 10, name="m1")
         fit = Mix([Normal(m0, 1.0), Normal(m1, 1.0)], free).fit(
-            self.data, how="nuts", constraints=m0 < m1, draws=500, burn=400, rng=np.random.RandomState(1)
+            self.data, how="nuts", constraints=m0 < m1, draws=300, burn=250, rng=np.random.RandomState(1)
         )
         self.assertAlmostEqual(fit.result.mean("m0"), -3.0, delta=0.4)
         self.assertAlmostEqual(fit.result.mean("m1"), 3.0, delta=0.4)

--- a/mixle/tests/ppl_guide_test.py
+++ b/mixle/tests/ppl_guide_test.py
@@ -80,11 +80,14 @@ class StructuredVITestCase(unittest.TestCase):
         gen = S.LDADistribution(
             [S.CategoricalDistribution(t) for t in true],
             alpha=[0.3, 0.3],
-            len_dist=S.CategoricalDistribution({30: 1.0}),
+            len_dist=S.CategoricalDistribution({20: 1.0}),
         )
-        docs = [list(d) for d in gen.sampler(seed=1).sample(500)]
+        docs = [list(d) for d in gen.sampler(seed=1).sample(150)]
         topics = [Dirichlet([0.1] * V, name=f"topic{k}") for k in range(2)]
-        post = admixture(docs, topics, alpha=0.3, max_its=80)
+        # A smaller corpus (150 docs x 20 words) with fewer CAVI iterations still recovers the
+        # topics comfortably within the assertion's tolerance (checked across 10 seeds: worst-case
+        # max deviation ~0.033, well under the 0.07 threshold below) at a fraction of the runtime.
+        post = admixture(docs, topics, alpha=0.3, max_its=30, inner_its=20)
 
         recovered = np.array([post.posterior(t)["mean"] for t in topics])  # (2, V)
         truth = np.array([[t.get(v, 0.0) for v in range(V)] for t in true])

--- a/mixle/tests/ppl_hierarchical_test.py
+++ b/mixle/tests/ppl_hierarchical_test.py
@@ -43,7 +43,7 @@ class HierarchicalPriorTest(unittest.TestCase):
         data = rng.normal(2.0, 1.0, 200)
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            fit = self._funnel().fit(data, how="nuts", draws=400, burn=400, chains=2, rng=np.random.RandomState(1))
+            fit = self._funnel().fit(data, how="nuts", draws=150, burn=150, chains=2, rng=np.random.RandomState(1))
         s = fit.summary()
         self.assertAlmostEqual(s["mu"]["mean"], 2.0, delta=0.3)  # mu tracks the data mean
         self.assertGreater(s["tau"]["mean"], 0.0)  # tau is a positive scale
@@ -66,7 +66,7 @@ class HierarchicalPriorTest(unittest.TestCase):
         model = Normal(Normal(0.0, tau, name="mu"), 1.0)
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            fit = model.fit(data, how="nuts", draws=300, burn=400, chains=2, rng=np.random.RandomState(3))
+            fit = model.fit(data, how="nuts", draws=100, burn=100, chains=2, rng=np.random.RandomState(3))
         s = fit.summary()
         for k in ("mu", "tau", "a"):
             self.assertTrue(np.isfinite(s[k]["mean"]))
@@ -99,8 +99,8 @@ class NonCenteredReparamTest(unittest.TestCase):
         data = np.random.RandomState(0).normal(2.0, 1.0, 60)
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            c = self._funnel(False).fit(data, how="nuts", draws=600, burn=600, chains=2, rng=np.random.RandomState(1))
-            nc = self._funnel(True).fit(data, how="nuts", draws=600, burn=600, chains=2, rng=np.random.RandomState(1))
+            c = self._funnel(False).fit(data, how="nuts", draws=200, burn=200, chains=2, rng=np.random.RandomState(1))
+            nc = self._funnel(True).fit(data, how="nuts", draws=200, burn=200, chains=2, rng=np.random.RandomState(1))
         # same model, different geometry -> same posterior
         self.assertAlmostEqual(c.summary()["mu"]["mean"], nc.summary()["mu"]["mean"], delta=0.15)
         self.assertAlmostEqual(c.summary()["tau"]["mean"], nc.summary()["tau"]["mean"], delta=0.5)
@@ -114,7 +114,7 @@ class NonCenteredReparamTest(unittest.TestCase):
                 warnings.simplefilter("ignore")
                 for seed in range(3):
                     fit = self._funnel(noncentered).fit(
-                        data, how="nuts", draws=600, burn=600, chains=2, rng=np.random.RandomState(seed)
+                        data, how="nuts", draws=600, burn=300, chains=2, rng=np.random.RandomState(seed)
                     )
                     d += fit.summary().get("_num_divergences", 0)
             return d

--- a/mixle/tests/ppl_leaf_families_test.py
+++ b/mixle/tests/ppl_leaf_families_test.py
@@ -316,11 +316,16 @@ class MultiChainDiagnosticsTestCase(unittest.TestCase):
     def test_process_parallel_matches_sequential(self):
         rng = np.random.RandomState(0)
         data = list(rng.normal(-1.0, 1.5, 1200))
+        # Correctness here is exact seq==par reproducibility (asserted below), not parameter
+        # recovery precision, so draws/burn can be cut hard -- verified bit-for-bit identical
+        # across 5 seeds at this smaller budget. Most of the wall time is the fixed per-process
+        # import cost paid by parallel=True's subprocess pool (unavoidable without touching
+        # library code), so this mainly shrinks the parallel=False portion.
         seq = Normal(free, free).fit(
-            data, how="hmc", draws=800, burn=300, chains=3, parallel=False, rng=np.random.RandomState(7)
+            data, how="hmc", draws=250, burn=150, chains=3, parallel=False, rng=np.random.RandomState(7)
         )
         par = Normal(free, free).fit(
-            data, how="hmc", draws=800, burn=300, chains=3, parallel=True, rng=np.random.RandomState(7)
+            data, how="hmc", draws=250, burn=150, chains=3, parallel=True, rng=np.random.RandomState(7)
         )
         # identical seeds + deterministic chains -> identical posterior means
         self.assertAlmostEqual(seq.result.mean("arg0"), par.result.mean("arg0"), places=6)

--- a/mixle/tests/ppl_plate_test.py
+++ b/mixle/tests/ppl_plate_test.py
@@ -66,8 +66,10 @@ class GroupedNutsTest(unittest.TestCase):
         data, _ = _hier_data()
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
+            # Only finiteness is asserted below (no recovery precision needed), so a short
+            # chain suffices -- verified stable across 10 seeds at these settings.
             fit = _model(True, free_mu=True).fit(
-                data, how="nuts", draws=500, burn=500, chains=2, rng=np.random.RandomState(2)
+                data, how="nuts", draws=100, burn=150, chains=2, rng=np.random.RandomState(2)
             )
         self.assertTrue(np.isfinite(fit.summary()["mu"]["mean"]))
 
@@ -85,8 +87,11 @@ class GroupedNutsTest(unittest.TestCase):
         def total_div(noncentered):
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore")
+                # Both parameterizations already settle at 0 divergences on this data at the
+                # original draws/burn; verified unchanged (0 vs 0, seeds 0-9) at this smaller
+                # budget, so the comparison is preserved while the chains run ~3x faster.
                 fit = _model(noncentered).fit(
-                    data, how="nuts", draws=500, burn=600, chains=2, rng=np.random.RandomState(0)
+                    data, how="nuts", draws=150, burn=200, chains=2, rng=np.random.RandomState(0)
                 )
             return fit.summary().get("_num_divergences", 0)
 

--- a/mixle/tests/ppl_relabel_test.py
+++ b/mixle/tests/ppl_relabel_test.py
@@ -42,8 +42,11 @@ class RelabelParallelChainsTest(unittest.TestCase):
         model = Mix([Normal(mi, 1.2) for mi in m])
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
+            # chains=6 is kept (relabeling reliability benefits from more independent label
+            # permutations); draws/burn trimmed -- verified stable (means within ~0.05 of the
+            # true modes, rhat ~1.0-1.005) across 10 seeds at this smaller budget.
             fit = model.fit(
-                data, how="nuts", draws=300, burn=300, chains=6, parallel=False, rng=np.random.RandomState(7)
+                data, how="nuts", draws=150, burn=200, chains=6, parallel=False, rng=np.random.RandomState(7)
             )
         s = fit.summary()
         means = sorted(s[f"m{i}"]["mean"] for i in range(3))

--- a/mixle/tests/ppl_vector_params_test.py
+++ b/mixle/tests/ppl_vector_params_test.py
@@ -147,8 +147,12 @@ class MVNParameterInferenceTestCase(unittest.TestCase):
         rng = np.random.RandomState(1)
         mu = np.array([-1.0, 0.5, 2.0])  # genuinely ordered
         X = [list(x) for x in (mu + rng.standard_normal((3000, 3)))]
+        # walkers=30 is kept (the ordered+Cholesky reparameterization needs the full ensemble
+        # width to mix reliably -- fewer walkers caused sporadic failures on some seeds even
+        # with draws/burn unchanged); draws/burn alone are trimmed, verified stable (increasing
+        # and within atol=0.3 of the true mean) across 7 seeds at this smaller budget.
         m = MVN(3, mean=ordered, cov=free).fit(
-            X, how="ensemble", draws=1000, burn=400, walkers=30, rng=np.random.RandomState(2)
+            X, how="ensemble", draws=700, burn=300, walkers=30, rng=np.random.RandomState(2)
         )
         mm = np.asarray(m.params["mean"])
         self.assertTrue(np.all(np.diff(mm) > 0))  # increasing by construction

--- a/mixle/tests/quantized_hmm_test.py
+++ b/mixle/tests/quantized_hmm_test.py
@@ -275,7 +275,11 @@ class QuantizedHmmEstimationTestCase(unittest.TestCase):
             model = seq_initialize(enc_data, est, RandomState(3), p=1.0)
             model = seq_estimate(enc_data, est, model)
             ll_first = np.sum(model.seq_log_density(enc_eval))
-            for _ in range(24):
+            # 10 refit iterations (down from 24) still clear the +100 margin with ~4x headroom
+            # (verified ll_last_on - ll_first_on / ll_last_off is ~440-450 nats at this count, vs. the
+            # ~490 nats reached by 24 iterations); data size (500) is load-bearing here -- halving it to
+            # 250 was verified to make the split never trigger at all, so it is left unchanged.
+            for _ in range(10):
                 model = seq_estimate(enc_data, est, model)
             lls[split] = (ll_first, np.sum(model.seq_log_density(enc_eval)))
 

--- a/mixle/tests/quotient_leaf_test.py
+++ b/mixle/tests/quotient_leaf_test.py
@@ -60,18 +60,32 @@ def _gather(split, n_per_class, classes=(0, 1, 2, 3)):
 
 @unittest.skipUnless(_HAS_CIFAR, "CIFAR-10 not available in the local HuggingFace datasets cache")
 class TranslationQuotientLeafTest(unittest.TestCase):
+    # Conv width/depth and training length below are deliberately small. The invariance property under test
+    # is architectural (global average pooling erases spatial position by construction, independent of how
+    # well-converged the fit is), and the quotient-vs-baseline shift-sensitivity comparison has a large margin
+    # (baseline shift-divergence is consistently one-to-two orders of magnitude larger than the quotient leaf's
+    # across many seeds -- checked with seeds 0-9 during a speed pass), so a much smaller/cheaper fit still
+    # supports both claims reliably; see the module docstring for the full comparison writeup.
+    _HIDDEN_CHANNELS = 8
+    _OUT_CHANNELS = 16
+    _M_STEPS = 10
+
     @classmethod
     def setUpClass(cls) -> None:
         torch.manual_seed(0)
         cls.n_classes = 4
-        cls.x_train, cls.y_train = _gather("train", 60)
-        cls.x_test, cls.y_test = _gather("test", 40)
+        cls.x_train, cls.y_train = _gather("train", 24)
+        cls.x_test, cls.y_test = _gather("test", 24)
 
-        cls.quotient_module = build_translation_quotient_module(cls.n_classes)
-        cls.baseline_module = build_unpooled_conv_module(cls.n_classes, spatial_size=32)
+        cls.quotient_module = build_translation_quotient_module(
+            cls.n_classes, hidden_channels=cls._HIDDEN_CHANNELS, out_channels=cls._OUT_CHANNELS
+        )
+        cls.baseline_module = build_unpooled_conv_module(
+            cls.n_classes, spatial_size=32, hidden_channels=cls._HIDDEN_CHANNELS, out_channels=cls._OUT_CHANNELS
+        )
 
-        cls.quotient_leaf = TranslationQuotientLeaf(cls.quotient_module, m_steps=30, lr=1e-3)
-        cls.baseline_leaf = UnpooledConvLeaf(cls.baseline_module, m_steps=30, lr=1e-3)
+        cls.quotient_leaf = TranslationQuotientLeaf(cls.quotient_module, m_steps=cls._M_STEPS, lr=1e-3)
+        cls.baseline_leaf = UnpooledConvLeaf(cls.baseline_module, m_steps=cls._M_STEPS, lr=1e-3)
 
         data = list(zip(cls.x_train, cls.y_train))
         cls.fitted_quotient = optimize(data, cls.quotient_leaf.estimator(), max_its=1, out=None)
@@ -123,13 +137,17 @@ class TranslationQuotientLeafTest(unittest.TestCase):
         data_quarter = list(zip(self.x_train[:quarter], self.y_train[:quarter]))
 
         torch.manual_seed(1)
-        q_module = build_translation_quotient_module(self.n_classes)
-        q_leaf = TranslationQuotientLeaf(q_module, m_steps=30, lr=1e-3)
+        q_module = build_translation_quotient_module(
+            self.n_classes, hidden_channels=self._HIDDEN_CHANNELS, out_channels=self._OUT_CHANNELS
+        )
+        q_leaf = TranslationQuotientLeaf(q_module, m_steps=self._M_STEPS, lr=1e-3)
         q_fit = optimize(data_quarter, q_leaf.estimator(), max_its=1, out=None)
 
         torch.manual_seed(1)
-        b_module = build_unpooled_conv_module(self.n_classes, spatial_size=32)
-        b_leaf = UnpooledConvLeaf(b_module, m_steps=30, lr=1e-3)
+        b_module = build_unpooled_conv_module(
+            self.n_classes, spatial_size=32, hidden_channels=self._HIDDEN_CHANNELS, out_channels=self._OUT_CHANNELS
+        )
+        b_leaf = UnpooledConvLeaf(b_module, m_steps=self._M_STEPS, lr=1e-3)
         b_fit = optimize(data_quarter, b_leaf.estimator(), max_its=1, out=None)
 
         q_pred = q_fit.predict(self.x_test)

--- a/mixle/tests/reason_fusion_test.py
+++ b/mixle/tests/reason_fusion_test.py
@@ -113,9 +113,9 @@ class ProductOfExpertsFusionTest(unittest.TestCase):
                 return (model(xte).argmax(1) == yte).float().mean().item()
 
         torch.manual_seed(0)
-        hybrid = fit_acc(HybridFusionClassifier(dtok, 16, 2, n_tok, attn_layers=2), 80)
+        hybrid = fit_acc(HybridFusionClassifier(dtok, 16, 2, n_tok, attn_layers=2), 20)
         torch.manual_seed(0)
-        poe = fit_acc(StructuredFusionClassifier(dtok, 16, 2), 80)
+        poe = fit_acc(StructuredFusionClassifier(dtok, 16, 2), 20)
         self.assertGreater(hybrid, 0.8)  # the attention layer supplies the relational structure...
         self.assertLess(poe, 0.6)  # ...that permutation-invariant PoE structurally cannot
         self.assertGreater(hybrid, poe + 0.2)

--- a/mixle/tests/sampler_seed_test.py
+++ b/mixle/tests/sampler_seed_test.py
@@ -309,6 +309,9 @@ def _stats_public_distribution_catalog():
         "GeneralizedParetoDistribution": stats.GeneralizedParetoDistribution(2.0, 0.3),
         "GeneralizedExtremeValueDistribution": stats.GeneralizedExtremeValueDistribution(0.0, 2.0, 0.2),
         "GaussianCopulaDistribution": stats.GaussianCopulaDistribution([[1.0, 0.5], [0.5, 1.0]]),
+        "ClaytonCopulaDistribution": stats.ClaytonCopulaDistribution(2, 2.0),
+        "FrankCopulaDistribution": stats.FrankCopulaDistribution(2, 3.0),
+        "StudentTCopulaDistribution": stats.StudentTCopulaDistribution([[1.0, 0.5], [0.5, 1.0]], 5.0),
         "MatrixNormalDistribution": stats.MatrixNormalDistribution(
             [[0.0, 0.0], [1.0, -1.0], [2.0, 0.5]],
             [[2.0, 0.3, 0.1], [0.3, 1.0, 0.2], [0.1, 0.2, 1.5]],

--- a/mixle/tests/scheduled_hmm_test.py
+++ b/mixle/tests/scheduled_hmm_test.py
@@ -90,10 +90,12 @@ class ScheduledHMMTest(unittest.TestCase):
             ByRelativePosition(2),
             len_dist=DCat({6: 0.5, 8: 0.5}),
         )
-        data = truth.sampler(0).sample(400)
+        # n=200/iters=8 (down from 400/12): verified the monotone-EM and rel-beats-homogeneous margin
+        # (~200-390 nats, well clear of 0) holds across 20 independent data/init seeds at this size.
+        data = truth.sampler(0).sample(200)
         held = truth.sampler(99).sample(200)
 
-        def fit(schedule, iters=12):
+        def fit(schedule, iters=8):
             est = ScheduledHMMEstimator(
                 k, schedule, Cat(0, [0.25] * v).estimator(), DCat({6: 0.5, 8: 0.5}).estimator(), pseudo_count=0.2
             )
@@ -129,12 +131,14 @@ class ScheduledHMMTest(unittest.TestCase):
             Homogeneous(),
             len_dist=DCat({9: 1.0}),
         )
+        # 100/class (down from 200) and iters=6 (down from 10): verified the by-length-beats-homogeneous
+        # margin (~300-390 nats) holds across 20 independent data/init seeds at this size.
         rng = np.random.RandomState(3)
-        data = short.sampler(0).sample(200) + long.sampler(1).sample(200)
+        data = short.sampler(0).sample(100) + long.sampler(1).sample(100)
         rng.shuffle(data)
         held = short.sampler(5).sample(100) + long.sampler(6).sample(100)
 
-        def fit(schedule, iters=10):
+        def fit(schedule, iters=6):
             est = ScheduledHMMEstimator(
                 k, schedule, Cat(0, [0.25] * v).estimator(), DCat({3: 0.5, 9: 0.5}).estimator(), pseudo_count=0.2
             )

--- a/mixle/tests/segmental_terminal_states_test.py
+++ b/mixle/tests/segmental_terminal_states_test.py
@@ -50,7 +50,7 @@ class SegmentalTerminalStatesTest(unittest.TestCase):
             [[0.45, 0.45, 0.1], [0.45, 0.45, 0.1], [0.0, 0.0, 1.0]],
             terminal_states={2},
         )
-        data = true.sampler(seed=0).sample(400)
+        data = true.sampler(seed=0).sample(250)
         init = SHMM(
             [GaussianDistribution(-3, 2.0), GaussianDistribution(1, 2.0), GaussianDistribution(4, 2.0)],
             [0.4, 0.4, 0.2],
@@ -58,7 +58,7 @@ class SegmentalTerminalStatesTest(unittest.TestCase):
             terminal_states={2},
         )
         m = init
-        for _ in range(30):
+        for _ in range(20):
             m = estimate(data, init.estimator(), m)
         self.assertEqual(m.terminal_states, {2})
         np.testing.assert_allclose(sorted(t.mu for t in m.emissions), [-5.0, 0.0, 5.0], atol=0.2)

--- a/mixle/tests/semi_supervised_terminal_states_test.py
+++ b/mixle/tests/semi_supervised_terminal_states_test.py
@@ -52,14 +52,14 @@ class SemiSupervisedTerminalStatesTest(unittest.TestCase):
             [[0.45, 0.45, 0.1], [0.45, 0.45, 0.1], [0.0, 0.0, 1.0]],
             terminal_states={2},
         )
-        data = true.sampler(seed=0).sample(400)
+        data = true.sampler(seed=0).sample(250)
         init = SS(
             [GaussianDistribution(-3, 2.0), GaussianDistribution(1, 2.0), GaussianDistribution(4, 2.0)],
             [[0.4, 0.4, 0.2], [0.4, 0.4, 0.2], [0.3, 0.3, 0.4]],
             terminal_states={2},
         )
         m = init
-        for _ in range(30):
+        for _ in range(20):
             m = estimate(data, init.estimator(), m)
         self.assertEqual(m.terminal_states, {2})
         np.testing.assert_allclose(sorted(t.mu for t in m.topics), [-5.0, 0.0, 5.0], atol=0.2)

--- a/mixle/tests/spark_executor_test.py
+++ b/mixle/tests/spark_executor_test.py
@@ -64,11 +64,15 @@ from mixle.inference.spark_executor import spark_em_step, spark_fit  # noqa: E40
 
 class SparkDistributedEMTest(unittest.TestCase):
     def test_spark_em_step_matches_serial(self):
+        # 1000 obs / 4 shards is plenty to exercise the depth=2 tree-reduce (still a genuine
+        # 4 -> 2 -> 1 combine tree) while avoiding redundant Spark task-scheduling overhead;
+        # data size beyond this does not change the numeric result (sufficient stats are
+        # shard-invariant) so it was only adding runtime, not coverage.
         m = _gmm()
-        data = m.sampler(1).sample(4000)
+        data = m.sampler(1).sample(1000)
         est = m.estimator()
         serial = heterogeneous_em_step(est, m, data, n_shards=8)
-        spark = spark_em_step(_SC, est, m, data, n_shards=8, depth=2)
+        spark = spark_em_step(_SC, est, m, data, n_shards=4, depth=2)
         self.assertTrue(np.allclose(sorted(serial.w), sorted(spark.w), atol=1e-9))
         sm = sorted(c.mu for c in serial.components)
         km = sorted(c.mu for c in spark.components)
@@ -76,9 +80,9 @@ class SparkDistributedEMTest(unittest.TestCase):
 
     def test_spark_fit_matches_serial(self):
         m = _gmm()
-        data = m.sampler(1).sample(4000)
+        data = m.sampler(1).sample(1000)
         serial = heterogeneous_fit(m, data, max_its=12, n_shards=1)
-        spark = spark_fit(_SC, m, data, max_its=12, n_shards=8, depth=2)
+        spark = spark_fit(_SC, m, data, max_its=12, n_shards=4, depth=2)
         self.assertTrue(np.allclose(sorted(serial.w), sorted(spark.w), atol=1e-7))
         sm = sorted(c.mu for c in serial.components)
         km = sorted(c.mu for c in spark.components)

--- a/mixle/tests/structure_learning_test.py
+++ b/mixle/tests/structure_learning_test.py
@@ -157,6 +157,11 @@ class MixtureOfTreesTest(unittest.TestCase):
         # more restarts so the mixture EM reliably reaches the good optimum: the fit is stochastic and
         # its convergence differs across numpy/BLAS versions (Linux-x64 CI vs local), so a low restart
         # count let one cluster miss the dependency edge on CI while passing locally.
+        # (Investigated other cost levers for this test: profiling shows its cost is dominated by the
+        # per-field automatic distribution-family detection inside learn_structure, which is called
+        # restarts * up-to-max_iter * n_components times and costs roughly the same regardless of
+        # max_its, n_bins, or training-data size (all measured flat) -- so restarts is the only real
+        # lever, and it's the one thing we must not touch here. Left unchanged.)
         mot = learn_mixture_structure(train, 2, restarts=12, seed=0)
         self.assertIsInstance(mot, MixtureOfDependencyTrees)
 
@@ -197,7 +202,10 @@ class MixtureOfTreesTest(unittest.TestCase):
         self.assertGreater(purity, 0.9)
 
     def test_samples_and_scores(self):
-        mot = learn_mixture_structure(_two_regime(3), 2, restarts=3, seed=0)
+        # restarts=1 suffices: this test only checks sampling/scoring plumbing, not recovery quality
+        # (unlike test_beats_single_tree_and_independent_mixture, which needs restarts=12 -- see its
+        # comment). Verified stable (finite log-density, correct shapes) across 10 independent seeds.
+        mot = learn_mixture_structure(_two_regime(3), 2, restarts=1, seed=0)
         s = mot.sampler(0).sample(50)
         self.assertEqual(len(s), 50)
         self.assertEqual(len(s[0]), 2)

--- a/mixle/tests/structured_hmm_test.py
+++ b/mixle/tests/structured_hmm_test.py
@@ -51,13 +51,13 @@ class StructuredHMMTest(unittest.TestCase):
             np.ones(K) / K,
             LowRankTransition(_row_normalize(rng.rand(K, r)), _row_normalize(rng.rand(r, K))),
         )
-        seqs = [gen.sampler(seed=s).sample(60) for s in range(60)]
+        seqs = [gen.sampler(seed=s).sample(50) for s in range(50)]
         init = StructuredHMM(
             [S.GaussianDistribution(3.0 * k + rng.uniform(-1, 1), 1.0) for k in range(K)],
             np.ones(K) / K,
             LowRankTransition(_row_normalize(rng.rand(K, r)), _row_normalize(rng.rand(r, K))),
         )
-        _, trace = init.fit(seqs, max_its=40)
+        _, trace = init.fit(seqs, max_its=30)
         self.assertTrue(np.all(np.diff(trace) >= -1e-6))  # EM log-likelihood non-decreasing
         means = sorted(e.mu for e in init.emissions)
         truth = [3.0 * k for k in range(K)]
@@ -138,13 +138,13 @@ class ContractTest(unittest.TestCase):
             np.ones(k) / k,
             LowRankTransition(_row_normalize(rng.rand(k, r)), _row_normalize(rng.rand(r, k))),
         )
-        seqs = [gen.sampler(seed=s).sample(50) for s in range(60)]
+        seqs = [gen.sampler(seed=s).sample(30) for s in range(24)]
         proto = StructuredHMM(
             [S.GaussianDistribution(4.0 * i + rng.uniform(-1, 1), 1) for i in range(k)],
             np.ones(k) / k,
             LowRankTransition(_row_normalize(rng.rand(k, r)), _row_normalize(rng.rand(r, k))),
         )
-        fit = optimize(seqs, proto.estimator(), prev_estimate=proto, max_its=40, out=None)
+        fit = optimize(seqs, proto.estimator(), prev_estimate=proto, max_its=20, out=None)
         means = sorted(e.mu for e in fit.emissions)
         truth = [4.0 * i for i in range(k)]
         self.assertLess(max(abs(m - t) for m, t in zip(means, truth)), 1.0)
@@ -186,7 +186,7 @@ class ForgettingParallelTest(unittest.TestCase):
     def test_chunked_em_recovers_chain_and_parallel_matches_serial(self):
         rng = np.random.RandomState(0)
         hmm = self._ergodic_hmm()
-        seqs = [hmm.sampler(seed=s).sample(400) for s in range(20)]
+        seqs = [hmm.sampler(seed=s).sample(200) for s in range(10)]
 
         def init():
             return StructuredHMM(
@@ -196,9 +196,9 @@ class ForgettingParallelTest(unittest.TestCase):
             )
 
         h_serial = init()
-        fit_chunked(h_serial, seqs, chunk=120, overlap=40, max_its=25, workers=0)
+        fit_chunked(h_serial, seqs, chunk=80, overlap=25, max_its=20, workers=0)
         h_par = init()  # same init stream consumed identically
-        fit_chunked(h_par, seqs, chunk=120, overlap=40, max_its=25, workers=4)
+        fit_chunked(h_par, seqs, chunk=80, overlap=25, max_its=20, workers=4)
         means = sorted(e.mu for e in h_serial.emissions)
         self.assertLess(max(abs(m - t) for m, t in zip(means, [-4, 0, 4])), 0.5)
         self.assertTrue(
@@ -725,7 +725,7 @@ class EDHMMContractTest(unittest.TestCase):
             dur_true,
             D,
         )
-        seqs = [gen.sampler(seed=s).sample(80) for s in range(50)]
+        seqs = [gen.sampler(seed=s).sample(55) for s in range(20)]
         proto = ExplicitDurationHMM(
             [S.GaussianDistribution(-2, 1), S.GaussianDistribution(2, 1)],
             [0.5, 0.5],
@@ -733,7 +733,7 @@ class EDHMMContractTest(unittest.TestCase):
             np.ones((2, D)) / D,
             D,
         )
-        fit = optimize(seqs, proto.estimator(), prev_estimate=proto, max_its=25, out=None)
+        fit = optimize(seqs, proto.estimator(), prev_estimate=proto, max_its=18, out=None)
         self.assertLess(max(abs(m - t) for m, t in zip(sorted(e.mu for e in fit.emissions), [-5, 5])), 0.5)
         d0 = float((np.arange(1, D + 1) * fit.dur[0]).sum())  # mean dwell, state 0
         self.assertAlmostEqual(d0, 3.8, delta=0.4)

--- a/mixle/tests/survival_regression_test.py
+++ b/mixle/tests/survival_regression_test.py
@@ -47,20 +47,31 @@ class CoxTest(unittest.TestCase):
         return X, time, event, beta
 
     def test_recovers_log_hazard_ratios(self):
-        X, time, event, beta = self._sim(0)
+        # n=1500 (half the default 3000): coefficient-recovery margin checked empirically across
+        # 150 seeds (max |coef-beta| = 0.093, comfortably under the atol=0.12 gate) and concordance
+        # never dropped below 0.70 (gate is 0.65).
+        X, time, event, beta = self._sim(0, n=1500)
         r = cox_ph(X, time, event, ties="efron")
         np.testing.assert_allclose(r.coef, beta, atol=0.12)
         self.assertTrue(np.all(r.se > 0))
         self.assertGreater(r.concordance, 0.65)
 
     def test_efron_and_breslow_close(self):
-        X, time, event, _ = self._sim(1)
+        # With continuous event times there are effectively no exact ties, so Efron and Breslow
+        # take the identical code path (d == 1) and agree exactly regardless of n; n=500 keeps this
+        # a real, well-behaved Cox fit while cutting cost. Verified across 20 seeds at n=500 (and
+        # down to n=50): efron/breslow coefficients are bit-identical every time.
+        X, time, event, _ = self._sim(1, n=500)
         re = cox_ph(X, time, event, ties="efron")
         rb = cox_ph(X, time, event, ties="breslow")
         np.testing.assert_allclose(re.coef, rb.coef, atol=0.05)
 
     def test_hazard_ratios_and_baseline_increasing(self):
-        X, time, event, beta = self._sim(2)
+        # Both checks are structural identities, not statistical recovery: hazard_ratios() = exp(coef)
+        # always holds, and baseline_cumhaz is a cumulative sum of non-negative increments so it is
+        # always non-decreasing. Verified across 30 seeds down to n=50 that both hold and that the
+        # baseline curve still has >=2 points at n=300.
+        X, time, event, beta = self._sim(2, n=300)
         r = cox_ph(X, time, event)
         np.testing.assert_allclose(np.log(r.hazard_ratios()), r.coef)
         self.assertTrue(np.all(np.diff(r.baseline_cumhaz) >= -1e-12))
@@ -144,7 +155,13 @@ class AalenAdditiveTest(unittest.TestCase):
 class FrailtyTest(unittest.TestCase):
     def test_recovers_coef_and_positive_frailty_variance(self):
         rng = np.random.RandomState(0)
-        n_groups, per = 60, 25
+        # Reduced from 60x25 groups (n=1500): theta detection needs enough *groups* (not just total
+        # n) to pick up the clustering signal, and enough *per-group* observations (per=25) for that
+        # signal to be estimable -- per=20 or fewer groups than ~45 caused sporadic near-zero theta
+        # over a 120-160 seed sweep. 45x25 (n=1125) was verified safe over 160 seeds spanning several
+        # seed ranges: max |coef-beta| = 0.146 (atol gate 0.2) and min theta = 0.187 (gate > 0.1),
+        # zero gate violations.
+        n_groups, per = 45, 25
         n = n_groups * per
         X = rng.normal(0, 1, (n, 2))
         beta = np.array([0.8, -0.5])

--- a/mixle/tests/survival_test.py
+++ b/mixle/tests/survival_test.py
@@ -37,7 +37,11 @@ class SurvivalDistributionTest(unittest.TestCase):
         self.assertGreater(1.0 - event.mean(), 0.3)  # substantial censoring
 
         prev = None
-        for _ in range(12):  # the imputation EM, iterated by the standard estimate() driver
+        # 7 rounds is plenty: the imputation EM (driven by the standard estimate() driver) is
+        # dominated by per-censored-point quantile calls, and empirically plateaus by ~iteration 5-6
+        # (verified via convergence traces across several seeds) -- extra rounds beyond that just
+        # burn time without moving the fitted params.
+        for _ in range(7):
             prev = estimate(data, self.d.estimator(), prev)
         self.assertAlmostEqual(prev.base.shape, 1.5, delta=0.12)
         self.assertAlmostEqual(prev.base.scale, 2.0, delta=0.12)

--- a/mixle/tests/task_constrained_test.py
+++ b/mixle/tests/task_constrained_test.py
@@ -103,8 +103,14 @@ class ConstrainedDecodeTest(unittest.TestCase):
         from mixle.task.sft_plan import _plans_match
 
         tools = [TS("lookup_order", ["order_id"]), TS("notify", ["user"])]
-        free = sft_planner(_teacher, _requests(160), tools, seed=0, epochs=10, d_model=64, n_layer=2, constrained=False)
-        con = sft_planner(_teacher, _requests(160), tools, seed=0, epochs=10, d_model=64, n_layer=2, constrained=True)
+        # block=128 comfortably covers every serialized prompt+completion pair in this fixture (max 96
+        # chars, verified empirically) while cutting the O(block^2) attention cost vs. the 192 default.
+        free = sft_planner(
+            _teacher, _requests(160), tools, seed=0, epochs=10, d_model=64, n_layer=2, constrained=False, block=128
+        )
+        con = sft_planner(
+            _teacher, _requests(160), tools, seed=0, epochs=10, d_model=64, n_layer=2, constrained=True, block=128
+        )
         self.assertGreater(con.plan_agreement, free.plan_agreement)  # the lift where compute is scarce
 
         specs = {t.name: t for t in tools}

--- a/mixle/tests/task_extract_test.py
+++ b/mixle/tests/task_extract_test.py
@@ -85,14 +85,20 @@ class ExtractionTest(unittest.TestCase):
         self.assertGreater(conf_in, conf_out)  # confidence drops on an unfamiliar line
 
     def test_returns_field_dict(self):
-        model, _ = self._train(epochs=120)
+        # epochs=30 already reaches train_f1==1.0 on this fixture (verified empirically down to epochs=15
+        # before the vendor/amount fields start dropping, epochs=10 misses vendor); 30 keeps a solid margin
+        # while cutting training cost ~4x vs. the 120 used by the accuracy-threshold tests in this file.
+        model, _ = self._train(epochs=30)
         out = model("Receipt 7777: Acme $12.34 (2026-05-05)")
         self.assertEqual(set(out).issubset(set(FIELDS)), True)
         self.assertEqual(out.get("vendor"), "Acme")
         self.assertEqual(out.get("amount"), "12.34")
 
     def test_fresh_process_reload(self):
-        model, _ = self._train(epochs=100)
+        # this test only checks save/load round-trip equality (before == after), never model accuracy,
+        # so epochs is not load-bearing for the claim -- verified the round-trip still holds bit-for-bit
+        # down to epochs=3; kept at 10 (still a real trained model) for a >>10x margin over that floor.
+        model, _ = self._train(epochs=10)
         text = "Payment to Globex of $88.10 ref 4321 dated 2026-03-03"
         before = model(text)
         with tempfile.TemporaryDirectory() as d:

--- a/mixle/tests/task_plan_refine_test.py
+++ b/mixle/tests/task_plan_refine_test.py
@@ -85,6 +85,19 @@ class OutcomeRefinementTest(unittest.TestCase):
         # the identical base model 3 times over for no behavioral difference.
         from mixle.task import sft_planner
 
+        # epochs=40/n_layer=2 is required here, not a stylistic choice: a 6-seed sweep using
+        # deepcopy'd (order-independent) planners showed every reduced config -- epochs 15/20/25 at
+        # n_layer=1, and epochs 15/25 at n_layer=2 -- fails test_solve_rate_improves_over_the_imitation_
+        # baseline's solve_rate_after>=solve_rate_before assertion 6/6 times in true isolation; only
+        # epochs=40/n_layer=2 passed 6/6. (A smaller config had appeared safe in an earlier pass, but
+        # that was a false negative from cross-test mutation: outcome_refine_planner() mutates
+        # cls.planner.lm in place, so running the class as a whole benefits from test_report_names'
+        # alphabetically-earlier refinement pass -- a single isolated run of test_solve_rate reveals the
+        # base model genuinely needs the deeper config to reliably demonstrate the effect.) n_train=180
+        # and held_out=40 are left unchanged: they set the statistical power behind
+        # verified_gain_pairs>0 and the solve-rate comparison, and shrinking either was observed
+        # (separately, at smaller scale) to risk zero verified samples across the k draws -- a hard
+        # failure of that assertion.
         cls.world = _SyntheticOrderWorld()
         tools = [ToolSpec("lookup_order", ["order_id"]), ToolSpec("notify", ["user"])]
         train_reqs = cls.world.requests(180, seed=0)

--- a/mixle/tests/task_sft_plan_test.py
+++ b/mixle/tests/task_sft_plan_test.py
@@ -84,7 +84,11 @@ class SftPlannerTest(unittest.TestCase):
         from mixle.task import ToolSpec, sft_planner
 
         tools = [ToolSpec("lookup_order", ["order_id"]), ToolSpec("notify", ["user"])]
-        planner = sft_planner(_teacher, _requests(180), tools, seed=0, epochs=40, d_model=64, n_layer=2)
+        # epochs=15/n_layer=1 verified (10+ seeds) to preserve the silent_wrong==0 invariant just as
+        # reliably as epochs=40/n_layer=2 while training ~4x faster; n_train=180 is NOT safely
+        # reducible -- smaller corpora starve the confidence-floor calibration and let wrong plans
+        # through confidently (see sft_planner's holdout calibration in mixle/task/sft_plan.py).
+        planner = sft_planner(_teacher, _requests(180), tools, seed=0, epochs=15, d_model=64, n_layer=1)
 
         specs = {t.name: t for t in tools}
         silent_wrong = 0
@@ -110,8 +114,11 @@ class ScoreAndSamplePlansTest(unittest.TestCase):
         # identical model 4 times over for no behavioral difference.
         from mixle.task import ToolSpec, sft_planner
 
+        # epochs=15/n_layer=1 verified (8+ seeds) to keep the same clean score separation between
+        # correct/wrong/implausible plans and the calibrated floor as epochs=40/n_layer=2, ~4x faster
+        # to train; n_train=180 is load-bearing for calibration quality and left unchanged.
         cls.tools = [ToolSpec("lookup_order", ["order_id"]), ToolSpec("notify", ["user"])]
-        cls.planner = sft_planner(_teacher, _requests(180), cls.tools, seed=0, epochs=40, d_model=64, n_layer=2)
+        cls.planner = sft_planner(_teacher, _requests(180), cls.tools, seed=0, epochs=15, d_model=64, n_layer=1)
 
     def test_the_teacher_plan_scores_far_above_a_wrong_plan(self):
         from mixle.task import score_plan
@@ -163,9 +170,13 @@ class GenerativePlannerPersistenceTest(unittest.TestCase):
 
         from mixle.task import GenerativePlanner, ToolSpec, sft_planner
 
+        # This test only checks that save/load reproduces the SAME planner byte-for-byte-behaviorally
+        # (identical plans/escalations from a fresh process) -- it makes no claim about plan quality,
+        # so the model/corpus can be as small as sft_planner allows (>=16 requests). Verified (6+ seeds)
+        # to round-trip identically at this size just as reliably as the original, ~10x+ faster.
         tools = [ToolSpec("lookup_order", ["order_id"]), ToolSpec("notify", ["user"])]
-        planner = sft_planner(_teacher, _requests(160), tools, seed=0, epochs=25, d_model=64, n_layer=2)
-        fresh = _requests(30, seed=11)
+        planner = sft_planner(_teacher, _requests(24), tools, seed=0, epochs=8, d_model=16, n_layer=1)
+        fresh = _requests(8, seed=11)
         want = [planner(r) for r in fresh]
         with tempfile.TemporaryDirectory() as d:
             path = planner.save(d + "/gen")

--- a/mixle/tests/task_traces_test.py
+++ b/mixle/tests/task_traces_test.py
@@ -158,14 +158,19 @@ class TraceHarvestTest(unittest.TestCase):
                 (Path(tmp) / f"{doc['id']}.json").write_text(json.dumps(doc))
             traces = harvest_agent_traces(tmp)
 
+        # block=96 comfortably covers every serialized prompt+completion pair here (max 69 chars, verified
+        # empirically), cutting the default block=192's O(block^2) attention cost; epochs=25 keeps the same
+        # plan_agreement (0.9167) as the original epochs=40 (verified the epochs=18->20 boundary is where it
+        # drops off), so 25 keeps a solid margin while training ~3.5x faster overall.
         planner = sft_planner(
             traces.plan_teacher(),
             traces.requests(min_steps=1),
             traces.tool_specs(),
             seed=0,
-            epochs=40,
+            epochs=25,
             d_model=64,
             n_layer=2,
+            block=96,
         )
         self.assertGreater(planner.plan_agreement, 0.8)  # the agent's own history taught the plan writer
 

--- a/mixle/tests/task_tune_test.py
+++ b/mixle/tests/task_tune_test.py
@@ -71,9 +71,13 @@ class TuneTest(unittest.TestCase):
     def test_cost_penalty_prefers_cheaper(self):
         train = _make_corpus(seed=3)
         val = _make_corpus(seed=4)
-        # a strong compute penalty should select a recipe no more expensive than the unpenalized search
-        free = tune_recipe(_teacher, train, val, n_init=4, n_iter=4, cost_weight=0.0, seed=5)
-        thrifty = tune_recipe(_teacher, train, val, n_init=4, n_iter=4, cost_weight=1.0, seed=5)
+        # a strong compute penalty should select a recipe no more expensive than the unpenalized search.
+        # The dominant cost here is the BO surrogate (GP) refit per iteration, not the tiny student
+        # models it evaluates, so n_init/n_iter is the lever: verified empirically (8+ seeds, incl. this
+        # one) that the cost-ordering claim holds just as reliably at n_init=n_iter=2 as at the original
+        # 4/4, since it only needs the penalty to steer the search toward cheap recipes, not to converge.
+        free = tune_recipe(_teacher, train, val, n_init=2, n_iter=2, cost_weight=0.0, seed=5)
+        thrifty = tune_recipe(_teacher, train, val, n_init=2, n_iter=2, cost_weight=1.0, seed=5)
         self.assertLessEqual(thrifty.cost, free.cost + 1e-9)
 
 

--- a/mixle/tests/temporal_graph_grammar_test.py
+++ b/mixle/tests/temporal_graph_grammar_test.py
@@ -262,7 +262,8 @@ class ScalableSamplerTest(unittest.TestCase):
             edge_remove_rate=2.0,
         )
         seqs = [
-            gt.sampler(seed=s).sample_one_scalable(num_steps=8, seed_edges=self._seed_edges(rng)) for s in range(120)
+            gt.sampler(seed=s).sample_one_scalable(num_steps=6, seed_edges=self._seed_edges(rng, n=40))
+            for s in range(60)
         ]
         self.assertTrue(all(sp.issparse(a) for seq in seqs for a in seq))  # never densified
         self.assertTrue(np.all(np.isfinite(gt.seq_log_density(seqs))))
@@ -335,9 +336,7 @@ class LatentRegimeTemporalGraphGrammarTest(unittest.TestCase):
         )
         A = [[0.85, 0.15], [0.15, 0.85]]
         gt = stats.LatentTemporalGraphGrammarDistribution([growth, decay], [0.5, 0.5], A)
-        data = [
-            gt.sampler(seed=s).sample_one(num_steps=12, seed_graph=_seed_graph(rng, n=30, p=0.3)) for s in range(80)
-        ]
+        data = [gt.sampler(seed=s).sample_one(num_steps=8, seed_graph=_seed_graph(rng, n=30, p=0.3)) for s in range(40)]
         self.assertTrue(np.all(np.isfinite(gt.seq_log_density(data))))
         # single-grammar baseline
         se = stats.TemporalGraphGrammarEstimator(pseudo_count=0.5)
@@ -350,7 +349,7 @@ class LatentRegimeTemporalGraphGrammarTest(unittest.TestCase):
         acc.seq_initialize(data, np.ones(len(data)), np.random.RandomState(1))
         cur = est.estimate(len(data), acc.value())
         prev_ll = -np.inf
-        for _ in range(10):
+        for _ in range(6):
             acc = est.accumulator_factory().make()
             acc.seq_update(data, np.ones(len(data)), cur)
             cur = est.estimate(len(data), acc.value())
@@ -381,16 +380,14 @@ class RegimeSwitchingAttributesTest(unittest.TestCase):
             [0.5, 0.5],
             [[0.85, 0.15], [0.15, 0.85]],
         )
-        data = [
-            gt.sampler(seed=s).sample_one(num_steps=14, seed_graph=_seed_graph(rng, n=30, p=0.3)) for s in range(90)
-        ]
+        data = [gt.sampler(seed=s).sample_one(num_steps=8, seed_graph=_seed_graph(rng, n=30, p=0.3)) for s in range(35)]
         self.assertTrue(np.all(np.isfinite(gt.seq_log_density(data))))
         est = gt.estimator(pseudo_count=0.3)
         acc = est.accumulator_factory().make()
         acc.seq_initialize(data, np.ones(len(data)), np.random.RandomState(2))
         cur = est.estimate(len(data), acc.value())
         prev_ll = -np.inf
-        for _ in range(12):
+        for _ in range(7):
             acc = est.accumulator_factory().make()
             acc.seq_update(data, np.ones(len(data)), cur)
             cur = est.estimate(len(data), acc.value())
@@ -478,9 +475,7 @@ class LatentChurningTemporalGraphGrammarTest(unittest.TestCase):
             initial_probs=[0.5, 0.5],
             transition_matrix=[[0.85, 0.15], [0.15, 0.85]],
         )
-        data = [
-            gt.sampler(seed=s).sample_one(num_steps=14, seed_graph=_seed_graph(rng, n=30, p=0.3)) for s in range(90)
-        ]
+        data = [gt.sampler(seed=s).sample_one(num_steps=8, seed_graph=_seed_graph(rng, n=30, p=0.3)) for s in range(35)]
         # nodes genuinely leave (counts swing) and ids disappear
         self.assertTrue(any(set(o[t - 1][1]) - set(o[t][1]) for o in data for t in range(1, len(o))))
         self.assertTrue(np.all(np.isfinite(gt.seq_log_density(data))))
@@ -489,7 +484,7 @@ class LatentChurningTemporalGraphGrammarTest(unittest.TestCase):
         acc.seq_initialize(data, np.ones(len(data)), np.random.RandomState(3))
         cur = est.estimate(len(data), acc.value())
         prev_ll = -np.inf
-        for _ in range(12):
+        for _ in range(7):
             acc = est.accumulator_factory().make()
             acc.seq_update(data, np.ones(len(data)), cur)
             cur = est.estimate(len(data), acc.value())

--- a/mixle/tests/variational_multihop_attention_test.py
+++ b/mixle/tests/variational_multihop_attention_test.py
@@ -28,16 +28,16 @@ def _transitive(rng, n):
     return out
 
 
-def _est(seed=0):
+def _est(seed=0, mc=4, anneal_iters=100):
     return VariationalMultiHopAttentionEstimator(
         num_symbols=S,
         embed_dim=Dm,
         num_targets=S,
         sigma2=0.3,
         lr=0.07,
-        mc=4,
+        mc=mc,
         prior_strength=0.05,
-        anneal_iters=100,
+        anneal_iters=anneal_iters,
         seed=seed,
     )
 
@@ -84,9 +84,16 @@ class MechanicsTest(unittest.TestCase):
 class LearningTest(unittest.TestCase):
     def test_variational_two_hop_solves_transitive_without_collapse(self):
         rng = np.random.RandomState(1)
-        tr = _transitive(rng, 2500)
-        te = _transitive(rng, 1000)
-        model = optimize(tr, _est(seed=0), max_its=180, delta=None, rng=np.random.RandomState(2), out=io.StringIO())
+        tr = _transitive(rng, 800)
+        te = _transitive(rng, 600)
+        model = optimize(
+            tr,
+            _est(seed=0, mc=2, anneal_iters=80),
+            max_its=140,
+            delta=None,
+            rng=np.random.RandomState(2),
+            out=io.StringIO(),
+        )
         ck = np.array([x[0] for x in te])
         cv = np.array([x[1] for x in te])
         q = np.array([x[2] for x in te])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,6 +126,7 @@ markers = [
     "numba: numba-accelerated path tests.",
     "mpi: MPI backend tests.",
     "dask: dask.distributed backend tests.",
+    "ray: Ray backend tests.",
     "spark: Spark backend tests.",
     "torchrun: torch.distributed/torchrun backend tests.",
     "parallel: multiprocessing or distributed backend tests.",


### PR DESCRIPTION
## Summary
- Registers the `ray` pytest marker (missing registration was crashing every CI job's pytest-xdist collection under `--strict-markers` on pytest 9.1) and folds in the FILE_MARKERS triage / sampler-catalog fixes from the earlier speed-up-fast-gate work.
- Cuts real (not just re-categorized) runtime across ~48 of the slowest test files, each profiled to find its true cost driver (sample sizes, EM/optimizer iteration counts, epochs, mpmath precision, BO restart counts, etc.) and reduced only after multi-seed verification that the reduction doesn't weaken statistical reliability.
- Fixes a genuine test-isolation regression found during verification: `task_plan_refine_test.py::OutcomeRefinementTest` had been reduced to a base-planner config (`epochs=15, n_layer=1`) that only passed because it inherited mutation from an earlier-alphabetical test method in the same class calling `outcome_refine_planner()` first. A deepcopy-isolated 6-seed sweep confirmed every reduced config fails `solve_rate_after>=solve_rate_before` 6/6 times in true isolation; only the original `epochs=40, n_layer=2` passes reliably. Reverted to that value for this one test class.
- This branch was rebuilt from scratch directly on top of the current `release/0.6.3-generic-capabilities` tip (superseding #109, whose branch ancestry got tangled from a mid-flight branch-name collision with another concurrent process) by diffing the fully-verified working tree against the release tip and applying it as a clean patch, rather than trying to reconcile divergent history.

Full-suite results on this branch (`pytest -m "not optional and not benchmark"`): **5231 passed, 0 failed, 6 skipped** (332.96s). Several files were investigated and deliberately left unchanged where no safe reduction existed (documented inline), e.g. `MixtureOfTreesTest`'s `restarts=12`, `ppl_vector_params_test.py`'s `walkers=30`, and most of the process-parallel subprocess-import floor.

## Test plan
- [x] Full suite (`pytest -m "not optional and not benchmark" -q`): 5231 passed, 0 failed, 6 skipped
- [x] `ruff check` / `ruff format --check` on every touched file: clean
- [x] Regression test (`task_plan_refine_test.py::OutcomeRefinementTest::test_solve_rate_improves_over_the_imitation_baseline`) reruns deterministically 3/3 in isolation after the fix
- [ ] CI green on this PR