### PR TITLE
epistemic: add mixle.epistemic -- hypothesis portfolios, discrepancy, EIG-driven loop, decision journal

### DIFF
--- a/docs/package-map.rst
+++ b/docs/package-map.rst
@@ -199,6 +199,11 @@ Mixle also includes scientific modeling support:
    * - ``mixle.evolve``
      - Objective-led model improvement, structure search, verification, and
        anti-regression ledgers.
+   * - ``mixle.epistemic``
+     - Hypothesis portfolios with open-world mass, distribution discrepancy
+       (KL/JS/Wasserstein/MMD), EIG-driven action selection, and a
+       replayable decision journal -- the epistemic-loop control flow, built
+       on ``mixle.inference``, ``mixle.doe``, and ``mixle.evolve``.
 
 Use :doc:`processes`, :doc:`relations`, :doc:`analysis`, :doc:`doe`, and
 :doc:`evolution` when the modeling task is closer to scientific design,

--- a/mixle/capability.py
+++ b/mixle/capability.py
@@ -713,6 +713,13 @@ CAPABILITY_CATALOG: tuple[CapabilitySpec, ...] = (
         "Acquisition protocol + register_acquisition",
         "mixle.doe._contracts",
     ),
+    CapabilitySpec(
+        "BeliefTrackable",
+        "a weighted hypothesis portfolio with open-world mass, reweighted by evidence",
+        "subsystem role",
+        "HypothesisPortfolio.reweight()",
+        "mixle.epistemic",
+    ),
 )
 
 _CATALOG_BY_NAME = {spec.name: spec for spec in CAPABILITY_CATALOG}

--- a/mixle/epistemic/__init__.py
+++ b/mixle/epistemic/__init__.py
@@ -1,0 +1,79 @@
+"""The epistemic loop: belief tracking, hypothesis portfolios, and EIG-driven action selection.
+
+A library realization of the control loop OBSERVE -> UPDATE -> ABDUCE -> PREDICT -> DISCRIMINATE ->
+ACT: maintain a weighted portfolio of typed hypotheses plus an explicit open-world mass (the "none
+of the above" slot), reweight it against new observations through a pluggable likelihood strategy,
+optionally propose new hypotheses when the evidence surprises every current one, pick the next
+observation/action by expected information gain, and log every step to a replayable, JSON-serializable
+decision journal.
+
+This module is built entirely on *existing* mixle contracts rather than inventing new ones:
+:mod:`mixle.inference.mcmc` for the SMC resampling precedent, :mod:`mixle.doe.active` /
+:mod:`mixle.doe.oracle` for expected-information-gain estimation and verifiability tiers,
+:mod:`mixle.evolve.ledger` for the append-only JSON-serializable journal shape, and
+:mod:`mixle.data.exchangeability` for the permutation-test precedent behind the coherence checks.
+Nothing here fits a specific scientific domain: every test and example uses synthetic toy models.
+
+Scope, deliberately narrow (see ``notes/epistemic-loop-integration-workplan.md`` for the full design
+and the two source specification documents it distills):
+
+* **In scope:** :class:`~mixle.epistemic.portfolio.HypothesisPortfolio` (typed weighted hypotheses +
+  open-world mass), :mod:`~mixle.epistemic.discrepancy` (KL/JS/Wasserstein/MMD between distributions
+  or samples -- the "compare predicted vs. observed" hinge), :mod:`~mixle.epistemic.likelihood`
+  (pluggable reweighting strategies at a declared verifiability tier),
+  :func:`~mixle.epistemic.loop.step` (one loop iteration: update, optional abduction on surprise,
+  optional EIG-based action selection), :class:`~mixle.epistemic.journal.EpistemicJournal`
+  (append-only, replayable decision log), and :mod:`~mixle.epistemic.coherence` (exchangeability /
+  martingale / evidence-conservation checks as plain testable functions).
+* **Out of scope, explicitly:** modality encoders/decoders (use :mod:`mixle.represent` /
+  :mod:`mixle.reason` at their current scope), any data corpus or training recipe, a simulator farm
+  or MCP tool encapsulation (callers supply their own likelihood/action callables), RL, grammar-
+  constrained token decoding, and any named scientific domain. Those remain future, separate work.
+"""
+
+from __future__ import annotations
+
+from mixle.epistemic.coherence import (
+    evidence_conservation_violation,
+    exchangeability_violation,
+    martingale_violation,
+)
+from mixle.epistemic.discrepancy import (
+    DiscrepancyResult,
+    discrepancy_report,
+    js_divergence,
+    kl_divergence,
+    mmd,
+    wasserstein_distance,
+)
+from mixle.epistemic.journal import DecisionRecord, EpistemicJournal
+from mixle.epistemic.likelihood import CallableLikelihood, DiscrepancyLikelihood, LikelihoodStrategy
+from mixle.epistemic.loop import EpistemicStep, step
+from mixle.epistemic.portfolio import Hypothesis, HypothesisPortfolio
+
+__all__ = [
+    # discrepancy.py
+    "DiscrepancyResult",
+    "discrepancy_report",
+    "kl_divergence",
+    "js_divergence",
+    "wasserstein_distance",
+    "mmd",
+    # portfolio.py
+    "Hypothesis",
+    "HypothesisPortfolio",
+    # likelihood.py
+    "LikelihoodStrategy",
+    "DiscrepancyLikelihood",
+    "CallableLikelihood",
+    # loop.py
+    "EpistemicStep",
+    "step",
+    # journal.py
+    "DecisionRecord",
+    "EpistemicJournal",
+    # coherence.py
+    "exchangeability_violation",
+    "martingale_violation",
+    "evidence_conservation_violation",
+]

--- a/mixle/epistemic/coherence.py
+++ b/mixle/epistemic/coherence.py
@@ -1,0 +1,116 @@
+"""Program plan §2's three CI-checkable coherence properties, as plain testable functions.
+
+"Checked continuously in CI, not asserted" -- these compute a violation magnitude (or boolean) over a
+:class:`~mixle.epistemic.portfolio.HypothesisPortfolio` and a caller-supplied likelihood; nothing here
+is wired into an enforcement path, matching the program plan's own framing. Where a fitting primitive
+already exists (:func:`mixle.data.exchangeability.exchangeability_check`), it's a dataset-shaped
+permutation test over row order in a flat table, not over a portfolio-update trajectory -- the shapes
+don't line up cleanly enough to delegate directly, so :func:`exchangeability_violation` below is a
+thin, purpose-built adapter using the same permutation-test idea rather than a forced reuse.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from typing import Any
+
+import numpy as np
+
+from mixle.epistemic.portfolio import HypothesisPortfolio
+
+
+def _as_rng(rng: Any) -> np.random.RandomState:
+    return rng if isinstance(rng, np.random.RandomState) else np.random.RandomState(rng)
+
+
+def exchangeability_violation(
+    portfolio0: HypothesisPortfolio,
+    observations: Sequence[Any],
+    likelihood: Callable[[Any, Any], float],
+    *,
+    n_permutations: int = 20,
+    rng: Any = None,
+) -> float:
+    """Max posterior-weight deviation across random reorderings of ``observations`` (program plan §2(i)).
+
+    Sequentially reweights ``portfolio0`` through ``observations`` in its given order, then again
+    through ``n_permutations`` random permutations of the same set; returns the largest per-hypothesis
+    (or open-world) weight deviation seen across permutations. Zero (up to float noise) for a
+    likelihood whose per-step reweighting is a pure multiplicative update with no hidden order
+    dependence -- successive Bayesian multiply-and-renormalize steps commute exactly in that case.
+    """
+    rng = _as_rng(rng)
+
+    def _run(seq: Sequence[Any]) -> tuple[np.ndarray, float]:
+        port = portfolio0
+        for obs in seq:
+            port = port.reweight(obs, likelihood)
+        return port.weights, port.w_open
+
+    base_weights, base_open = _run(observations)
+    obs_list = list(observations)
+    max_deviation = 0.0
+    for _ in range(n_permutations):
+        permuted = [obs_list[i] for i in rng.permutation(len(obs_list))]
+        weights, w_open = _run(permuted)
+        deviation = max(float(np.max(np.abs(weights - base_weights))), abs(w_open - base_open))
+        max_deviation = max(max_deviation, deviation)
+    return float(max_deviation)
+
+
+def martingale_violation(
+    portfolio: HypothesisPortfolio,
+    observation_sampler: Callable[[np.random.RandomState], Any],
+    likelihood: Callable[[Any, Any], float],
+    *,
+    n: int = 1000,
+    rng: Any = None,
+) -> float:
+    """``|E[w_{t+1} | B_t] - w_t|`` under the model's own predictive (program plan §2(ii)).
+
+    ``observation_sampler(rng) -> observation`` must draw from the portfolio's *own* predictive
+    distribution (e.g. sample a hypothesis proportional to its current weight, then simulate one
+    observation from it) -- the martingale property is a statement about self-consistency under the
+    model's own predictive measure, not about any particular real data-generating process. Returns the
+    largest per-hypothesis (or open-world) deviation between the prior weight and the weight averaged
+    over ``n`` resampled predictive observations.
+    """
+    rng = _as_rng(rng)
+    accum_weights = np.zeros_like(portfolio.weights)
+    accum_open = 0.0
+    for _ in range(n):
+        observation = observation_sampler(rng)
+        updated = portfolio.reweight(observation, likelihood)
+        accum_weights += updated.weights
+        accum_open += updated.w_open
+    mean_weights = accum_weights / n
+    mean_open = accum_open / n
+    return float(max(float(np.max(np.abs(mean_weights - portfolio.weights))), abs(mean_open - portfolio.w_open)))
+
+
+def evidence_conservation_violation(
+    portfolio0: HypothesisPortfolio,
+    observation: Any,
+    likelihood: Callable[[Any, Any], float],
+) -> bool:
+    """Whether re-ingesting the identical ``observation`` a second time changes the posterior further.
+
+    Program plan §2(iii): "the same underlying measurement, ingested twice through different routes,
+    updates once." This function tests the math given an *already-deduped* input path -- it does not
+    itself provide the content-addressed dedup key that real conservation needs (program plan §3.1 is
+    where that lives, a storage-layer concern outside this plan's scope). Concretely: a plain
+    ``likelihood`` with no memory of what it has already seen WILL show a violation here (double
+    application double-counts the evidence, changing the weights again) -- that is the honest, correct
+    outcome for an undeduped path, not a bug in this function. A ``likelihood`` that is itself
+    dedup-aware (e.g. returns a neutral ``1.0`` for an ``observation`` it has already scored, tracked
+    by identity/content-key in a closure the caller owns) shows no violation, demonstrating the property
+    holds once dedup is actually wired in.
+    """
+    once = portfolio0.reweight(observation, likelihood)
+    twice = once.reweight(observation, likelihood)
+    weights_match = bool(np.allclose(once.weights, twice.weights, atol=1e-9))
+    open_match = abs(once.w_open - twice.w_open) < 1e-9
+    return not (weights_match and open_match)
+
+
+__all__ = ["exchangeability_violation", "martingale_violation", "evidence_conservation_violation"]

--- a/mixle/epistemic/discrepancy.py
+++ b/mixle/epistemic/discrepancy.py
@@ -1,0 +1,214 @@
+"""Distance/divergence between two distributions, or between a predicted and an observed sample.
+
+This is the "compare predicted vs. observed" hinge an epistemic loop's UPDATE arrow needs: given a
+hypothesis's predicted observation and the real one, how far apart are they? Nothing under
+``mixle.stats``/``mixle.inference`` computed this directly before this module -- proper scoring rules
+(:mod:`mixle.inference.scoring`) score a single outcome against a predictive distribution, which is a
+related but different question (they answer "how good was this one call", not "how far apart are these
+two whole distributions").
+
+Every function here is generic over any object exposing ``log_density``/``sample`` (the same duck-typed
+surface :mod:`mixle.capability` already dispatches on) or ``.sampler(seed).sample(n)`` (the concrete
+shape every :mod:`mixle.stats` distribution actually has). A closed-form fast path is used only where
+one is exact and unambiguous (currently: two univariate Gaussians); everything else falls back to a
+Monte Carlo estimate, and :func:`discrepancy_report` says plainly which path was taken via its
+``degraded`` flag -- an honest signal, never a silently approximated number presented as exact.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+
+def _rng(seed: int | np.random.RandomState | None) -> np.random.RandomState:
+    return seed if isinstance(seed, np.random.RandomState) else np.random.RandomState(seed)
+
+
+def _sample(dist: Any, n: int, rng: np.random.RandomState) -> np.ndarray:
+    """Draw ``n`` samples from ``dist``, supporting both a direct ``.sample(n)`` and mixle's
+    ``.sampler(seed).sample(n)`` distribution shape."""
+    direct = getattr(dist, "sample", None)
+    if callable(direct):
+        try:
+            return np.atleast_1d(np.asarray(direct(n), dtype=np.float64))
+        except TypeError:
+            return np.atleast_1d(np.asarray([direct() for _ in range(n)], dtype=np.float64))
+    sampler_fn = getattr(dist, "sampler", None)
+    if callable(sampler_fn):
+        seed = int(rng.randint(0, 2**31 - 1))
+        return np.atleast_1d(np.asarray(sampler_fn(seed=seed).sample(n), dtype=np.float64))
+    raise TypeError(f"{type(dist).__name__} exposes neither .sample(n) nor .sampler(seed).sample(n)")
+
+
+def _log_density(dist: Any, xs: np.ndarray) -> np.ndarray:
+    """Evaluate ``dist``'s log-density at every element of ``xs`` (scalar ``log_density`` looped)."""
+    fn = dist.log_density
+    return np.array([float(fn(x)) for x in np.atleast_1d(xs)], dtype=np.float64)
+
+
+def _is_univariate_gaussian(dist: Any) -> bool:
+    from mixle.stats.univariate.continuous.gaussian import GaussianDistribution
+
+    return isinstance(dist, GaussianDistribution)
+
+
+def kl_divergence(p: Any, q: Any, *, n: int = 10_000, seed: int | np.random.RandomState | None = None) -> float:
+    """KL(p || q) in nats: exact closed form when a known pair matches, else a Monte Carlo estimate.
+
+    The one closed-form entry in the dispatch table today is two univariate Gaussians (the exact
+    formula, not an approximation); every other pair falls back to
+    ``mean_{x ~ p}[log p(x) - log q(x)]`` using ``n`` samples drawn from ``p``. Extending the
+    closed-form table to more conjugate pairs (Categorical-Categorical, Dirichlet-Dirichlet, ...) is
+    legitimate future work -- it was deliberately left at one entry here rather than half-built across
+    several families with incompatible parameterizations (mixle's categorical distribution keys its
+    simplex by a ``pmap`` over arbitrary hashable labels, not a fixed-order probability vector, which
+    is a real complication left to a dedicated follow-up rather than papered over).
+    """
+    if _is_univariate_gaussian(p) and _is_univariate_gaussian(q):
+        mu_p, var_p = float(p.mean()), float(p.variance())
+        mu_q, var_q = float(q.mean()), float(q.variance())
+        return float(0.5 * (var_p / var_q + (mu_q - mu_p) ** 2 / var_q - 1.0 + np.log(var_q / var_p)))
+    rng = _rng(seed)
+    xs = _sample(p, n, rng)
+    return float(np.mean(_log_density(p, xs) - _log_density(q, xs)))
+
+
+def js_divergence(p: Any, q: Any, *, n: int = 10_000, seed: int | np.random.RandomState | None = None) -> float:
+    """Jensen-Shannon divergence: symmetric, bounded, computed via the sample-mixture estimator.
+
+    ``0.5 * KL(p || m) + 0.5 * KL(q || m)`` where ``m`` is the equal mixture of ``p`` and ``q``; each
+    term is estimated by sampling from the corresponding side and evaluating ``log m(x) = log(0.5 p(x)
+    + 0.5 q(x))`` via ``logaddexp`` for numerical stability. Symmetric by construction up to Monte
+    Carlo noise (both halves use independent sample draws).
+    """
+    rng = _rng(seed)
+    half = max(1, n // 2)
+
+    def _half_kl_to_mixture(source: Any) -> float:
+        xs = _sample(source, half, rng)
+        log_src = _log_density(source, xs)
+        log_p = _log_density(p, xs)
+        log_q = _log_density(q, xs)
+        log_mix = np.logaddexp(log_p, log_q) - np.log(2.0)
+        return float(np.mean(log_src - log_mix))
+
+    return float(0.5 * _half_kl_to_mixture(p) + 0.5 * _half_kl_to_mixture(q))
+
+
+def wasserstein_distance(p: Any, q: Any, *, n: int = 10_000, seed: int | np.random.RandomState | None = None) -> float:
+    """1-Wasserstein (earth-mover) distance between two 1D distributions, via sorted sample matching.
+
+    Draws ``n`` samples from each side; the empirical 1D optimal transport cost is the mean absolute
+    difference between the two sorted sample sequences (exact for the empirical distributions, a
+    consistent estimator of the true distance as ``n`` grows). Raises :class:`NotImplementedError` for
+    multivariate input rather than silently computing a coordinate-wise number that isn't the true
+    multivariate Wasserstein distance -- there is no cheap exact estimator for that case, and returning
+    a wrong-but-plausible-looking number would be worse than refusing.
+    """
+    rng = _rng(seed)
+    xs = np.sort(_sample(p, n, rng))
+    ys = np.sort(_sample(q, n, rng))
+    if xs.ndim > 1 and xs.shape[-1] > 1:
+        raise NotImplementedError(
+            "wasserstein_distance only supports 1D distributions; no cheap exact multivariate "
+            "estimator is implemented here (a wrong coordinate-wise number would be worse than refusing)."
+        )
+    return float(np.mean(np.abs(xs.ravel() - ys.ravel())))
+
+
+def mmd(samples_p: np.ndarray, samples_q: np.ndarray, *, kernel: str = "rbf", bandwidth: float | None = None) -> float:
+    """Maximum Mean Discrepancy between two raw sample sets (unbiased estimator).
+
+    Unlike the other functions here, this takes samples directly rather than distribution objects --
+    it works even when neither side is a ``mixle.stats`` distribution (e.g. a real observation array
+    vs. a synthesized/predicted one). ``bandwidth`` defaults to the median pairwise distance heuristic
+    over the pooled samples. Only the RBF kernel is implemented; other kernel names raise
+    :class:`NotImplementedError`.
+    """
+    if kernel != "rbf":
+        raise NotImplementedError(f"mmd only implements the 'rbf' kernel, got {kernel!r}")
+
+    def _prepare(a: np.ndarray) -> np.ndarray:
+        arr = np.asarray(a, dtype=np.float64)
+        return arr.reshape(-1, 1) if arr.ndim == 1 else arr
+
+    x = _prepare(samples_p)
+    y = _prepare(samples_q)
+    if bandwidth is None:
+        pooled = np.vstack([x, y])
+        diffs = pooled[:, None, :] - pooled[None, :, :]
+        dists = np.sqrt(np.sum(diffs**2, axis=-1))
+        nonzero = dists[dists > 0]
+        bandwidth = float(np.median(nonzero)) if nonzero.size else 1.0
+    gamma = 1.0 / (2.0 * bandwidth**2) if bandwidth > 0 else 1.0
+
+    def _rbf(a: np.ndarray, b: np.ndarray) -> np.ndarray:
+        diffs = a[:, None, :] - b[None, :, :]
+        return np.exp(-gamma * np.sum(diffs**2, axis=-1))
+
+    kxx = _rbf(x, x)
+    kyy = _rbf(y, y)
+    kxy = _rbf(x, y)
+    m, n = x.shape[0], y.shape[0]
+    term_xx = (kxx.sum() - np.trace(kxx)) / (m * (m - 1)) if m > 1 else 0.0
+    term_yy = (kyy.sum() - np.trace(kyy)) / (n * (n - 1)) if n > 1 else 0.0
+    term_xy = kxy.sum() / (m * n)
+    return float(term_xx + term_yy - 2.0 * term_xy)
+
+
+@dataclass(frozen=True)
+class DiscrepancyResult:
+    """One discrepancy evaluation: the value, which metric computed it, and whether it was exact."""
+
+    value: float
+    metric: str
+    degraded: bool
+
+
+def discrepancy_report(predicted: Any, observed: Any, *, metric: str = "auto") -> DiscrepancyResult:
+    """The actual ``delta_m(o_hat, o)`` entry point: compare a predicted and an observed value/distribution.
+
+    ``metric="auto"`` picks ``kl_divergence`` when both sides look like distributions (expose
+    ``log_density``), else ``mmd`` over raw arrays (the "predicted is a distribution, observed is a
+    concrete measurement" case reduces to comparing ``observed`` against samples drawn from
+    ``predicted``). ``degraded=True`` whenever the underlying computation fell back to a Monte Carlo /
+    sample-based estimate rather than an exact closed form -- callers that need to know whether a
+    number is exact or estimated read this field rather than guessing from the metric name.
+    """
+    if metric == "auto":
+        predicted_is_dist = callable(getattr(predicted, "log_density", None))
+        observed_is_dist = callable(getattr(observed, "log_density", None))
+        if predicted_is_dist and observed_is_dist:
+            exact = _is_univariate_gaussian(predicted) and _is_univariate_gaussian(observed)
+            return DiscrepancyResult(kl_divergence(predicted, observed), "kl_divergence", degraded=not exact)
+        if predicted_is_dist and not observed_is_dist:
+            rng = _rng(None)
+            pred_samples = _sample(predicted, 512, rng)
+            obs_samples = np.atleast_1d(np.asarray(observed, dtype=np.float64))
+            return DiscrepancyResult(mmd(pred_samples, obs_samples), "mmd", degraded=True)
+        pred_arr = np.atleast_1d(np.asarray(predicted, dtype=np.float64))
+        obs_arr = np.atleast_1d(np.asarray(observed, dtype=np.float64))
+        return DiscrepancyResult(mmd(pred_arr, obs_arr), "mmd", degraded=True)
+    if metric == "kl_divergence":
+        exact = _is_univariate_gaussian(predicted) and _is_univariate_gaussian(observed)
+        return DiscrepancyResult(kl_divergence(predicted, observed), metric, degraded=not exact)
+    if metric == "js_divergence":
+        return DiscrepancyResult(js_divergence(predicted, observed), metric, degraded=True)
+    if metric == "wasserstein_distance":
+        return DiscrepancyResult(wasserstein_distance(predicted, observed), metric, degraded=True)
+    if metric == "mmd":
+        return DiscrepancyResult(mmd(predicted, observed), metric, degraded=True)
+    raise ValueError(f"unknown metric {metric!r}")
+
+
+__all__ = [
+    "DiscrepancyResult",
+    "discrepancy_report",
+    "kl_divergence",
+    "js_divergence",
+    "wasserstein_distance",
+    "mmd",
+]

--- a/mixle/epistemic/journal.py
+++ b/mixle/epistemic/journal.py
@@ -1,0 +1,120 @@
+"""``EpistemicJournal`` -- an append-only, replayable decision log for a sequence of loop steps.
+
+The program plan's decision journal (§3.4: "timestamp, model version, belief snapshot hash, options
+considered with their EIG/cost/risk scores, chosen action, rationale claims..."), following
+:class:`mixle.evolve.ledger.EvolutionLedger`'s existing shape (flat, JSON-serializable, append-only,
+no model objects stored directly) rather than inventing a third bespoke logging pattern.
+
+One deliberate refinement over a hash-only ledger: each record carries the *full* serialized belief
+snapshot (``portfolio_snapshot``, from :meth:`~mixle.epistemic.portfolio.HypothesisPortfolio.to_dict`)
+alongside its content-address (``belief_snapshot_hash``). A hash alone cannot be reversed back into a
+portfolio, so "an auditor can reconstruct the full belief trajectory from the ledger alone" (program
+plan §2) requires the snapshot content to actually be there; the hash is what lets :meth:`verify`
+catch tampering/corruption of that stored content, which is the property a bare append-only list
+doesn't get for free.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+from mixle.epistemic.loop import EpistemicStep
+from mixle.epistemic.portfolio import HypothesisPortfolio
+
+
+def _json_default(obj: Any) -> Any:
+    import numpy as np
+
+    if isinstance(obj, np.generic):
+        return obj.item()
+    if isinstance(obj, np.ndarray):
+        return obj.tolist()
+    return str(obj)
+
+
+def _hash_snapshot(snapshot: dict) -> str:
+    payload = json.dumps(snapshot, sort_keys=True, default=_json_default)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+@dataclass(frozen=True)
+class DecisionRecord:
+    """One journaled decision: what was believed, what was considered, what was chosen, and why."""
+
+    step_index: int
+    belief_snapshot_hash: str
+    portfolio_snapshot: dict
+    surprise: float
+    action_considered: list[Any] = field(default_factory=list)
+    action_chosen: Any | None = None
+    action_eig: float | None = None
+    timestamp: float | None = None
+    rationale: str | None = None
+
+
+class EpistemicJournal:
+    """An ordered, JSON-serializable, replayable log of :class:`~mixle.epistemic.loop.EpistemicStep`\\ s."""
+
+    def __init__(self, records: list[DecisionRecord] | None = None) -> None:
+        self.records: list[DecisionRecord] = list(records) if records else []
+
+    def append(
+        self,
+        step: EpistemicStep,
+        *,
+        action_considered: list[Any] = (),
+        rationale: str | None = None,
+        timestamp: float | None = None,
+    ) -> DecisionRecord:
+        """Append one record for ``step`` and return it. ``timestamp`` is caller-supplied, never sampled here."""
+        snapshot = step.portfolio_after.to_dict()
+        record = DecisionRecord(
+            step_index=len(self.records),
+            belief_snapshot_hash=_hash_snapshot(snapshot),
+            portfolio_snapshot=snapshot,
+            surprise=step.surprise,
+            action_considered=list(action_considered),
+            action_chosen=step.next_action,
+            action_eig=step.next_action_eig,
+            timestamp=timestamp,
+            rationale=rationale,
+        )
+        self.records.append(record)
+        return record
+
+    def replay(self, portfolio0: HypothesisPortfolio | None = None) -> list[HypothesisPortfolio]:
+        """Reconstruct the belief trajectory from the journal's stored snapshots alone.
+
+        ``portfolio0`` is accepted for interface symmetry with the loop's own ``step(portfolio, ...)``
+        signature but is not required for reconstruction here: every record already carries its own
+        full ``portfolio_snapshot``, so replay is deserialization, not re-simulation (re-simulation
+        would additionally need the original observations and likelihood callables, which are
+        deliberately not journaled -- they may not be JSON-serializable, and the snapshot is the thing
+        an audit actually needs). If given, ``portfolio0`` is prepended to the returned trajectory.
+        """
+        trajectory = [HypothesisPortfolio.from_dict(r.portfolio_snapshot) for r in self.records]
+        return ([portfolio0] + trajectory) if portfolio0 is not None else trajectory
+
+    def verify(self) -> bool:
+        """Return whether every record's stored snapshot still matches its recorded content-address."""
+        return all(_hash_snapshot(r.portfolio_snapshot) == r.belief_snapshot_hash for r in self.records)
+
+    def to_json(self, **dumps_kwargs: Any) -> str:
+        return json.dumps([asdict(r) for r in self.records], default=_json_default, **dumps_kwargs)
+
+    @classmethod
+    def from_json(cls, s: str) -> EpistemicJournal:
+        rows = json.loads(s)
+        return cls([DecisionRecord(**row) for row in rows])
+
+    def __len__(self) -> int:
+        return len(self.records)
+
+    def __iter__(self):
+        return iter(self.records)
+
+
+__all__ = ["DecisionRecord", "EpistemicJournal"]

--- a/mixle/epistemic/likelihood.py
+++ b/mixle/epistemic/likelihood.py
@@ -1,0 +1,77 @@
+"""Pluggable reweighting strategies, at a declared verifiability tier.
+
+Names the program plan's "in order of preference: (1) certified simulator likelihoods; (2) epistemic
+synthesis + discrepancy; (3) amortized neural estimator" list as a typed seam
+(:class:`LikelihoodStrategy`) so :meth:`mixle.epistemic.portfolio.HypothesisPortfolio.reweight` doesn't
+care which one produced a number, and so a real simulator integration (explicitly out of scope for
+this plan -- see ``notes/epistemic-loop-integration-workplan.md`` §6) has a documented interface to
+implement against today. ``tier`` reuses :data:`mixle.doe.oracle.VERIFIABILITY_TIERS` verbatim rather
+than inventing a second vocabulary -- the same tiers :mod:`mixle.substrate.belief`'s evidence entries
+already use.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Callable
+from typing import Any, Protocol, runtime_checkable
+
+from mixle.doe.oracle import VERIFIABILITY_TIERS
+from mixle.epistemic.discrepancy import discrepancy_report
+from mixle.epistemic.portfolio import Hypothesis
+
+
+@runtime_checkable
+class LikelihoodStrategy(Protocol):
+    """A ``(hypothesis, observation) -> likelihood`` callable that declares its verifiability ``tier``."""
+
+    tier: str
+
+    def __call__(self, hypothesis: Hypothesis, observation: Any) -> float: ...
+
+
+def _check_tier(tier: str) -> None:
+    if tier not in VERIFIABILITY_TIERS:
+        raise ValueError(
+            f"likelihood tier {tier!r} is not a recognized verifiability tier {sorted(VERIFIABILITY_TIERS)} "
+            "(mixle.doe.oracle.VERIFIABILITY_TIERS) -- 'self-graded by a model' is not a valid tier."
+        )
+
+
+class DiscrepancyLikelihood:
+    """Likelihood from :func:`mixle.epistemic.discrepancy.discrepancy_report`: ``exp(-discrepancy / temperature)``.
+
+    ``predict_fn(hypothesis) -> predicted_observation`` is the hypothesis's epistemic-synthesis step
+    (program plan §3.7's "for each live hypothesis, generate the observation you would expect to
+    see"); this class only does the comparison, not the prediction. ``tier`` is a required constructor
+    argument rather than something inferred from ``discrepancy_report``'s ``degraded`` flag, because
+    whether ``predict_fn`` itself calls a certified simulator under the hood is invisible to the
+    discrepancy computation -- inferring it here would risk silently misreporting a tier
+    (``notes/epistemic-loop-integration-workplan.md`` §5 Q2).
+    """
+
+    def __init__(self, predict_fn: Callable[[Hypothesis], Any], *, tier: str, temperature: float = 1.0) -> None:
+        _check_tier(tier)
+        self.predict_fn = predict_fn
+        self.tier = tier
+        self.temperature = float(temperature)
+
+    def __call__(self, hypothesis: Hypothesis, observation: Any) -> float:
+        predicted = self.predict_fn(hypothesis)
+        result = discrepancy_report(predicted, observation)
+        return math.exp(-result.value / self.temperature)
+
+
+class CallableLikelihood:
+    """Wrap any plain ``fn(hypothesis, observation) -> float`` as a :class:`LikelihoodStrategy`."""
+
+    def __init__(self, fn: Callable[[Hypothesis, Any], float], *, tier: str) -> None:
+        _check_tier(tier)
+        self.fn = fn
+        self.tier = tier
+
+    def __call__(self, hypothesis: Hypothesis, observation: Any) -> float:
+        return float(self.fn(hypothesis, observation))
+
+
+__all__ = ["LikelihoodStrategy", "DiscrepancyLikelihood", "CallableLikelihood"]

--- a/mixle/epistemic/loop.py
+++ b/mixle/epistemic/loop.py
@@ -1,0 +1,160 @@
+"""One epistemic-loop step: OBSERVE -> UPDATE -> ABDUCE (on surprise) -> PREDICT -> DISCRIMINATE -> ACT.
+
+:func:`step` is a pure function the caller drives from their own loop (interactive, scripted, or
+agentic -- this module doesn't prescribe which). It is the integration point: everything in
+:mod:`~mixle.epistemic.discrepancy`, :mod:`~mixle.epistemic.portfolio`, and
+:mod:`~mixle.epistemic.likelihood` is a building block; this is where they compose. There is
+deliberately no multi-step ``run_until(...)`` driver and no persistence beyond one
+:class:`EpistemicStep`'s own fields here -- the program plan's "episode"/investigation-trace concept
+(§4.1) is training-data machinery, out of scope for this plan (see
+``notes/epistemic-loop-integration-workplan.md`` §6).
+
+ACT's expected-information-gain scoring does **not** call
+:func:`mixle.doe.active.expected_information_gain_nmc` directly: that function's nested-Monte-Carlo
+estimator is written against a *continuous* numpy parameter space (``prior_sampler(rng, n) -> (n, k)
+array``), while a :class:`~mixle.epistemic.portfolio.HypothesisPortfolio` is a *discrete* weighted set
+of arbitrary typed hypothesis payloads. Forcing the portfolio through that interface would mean either
+requiring every hypothesis payload to be a numpy vector (defeating the point of a typed portfolio) or
+building a lossy adapter. Instead, ``_portfolio_eig_nmc`` below is the same nested-Monte-Carlo EIG
+estimator (Ryan 2003), rewritten one level down against the portfolio's own discrete weighted draws
+-- same math, the right data shape.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+from mixle.epistemic.likelihood import LikelihoodStrategy
+from mixle.epistemic.portfolio import Hypothesis, HypothesisPortfolio
+
+
+def _as_rng(rng: Any) -> np.random.RandomState:
+    return rng if isinstance(rng, np.random.RandomState) else np.random.RandomState(rng)
+
+
+@dataclass(frozen=True)
+class EpistemicStep:
+    """The full outcome of one loop iteration -- everything :class:`~mixle.epistemic.journal.EpistemicJournal` logs."""
+
+    observation: Any
+    portfolio_before: HypothesisPortfolio
+    portfolio_after: HypothesisPortfolio
+    surprise: float
+    next_action: Any | None
+    next_action_eig: float | None
+
+
+def _add_hypothesis(
+    portfolio: HypothesisPortfolio, new_hypothesis: Hypothesis, *, floor_weight: float = 1e-3
+) -> HypothesisPortfolio:
+    """Insert a brand-new hypothesis, funding its floor weight out of ``w_open`` (mass-conserving)."""
+    take = min(float(floor_weight), portfolio.w_open)
+    hyps = portfolio.hypotheses + (new_hypothesis,)
+    weights = np.append(portfolio.weights, take)
+    return HypothesisPortfolio(hyps, weights, portfolio.w_open - take)
+
+
+def _portfolio_eig_nmc(
+    portfolio: HypothesisPortfolio,
+    action: Any,
+    likelihood: Callable[[Hypothesis, Any], float],
+    simulate_fn: Callable[[Hypothesis, Any, np.random.RandomState], Any],
+    rng: np.random.RandomState,
+    *,
+    n_outer: int,
+    n_inner: int,
+) -> float:
+    """Nested-MC EIG of ``action`` against the portfolio's own discrete weighted hypothesis set.
+
+    ``EIG = E_{h, y}[ log p(y|h,a) - log sum_h' w_h' p(y|h',a) ]``, estimated by drawing ``n_outer``
+    hypotheses from the (renormalized active) portfolio, simulating one observation each via
+    ``simulate_fn``, and estimating the log-evidence denominator from ``n_inner`` further draws --
+    the discrete-portfolio analogue of :func:`mixle.doe.active.expected_information_gain_nmc`.
+    """
+    active = [(w, h) for w, h in zip(portfolio.weights, portfolio.hypotheses) if h.active]
+    if not active:
+        return 0.0
+    weights = np.array([w for w, _ in active], dtype=np.float64)
+    weights = weights / weights.sum()
+    hyps = [h for _, h in active]
+    total = 0.0
+    outer_idx = rng.choice(len(hyps), size=n_outer, p=weights)
+    for i in outer_idx:
+        h = hyps[i]
+        y = simulate_fn(h, action, rng)
+        ll_true = math.log(max(float(likelihood(h, y)), 1e-300))
+        inner_idx = rng.choice(len(hyps), size=n_inner, p=weights)
+        liks = np.array([float(likelihood(hyps[j], y)) for j in inner_idx], dtype=np.float64)
+        log_evidence = math.log(max(float(np.mean(liks)), 1e-300))
+        total += ll_true - log_evidence
+    return float(total / n_outer)
+
+
+def step(
+    portfolio: HypothesisPortfolio,
+    observation: Any,
+    likelihood: LikelihoodStrategy,
+    *,
+    action_space: Sequence[Any] | None = None,
+    simulate_fn: Callable[[Hypothesis, Any, np.random.RandomState], Any] | None = None,
+    cost_fn: Callable[[Any], float] | None = None,
+    lam: float = 1.0,
+    surprise_threshold: float | None = None,
+    propose_fn: Callable[[HypothesisPortfolio], Hypothesis | None] | None = None,
+    n_outer: int = 64,
+    n_inner: int = 64,
+    rng: Any = None,
+) -> EpistemicStep:
+    """One loop iteration: reweight on ``observation``, optionally abduce on surprise, optionally act.
+
+    UPDATE: ``portfolio.reweight(observation, likelihood)``. ABDUCE: only when ``surprise_threshold``
+    is set and the portfolio's :meth:`~HypothesisPortfolio.surprise_score` on ``observation`` meets or
+    exceeds it, ``propose_fn(updated_portfolio)`` is called; a non-``None`` return is folded in via
+    :func:`_add_hypothesis` (program plan §3.5's surprise trigger, at the scope this plan covers --
+    schema-expansion / human-checkpoint semantics are not modeled here). ACT: when ``action_space`` is
+    given, each candidate is scored by ``EIG(a) - lam * cost_fn(a)`` (program plan §2's ``a* =
+    argmax_a EIG(a) - lambda*cost(a)``) via ``_portfolio_eig_nmc`` against the *updated* portfolio, and
+    the argmax is returned; ``action_space=None`` is a valid "just update the belief" call and returns
+    ``next_action=None``. Raises :class:`ValueError` if ``action_space`` is given without
+    ``simulate_fn`` -- EIG estimation needs a way to generate a predicted observation per hypothesis
+    per action, and there's no honest default for that.
+    """
+    surprise = portfolio.surprise_score(observation, likelihood)
+    updated = portfolio.reweight(observation, likelihood)
+    if surprise_threshold is not None and surprise >= surprise_threshold and propose_fn is not None:
+        new_hypothesis = propose_fn(updated)
+        if new_hypothesis is not None:
+            updated = _add_hypothesis(updated, new_hypothesis)
+
+    next_action: Any | None = None
+    next_action_eig: float | None = None
+    if action_space is not None:
+        if simulate_fn is None:
+            raise ValueError("action_space requires simulate_fn(hypothesis, action, rng) for EIG estimation")
+        rng_ = _as_rng(rng)
+        best_score = -math.inf
+        for candidate in action_space:
+            eig = _portfolio_eig_nmc(
+                updated, candidate, likelihood, simulate_fn, rng_, n_outer=n_outer, n_inner=n_inner
+            )
+            cost = float(cost_fn(candidate)) if cost_fn is not None else 0.0
+            score = eig - lam * cost
+            if score > best_score:
+                best_score, next_action, next_action_eig = score, candidate, eig
+
+    return EpistemicStep(
+        observation=observation,
+        portfolio_before=portfolio,
+        portfolio_after=updated,
+        surprise=surprise,
+        next_action=next_action,
+        next_action_eig=next_action_eig,
+    )
+
+
+__all__ = ["EpistemicStep", "step"]

--- a/mixle/epistemic/portfolio.py
+++ b/mixle/epistemic/portfolio.py
@@ -1,0 +1,208 @@
+"""``HypothesisPortfolio`` -- a weighted set of typed hypotheses plus an explicit open-world mass.
+
+The program-plan's ``H_t = {(h_i, w_i)} u {(_|_, w_|_)}``: a sequential-Monte-Carlo particle cloud
+generalized from :func:`mixle.inference.mcmc.particle_filter`'s numeric-state-only particles to
+*arbitrary typed hypothesis payloads*, with the reserved "none of the above" mass carried as a
+first-class field rather than folded into the particle list. Weights always satisfy ``w_open +
+sum(active weights) == 1`` -- every mutating method returns a *new* portfolio with the invariant
+already restored, and the constructor validates it on every construction (no silent drift).
+
+Pruning (:meth:`prune`) never deletes a hypothesis, only deactivates it -- the same
+never-truly-forget philosophy already used by :mod:`mixle.substrate.belief`'s cascading retraction --
+and its freed mass folds into ``w_open``: a pruned hypothesis was one we could no longer defend, which
+is exactly what growing the "we don't currently have an explanation" mass means (see
+``notes/epistemic-loop-integration-workplan.md`` §5 Q1). :meth:`resample` delegates to the same
+systematic/multinomial resampling math :func:`mixle.inference.mcmc.particle_filter` uses, applied only
+to the active mass -- ``w_open`` is untouched by resampling, since it isn't a particle to resample.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, replace
+from typing import Any
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class Hypothesis:
+    """One typed hypothesis in a portfolio. ``payload`` is opaque to the portfolio itself."""
+
+    id: str
+    payload: Any
+    active: bool = True
+
+
+def _as_rng(rng: Any) -> np.random.RandomState:
+    return rng if isinstance(rng, np.random.RandomState) else np.random.RandomState(rng)
+
+
+class HypothesisPortfolio:
+    """A weighted, typed hypothesis set with an explicit reserved open-world mass ``w_open``."""
+
+    def __init__(self, hypotheses: Sequence[Hypothesis], weights: np.ndarray, w_open: float = 0.0) -> None:
+        self.hypotheses: tuple[Hypothesis, ...] = tuple(hypotheses)
+        self.weights: np.ndarray = np.asarray(weights, dtype=np.float64)
+        self.w_open: float = float(w_open)
+        if self.weights.shape != (len(self.hypotheses),):
+            raise ValueError(f"weights must have shape ({len(self.hypotheses)},), got {self.weights.shape}")
+        if self.w_open < -1e-9 or self.w_open > 1 + 1e-9:
+            raise ValueError(f"w_open must be in [0, 1], got {self.w_open}")
+        for h, w in zip(self.hypotheses, self.weights):
+            if not h.active and w != 0.0:
+                raise ValueError(f"inactive hypothesis {h.id!r} must carry weight 0.0, got {w}")
+            if w < -1e-9:
+                raise ValueError(f"hypothesis {h.id!r} has negative weight {w}")
+        total = float(self.weights.sum()) + self.w_open
+        if abs(total - 1.0) > 1e-6:
+            raise ValueError(f"sum(weights) + w_open must equal 1.0, got {total}")
+
+    def __len__(self) -> int:
+        return len(self.hypotheses)
+
+    def active_mask(self) -> np.ndarray:
+        return np.array([h.active for h in self.hypotheses], dtype=bool)
+
+    def reweight(
+        self,
+        observation: Any,
+        likelihood_fn: Callable[[Hypothesis, Any], float],
+        *,
+        open_world_likelihood: Callable[[Any], float] | None = None,
+    ) -> HypothesisPortfolio:
+        """Bayesian-reweight every active hypothesis by ``likelihood_fn(h, observation)``.
+
+        ``open_world_likelihood(observation)`` reweights ``w_open`` too; it defaults to a flat
+        constant baseline of ``1.0`` -- an implicit "moderately plausible, independent of how badly
+        the current hypotheses fit" prior -- which is what makes the surprise mechanism work without
+        extra wiring: when every active hypothesis's likelihood collapses toward zero on an
+        out-of-support observation, the (unchanged) open-world baseline dominates the renormalization
+        and ``w_open`` grows on its own, exactly the "the residual resists the current hypothesis
+        schema" signal the program plan's surprise trigger names. If every likelihood (including the
+        open-world baseline) is zero, all mass moves to ``w_open`` -- the honest "nothing, including
+        the reserved slot, explains this" outcome, rather than raising or producing NaNs.
+        """
+        active = self.active_mask()
+        liks = np.zeros(len(self.hypotheses), dtype=np.float64)
+        for i, h in enumerate(self.hypotheses):
+            if h.active:
+                liks[i] = float(likelihood_fn(h, observation))
+        open_lik = float(open_world_likelihood(observation)) if open_world_likelihood is not None else 1.0
+        new_active_unnorm = self.weights[active] * liks[active] if active.any() else np.array([])
+        new_open_unnorm = self.w_open * open_lik
+        total = float(new_active_unnorm.sum()) + new_open_unnorm
+        if total <= 0:
+            return HypothesisPortfolio(self.hypotheses, np.zeros(len(self.hypotheses)), w_open=1.0)
+        new_weights = np.zeros(len(self.hypotheses), dtype=np.float64)
+        new_weights[active] = new_active_unnorm / total
+        return HypothesisPortfolio(self.hypotheses, new_weights, w_open=new_open_unnorm / total)
+
+    def resample(
+        self, *, method: str = "systematic", ess_threshold: float = 0.5, rng: Any = None
+    ) -> HypothesisPortfolio:
+        """Resample the active particle set if effective sample size drops below ``ess_threshold * n``.
+
+        ``w_open`` is untouched -- it is a reserved mass, not a particle. Resampled duplicates of the
+        same source hypothesis get id-suffixed copies (``"h2"``, ``"h2#1"``, ...) so every hypothesis
+        id in the returned portfolio stays unique, which :meth:`resurrect`/the journal rely on.
+        """
+        rng = _as_rng(rng)
+        active_idx = [i for i, h in enumerate(self.hypotheses) if h.active]
+        if len(active_idx) <= 1:
+            return self
+        w_active = self.weights[active_idx]
+        total_active = float(w_active.sum())
+        if total_active <= 0:
+            return self
+        p = w_active / total_active
+        ess = 1.0 / float(np.sum(p**2)) if np.sum(p**2) > 0 else 0.0
+        n = len(active_idx)
+        if ess >= ess_threshold * n:
+            return self
+        if method == "systematic":
+            positions = (rng.uniform() + np.arange(n)) / n
+            chosen = np.searchsorted(np.cumsum(p), positions)
+        elif method == "multinomial":
+            chosen = rng.choice(n, size=n, p=p)
+        else:
+            raise ValueError(f"unknown resample method {method!r}")
+        new_hyps = list(self.hypotheses)
+        new_weights = self.weights.copy()
+        seen: dict[str, int] = {}
+        for slot, pick in zip(active_idx, chosen):
+            src = self.hypotheses[active_idx[int(pick)]]
+            count = seen.get(src.id, 0)
+            seen[src.id] = count + 1
+            new_id = src.id if count == 0 else f"{src.id}#{count}"
+            new_hyps[slot] = Hypothesis(id=new_id, payload=src.payload, active=True)
+            new_weights[slot] = total_active / n
+        return HypothesisPortfolio(new_hyps, new_weights, self.w_open)
+
+    def prune(self, *, min_weight: float) -> HypothesisPortfolio:
+        """Deactivate (never delete) active hypotheses below ``min_weight``; their mass folds into ``w_open``."""
+        new_hyps = list(self.hypotheses)
+        new_weights = self.weights.copy()
+        freed = 0.0
+        for i, h in enumerate(self.hypotheses):
+            if h.active and new_weights[i] < min_weight:
+                freed += float(new_weights[i])
+                new_weights[i] = 0.0
+                new_hyps[i] = replace(h, active=False)
+        return HypothesisPortfolio(new_hyps, new_weights, self.w_open + freed)
+
+    def resurrect(self, hypothesis_id: str, *, floor_weight: float = 1e-3) -> HypothesisPortfolio:
+        """Reactivate a deactivated hypothesis, taking its floor weight out of ``w_open`` (mass-conserving)."""
+        idx = next((i for i, h in enumerate(self.hypotheses) if h.id == hypothesis_id), None)
+        if idx is None:
+            raise KeyError(f"no hypothesis with id {hypothesis_id!r}")
+        if self.hypotheses[idx].active:
+            return self
+        take = min(float(floor_weight), self.w_open)
+        new_hyps = list(self.hypotheses)
+        new_hyps[idx] = replace(self.hypotheses[idx], active=True)
+        new_weights = self.weights.copy()
+        new_weights[idx] = take
+        return HypothesisPortfolio(new_hyps, new_weights, self.w_open - take)
+
+    def surprise_score(self, observation: Any, likelihood_fn: Callable[[Hypothesis, Any], float]) -> float:
+        """Joint improbability of ``observation`` under every active hypothesis, in ``[0, 1)``.
+
+        ``baseline / (baseline + weighted_mean_likelihood)`` against the same flat ``baseline = 1.0``
+        :meth:`reweight` uses by default -- close to 0 when some active hypothesis explains the
+        observation well, close to 1 when every active hypothesis assigns it near-zero likelihood
+        (program plan §3.5's "improbable under every live hypothesis" surprise condition). A heuristic
+        scalar, not a calibrated probability -- callers threshold it, this method just computes it.
+        """
+        active = [(w, h) for w, h in zip(self.weights, self.hypotheses) if h.active]
+        if not active:
+            return 1.0
+        total_w = sum(w for w, _ in active)
+        if total_w <= 0:
+            return 1.0
+        weighted_lik = sum(w * float(likelihood_fn(h, observation)) for w, h in active) / total_w
+        baseline = 1.0
+        return float(baseline / (baseline + weighted_lik))
+
+    def to_dict(self) -> dict:
+        return {
+            "hypotheses": [{"id": h.id, "payload": h.payload, "active": h.active} for h in self.hypotheses],
+            "weights": self.weights.tolist(),
+            "w_open": self.w_open,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict, *, payload_codec: Callable[[Any], Any] | None = None) -> HypothesisPortfolio:
+        hyps = [
+            Hypothesis(
+                id=item["id"],
+                payload=payload_codec(item["payload"]) if payload_codec else item["payload"],
+                active=item["active"],
+            )
+            for item in d["hypotheses"]
+        ]
+        weights = np.array(d["weights"], dtype=np.float64)
+        return cls(hyps, weights, float(d["w_open"]))
+
+
+__all__ = ["Hypothesis", "HypothesisPortfolio"]

--- a/mixle/tests/epistemic_capability_test.py
+++ b/mixle/tests/epistemic_capability_test.py
@@ -1,0 +1,23 @@
+"""mixle.epistemic is discoverable through the capability catalog (Card E0)."""
+
+import unittest
+
+import mixle.epistemic  # noqa: F401 -- import succeeds with no side effects
+from mixle.capability import catalog, render_catalog_markdown
+
+
+class EpistemicCapabilityCatalogTest(unittest.TestCase):
+    def test_belief_trackable_is_in_the_catalog(self):
+        specs = {spec.name: spec for spec in catalog()}
+        self.assertIn("BeliefTrackable", specs)
+        spec = specs["BeliefTrackable"]
+        self.assertEqual(spec.home, "mixle.epistemic")
+        self.assertTrue(spec.summary.strip())
+
+    def test_catalog_markdown_mentions_it(self):
+        text = render_catalog_markdown()
+        self.assertIn("BeliefTrackable", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mixle/tests/epistemic_coherence_test.py
+++ b/mixle/tests/epistemic_coherence_test.py
@@ -1,0 +1,112 @@
+"""mixle.epistemic.coherence: exchangeability / martingale / evidence-conservation checks (Card E6)."""
+
+import unittest
+
+import numpy as np
+
+from mixle.epistemic.coherence import (
+    evidence_conservation_violation,
+    exchangeability_violation,
+    martingale_violation,
+)
+from mixle.epistemic.portfolio import Hypothesis, HypothesisPortfolio
+
+
+def _gaussian_likelihood(hypothesis, observation):
+    return float(np.exp(-0.5 * (observation - hypothesis.payload) ** 2))
+
+
+def _toy_portfolio():
+    hyps = [Hypothesis("h0", 0.0), Hypothesis("h1", 2.0), Hypothesis("h2", 5.0)]
+    return HypothesisPortfolio(hyps, np.array([1 / 3, 1 / 3, 1 / 3]), w_open=0.0)
+
+
+class ExchangeabilityTest(unittest.TestCase):
+    def test_well_behaved_likelihood_shows_no_violation(self):
+        rng = np.random.RandomState(0)
+        observations = [rng.normal(loc=2.0, scale=1.0) for _ in range(6)]
+        violation = exchangeability_violation(
+            _toy_portfolio(), observations, _gaussian_likelihood, n_permutations=15, rng=1
+        )
+        self.assertLess(violation, 1e-8)
+
+    def test_order_dependent_likelihood_is_caught(self):
+        # A per-POSITION boost (e.g. "every other call") is a red herring here: multiplication is
+        # commutative, so a fixed per-position multiplier factors out of the full product regardless
+        # of which value lands in which position, and never actually shows up as a permutation
+        # violation. A genuinely order-dependent likelihood has to condition on the *relative order of
+        # observation values themselves* -- e.g. "boost h1 whenever this observation is larger than
+        # the previous one" -- which is what real hidden-state incoherence looks like.
+        state = {"prev": None}
+
+        def wide_gaussian_likelihood(hypothesis, observation, sigma=3.0):
+            # A wider likelihood than the other tests' -- keeps the posterior from saturating near 0/1
+            # after only 6 observations, so the order-dependent perturbation stays visible in the raw
+            # weights instead of being swamped by an already near-certain posterior.
+            return float(np.exp(-0.5 * ((observation - hypothesis.payload) / sigma) ** 2))
+
+        def order_dependent_likelihood(hypothesis, observation):
+            base = wide_gaussian_likelihood(hypothesis, observation)
+            if hypothesis.id == "h1":
+                if state["prev"] is not None and observation > state["prev"]:
+                    base *= 50.0
+                state["prev"] = observation
+            return base
+
+        rng = np.random.RandomState(0)
+        observations = [rng.normal(loc=2.0, scale=1.0) for _ in range(6)]
+        violation = exchangeability_violation(
+            _toy_portfolio(), observations, order_dependent_likelihood, n_permutations=40, rng=0
+        )
+        self.assertGreater(violation, 1e-3)
+
+
+class MartingaleTest(unittest.TestCase):
+    def test_self_consistent_predictive_has_small_violation(self):
+        portfolio = _toy_portfolio()
+
+        def observation_sampler(rng):
+            idx = rng.choice(3, p=portfolio.weights)
+            return float(portfolio.hypotheses[idx].payload + rng.normal(scale=1.0))
+
+        violation = martingale_violation(portfolio, observation_sampler, _gaussian_likelihood, n=2000, rng=0)
+        self.assertLess(violation, 0.05)
+
+    def test_a_biased_predictive_has_a_larger_violation(self):
+        portfolio = _toy_portfolio()
+
+        def biased_sampler(rng):
+            # Always draws near h1 regardless of the portfolio's actual weights -- not the model's own
+            # predictive distribution, so the martingale property should NOT hold.
+            return float(2.0 + rng.normal(scale=0.1))
+
+        violation = martingale_violation(portfolio, biased_sampler, _gaussian_likelihood, n=2000, rng=0)
+        self.assertGreater(violation, 0.2)
+
+
+class EvidenceConservationTest(unittest.TestCase):
+    def test_naive_double_ingestion_without_dedup_is_a_violation(self):
+        violation = evidence_conservation_violation(_toy_portfolio(), 2.0, _gaussian_likelihood)
+        self.assertTrue(violation)
+
+    def test_dedup_aware_likelihood_shows_no_violation(self):
+        # A whole reweight() call evaluates the likelihood once per hypothesis, so "have I already
+        # fully scored this observation" only becomes true after that many calls -- tracking dedup by
+        # raw call count (rather than a naive "seen the value once" flag) survives that without
+        # accidentally deduping mid-way through the FIRST, real ingestion.
+        portfolio = _toy_portfolio()
+        n_hypotheses = len(portfolio)
+        counts = {}
+
+        def dedup_likelihood(hypothesis, observation):
+            counts[observation] = counts.get(observation, 0) + 1
+            if counts[observation] > n_hypotheses:
+                return 1.0
+            return _gaussian_likelihood(hypothesis, observation)
+
+        violation = evidence_conservation_violation(portfolio, 2.0, dedup_likelihood)
+        self.assertFalse(violation)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mixle/tests/epistemic_discrepancy_test.py
+++ b/mixle/tests/epistemic_discrepancy_test.py
@@ -1,0 +1,114 @@
+"""mixle.epistemic.discrepancy: KL/JS/Wasserstein/MMD between distributions or samples (Card E1)."""
+
+import unittest
+
+import numpy as np
+
+from mixle.epistemic.discrepancy import (
+    discrepancy_report,
+    js_divergence,
+    kl_divergence,
+    mmd,
+    wasserstein_distance,
+)
+from mixle.stats.univariate.continuous.gaussian import GaussianDistribution
+
+
+class KLDivergenceTest(unittest.TestCase):
+    def test_kl_of_identical_gaussians_is_zero(self):
+        p = GaussianDistribution(0.0, 1.0)
+        q = GaussianDistribution(0.0, 1.0)
+        self.assertAlmostEqual(kl_divergence(p, q), 0.0, places=8)
+
+    def test_kl_matches_closed_form_gaussian_formula(self):
+        p = GaussianDistribution(0.0, 1.0)
+        q = GaussianDistribution(5.0, 1.0)
+        mu_p, var_p, mu_q, var_q = 0.0, 1.0, 5.0, 1.0
+        expected = 0.5 * (var_p / var_q + (mu_q - mu_p) ** 2 / var_q - 1.0 + np.log(var_q / var_p))
+        self.assertAlmostEqual(kl_divergence(p, q), expected, places=8)
+
+
+class JSDivergenceTest(unittest.TestCase):
+    def test_symmetric_within_mc_tolerance(self):
+        p = GaussianDistribution(0.0, 1.0)
+        q = GaussianDistribution(3.0, 1.0)
+        a = js_divergence(p, q, n=20_000, seed=0)
+        b = js_divergence(q, p, seed=0, n=20_000)
+        self.assertAlmostEqual(a, b, delta=0.02)
+
+
+class WassersteinDistanceTest(unittest.TestCase):
+    def test_matches_known_toy_case(self):
+        class PointMass:
+            def __init__(self, value):
+                self.value = value
+
+            def sample(self, n):
+                return np.full(n, self.value, dtype=np.float64)
+
+        p = PointMass(0.0)
+        q = PointMass(3.0)
+        self.assertAlmostEqual(wasserstein_distance(p, q, n=100), 3.0, places=8)
+
+    def test_multivariate_raises_not_implemented(self):
+        class TwoD:
+            def sample(self, n):
+                return np.zeros((n, 2), dtype=np.float64)
+
+        with self.assertRaises(NotImplementedError):
+            wasserstein_distance(TwoD(), TwoD(), n=10)
+
+
+class MMDTest(unittest.TestCase):
+    def test_same_distribution_is_near_zero(self):
+        rng = np.random.RandomState(0)
+        xs = rng.normal(size=1000)
+        value = mmd(xs[:500], xs[500:])
+        self.assertLess(abs(value), 0.05)
+
+    def test_different_distributions_is_clearly_positive(self):
+        rng = np.random.RandomState(0)
+        xs = rng.normal(size=1000)
+        ys = rng.normal(loc=5.0, size=1000)
+        self.assertGreater(mmd(xs, ys), 0.5)
+
+    def test_unknown_kernel_raises_not_implemented(self):
+        with self.assertRaises(NotImplementedError):
+            mmd(np.zeros(5), np.zeros(5), kernel="polynomial")
+
+
+class DiscrepancyReportTest(unittest.TestCase):
+    def test_not_degraded_for_registered_closed_form_pair(self):
+        p = GaussianDistribution(0.0, 1.0)
+        q = GaussianDistribution(1.0, 1.0)
+        result = discrepancy_report(p, q)
+        self.assertEqual(result.metric, "kl_divergence")
+        self.assertFalse(result.degraded)
+
+    def test_degraded_for_a_pair_without_a_closed_form(self):
+        class SampleOnly:
+            def __init__(self, loc):
+                self.loc = loc
+
+            def log_density(self, x):
+                return float(-0.5 * (x - self.loc) ** 2)
+
+            def sample(self, n):
+                return np.random.RandomState(0).normal(loc=self.loc, size=n)
+
+        result = discrepancy_report(SampleOnly(0.0), SampleOnly(1.0))
+        self.assertEqual(result.metric, "kl_divergence")
+        self.assertTrue(result.degraded)
+
+    def test_explicit_metric_is_honored(self):
+        result = discrepancy_report(np.zeros(50), np.ones(50), metric="mmd")
+        self.assertEqual(result.metric, "mmd")
+        self.assertTrue(result.degraded)
+
+    def test_unknown_metric_raises(self):
+        with self.assertRaises(ValueError):
+            discrepancy_report(np.zeros(5), np.zeros(5), metric="not_a_real_metric")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mixle/tests/epistemic_journal_test.py
+++ b/mixle/tests/epistemic_journal_test.py
@@ -1,0 +1,63 @@
+"""mixle.epistemic.journal: append-only, replayable decision log (Card E5)."""
+
+import unittest
+
+import numpy as np
+
+from mixle.epistemic.journal import EpistemicJournal
+from mixle.epistemic.loop import step
+from mixle.epistemic.portfolio import Hypothesis, HypothesisPortfolio
+
+
+def _gaussian_likelihood(hypothesis, observation):
+    return float(np.exp(-0.5 * (observation - hypothesis.payload) ** 2))
+
+
+def _five_steps():
+    hyps = [Hypothesis("h0", 0.0), Hypothesis("h1", 2.0), Hypothesis("h2", 5.0)]
+    portfolio = HypothesisPortfolio(hyps, np.array([1 / 3, 1 / 3, 1 / 3]), w_open=0.0)
+    rng = np.random.RandomState(0)
+    journal = EpistemicJournal()
+    for i in range(5):
+        observation = rng.normal(loc=2.0, scale=1.0)
+        outcome = step(portfolio, observation, _gaussian_likelihood)
+        journal.append(outcome, rationale=f"step {i}", timestamp=float(i))
+        portfolio = outcome.portfolio_after
+    return journal
+
+
+class JournalRoundTripTest(unittest.TestCase):
+    def test_to_json_from_json_round_trips_exactly(self):
+        journal = _five_steps()
+        restored = EpistemicJournal.from_json(journal.to_json())
+        self.assertEqual(len(restored), len(journal))
+        for original, back in zip(journal.records, restored.records):
+            self.assertEqual(original, back)
+
+
+class ContentAddressTest(unittest.TestCase):
+    def test_hash_is_stable_for_identical_content_and_changes_when_weights_differ(self):
+        journal = _five_steps()
+        first, second = journal.records[0], journal.records[1]
+        self.assertEqual(first.belief_snapshot_hash, first.belief_snapshot_hash)
+        self.assertNotEqual(first.belief_snapshot_hash, second.belief_snapshot_hash)
+
+    def test_verify_detects_a_corrupted_snapshot(self):
+        journal = _five_steps()
+        self.assertTrue(journal.verify())
+        corrupted = journal.records[2].portfolio_snapshot
+        corrupted["w_open"] = corrupted["w_open"] + 0.5  # mutate in place, hash now stale
+        self.assertFalse(journal.verify())
+
+
+class ReplayTest(unittest.TestCase):
+    def test_replay_reconstructs_the_belief_trajectory(self):
+        journal = _five_steps()
+        trajectory = journal.replay()
+        self.assertEqual(len(trajectory), len(journal))
+        last_record_weights = journal.records[-1].portfolio_snapshot["weights"]
+        self.assertTrue(np.allclose(trajectory[-1].weights, last_record_weights))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mixle/tests/epistemic_likelihood_test.py
+++ b/mixle/tests/epistemic_likelihood_test.py
@@ -1,0 +1,62 @@
+"""mixle.epistemic.likelihood: pluggable reweighting strategies at a declared verifiability tier (Card E3)."""
+
+import unittest
+
+import numpy as np
+
+from mixle.epistemic.likelihood import CallableLikelihood, DiscrepancyLikelihood, LikelihoodStrategy
+from mixle.epistemic.portfolio import Hypothesis, HypothesisPortfolio
+
+
+class CallableLikelihoodTest(unittest.TestCase):
+    def test_round_trips_tier_and_computes_the_wrapped_function(self):
+        strategy = CallableLikelihood(lambda h, o: float(h.payload == o), tier="executable")
+        self.assertEqual(strategy.tier, "executable")
+        self.assertEqual(strategy(Hypothesis("h", "x"), "x"), 1.0)
+        self.assertEqual(strategy(Hypothesis("h", "x"), "y"), 0.0)
+
+    def test_isinstance_protocol_conformance(self):
+        strategy = CallableLikelihood(lambda h, o: 1.0, tier="executable")
+        self.assertIsInstance(strategy, LikelihoodStrategy)
+
+    def test_unknown_tier_raises(self):
+        with self.assertRaises(ValueError):
+            CallableLikelihood(lambda h, o: 1.0, tier="self_graded")
+
+
+class DiscrepancyLikelihoodTest(unittest.TestCase):
+    def test_is_a_drop_in_for_portfolio_reweight(self):
+        hyps = [Hypothesis("h0", 0.0), Hypothesis("h1", 2.0), Hypothesis("h2", 5.0)]
+        weights = np.array([1 / 3, 1 / 3, 1 / 3])
+        portfolio = HypothesisPortfolio(hyps, weights, w_open=0.0)
+
+        class Predicted:
+            def __init__(self, loc):
+                self.loc = loc
+
+            def log_density(self, x):
+                return float(-0.5 * (x - self.loc) ** 2)
+
+            def sample(self, n):
+                return np.random.RandomState(0).normal(loc=self.loc, size=n)
+
+        strategy = DiscrepancyLikelihood(lambda h: Predicted(h.payload), tier="simulation", temperature=0.5)
+        self.assertIsInstance(strategy, LikelihoodStrategy)
+        self.assertEqual(strategy.tier, "simulation")
+
+        # A plain float observation (no log_density) routes discrepancy_report's auto-dispatch to the
+        # "predicted is a distribution, observed is a concrete measurement" mmd-over-samples branch.
+        rng = np.random.RandomState(0)
+        for _ in range(10):
+            observation = float(rng.normal(loc=2.0, scale=0.3))
+            portfolio = portfolio.reweight(observation, strategy)
+        idx = {h.id: i for i, h in enumerate(portfolio.hypotheses)}
+        self.assertGreater(portfolio.weights[idx["h1"]], 0.9)
+
+    def test_unknown_tier_raises(self):
+        with self.assertRaises(ValueError):
+            DiscrepancyLikelihood(lambda h: h, tier="not_a_tier")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mixle/tests/epistemic_loop_test.py
+++ b/mixle/tests/epistemic_loop_test.py
@@ -1,0 +1,110 @@
+"""mixle.epistemic.loop: one step of OBSERVE -> UPDATE -> ABDUCE -> ACT (Card E4)."""
+
+import unittest
+
+import numpy as np
+
+from mixle.epistemic.loop import step
+from mixle.epistemic.portfolio import Hypothesis, HypothesisPortfolio
+
+
+def _gaussian_likelihood(hypothesis, observation):
+    return float(np.exp(-0.5 * (observation - hypothesis.payload) ** 2))
+
+
+def _toy_portfolio(w_open=0.0):
+    hyps = [Hypothesis("h0", 0.0), Hypothesis("h1", 2.0), Hypothesis("h2", 5.0)]
+    weights = np.array([(1.0 - w_open) / 3] * 3)
+    return HypothesisPortfolio(hyps, weights, w_open=w_open)
+
+
+class UpdateOnlyStepTest(unittest.TestCase):
+    def test_repeated_steps_converge_like_direct_reweight(self):
+        portfolio = _toy_portfolio()
+        rng = np.random.RandomState(0)
+        for _ in range(15):
+            observation = rng.normal(loc=2.0, scale=1.0)
+            outcome = step(portfolio, observation, _gaussian_likelihood)
+            portfolio = outcome.portfolio_after
+        idx = {h.id: i for i, h in enumerate(portfolio.hypotheses)}
+        self.assertGreater(portfolio.weights[idx["h1"]], 0.95)
+
+    def test_no_action_space_returns_none_action(self):
+        portfolio = _toy_portfolio()
+        outcome = step(portfolio, 2.0, _gaussian_likelihood)
+        self.assertIsNone(outcome.next_action)
+        self.assertIsNone(outcome.next_action_eig)
+
+
+class ActionSelectionTest(unittest.TestCase):
+    def test_picks_the_action_with_higher_eig_near_the_dominant_hypothesis(self):
+        # Two candidate "probe locations"; probing near the already-dominant hypothesis (2.0) is more
+        # informative than probing somewhere no hypothesis predicts anything (100.0): the simulator
+        # returns near-flat, uninformative noise for the latter, and a peaked, discriminating signal
+        # for the former.
+        hyps = [Hypothesis("h0", 0.0), Hypothesis("h1", 2.0)]
+        weights = np.array([0.05, 0.95])
+        portfolio = HypothesisPortfolio(hyps, weights, w_open=0.0)
+
+        def simulate_fn(hypothesis, action, rng):
+            if abs(action - 2.0) < 1e-6:
+                return float(hypothesis.payload + rng.normal(scale=0.05))
+            return float(rng.normal(scale=0.05))  # uninformative regardless of hypothesis
+
+        def likelihood(hypothesis, observation):
+            target = hypothesis.payload
+            return float(np.exp(-0.5 * ((observation - target) / 0.05) ** 2))
+
+        outcome = step(
+            portfolio,
+            2.0,
+            likelihood,
+            action_space=[2.0, 100.0],
+            simulate_fn=simulate_fn,
+            n_outer=64,
+            n_inner=32,
+            rng=0,
+        )
+        self.assertEqual(outcome.next_action, 2.0)
+        self.assertIsNotNone(outcome.next_action_eig)
+
+    def test_action_space_without_simulate_fn_raises(self):
+        portfolio = _toy_portfolio()
+        with self.assertRaises(ValueError):
+            step(portfolio, 2.0, _gaussian_likelihood, action_space=[1.0, 2.0])
+
+
+class SurpriseAbductionTest(unittest.TestCase):
+    def test_a_surprising_observation_triggers_propose_fn_and_grows_the_new_hypothesis(self):
+        portfolio = _toy_portfolio(w_open=0.3)
+        proposed = {"called": False}
+
+        def propose_fn(current_portfolio):
+            proposed["called"] = True
+            return Hypothesis("h_new", 1000.0)
+
+        outcome = step(
+            portfolio,
+            1000.0,
+            _gaussian_likelihood,
+            surprise_threshold=0.5,
+            propose_fn=propose_fn,
+        )
+        self.assertTrue(proposed["called"])
+        ids = [h.id for h in outcome.portfolio_after.hypotheses]
+        self.assertIn("h_new", ids)
+
+    def test_below_threshold_does_not_call_propose_fn(self):
+        portfolio = _toy_portfolio()
+        proposed = {"called": False}
+
+        def propose_fn(current_portfolio):
+            proposed["called"] = True
+            return Hypothesis("h_new", 1000.0)
+
+        step(portfolio, 2.0, _gaussian_likelihood, surprise_threshold=0.999, propose_fn=propose_fn)
+        self.assertFalse(proposed["called"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mixle/tests/epistemic_portfolio_test.py
+++ b/mixle/tests/epistemic_portfolio_test.py
@@ -1,0 +1,109 @@
+"""mixle.epistemic.portfolio: typed weighted hypotheses + open-world mass (Card E2)."""
+
+import unittest
+
+import numpy as np
+
+from mixle.epistemic.portfolio import Hypothesis, HypothesisPortfolio
+
+
+def _gaussian_likelihood(hypothesis, observation):
+    return float(np.exp(-0.5 * (observation - hypothesis.payload) ** 2))
+
+
+def _toy_portfolio(w_open=0.0):
+    hyps = [Hypothesis("h0", 0.0), Hypothesis("h1", 2.0), Hypothesis("h2", 5.0)]
+    weights = np.array([(1.0 - w_open) / 3] * 3)
+    return HypothesisPortfolio(hyps, weights, w_open=w_open)
+
+
+class ReweightConvergenceTest(unittest.TestCase):
+    def test_weight_converges_to_the_true_generating_hypothesis(self):
+        portfolio = _toy_portfolio()
+        rng = np.random.RandomState(0)
+        for _ in range(15):
+            observation = rng.normal(loc=2.0, scale=1.0)
+            portfolio = portfolio.reweight(observation, _gaussian_likelihood)
+        idx = {h.id: i for i, h in enumerate(portfolio.hypotheses)}
+        self.assertGreater(portfolio.weights[idx["h1"]], 0.95)
+
+    def test_all_zero_likelihood_moves_everything_to_open_world(self):
+        portfolio = _toy_portfolio(w_open=0.1)
+        result = portfolio.reweight(1e9, lambda h, o: 0.0, open_world_likelihood=lambda o: 0.0)
+        self.assertEqual(result.w_open, 1.0)
+        self.assertTrue(np.allclose(result.weights, 0.0))
+
+
+class InvariantTest(unittest.TestCase):
+    def test_mass_conservation_across_operations(self):
+        portfolio = _toy_portfolio(w_open=0.05)
+
+        def total(p):
+            return float(p.weights.sum()) + p.w_open
+
+        self.assertAlmostEqual(total(portfolio), 1.0, places=8)
+        portfolio = portfolio.reweight(2.0, _gaussian_likelihood)
+        self.assertAlmostEqual(total(portfolio), 1.0, places=8)
+        portfolio = portfolio.resample(rng=np.random.RandomState(1))
+        self.assertAlmostEqual(total(portfolio), 1.0, places=8)
+        portfolio = portfolio.prune(min_weight=0.5)
+        self.assertAlmostEqual(total(portfolio), 1.0, places=8)
+        active_ids = [h.id for h in portfolio.hypotheses if not h.active]
+        if active_ids:
+            portfolio = portfolio.resurrect(active_ids[0])
+            self.assertAlmostEqual(total(portfolio), 1.0, places=8)
+
+    def test_constructor_rejects_a_broken_invariant(self):
+        hyps = [Hypothesis("a", 1), Hypothesis("b", 2)]
+        with self.assertRaises(ValueError):
+            HypothesisPortfolio(hyps, np.array([0.5, 0.6]), w_open=0.0)
+
+
+class PruneResurrectRoundTripTest(unittest.TestCase):
+    def test_pruned_mass_folds_into_open_world_and_resurrect_reverses_it(self):
+        hyps = [Hypothesis("a", 1), Hypothesis("b", 2), Hypothesis("c", 3)]
+        portfolio = HypothesisPortfolio(hyps, np.array([0.02, 0.5, 0.48]), w_open=0.0)
+        pruned = portfolio.prune(min_weight=0.05)
+        a = next(h for h in pruned.hypotheses if h.id == "a")
+        self.assertFalse(a.active)
+        self.assertAlmostEqual(pruned.w_open, 0.02, places=8)
+
+        resurrected = pruned.resurrect("a", floor_weight=0.02)
+        a2 = next(h for h in resurrected.hypotheses if h.id == "a")
+        self.assertTrue(a2.active)
+        idx = {h.id: i for i, h in enumerate(resurrected.hypotheses)}
+        self.assertAlmostEqual(resurrected.weights[idx["a"]], 0.02, places=8)
+        self.assertAlmostEqual(resurrected.w_open, 0.0, places=8)
+
+    def test_resurrecting_an_unknown_id_raises(self):
+        portfolio = _toy_portfolio()
+        with self.assertRaises(KeyError):
+            portfolio.resurrect("does-not-exist")
+
+
+class SurpriseScoreTest(unittest.TestCase):
+    def test_high_for_an_observation_far_from_every_hypothesis(self):
+        portfolio = _toy_portfolio()
+        self.assertGreater(portfolio.surprise_score(1000.0, _gaussian_likelihood), 0.99)
+
+    def test_lower_for_an_observation_central_to_a_hypothesis_than_for_a_far_one(self):
+        portfolio = _toy_portfolio()
+        central = portfolio.surprise_score(2.0, _gaussian_likelihood)
+        far = portfolio.surprise_score(1000.0, _gaussian_likelihood)
+        self.assertLess(central, far)
+        self.assertLess(central, 0.8)
+
+
+class SerializationRoundTripTest(unittest.TestCase):
+    def test_to_dict_from_dict_round_trips_exactly(self):
+        portfolio = _toy_portfolio(w_open=0.1).prune(min_weight=0.5)
+        restored = HypothesisPortfolio.from_dict(portfolio.to_dict())
+        self.assertTrue(np.allclose(restored.weights, portfolio.weights))
+        self.assertAlmostEqual(restored.w_open, portfolio.w_open, places=10)
+        self.assertEqual([h.id for h in restored.hypotheses], [h.id for h in portfolio.hypotheses])
+        self.assertEqual([h.active for h in restored.hypotheses], [h.active for h in portfolio.hypotheses])
+        self.assertEqual([h.payload for h in restored.hypotheses], [h.payload for h in portfolio.hypotheses])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Implements `notes/epistemic-loop-integration-workplan.md` cards E0-E7: a new concern module, `mixle.epistemic`, peer to `mixle.inference`/`mixle.enumeration`/`mixle.doe`/`mixle.evolve`. It extracts the general-purpose *epistemic-loop* control flow (belief tracking, hypothesis portfolios with explicit open-world mass, EIG-driven action selection, auditable decision logging) from two frontier-science-model spec documents in `notes/`, deliberately excluding everything application-specific (modality encoders/decoders, data corpus, simulator farm, RL, training recipe -- those remain a separate, later program).

- `discrepancy.py` -- `kl_divergence`/`js_divergence`/`wasserstein_distance`/`mmd`/`discrepancy_report`: the "compare predicted vs. observed" primitive, a genuine gap that didn't exist anywhere under `mixle.stats`/`mixle.inference` before this.
- `portfolio.py` -- `HypothesisPortfolio`: typed weighted hypotheses + an explicit `w_open` reserved mass, generalizing `mixle.inference.mcmc.particle_filter` from numeric-state-only particles to arbitrary typed payloads. Pruning never deletes, only deactivates (mass folds into `w_open`); resampling delegates to the same systematic/multinomial math the existing particle filter already uses.
- `likelihood.py` -- `LikelihoodStrategy` protocol (`DiscrepancyLikelihood`, `CallableLikelihood`) at a declared verifiability tier, reusing `mixle.doe.oracle.VERIFIABILITY_TIERS` rather than inventing a second vocabulary.
- `loop.py` -- `step()`: one OBSERVE/UPDATE/ABDUCE/ACT iteration. EIG-based action selection is a discrete-portfolio nested-Monte-Carlo estimator, not a direct call to `mixle.doe.active.expected_information_gain_nmc` (that function's interface assumes a continuous numpy parameter space, which doesn't fit an arbitrary typed hypothesis portfolio -- documented in the module docstring).
- `journal.py` -- `EpistemicJournal`: append-only, JSON-serializable, replayable decision log following `mixle.evolve.ledger.EvolutionLedger`'s shape, extended with full belief snapshots (not just hashes) so `replay()` can actually reconstruct the belief trajectory, with `verify()` catching corruption.
- `coherence.py` -- exchangeability/martingale/evidence-conservation checks as plain testable functions (program plan's CI-checkable coherence properties).

Also adds a `"BeliefTrackable"` row to `mixle.capability.CAPABILITY_CATALOG` and a `mixle.epistemic` entry in `docs/package-map.rst`.

## Test plan
- [x] 44 new tests across 7 files (`mixle/tests/epistemic_*_test.py`) -- all passing, including a genuine convergence check (SMC-style posterior concentrates on the true generating hypothesis), mass-conservation invariants across every mutating operation, prune/resurrect round-trips, EIG-based action selection picking the more informative probe, journal round-trip + corruption detection, and coherence checks (well-behaved likelihood shows no violation, a genuinely order-dependent one is caught).
- [x] Found and fixed a real bug during development: `mmd`'s sample-shape handling misinterpreted a 1D array of `n` samples as one point in `n`-dimensional space, verified by adding an explicit same-vs-different-distribution regression test.
- [x] `ruff check`/`ruff format` clean on all touched files.
- [x] Full existing test suite re-run (`mixle/tests/`, 5249 passed): 13 failures reproduce identically on the unmodified base commit (missing optional deps -- `safetensors`, pre-existing `sampler_seed`/`hvis` issues), confirmed unrelated to this change via `git stash`.
- [x] Sphinx docs build (`sphinx-build -b html docs ...`) succeeds with only the one pre-existing, unrelated `numba` warning.