### PR TITLE
models: GradLeaf -- the five-piece contract, manufactured; optimize(x, module) just works

### DIFF
--- a/mixle/inference/estimation.py
+++ b/mixle/inference/estimation.py
@@ -38,6 +38,9 @@ def _coerce_estimator(estimator: Any, data: Any) -> ParameterEstimator:
     *shape* need not be written twice:
 
       * a :class:`ParameterEstimator` -- used as-is (the historical contract);
+      * a bare **torch module** with ``log_density(batch)`` -- wrapped as a
+        :class:`~mixle.models.grad_leaf.GradLeaf`, so ``optimize(x, module)`` needs no contract
+        code at all;
       * a distribution **prototype** (any :class:`ProbabilityDistribution`) -- its matching
         estimator tree is taken from ``proto.estimator()``, so you build the structure once and fit
         it directly;
@@ -46,6 +49,13 @@ def _coerce_estimator(estimator: Any, data: Any) -> ParameterEstimator:
     """
     if isinstance(estimator, ProbabilityDistribution):
         return estimator.estimator()
+    if hasattr(estimator, "log_density") and callable(getattr(estimator, "state_dict", None)):
+        # a bare torch density module (scores batches, carries parameters): fit it as a gradient
+        # leaf -- the module owns forward and objective, the manufactured contract owns the loop.
+        from mixle.models.grad_leaf import GradLeaf, looks_like_torch_module
+
+        if looks_like_torch_module(estimator):
+            return GradLeaf(estimator).estimator()
     if estimator is None:
         if data is None:
             raise ValueError(

--- a/mixle/models/__init__.py
+++ b/mixle/models/__init__.py
@@ -54,6 +54,7 @@ from mixle.models.energy import (
 )
 from mixle.models.feature_map import FeatureMapDensity, FeatureMapEstimator, feature_fn, register_feature_fn
 from mixle.models.gaussian_process import GaussianProcessRegressor
+from mixle.models.grad_leaf import GradEstimator, GradLeaf
 from mixle.models.grammar import (
     GrammarLearningResult,
     PCFGParseNode,
@@ -141,6 +142,8 @@ __all__ = [
     "GaussianRegressionNeuralNetwork",
     "NeuralCategorical",
     "NeuralConditionalDensity",
+    "GradEstimator",
+    "GradLeaf",
     "NeuralDensity",
     "NeuralDensityEstimator",
     "NeuralGaussian",

--- a/mixle/models/grad_leaf.py
+++ b/mixle/models/grad_leaf.py
@@ -1,0 +1,284 @@
+"""``GradLeaf`` -- a torch module IS the model: the five-piece contract, manufactured.
+
+The contract (Distribution / Sampler / Estimator / Accumulator / DataEncoder) earns its keep for
+closed-form families: additive sufficient statistics are what make EM exact and distributable. A
+GRADIENT leaf has no sufficient statistics -- its "accumulator" can only buffer the
+responsibility-weighted data, its encoder is ``np.asarray``, and its M-step is SGD -- so per-family
+contract code is pure ceremony (mixle.models grew nine hand-written buffer accumulators saying so).
+This module writes that ceremony ONCE, generically. A neural family is now just a module:
+
+    fitted = optimize(x, module)                     # a bare nn.Module coerces -- no wrapper at all
+    leaf = GradLeaf(module)                          # or wrap explicitly to set knobs/hooks ...
+    mix = MixtureDistribution([leaf, gamma], w)      # ... and compose with classical families
+
+The module owns **forward and objective**; mixle owns the loop. The contract's requirements on the
+module are two methods: ``log_density(x) -> (n,)`` (scoring; also the default M-step objective) and,
+only if you draw samples, ``sample(n) -> (n, d)``. Control never leaves the caller:
+
+* ``loss(module, x, w) -> scalar`` overrides the default responsibility-weighted NLL -- custom
+  objectives are a hook, not a subclass tree;
+* ``optimizer(params) -> torch.optim.Optimizer`` picks the optimizer; it receives only TRAINABLE
+  parameters, so freezing submodules with ``requires_grad_(False)`` just works (train a projection
+  head against a frozen encoder; a FULLY frozen module is a fixed distribution and the M-step is a
+  no-op);
+* ``fitted.module`` is the raw torch module -- nothing is trapped.
+
+Serialization: the module round-trips as portable bytes (``mixle.models._neural_serial``); custom
+``loss``/``optimizer`` hooks must be module-level functions to survive pickling, like any hook.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from mixle.models._neural_serial import check_finite, decode_module, encode_module
+from mixle.stats.compute.pdist import (
+    DataSequenceEncoder,
+    DistributionSampler,
+    ParameterEstimator,
+    SequenceEncodableProbabilityDistribution,
+    SequenceEncodableStatisticAccumulator,
+    StatisticAccumulatorFactory,
+)
+
+__all__ = ["GradEstimator", "GradLeaf"]
+
+
+def _torch() -> Any:
+    import torch
+
+    return torch
+
+
+def looks_like_torch_module(obj: Any) -> bool:
+    """A bare torch density module: scores batches and carries parameters -- coercible to a leaf."""
+    return (
+        hasattr(obj, "log_density")
+        and callable(getattr(obj, "parameters", None))
+        and callable(getattr(obj, "state_dict", None))
+        and not isinstance(obj, (SequenceEncodableProbabilityDistribution, ParameterEstimator))
+    )
+
+
+class GradLeaf(SequenceEncodableProbabilityDistribution):
+    """Wrap a torch density ``module`` (``module.log_density(x) -> (n,)``) as a composable mixle
+    distribution (see the module docstring). ``loss`` and ``optimizer`` are the M-step hooks."""
+
+    __pysp_serializable__ = True  # module persisted as bytes (see __pysp_getstate__)
+
+    def __init__(
+        self,
+        module: Any,
+        *,
+        m_steps: int = 60,
+        lr: float = 5e-3,
+        device: str = "cpu",
+        name: str | None = None,
+        loss: Any = None,
+        optimizer: Any = None,
+    ) -> None:
+        self.module = module
+        self.m_steps = int(m_steps)
+        self.lr = float(lr)
+        self.device = device
+        self.name = name
+        self.loss = loss
+        self.optimizer = optimizer
+
+    def __str__(self) -> str:
+        return f"{type(self).__name__}({type(self.module).__name__})"
+
+    def log_density(self, x: Any) -> float:
+        return float(self.seq_log_density(np.atleast_2d(np.asarray(x, dtype=float)))[0])
+
+    def seq_log_density(self, x: Any) -> np.ndarray:
+        torch = _torch()
+        xx = check_finite(np.atleast_2d(np.asarray(x, dtype=float)), f"{type(self).__name__}.seq_log_density")
+        self.module.to(self.device).eval()
+        xt = torch.as_tensor(xx, dtype=torch.float32, device=self.device)
+        with torch.no_grad():
+            return self.module.log_density(xt).cpu().numpy().reshape(-1)
+
+    def sampler(self, seed: int | None = None) -> GradLeafSampler:
+        return GradLeafSampler(self, seed)
+
+    def estimator(self, pseudo_count: float | None = None) -> GradEstimator:
+        return GradEstimator(
+            self.module,
+            m_steps=self.m_steps,
+            lr=self.lr,
+            device=self.device,
+            name=self.name,
+            loss=self.loss,
+            optimizer=self.optimizer,
+        )
+
+    def dist_to_encoder(self) -> GradLeafEncoder:
+        return GradLeafEncoder()
+
+    def __pysp_getstate__(self) -> dict[str, Any]:
+        state = dict(self.__dict__)
+        state["module"] = encode_module(self.module)
+        return state
+
+    def __pysp_setstate__(self, state: dict[str, Any]) -> None:
+        self.__dict__.update(state)
+        self.module = decode_module(state["module"])
+
+
+class GradLeafSampler(DistributionSampler):
+    def __init__(self, dist: GradLeaf, seed: int | None = None) -> None:
+        self.dist = dist
+        self.rng = np.random.RandomState(seed)
+
+    def sample(self, size: int | None = None, *, batched: bool = True) -> Any:
+        if not callable(getattr(self.dist.module, "sample", None)):
+            raise TypeError(
+                f"{type(self.dist.module).__name__} has no sample(n); scoring and fitting need only "
+                "log_density, but drawing samples needs the module to implement sample(n) -> (n, d)."
+            )
+        torch = _torch()
+        n = int(size or 1)
+        self.dist.module.to(self.dist.device).eval()
+        torch.manual_seed(int(self.rng.randint(0, 2**31 - 1)))
+        with torch.no_grad():
+            out = self.dist.module.sample(n).cpu().numpy()
+        return out if (size is not None) else out[0]
+
+
+class GradLeafEncoder(DataSequenceEncoder):
+    """The whole "encoding": rows to one contiguous float array."""
+
+    def __str__(self) -> str:
+        return "GradLeafEncoder"
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, GradLeafEncoder)
+
+    def seq_encode(self, data: list) -> np.ndarray:
+        return np.array([np.atleast_1d(np.asarray(x, dtype=float)) for x in data])
+
+
+class GradAccumulator(SequenceEncodableStatisticAccumulator):
+    """A gradient leaf's only possible "sufficient statistic": the (responsibility-weighted) data
+    itself, buffered for the M-step. The weights are the E-step's soft counts."""
+
+    def __init__(self) -> None:
+        self.x: list = []
+        self.w: list = []
+
+    # Contiguous batch arrays concatenated once at value() (shape-preserving) rather than one ndarray per row.
+    def update(self, x: Any, weight: float, estimate: Any) -> None:
+        self.x.append(np.atleast_1d(np.asarray(x, dtype=float))[None, ...])
+        self.w.append(np.asarray([float(weight)], dtype=float))
+
+    def seq_update(self, enc: Any, weights: np.ndarray, estimate: Any) -> None:
+        xb = np.asarray(enc, dtype=float)
+        self.x.append(xb.reshape(xb.shape[0], 1) if xb.ndim == 1 else xb)
+        self.w.append(np.asarray(weights, dtype=float).ravel())
+
+    def initialize(self, x: Any, weight: float, rng: Any) -> None:
+        self.update(x, weight, None)
+
+    def seq_initialize(self, enc: Any, weights: np.ndarray, rng: Any) -> None:
+        self.seq_update(enc, weights, None)
+
+    def combine(self, other: Any) -> GradAccumulator:
+        xs, ws = other
+        if len(xs):
+            self.x.append(np.asarray(xs, dtype=float))
+            self.w.append(np.asarray(ws, dtype=float).ravel())
+        return self
+
+    def value(self) -> tuple:
+        x = np.concatenate(self.x, axis=0) if self.x else np.zeros((0, 0))
+        w = np.concatenate(self.w) if self.w else np.zeros((0,))
+        return (x, w)
+
+    def from_value(self, v: tuple) -> GradAccumulator:
+        x, w = v
+        self.x = [np.asarray(x, dtype=float)] if len(x) else []
+        self.w = [np.asarray(w, dtype=float).ravel()] if len(w) else []
+        return self
+
+    def acc_to_encoder(self) -> GradLeafEncoder:
+        return GradLeafEncoder()
+
+
+class GradAccumulatorFactory(StatisticAccumulatorFactory):
+    def make(self) -> GradAccumulator:
+        return GradAccumulator()
+
+
+class GradEstimator(ParameterEstimator):
+    """M-step: responsibility-weighted MLE -- ``max sum_i w_i log p(x_i)`` by gradient ascent on the
+    module (warm-started across EM iterations). ``loss``/``optimizer`` are the caller's hooks; the
+    optimizer only ever sees trainable parameters, so frozen submodules stay frozen and a fully
+    frozen module makes the M-step a no-op (a fixed distribution)."""
+
+    def __init__(
+        self,
+        module: Any,
+        *,
+        m_steps: int = 60,
+        lr: float = 5e-3,
+        device: str = "cpu",
+        name: str | None = None,
+        loss: Any = None,
+        optimizer: Any = None,
+    ) -> None:
+        self.module = module
+        self.m_steps = int(m_steps)
+        self.lr = float(lr)
+        self.device = device
+        self.name = name
+        self.loss = loss
+        self.optimizer = optimizer
+
+    def _leaf(self) -> GradLeaf:
+        return GradLeaf(
+            self.module,
+            m_steps=self.m_steps,
+            lr=self.lr,
+            device=self.device,
+            name=self.name,
+            loss=self.loss,
+            optimizer=self.optimizer,
+        )
+
+    def accumulator_factory(self) -> GradAccumulatorFactory:
+        return GradAccumulatorFactory()
+
+    def estimate(self, nobs: float | None, suff_stat: tuple) -> GradLeaf:
+        torch = _torch()
+        xs, ws = suff_stat
+        params = [p for p in self.module.parameters() if p.requires_grad]
+        if len(xs) == 0 or not params:  # nothing to fit, or a fully frozen (fixed) module
+            return self._leaf()
+        x = torch.as_tensor(np.asarray(xs, dtype=float), dtype=torch.float32, device=self.device)
+        w = torch.as_tensor(np.asarray(ws, dtype=float), dtype=torch.float32, device=self.device)
+        w = w / w.sum().clamp(min=1e-8)
+        self.module.to(self.device).train()
+        opt = self.optimizer(params) if self.optimizer is not None else torch.optim.Adam(params, lr=self.lr)
+        for _ in range(self.m_steps):
+            opt.zero_grad()
+            if self.loss is not None:
+                loss = self.loss(self.module, x, w)
+            else:
+                loss = -(w * self.module.log_density(x)).sum()  # weighted negative log-likelihood
+            loss.backward()
+            opt.step()
+        return self._leaf()
+
+
+def _register_serializable() -> None:
+    try:
+        from mixle.utils.serialization import register_serializable_class
+    except ImportError:  # pragma: no cover - serialization is core, but never block import on it
+        return
+    register_serializable_class(GradLeaf)
+
+
+_register_serializable()

--- a/mixle/models/neural_density.py
+++ b/mixle/models/neural_density.py
@@ -21,15 +21,8 @@ from typing import Any
 
 import numpy as np
 
-from mixle.models._neural_serial import check_finite, decode_module, encode_module
-from mixle.stats.compute.pdist import (
-    DataSequenceEncoder,
-    DistributionSampler,
-    ParameterEstimator,
-    SequenceEncodableProbabilityDistribution,
-    SequenceEncodableStatisticAccumulator,
-    StatisticAccumulatorFactory,
-)
+from mixle.models._neural_serial import decode_module, encode_module
+from mixle.models.grad_leaf import GradEstimator, GradLeaf
 
 
 def _torch() -> Any:
@@ -38,53 +31,25 @@ def _torch() -> Any:
     return torch
 
 
-class NeuralDensity(SequenceEncodableProbabilityDistribution):
-    """Wrap a torch density ``module`` (``module.log_density(x) -> (n,)``) as a composable mixle distribution."""
+class NeuralDensity(GradLeaf):
+    """Wrap a torch density ``module`` (``module.log_density(x) -> (n,)``) as a composable mixle distribution.
 
-    __pysp_serializable__ = True  # module persisted as bytes (see __pysp_getstate__); leaf round-trips in a mixture
-
-    def __init__(
-        self, module: Any, *, m_steps: int = 60, lr: float = 5e-3, device: str = "cpu", name: str | None = None
-    ) -> None:
-        self.module = module
-        self.m_steps = int(m_steps)
-        self.lr = float(lr)
-        self.device = device
-        self.name = name
-
-    def __str__(self) -> str:
-        return f"NeuralDensity({type(self.module).__name__})"
-
-    def log_density(self, x: Any) -> float:
-        return float(self.seq_log_density(np.atleast_2d(np.asarray(x, dtype=float)))[0])
-
-    def seq_log_density(self, x: Any) -> np.ndarray:
-        torch = _torch()
-        xx = check_finite(np.atleast_2d(np.asarray(x, dtype=float)), "NeuralDensity.seq_log_density")
-        self.module.to(self.device).eval()
-        xt = torch.as_tensor(xx, dtype=torch.float32, device=self.device)
-        with torch.no_grad():
-            return self.module.log_density(xt).cpu().numpy().reshape(-1)
-
-    def sampler(self, seed: int | None = None) -> NeuralDensitySampler:
-        return NeuralDensitySampler(self, seed)
+    A thin named subclass of :class:`~mixle.models.grad_leaf.GradLeaf` -- the generic bridge owns the
+    manufactured contract (buffer accumulator, array encoder, gradient M-step, sampler); this class owns
+    only its name, its JSON payload, and its ready-module builders below. ``loss``/``optimizer`` hooks
+    pass through (see the grad_leaf module docstring for the control story).
+    """
 
     def estimator(self, pseudo_count: float | None = None) -> NeuralDensityEstimator:
-        return NeuralDensityEstimator(self.module, m_steps=self.m_steps, lr=self.lr, device=self.device, name=self.name)
-
-    def dist_to_encoder(self) -> NeuralDensityEncoder:
-        return NeuralDensityEncoder()
-
-    # --- serialization: persist hparams + the module (as portable bytes); registered below so a mixture holding
-    # this leaf round-trips through to_dict/to_json/pickle as well. ---
-    def __pysp_getstate__(self) -> dict[str, Any]:
-        state = dict(self.__dict__)
-        state["module"] = encode_module(self.module)
-        return state
-
-    def __pysp_setstate__(self, state: dict[str, Any]) -> None:
-        self.__dict__.update(state)
-        self.module = decode_module(state["module"])
+        return NeuralDensityEstimator(
+            self.module,
+            m_steps=self.m_steps,
+            lr=self.lr,
+            device=self.device,
+            name=self.name,
+            loss=self.loss,
+            optimizer=self.optimizer,
+        )
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -106,113 +71,19 @@ class NeuralDensity(SequenceEncodableProbabilityDistribution):
         )
 
 
-class NeuralDensitySampler(DistributionSampler):
-    def __init__(self, dist: NeuralDensity, seed: int | None = None) -> None:
-        self.dist = dist
-        self.rng = np.random.RandomState(seed)
-
-    def sample(self, size: int | None = None, *, batched: bool = True) -> Any:
-        torch = _torch()
-        n = int(size or 1)
-        self.dist.module.to(self.dist.device).eval()
-        torch.manual_seed(int(self.rng.randint(0, 2**31 - 1)))
-        with torch.no_grad():
-            out = self.dist.module.sample(n).cpu().numpy()
-        return out if (size is not None) else out[0]
-
-
-class NeuralDensityEncoder(DataSequenceEncoder):
-    def __str__(self) -> str:
-        return "NeuralDensityEncoder"
-
-    def __eq__(self, other: object) -> bool:
-        return isinstance(other, NeuralDensityEncoder)
-
-    def seq_encode(self, data: list) -> np.ndarray:
-        return np.array([np.atleast_1d(np.asarray(x, dtype=float)) for x in data])
-
-
-class NeuralDensityAccumulator(SequenceEncodableStatisticAccumulator):
-    """Buffers the (responsibility-weighted) data for the M-step -- the weights are the E-step's soft counts."""
-
-    def __init__(self) -> None:
-        self.x: list = []
-        self.w: list = []
-
-    # Contiguous batch arrays concatenated once at value() (shape-preserving) rather than one ndarray per row.
-    def update(self, x: Any, weight: float, estimate: Any) -> None:
-        self.x.append(np.atleast_1d(np.asarray(x, dtype=float))[None, ...])
-        self.w.append(np.asarray([float(weight)], dtype=float))
-
-    def seq_update(self, enc: Any, weights: np.ndarray, estimate: Any) -> None:
-        xb = np.asarray(enc, dtype=float)
-        self.x.append(xb.reshape(xb.shape[0], 1) if xb.ndim == 1 else xb)
-        self.w.append(np.asarray(weights, dtype=float).ravel())
-
-    def initialize(self, x: Any, weight: float, rng: Any) -> None:
-        self.update(x, weight, None)
-
-    def seq_initialize(self, enc: Any, weights: np.ndarray, rng: Any) -> None:
-        self.seq_update(enc, weights, None)
-
-    def combine(self, other: Any) -> NeuralDensityAccumulator:
-        xs, ws = other
-        if len(xs):
-            self.x.append(np.asarray(xs, dtype=float))
-            self.w.append(np.asarray(ws, dtype=float).ravel())
-        return self
-
-    def value(self) -> tuple:
-        x = np.concatenate(self.x, axis=0) if self.x else np.zeros((0, 0))
-        w = np.concatenate(self.w) if self.w else np.zeros((0,))
-        return (x, w)
-
-    def from_value(self, v: tuple) -> NeuralDensityAccumulator:
-        x, w = v
-        self.x = [np.asarray(x, dtype=float)] if len(x) else []
-        self.w = [np.asarray(w, dtype=float).ravel()] if len(w) else []
-        return self
-
-    def acc_to_encoder(self) -> NeuralDensityEncoder:
-        return NeuralDensityEncoder()
-
-
-class NeuralDensityAccumulatorFactory(StatisticAccumulatorFactory):
-    def make(self) -> NeuralDensityAccumulator:
-        return NeuralDensityAccumulator()
-
-
-class NeuralDensityEstimator(ParameterEstimator):
+class NeuralDensityEstimator(GradEstimator):
     """M-step: responsibility-weighted MLE -- ``max sum_i w_i log p(x_i)`` by gradient ascent on the module (warm)."""
 
-    def __init__(
-        self, module: Any, *, m_steps: int = 60, lr: float = 5e-3, device: str = "cpu", name: str | None = None
-    ) -> None:
-        self.module = module
-        self.m_steps = int(m_steps)
-        self.lr = float(lr)
-        self.device = device
-        self.name = name
-
-    def accumulator_factory(self) -> NeuralDensityAccumulatorFactory:
-        return NeuralDensityAccumulatorFactory()
-
-    def estimate(self, nobs: float | None, suff_stat: tuple) -> NeuralDensity:
-        torch = _torch()
-        xs, ws = suff_stat
-        if len(xs) == 0:
-            return NeuralDensity(self.module, m_steps=self.m_steps, lr=self.lr, device=self.device, name=self.name)
-        x = torch.as_tensor(np.asarray(xs, dtype=float), dtype=torch.float32, device=self.device)
-        w = torch.as_tensor(np.asarray(ws, dtype=float), dtype=torch.float32, device=self.device)
-        w = w / w.sum().clamp(min=1e-8)
-        self.module.to(self.device).train()
-        opt = torch.optim.Adam(self.module.parameters(), lr=self.lr)
-        for _ in range(self.m_steps):
-            opt.zero_grad()
-            loss = -(w * self.module.log_density(x)).sum()  # weighted negative log-likelihood
-            loss.backward()
-            opt.step()
-        return NeuralDensity(self.module, m_steps=self.m_steps, lr=self.lr, device=self.device, name=self.name)
+    def _leaf(self) -> NeuralDensity:
+        return NeuralDensity(
+            self.module,
+            m_steps=self.m_steps,
+            lr=self.lr,
+            device=self.device,
+            name=self.name,
+            loss=self.loss,
+            optimizer=self.optimizer,
+        )
 
 
 # --- ready density modules to wrap ---------------------------------------------------------------------------

--- a/mixle/tests/grad_leaf_test.py
+++ b/mixle/tests/grad_leaf_test.py
@@ -1,0 +1,155 @@
+"""The gradient bridge (mixle.models.grad_leaf): a torch module IS the model.
+
+The load-bearing claims: a bare nn.Module fits via ``optimize(x, module)`` with zero contract code
+and matches the explicit wrapper bitwise; gradient leaves compose with classical families in
+mixture EM; and the control story holds -- frozen parameters stay frozen (a fully frozen module is
+a fixed distribution), custom losses and optimizers are hooks, and the raw module is always
+reachable on the fitted leaf.
+"""
+
+import unittest
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from mixle.inference.estimation import optimize  # noqa: E402
+from mixle.models import GradLeaf, NeuralDensity  # noqa: E402
+from mixle.stats import GaussianDistribution, MixtureDistribution  # noqa: E402
+
+
+class DiagGauss(torch.nn.Module):
+    """The smallest honest density module: a learnable diagonal Gaussian."""
+
+    def __init__(self, dim: int = 1, mu0: float = 0.0):
+        super().__init__()
+        self.mu = torch.nn.Parameter(torch.full((dim,), float(mu0)))
+        self.log_sigma = torch.nn.Parameter(torch.zeros(dim))
+
+    def _dist(self):
+        return torch.distributions.Normal(self.mu, torch.exp(self.log_sigma))
+
+    def log_density(self, x):
+        return self._dist().log_prob(x).sum(-1)
+
+    def sample(self, n: int):
+        return self._dist().sample((n,))
+
+
+def _data(mu, sigma, n, seed):
+    rng = np.random.RandomState(seed)
+    return [float(v) for v in rng.normal(mu, sigma, n)]
+
+
+class BareModuleTest(unittest.TestCase):
+    def test_optimize_accepts_a_bare_module(self):
+        # the whole point: no wrapper, no estimator, no contract -- optimize(x, module)
+        data = _data(3.0, 0.5, 300, seed=0)
+        fitted = optimize(data, DiagGauss(1), max_its=25, out=None)  # EM iterations are the outer budget
+        self.assertIsInstance(fitted, GradLeaf)
+        self.assertAlmostEqual(float(fitted.module.mu.detach()[0]), 3.0, delta=0.3)
+        self.assertGreater(fitted.log_density(3.0), fitted.log_density(0.0))
+
+    def test_bare_module_matches_the_explicit_wrapper_bitwise(self):
+        # coercion is a spelling, not a different code path: identical module state, identical fit
+        data = _data(1.5, 1.0, 200, seed=1)
+        m1, m2 = DiagGauss(1), DiagGauss(1)
+        m2.load_state_dict(m1.state_dict())
+        a = optimize(data, m1, max_its=3, out=None)
+        b = optimize(data, GradLeaf(m2), max_its=3, out=None)
+        np.testing.assert_array_equal(
+            a.seq_log_density(np.asarray(data)[:, None]), b.seq_log_density(np.asarray(data)[:, None])
+        )
+
+    def test_neural_density_is_the_same_machinery(self):
+        # the historical wrapper is now a thin name over the bridge -- same fit, same numbers
+        data = _data(-2.0, 0.7, 200, seed=2)
+        m1, m2 = DiagGauss(1), DiagGauss(1)
+        m2.load_state_dict(m1.state_dict())
+        a = optimize(data, GradLeaf(m1), max_its=3, out=None)
+        b = optimize(data, NeuralDensity(m2), max_its=3, out=None)
+        self.assertIsInstance(b, NeuralDensity)
+        np.testing.assert_array_equal(
+            a.seq_log_density(np.asarray(data)[:, None]), b.seq_log_density(np.asarray(data)[:, None])
+        )
+
+    def test_sampling_and_the_escape_hatch(self):
+        fitted = optimize(_data(0.0, 1.0, 150, seed=3), DiagGauss(1), max_its=2, out=None)
+        s = fitted.sampler(seed=0).sample(size=25)
+        self.assertEqual(s.shape, (25, 1))
+        self.assertIsInstance(fitted.module, torch.nn.Module)  # nothing is trapped
+
+        class NoSample(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.mu = torch.nn.Parameter(torch.zeros(1))
+
+            def log_density(self, x):
+                return -0.5 * ((x - self.mu) ** 2).sum(-1)
+
+        with self.assertRaises(TypeError):  # scoring-only modules refuse to sample, with a real message
+            GradLeaf(NoSample()).sampler(seed=0).sample(size=3)
+
+
+class CompositionTest(unittest.TestCase):
+    def test_gradient_leaves_mix_with_classical_families(self):
+        # a neural leaf and a classical Gaussian in ONE mixture, fit by ONE EM call -- warm-started
+        # from the composed prototype (build the structure, fit it), so the E-step splits the two
+        # regimes between a torch module and a closed-form family from iteration one.
+        rng = np.random.RandomState(4)
+        data = [float(v) for v in np.concatenate([rng.normal(-4.0, 1.0, 150), rng.normal(4.0, 1.0, 150)])]
+        proto = MixtureDistribution(
+            [GradLeaf(DiagGauss(1, mu0=-1.0), m_steps=60, lr=0.05), GaussianDistribution(1.0, 1.0)], [0.5, 0.5]
+        )
+        fitted = optimize(data, proto.estimator(), prev_estimate=proto, max_its=10, out=None)
+        self.assertIsInstance(fitted, MixtureDistribution)
+        comp_means = sorted([float(fitted.components[0].module.mu.detach()[0]), float(fitted.components[1].mu)])
+        self.assertAlmostEqual(comp_means[0], -4.0, delta=0.6)
+        self.assertAlmostEqual(comp_means[1], 4.0, delta=0.6)
+
+
+class ControlStoryTest(unittest.TestCase):
+    def test_frozen_parameters_stay_frozen(self):
+        # LLaVA-style: freeze one part, train the other -- requires_grad_(False) is the whole API
+        module = DiagGauss(1)
+        module.log_sigma.requires_grad_(False)
+        before = module.log_sigma.detach().clone()
+        fitted = optimize(_data(5.0, 2.0, 250, seed=5), module, max_its=25, out=None)
+        np.testing.assert_array_equal(fitted.module.log_sigma.detach().numpy(), before.numpy())
+        self.assertAlmostEqual(float(fitted.module.mu.detach()[0]), 5.0, delta=0.5)
+
+    def test_a_fully_frozen_module_is_a_fixed_distribution(self):
+        module = DiagGauss(1, mu0=1.0)
+        for p in module.parameters():
+            p.requires_grad_(False)
+        before = {k: v.clone() for k, v in module.state_dict().items()}
+        fitted = optimize(_data(9.0, 1.0, 100, seed=6), module, max_its=2, out=None)
+        for k, v in fitted.module.state_dict().items():
+            np.testing.assert_array_equal(v.numpy(), before[k].numpy())
+
+    def test_custom_loss_hook_owns_the_objective(self):
+        # an L2 anchor toward zero in the loss visibly shrinks the fitted mean vs the default NLL
+        data = _data(4.0, 0.5, 200, seed=7)
+
+        def anchored(module, x, w):
+            return -(w * module.log_density(x)).sum() + 50.0 * (module.mu**2).sum()
+
+        m1, m2 = DiagGauss(1), DiagGauss(1)
+        m2.load_state_dict(m1.state_dict())
+        free = optimize(data, GradLeaf(m1), max_its=3, out=None)
+        pulled = optimize(data, GradLeaf(m2, loss=anchored), max_its=3, out=None)
+        self.assertLess(abs(float(pulled.module.mu.detach()[0])), abs(float(free.module.mu.detach()[0])))
+
+    def test_custom_optimizer_hook(self):
+        fitted = optimize(
+            _data(2.0, 1.0, 200, seed=8),
+            GradLeaf(DiagGauss(1), optimizer=lambda params: torch.optim.SGD(params, lr=0.05)),
+            max_its=3,
+            out=None,
+        )
+        self.assertAlmostEqual(float(fitted.module.mu.detach()[0]), 2.0, delta=0.5)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The five-piece contract earns its keep for closed-form families — additive sufficient statistics are what make EM exact and distributable. For **gradient** leaves it is pure ceremony: the "sufficient statistic" is a list buffering `(x, w)`, the encoder is `np.asarray`, and the M-step is SGD. The receipts are in-repo: nine hand-written buffer accumulators across `mixle.models` (NeuralDensity, NeuralGaussian, NeuralConditionalDensity, NeuralCategorical, EnergyModel, DPO, StreamingTransformer, RandomForest, FeatureMap), each re-implementing the same plumbing.

`mixle.models.grad_leaf` writes that ceremony **once**:

- `GradLeaf(module)` — any torch module exposing `log_density(batch) -> (n,)` is a full mixle distribution (mixture component, composite field, HMM emission). `sample(n)` is required only to draw samples, and scoring-only modules refuse with a real message instead of an AttributeError.
- `optimize(x, module)` — `_coerce_estimator` gains a fourth spelling: a **bare nn.Module** fits with zero contract code. Coercion is a spelling, not a code path: pinned bitwise-equal to the explicit wrapper.
- **The control story is hooks, not subclasses**: `loss(module, x, w)` owns the objective; `optimizer(params)` picks the optimizer and only ever receives *trainable* parameters — `requires_grad_(False)` freezing just works (the projection-head-against-frozen-encoder pattern), and a fully frozen module is a fixed distribution whose M-step is a no-op. `fitted.module` hands back the raw torch module; nothing is trapped.
- `NeuralDensity` collapses onto the bridge: ~150 lines of per-family plumbing become two thin subclasses with the same names, JSON payload, serialization registration, and fit numbers (pinned bitwise). Net: **−116 lines** in `neural_density.py` while *adding* the loss/optimizer/freezing capabilities.

Follow-up (separate PR): migrate the remaining gradient-leaf families onto the bridge — each is a repeat of the `NeuralDensity` collapse.

Tests: 9 new (bare-module fit, coercion≡wrapper bitwise, NeuralDensity≡GradLeaf bitwise, neural+classical mixture EM from a composed prototype, frozen-params bitwise-unchanged, fully-frozen no-op, custom loss, custom optimizer, sampling + escape hatch). All existing NeuralDensity consumers pass unchanged: neural_density, neural_families, project_neural, inference_placement, automatic_modality_routing, structure_clone_isolation — 46 tests. Pickle round-trip of a VAE leaf through the bridge verified.