### PR TITLE
models: sweep the gradient families onto the GradLeaf bridge + parity receipt

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,34 @@ The tiny model handles the easy majority and defers the hard cases, so the blend
 running the large model on a fraction of requests. The same pattern distills tool-callers, extractors, and
 structured classifiers (`mixle.task`).
 
+**A torch module is a distribution — the training code you didn't write.** Any module exposing
+`log_density(batch)` fits with one call: no training loop, no batching/eval/convergence boilerplate, no
+adapter classes. And because the fitted leaf *is* a distribution, it composes with classical families and
+fits jointly by EM.
+
+```python
+import torch
+from mixle.inference import optimize
+from mixle.stats import GammaDistribution, MixtureDistribution
+
+class Flow(torch.nn.Module):        # your module: forward and objective, nothing else
+    def log_density(self, x): ...   # (n, d) -> (n,)
+
+fitted = optimize(x, Flow())        # the loop, batching, eval, convergence — manufactured
+fitted.module                       # the raw torch module back — nothing is trapped
+
+# ...and it composes: a flow and a Gamma in ONE mixture, fit jointly by EM
+mix = MixtureDistribution([fitted, GammaDistribution(2.0, 1.0)], [0.5, 0.5])
+```
+
+Control never leaves you: freeze submodules with `requires_grad_(False)` (the optimizer only sees
+trainable parameters — train a projection head against a frozen encoder), override the objective or
+optimizer as hooks (`GradLeaf(module, loss=..., optimizer=...)`), and parity with a hand-written torch
+loop is pinned by a test (`mixle/tests/torch_parity_test.py`), not claimed in prose. Scaling stays a
+flag: `optimize(..., backend=...)` distributes EM across Spark/Dask/Ray/MPI, and the transformer LM's
+`fit(token_ids, distributed=True, precision="bf16")` runs FSDP2 (ZeRO-3) with DCP checkpoints under
+torchrun.
+
 **Compose arbitrarily deep — and tie parameters across the structure.** A segmental HMM whose every state
 emits a *composite* segment (a two-mode mixture plus a phrase scored by a PCFG), with the mixture's first
 mode **coupled across states by `keys=`**. One `optimize` call fits the whole tree by EM:

--- a/README.md
+++ b/README.md
@@ -106,12 +106,15 @@ mix = MixtureDistribution([fitted, GammaDistribution(2.0, 1.0)], [0.5, 0.5])
 ```
 
 Control never leaves you: freeze submodules with `requires_grad_(False)` (the optimizer only sees
-trainable parameters — train a projection head against a frozen encoder), override the objective or
-optimizer as hooks (`GradLeaf(module, loss=..., optimizer=...)`), and parity with a hand-written torch
-loop is pinned by a test (`mixle/tests/torch_parity_test.py`), not claimed in prose. Scaling stays a
-flag: `optimize(..., backend=...)` distributes EM across Spark/Dask/Ray/MPI, and the transformer LM's
-`fit(token_ids, distributed=True, precision="bf16")` runs FSDP2 (ZeRO-3) with DCP checkpoints under
-torchrun.
+trainable parameters — train a projection head against a frozen encoder, or a LoRA-style adapter over a
+frozen base), override the objective or optimizer as hooks (`GradLeaf(module, loss=..., optimizer=...)`),
+and parity with a hand-written torch loop is pinned by a test (`mixle/tests/torch_parity_test.py`), not
+claimed in prose. Scaling stays a flag: `optimize(..., backend=...)` distributes EM across
+Spark/Dask/Ray/MPI; the transformer LM's `fit(token_ids, distributed=True, precision="bf16")` runs FSDP2
+(ZeRO-3) with DCP checkpoints under torchrun, and `build_causal_lm(..., gradient_checkpointing=True)`
+trades recompute for activation memory with gradients pinned identical by test. The receipts cover the
+manufactured loop and mixle's own leaves; frontier-scale multimodal stacks remain torch/DeepSpeed
+territory — bring the trained module back as a leaf.
 
 **Compose arbitrarily deep — and tie parameters across the structure.** A segmental HMM whose every state
 emits a *composite* segment (a two-mode mixture plus a phrase scored by a PCFG), with the mixture's first

--- a/mixle/models/dpo_leaf.py
+++ b/mixle/models/dpo_leaf.py
@@ -21,13 +21,12 @@ from typing import Any
 import numpy as np
 
 from mixle.models._neural_serial import decode_module, encode_module
+from mixle.models.grad_leaf import DataBufferAccumulatorFactory
 from mixle.stats.compute.pdist import (
     DataSequenceEncoder,
     DistributionSampler,
     ParameterEstimator,
     SequenceEncodableProbabilityDistribution,
-    SequenceEncodableStatisticAccumulator,
-    StatisticAccumulatorFactory,
 )
 
 
@@ -151,58 +150,6 @@ class DPOEncoder(DataSequenceEncoder):
         return (x, ch, rj)
 
 
-class DPOAccumulator(SequenceEncodableStatisticAccumulator):
-    def __init__(self) -> None:
-        self.x: list = []
-        self.ch: list = []
-        self.rj: list = []
-        self.w: list = []  # per-pair weight (EM responsibility / streaming decay / sample weight)
-
-    def update(self, xcr: Any, weight: float, estimate: Any) -> None:
-        self.x.append(np.atleast_1d(np.asarray(xcr[0], dtype=float)))
-        self.ch.append(int(xcr[1]))
-        self.rj.append(int(xcr[2]))
-        self.w.append(float(weight))
-
-    def seq_update(self, enc: Any, weights: Any, estimate: Any) -> None:
-        x, ch, rj = enc
-        ws = np.asarray(weights, dtype=float).ravel() if weights is not None else np.ones(len(x))
-        for i in range(len(x)):
-            self.x.append(np.atleast_1d(x[i]))
-            self.ch.append(int(ch[i]))
-            self.rj.append(int(rj[i]))
-            self.w.append(float(ws[i]))
-
-    def initialize(self, xcr: Any, weight: float, rng: Any) -> None:
-        self.update(xcr, weight, None)
-
-    def seq_initialize(self, enc: Any, weights: Any, rng: Any) -> None:
-        self.seq_update(enc, weights, None)
-
-    def combine(self, other: Any) -> DPOAccumulator:
-        xo, co, ro, wo = other
-        self.x.extend(xo)
-        self.ch.extend(co)
-        self.rj.extend(ro)
-        self.w.extend(wo)
-        return self
-
-    def value(self) -> tuple:
-        return (list(self.x), list(self.ch), list(self.rj), list(self.w))
-
-    def from_value(self, v: tuple) -> DPOAccumulator:
-        self.x, self.ch, self.rj, self.w = list(v[0]), list(v[1]), list(v[2]), list(v[3])
-        return self
-
-    def acc_to_encoder(self) -> DPOEncoder:
-        return DPOEncoder()
-
-
-class DPOAccumulatorFactory(StatisticAccumulatorFactory):
-    def make(self) -> DPOAccumulator:
-        return DPOAccumulator()
-
-
 class DPOModelEstimator(ParameterEstimator):
     """DPO M-step: ``m_steps`` of gradient on the POLICY minimizing ``-log sigmoid(beta * margin)``; ref frozen."""
 
@@ -214,8 +161,8 @@ class DPOModelEstimator(ParameterEstimator):
         self.lr = float(lr)
         self.device = device
 
-    def accumulator_factory(self) -> DPOAccumulatorFactory:
-        return DPOAccumulatorFactory()
+    def accumulator_factory(self) -> DataBufferAccumulatorFactory:
+        return DataBufferAccumulatorFactory(DPOEncoder(), n_fields=3)
 
     def estimate(self, nobs: float | None, suff_stat: tuple) -> DPOModel:
         torch = _torch()
@@ -228,9 +175,10 @@ class DPOModelEstimator(ParameterEstimator):
         self.ref.to(dev)
         for p in self.ref.parameters():
             p.requires_grad_(False)  # frozen reference
-        xt = torch.as_tensor(np.array(xs), dtype=torch.float32).to(dev)
-        ct = torch.as_tensor(np.array(chs), dtype=torch.long).to(dev)
-        rt = torch.as_tensor(np.array(rjs), dtype=torch.long).to(dev)
+        # the generic buffer stores every field as float batch arrays; restore shapes/dtypes at tensor prep
+        xt = torch.as_tensor(np.asarray(xs, dtype=float).reshape(len(xs), -1), dtype=torch.float32).to(dev)
+        ct = torch.as_tensor(np.asarray(chs).ravel().astype(int), dtype=torch.long).to(dev)
+        rt = torch.as_tensor(np.asarray(rjs).ravel().astype(int), dtype=torch.long).to(dev)
         wt = torch.as_tensor(np.asarray(ws, dtype=float), dtype=torch.float32).to(dev)  # per-pair weight
         wsum = wt.sum().clamp(min=1e-8)
         ar = torch.arange(len(ct), device=dev)

--- a/mixle/models/energy.py
+++ b/mixle/models/energy.py
@@ -24,13 +24,12 @@ from typing import Any
 import numpy as np
 
 from mixle.models._neural_serial import check_finite, decode_module, encode_module
+from mixle.models.grad_leaf import DataBufferAccumulatorFactory
 from mixle.stats.compute.pdist import (
     DataSequenceEncoder,
     DistributionSampler,
     ParameterEstimator,
     SequenceEncodableProbabilityDistribution,
-    SequenceEncodableStatisticAccumulator,
-    StatisticAccumulatorFactory,
 )
 
 
@@ -172,56 +171,6 @@ class EnergyModelEncoder(DataSequenceEncoder):
         return np.array([np.atleast_1d(np.asarray(x, dtype=float)) for x in data])
 
 
-class EnergyModelAccumulator(SequenceEncodableStatisticAccumulator):
-    """Buffers responsibility-weighted data for the NCE M-step (weights = the E-step soft counts)."""
-
-    def __init__(self) -> None:
-        self.x: list = []
-        self.w: list = []
-
-    # Contiguous batch arrays concatenated once at value() (shape-preserving) rather than one ndarray per row.
-    def update(self, x: Any, weight: float, estimate: Any) -> None:
-        self.x.append(np.atleast_1d(np.asarray(x, dtype=float))[None, ...])
-        self.w.append(np.asarray([float(weight)], dtype=float))
-
-    def seq_update(self, enc: Any, weights: np.ndarray, estimate: Any) -> None:
-        xb = np.asarray(enc, dtype=float)
-        self.x.append(xb.reshape(xb.shape[0], 1) if xb.ndim == 1 else xb)
-        self.w.append(np.asarray(weights, dtype=float).ravel())
-
-    def initialize(self, x: Any, weight: float, rng: Any) -> None:
-        self.update(x, weight, None)
-
-    def seq_initialize(self, enc: Any, weights: np.ndarray, rng: Any) -> None:
-        self.seq_update(enc, weights, None)
-
-    def combine(self, other: Any) -> EnergyModelAccumulator:
-        xs, ws = other
-        if len(xs):
-            self.x.append(np.asarray(xs, dtype=float))
-            self.w.append(np.asarray(ws, dtype=float).ravel())
-        return self
-
-    def value(self) -> tuple:
-        x = np.concatenate(self.x, axis=0) if self.x else np.zeros((0, 0))
-        w = np.concatenate(self.w) if self.w else np.zeros((0,))
-        return (x, w)
-
-    def from_value(self, v: tuple) -> EnergyModelAccumulator:
-        x, w = v
-        self.x = [np.asarray(x, dtype=float)] if len(x) else []
-        self.w = [np.asarray(w, dtype=float).ravel()] if len(w) else []
-        return self
-
-    def acc_to_encoder(self) -> EnergyModelEncoder:
-        return EnergyModelEncoder()
-
-
-class EnergyModelAccumulatorFactory(StatisticAccumulatorFactory):
-    def make(self) -> EnergyModelAccumulator:
-        return EnergyModelAccumulator()
-
-
 class EnergyModelEstimator(ParameterEstimator):
     """M-step: Noise-Contrastive Estimation against a Gaussian noise fit to the (weighted) data.
 
@@ -250,8 +199,8 @@ class EnergyModelEstimator(ParameterEstimator):
         self.device = device
         self.name = name
 
-    def accumulator_factory(self) -> EnergyModelAccumulatorFactory:
-        return EnergyModelAccumulatorFactory()
+    def accumulator_factory(self) -> DataBufferAccumulatorFactory:
+        return DataBufferAccumulatorFactory(EnergyModelEncoder(), n_fields=1)
 
     def _make(self) -> EnergyModel:
         return EnergyModel(

--- a/mixle/models/grad_leaf.py
+++ b/mixle/models/grad_leaf.py
@@ -43,7 +43,7 @@ from mixle.stats.compute.pdist import (
     StatisticAccumulatorFactory,
 )
 
-__all__ = ["GradEstimator", "GradLeaf"]
+__all__ = ["DataBufferAccumulator", "DataBufferAccumulatorFactory", "GradEstimator", "GradLeaf"]
 
 
 def _torch() -> Any:
@@ -161,23 +161,33 @@ class GradLeafEncoder(DataSequenceEncoder):
         return np.array([np.atleast_1d(np.asarray(x, dtype=float)) for x in data])
 
 
-class GradAccumulator(SequenceEncodableStatisticAccumulator):
-    """A gradient leaf's only possible "sufficient statistic": the (responsibility-weighted) data
-    itself, buffered for the M-step. The weights are the E-step's soft counts."""
+class DataBufferAccumulator(SequenceEncodableStatisticAccumulator):
+    """THE gradient-leaf "sufficient statistic": the encoded, responsibility-weighted data itself,
+    buffered for the M-step (the weights are the E-step's soft counts). Generic over the encoding
+    arity -- a single array for unconditional leaves, a tuple like ``(x, y)`` for conditional ones
+    -- so every gradient family shares this one class instead of hand-writing its own buffer.
+    Single observations route through the family's own encoder, so per-row quirks live in exactly
+    one place."""
 
-    def __init__(self) -> None:
-        self.x: list = []
+    def __init__(self, encoder: Any, n_fields: int = 1) -> None:
+        self.encoder = encoder
+        self.n_fields = int(n_fields)
+        self.parts: list[list] = [[] for _ in range(self.n_fields)]
         self.w: list = []
 
     # Contiguous batch arrays concatenated once at value() (shape-preserving) rather than one ndarray per row.
+    def _append(self, enc: Any, weights: np.ndarray) -> None:
+        fields = enc if isinstance(enc, tuple) else (enc,)
+        for buf, f in zip(self.parts, fields):
+            fb = np.asarray(f, dtype=float)
+            buf.append(fb.reshape(fb.shape[0], 1) if fb.ndim == 1 else fb)
+        self.w.append(np.asarray(weights, dtype=float).ravel())
+
     def update(self, x: Any, weight: float, estimate: Any) -> None:
-        self.x.append(np.atleast_1d(np.asarray(x, dtype=float))[None, ...])
-        self.w.append(np.asarray([float(weight)], dtype=float))
+        self._append(self.encoder.seq_encode([x]), np.asarray([float(weight)]))
 
     def seq_update(self, enc: Any, weights: np.ndarray, estimate: Any) -> None:
-        xb = np.asarray(enc, dtype=float)
-        self.x.append(xb.reshape(xb.shape[0], 1) if xb.ndim == 1 else xb)
-        self.w.append(np.asarray(weights, dtype=float).ravel())
+        self._append(enc, weights)
 
     def initialize(self, x: Any, weight: float, rng: Any) -> None:
         self.update(x, weight, None)
@@ -185,31 +195,36 @@ class GradAccumulator(SequenceEncodableStatisticAccumulator):
     def seq_initialize(self, enc: Any, weights: np.ndarray, rng: Any) -> None:
         self.seq_update(enc, weights, None)
 
-    def combine(self, other: Any) -> GradAccumulator:
-        xs, ws = other
-        if len(xs):
-            self.x.append(np.asarray(xs, dtype=float))
+    def combine(self, other: Any) -> DataBufferAccumulator:
+        *fields, ws = other
+        if len(ws):
+            for buf, f in zip(self.parts, fields):
+                buf.append(np.asarray(f, dtype=float))
             self.w.append(np.asarray(ws, dtype=float).ravel())
         return self
 
     def value(self) -> tuple:
-        x = np.concatenate(self.x, axis=0) if self.x else np.zeros((0, 0))
+        fields = tuple(np.concatenate(buf, axis=0) if buf else np.zeros((0, 0)) for buf in self.parts)
         w = np.concatenate(self.w) if self.w else np.zeros((0,))
-        return (x, w)
+        return (*fields, w)
 
-    def from_value(self, v: tuple) -> GradAccumulator:
-        x, w = v
-        self.x = [np.asarray(x, dtype=float)] if len(x) else []
+    def from_value(self, v: tuple) -> DataBufferAccumulator:
+        *fields, w = v
+        self.parts = [[np.asarray(f, dtype=float)] if len(f) else [] for f in fields]
         self.w = [np.asarray(w, dtype=float).ravel()] if len(w) else []
         return self
 
-    def acc_to_encoder(self) -> GradLeafEncoder:
-        return GradLeafEncoder()
+    def acc_to_encoder(self) -> Any:
+        return self.encoder
 
 
-class GradAccumulatorFactory(StatisticAccumulatorFactory):
-    def make(self) -> GradAccumulator:
-        return GradAccumulator()
+class DataBufferAccumulatorFactory(StatisticAccumulatorFactory):
+    def __init__(self, encoder: Any, n_fields: int = 1) -> None:
+        self.encoder = encoder
+        self.n_fields = int(n_fields)
+
+    def make(self) -> DataBufferAccumulator:
+        return DataBufferAccumulator(self.encoder, self.n_fields)
 
 
 class GradEstimator(ParameterEstimator):
@@ -248,12 +263,13 @@ class GradEstimator(ParameterEstimator):
             optimizer=self.optimizer,
         )
 
-    def accumulator_factory(self) -> GradAccumulatorFactory:
-        return GradAccumulatorFactory()
+    def accumulator_factory(self) -> DataBufferAccumulatorFactory:
+        return DataBufferAccumulatorFactory(GradLeafEncoder(), n_fields=1)
 
     def estimate(self, nobs: float | None, suff_stat: tuple) -> GradLeaf:
         torch = _torch()
-        xs, ws = suff_stat
+        *fields, ws = suff_stat
+        xs = fields[0]
         params = [p for p in self.module.parameters() if p.requires_grad]
         if len(xs) == 0 or not params:  # nothing to fit, or a fully frozen (fixed) module
             return self._leaf()

--- a/mixle/models/mixture_density.py
+++ b/mixle/models/mixture_density.py
@@ -23,13 +23,12 @@ from typing import Any
 import numpy as np
 
 from mixle.models._neural_serial import check_finite, decode_module, encode_module
+from mixle.models.grad_leaf import DataBufferAccumulatorFactory
 from mixle.stats.compute.pdist import (
     DataSequenceEncoder,
     DistributionSampler,
     ParameterEstimator,
     SequenceEncodableProbabilityDistribution,
-    SequenceEncodableStatisticAccumulator,
-    StatisticAccumulatorFactory,
 )
 
 
@@ -197,64 +196,6 @@ class NeuralConditionalDensityEncoder(DataSequenceEncoder):
         return (x, y)
 
 
-class NeuralConditionalDensityAccumulator(SequenceEncodableStatisticAccumulator):
-    """Buffers responsibility-weighted ``(x, y)`` pairs for the M-step (the weights are the E-step soft counts)."""
-
-    def __init__(self) -> None:
-        self.x: list = []
-        self.y: list = []
-        self.w: list = []
-
-    # Contiguous batch arrays concatenated once at value() (shape-preserving) rather than one ndarray per row.
-    def update(self, xy: Any, weight: float, estimate: Any) -> None:
-        self.x.append(np.atleast_1d(np.asarray(xy[0], dtype=float))[None, ...])
-        self.y.append(np.atleast_1d(np.asarray(xy[1], dtype=float))[None, ...])
-        self.w.append(np.asarray([float(weight)], dtype=float))
-
-    def seq_update(self, enc: Any, weights: np.ndarray, estimate: Any) -> None:
-        x, y = enc
-        xb = np.asarray(x, dtype=float)
-        yb = np.asarray(y, dtype=float)
-        self.x.append(xb.reshape(xb.shape[0], 1) if xb.ndim == 1 else xb)
-        self.y.append(yb.reshape(yb.shape[0], 1) if yb.ndim == 1 else yb)
-        self.w.append(np.asarray(weights, dtype=float).ravel())
-
-    def initialize(self, xy: Any, weight: float, rng: Any) -> None:
-        self.update(xy, weight, None)
-
-    def seq_initialize(self, enc: Any, weights: np.ndarray, rng: Any) -> None:
-        self.seq_update(enc, weights, None)
-
-    def combine(self, other: Any) -> NeuralConditionalDensityAccumulator:
-        xo, yo, wo = other
-        if len(xo):
-            self.x.append(np.asarray(xo, dtype=float))
-            self.y.append(np.asarray(yo, dtype=float))
-            self.w.append(np.asarray(wo, dtype=float).ravel())
-        return self
-
-    def value(self) -> tuple:
-        x = np.concatenate(self.x, axis=0) if self.x else np.zeros((0, 0))
-        y = np.concatenate(self.y, axis=0) if self.y else np.zeros((0, 0))
-        w = np.concatenate(self.w) if self.w else np.zeros((0,))
-        return (x, y, w)
-
-    def from_value(self, value: tuple) -> NeuralConditionalDensityAccumulator:
-        x, y, w = value
-        self.x = [np.asarray(x, dtype=float)] if len(x) else []
-        self.y = [np.asarray(y, dtype=float)] if len(y) else []
-        self.w = [np.asarray(w, dtype=float).ravel()] if len(w) else []
-        return self
-
-    def acc_to_encoder(self) -> NeuralConditionalDensityEncoder:
-        return NeuralConditionalDensityEncoder()
-
-
-class NeuralConditionalDensityAccumulatorFactory(StatisticAccumulatorFactory):
-    def make(self) -> NeuralConditionalDensityAccumulator:
-        return NeuralConditionalDensityAccumulator()
-
-
 class NeuralConditionalDensityEstimator(ParameterEstimator):
     """M-step: responsibility-weighted MLE ``max sum_i w_i log p(y_i | x_i)`` by gradient ascent (warm-started)."""
 
@@ -267,8 +208,8 @@ class NeuralConditionalDensityEstimator(ParameterEstimator):
         self.device = device
         self.name = name
 
-    def accumulator_factory(self) -> NeuralConditionalDensityAccumulatorFactory:
-        return NeuralConditionalDensityAccumulatorFactory()
+    def accumulator_factory(self) -> DataBufferAccumulatorFactory:
+        return DataBufferAccumulatorFactory(NeuralConditionalDensityEncoder(), n_fields=2)
 
     def _make(self) -> NeuralConditionalDensity:
         return NeuralConditionalDensity(

--- a/mixle/models/neural_leaf.py
+++ b/mixle/models/neural_leaf.py
@@ -24,13 +24,12 @@ from typing import Any
 import numpy as np
 
 from mixle.models._neural_serial import check_finite, decode_module, encode_module
+from mixle.models.grad_leaf import DataBufferAccumulatorFactory
 from mixle.stats.compute.pdist import (
     DataSequenceEncoder,
     DistributionSampler,
     ParameterEstimator,
     SequenceEncodableProbabilityDistribution,
-    SequenceEncodableStatisticAccumulator,
-    StatisticAccumulatorFactory,
 )
 
 
@@ -195,63 +194,6 @@ class NeuralGaussianEncoder(DataSequenceEncoder):
         return (x, y)
 
 
-class NeuralGaussianAccumulator(SequenceEncodableStatisticAccumulator):
-    def __init__(self) -> None:
-        self.x: list = []
-        self.y: list = []
-        self.w: list = []
-
-    # x/y/w hold a list of contiguous (n_i, dim) batch arrays; they are concatenated once at value(), so a
-    # streamed shard is a few batch arrays rather than one tiny ndarray per row (the audit's 50k-ndarray blowup).
-    def update(self, xy: Any, weight: float, estimate: Any) -> None:
-        self.x.append(np.asarray(xy[0], dtype=float).reshape(1, -1))
-        self.y.append(np.asarray(xy[1], dtype=float).reshape(1, -1))
-        self.w.append(np.asarray([float(weight)], dtype=float))
-
-    def seq_update(self, enc: Any, weights: np.ndarray, estimate: Any) -> None:
-        x, y = enc
-        xb = np.asarray(x, dtype=float)
-        yb = np.asarray(y, dtype=float)
-        self.x.append(xb.reshape(len(xb), -1))
-        self.y.append(yb.reshape(len(yb), -1))
-        self.w.append(np.asarray(weights, dtype=float).ravel())
-
-    def initialize(self, xy: Any, weight: float, rng: Any) -> None:
-        self.update(xy, weight, None)
-
-    def seq_initialize(self, enc: Any, weights: np.ndarray, rng: Any) -> None:
-        self.seq_update(enc, weights, None)
-
-    def combine(self, other: Any) -> NeuralGaussianAccumulator:
-        xo, yo, wo = other  # another accumulator's value(): contiguous (n, dim) arrays
-        if len(xo):
-            self.x.append(np.asarray(xo, dtype=float))
-            self.y.append(np.asarray(yo, dtype=float))
-            self.w.append(np.asarray(wo, dtype=float).ravel())
-        return self
-
-    def value(self) -> tuple:
-        x = np.concatenate(self.x, axis=0) if self.x else np.zeros((0, 0))
-        y = np.concatenate(self.y, axis=0) if self.y else np.zeros((0, 0))
-        w = np.concatenate(self.w) if self.w else np.zeros((0,))
-        return (x, y, w)
-
-    def from_value(self, value: tuple) -> NeuralGaussianAccumulator:
-        x, y, w = value
-        self.x = [np.asarray(x, dtype=float)] if len(x) else []
-        self.y = [np.asarray(y, dtype=float)] if len(y) else []
-        self.w = [np.asarray(w, dtype=float).ravel()] if len(w) else []
-        return self
-
-    def acc_to_encoder(self) -> NeuralGaussianEncoder:
-        return NeuralGaussianEncoder()
-
-
-class NeuralGaussianAccumulatorFactory(StatisticAccumulatorFactory):
-    def make(self) -> NeuralGaussianAccumulator:
-        return NeuralGaussianAccumulator()
-
-
 class NeuralGaussianEstimator(ParameterEstimator):
     """EM estimator for a :class:`NeuralGaussian`: the M-step is ``m_steps`` of weighted-NLL gradient on the module.
 
@@ -275,8 +217,8 @@ class NeuralGaussianEstimator(ParameterEstimator):
         self.name = name
         self.device = device
 
-    def accumulator_factory(self) -> NeuralGaussianAccumulatorFactory:
-        return NeuralGaussianAccumulatorFactory()
+    def accumulator_factory(self) -> DataBufferAccumulatorFactory:
+        return DataBufferAccumulatorFactory(NeuralGaussianEncoder(), n_fields=2)
 
     def estimate(self, nobs: float | None, suff_stat: tuple) -> NeuralGaussian:
         torch = _torch()
@@ -285,8 +227,10 @@ class NeuralGaussianEstimator(ParameterEstimator):
             return NeuralGaussian(self.module, self.noise, self.m_steps, self.lr, self.name, self.device)
         dev = _resolve_device(self.device, torch)
         self.module.to(dev)
-        xt = torch.as_tensor(np.array(xs), dtype=torch.float32, device=dev)
-        yt = torch.as_tensor(np.array(ys), dtype=torch.float32, device=dev)
+        xs = np.asarray(xs, dtype=float).reshape(len(xs), -1)
+        ys = np.asarray(ys, dtype=float).reshape(len(ys), -1)
+        xt = torch.as_tensor(xs, dtype=torch.float32, device=dev)
+        yt = torch.as_tensor(ys, dtype=torch.float32, device=dev)
         wt = torch.as_tensor(np.array(ws), dtype=torch.float32, device=dev)
         wsum = float(wt.sum()) + 1e-8
         log_noise = torch.log(torch.tensor(float(self.noise), device=dev)).clone().detach().requires_grad_(True)

--- a/mixle/models/pinn.py
+++ b/mixle/models/pinn.py
@@ -43,9 +43,9 @@ from typing import Any
 import numpy as np
 
 from mixle.models._neural_serial import decode_module, encode_module
+from mixle.models.grad_leaf import DataBufferAccumulatorFactory
 from mixle.models.neural_leaf import (
     NeuralGaussian,
-    NeuralGaussianAccumulatorFactory,
     NeuralGaussianEncoder,
     NeuralGaussianEstimator,
     _resolve_device,
@@ -197,8 +197,8 @@ class PINNRegressionEstimator(NeuralGaussianEstimator):
         self.seed = int(seed)
         self._rng = np.random.RandomState(self.seed)
 
-    def accumulator_factory(self) -> NeuralGaussianAccumulatorFactory:
-        return NeuralGaussianAccumulatorFactory()
+    def accumulator_factory(self) -> DataBufferAccumulatorFactory:
+        return DataBufferAccumulatorFactory(NeuralGaussianEncoder(), n_fields=2)
 
     def _sample_collocation(self, dev: Any, torch: Any) -> Any:
         low, high = self.domain

--- a/mixle/models/softmax_leaf.py
+++ b/mixle/models/softmax_leaf.py
@@ -22,13 +22,12 @@ from typing import Any
 import numpy as np
 
 from mixle.models._neural_serial import check_finite, decode_module, encode_module
+from mixle.models.grad_leaf import DataBufferAccumulatorFactory
 from mixle.stats.compute.pdist import (
     DataSequenceEncoder,
     DistributionSampler,
     ParameterEstimator,
     SequenceEncodableProbabilityDistribution,
-    SequenceEncodableStatisticAccumulator,
-    StatisticAccumulatorFactory,
 )
 
 
@@ -164,63 +163,6 @@ class NeuralCategoricalEncoder(DataSequenceEncoder):
         return (x, y)
 
 
-class NeuralCategoricalAccumulator(SequenceEncodableStatisticAccumulator):
-    def __init__(self) -> None:
-        self.x: list = []
-        self.y: list = []
-        self.w: list = []
-
-    # x/y/w hold contiguous batch arrays, concatenated once at value() rather than one ndarray per row (the
-    # audit's per-row buffering blowup). x batching is shape-PRESERVING so conv/structured inputs survive;
-    # y stays an integer class index.
-    def update(self, xy: Any, weight: float, estimate: Any) -> None:
-        self.x.append(np.atleast_1d(np.asarray(xy[0], dtype=float))[None, ...])
-        self.y.append(np.asarray([int(xy[1])], dtype=int))
-        self.w.append(np.asarray([float(weight)], dtype=float))
-
-    def seq_update(self, enc: Any, weights: np.ndarray, estimate: Any) -> None:
-        x, y = enc
-        xb = np.asarray(x, dtype=float)
-        self.x.append(xb.reshape(xb.shape[0], 1) if xb.ndim == 1 else xb)
-        self.y.append(np.asarray(y, dtype=int).ravel())
-        self.w.append(np.asarray(weights, dtype=float).ravel())
-
-    def initialize(self, xy: Any, weight: float, rng: Any) -> None:
-        self.update(xy, weight, None)
-
-    def seq_initialize(self, enc: Any, weights: np.ndarray, rng: Any) -> None:
-        self.seq_update(enc, weights, None)
-
-    def combine(self, other: Any) -> NeuralCategoricalAccumulator:
-        xo, yo, wo = other
-        if len(xo):
-            self.x.append(np.asarray(xo, dtype=float))
-            self.y.append(np.asarray(yo, dtype=int).ravel())
-            self.w.append(np.asarray(wo, dtype=float).ravel())
-        return self
-
-    def value(self) -> tuple:
-        x = np.concatenate(self.x, axis=0) if self.x else np.zeros((0, 0))
-        y = np.concatenate(self.y) if self.y else np.zeros((0,), dtype=int)
-        w = np.concatenate(self.w) if self.w else np.zeros((0,))
-        return (x, y, w)
-
-    def from_value(self, value: tuple) -> NeuralCategoricalAccumulator:
-        x, y, w = value
-        self.x = [np.asarray(x, dtype=float)] if len(x) else []
-        self.y = [np.asarray(y, dtype=int).ravel()] if len(y) else []
-        self.w = [np.asarray(w, dtype=float).ravel()] if len(w) else []
-        return self
-
-    def acc_to_encoder(self) -> NeuralCategoricalEncoder:
-        return NeuralCategoricalEncoder()
-
-
-class NeuralCategoricalAccumulatorFactory(StatisticAccumulatorFactory):
-    def make(self) -> NeuralCategoricalAccumulator:
-        return NeuralCategoricalAccumulator()
-
-
 class NeuralCategoricalEstimator(ParameterEstimator):
     """EM estimator for a :class:`NeuralCategorical`: the M-step is ``m_steps`` of responsibility-weighted
     cross-entropy gradient on the module (the module is warm-started across EM iterations => generalized EM).
@@ -248,8 +190,8 @@ class NeuralCategoricalEstimator(ParameterEstimator):
         # ewc = (anchor_params, fisher_diag, lambda): the EWC anti-forgetting penalty for continued pretraining
         self.ewc = ewc
 
-    def accumulator_factory(self) -> NeuralCategoricalAccumulatorFactory:
-        return NeuralCategoricalAccumulatorFactory()
+    def accumulator_factory(self) -> DataBufferAccumulatorFactory:
+        return DataBufferAccumulatorFactory(NeuralCategoricalEncoder(), n_fields=2)
 
     def estimate(self, nobs: float | None, suff_stat: tuple) -> NeuralCategorical:
         torch = _torch()
@@ -259,9 +201,11 @@ class NeuralCategoricalEstimator(ParameterEstimator):
             return out
         dev = self.device
         self.module.to(dev)
-        # data stays on CPU (a large image set won't fit on the GPU); each minibatch is moved to the device
+        # data stays on CPU (a large image set won't fit on the GPU); each minibatch is moved to the device.
+        # x arrives shape-preserving from the buffer so conv/structured inputs survive; the generic buffer
+        # stores labels as a (n, 1) float64 column -- integral class indices cast to long exactly.
         xt = torch.as_tensor(np.array(xs), dtype=torch.float32)
-        yt = torch.as_tensor(np.array(ys), dtype=torch.long)
+        yt = torch.as_tensor(np.asarray(ys).reshape(-1), dtype=torch.long)
         wt = torch.as_tensor(np.array(ws), dtype=torch.float32)
         n = xt.shape[0]
         bs = self.batch_size or n

--- a/mixle/models/transformer.py
+++ b/mixle/models/transformer.py
@@ -70,6 +70,10 @@ if _HAS_TORCH:
             self.ln = nn.LayerNorm(d_model)
             self.head = nn.Linear(d_model, vocab, bias=False)
             self.head.weight = self.tok.weight  # weight tying
+            # activation (gradient) checkpointing: recompute block activations in backward instead of
+            # storing them -- the standard memory/compute trade for long blocks or deep stacks. A plain
+            # attribute (not a ctor arg) so modules saved before the flag existed rebuild unchanged.
+            self.gradient_checkpointing = False
 
         def forward(self, x: Any) -> Any:
             x = x.long()
@@ -77,20 +81,35 @@ if _HAS_TORCH:
             pos = torch.arange(t, device=x.device)
             h = self.tok(x) + self.pos(pos)[None, :, :]
             for blk in self.blocks:
-                h = blk(h)
+                if getattr(self, "gradient_checkpointing", False) and self.training and torch.is_grad_enabled():
+                    h = torch.utils.checkpoint.checkpoint(blk, h, use_reentrant=False)
+                else:
+                    h = blk(h)
             return self.head(self.ln(h))[:, -1]  # next-token logits from the last position -> (batch, vocab)
 
 
 def build_causal_lm(
-    vocab: int, d_model: int = 128, n_layer: int = 3, n_head: int = 4, block: int = 64, embedding: Any = None
+    vocab: int,
+    d_model: int = 128,
+    n_layer: int = 3,
+    n_head: int = 4,
+    block: int = 64,
+    embedding: Any = None,
+    gradient_checkpointing: bool = False,
 ) -> Any:
     """Build a causal decoder-only Transformer LM (token+pos embeddings, pre-norm blocks, weight-tied head).
 
     ``embedding`` optionally injects a *shared* token ``nn.Embedding`` (``vocab x d_model``) to use in place of a
     fresh one -- so several language models can tie the same word embedding and train it jointly (the weight-tied
     head follows it). Its shape must match ``(vocab, d_model)``.
+
+    ``gradient_checkpointing=True`` recomputes block activations during backward instead of storing them --
+    identical gradients (pinned by test) for a large activation-memory cut on deep stacks or long blocks.
+    The flag is a plain module attribute, so it can also be toggled on an existing model.
     """
     from mixle.models.embedding import resolve_embedding
 
     embedding = resolve_embedding(embedding, vocab, d_model)  # CategoricalEmbedding | nn.Embedding | None -> module
-    return CausalLM(vocab, d_model, n_layer, n_head, block, embedding=embedding)
+    lm = CausalLM(vocab, d_model, n_layer, n_head, block, embedding=embedding)
+    lm.gradient_checkpointing = bool(gradient_checkpointing)
+    return lm

--- a/mixle/tests/dpo_and_registry_hardening_test.py
+++ b/mixle/tests/dpo_and_registry_hardening_test.py
@@ -1,7 +1,8 @@
 """Regression tests for two fixed defects.
 
-1. DPOAccumulator dropped the per-pair weight, so weighted EM / mixture responsibilities / streaming decay
-   silently trained an unweighted DPO loss. It now carries and applies the weight.
+1. The DPO accumulator dropped the per-pair weight, so weighted EM / mixture responsibilities / streaming decay
+   silently trained an unweighted DPO loss. It now carries and applies the weight (buffering lives in the shared
+   ``DataBufferAccumulator``, which DPO wires with three encoded fields plus weights).
 2. Registry joined a raw name/alias onto the store root, so ``../escape`` traversed outside it. Segments are
    now constrained to a single path component.
 """
@@ -18,27 +19,31 @@ pytestmark = pytest.mark.fast
 # --------------------------------------------------------------------------- DPO weights
 
 
-def test_dpo_accumulator_carries_the_weight():
-    from mixle.models.dpo_leaf import DPOAccumulator
+def _dpo_accumulator():
+    """The accumulator exactly as DPO estimation wires it (generic data buffer over the DPO encoding)."""
+    from mixle.models.dpo_leaf import DPOModelEstimator
 
-    lo, hi = DPOAccumulator(), DPOAccumulator()
+    est = DPOModelEstimator(policy=None, ref=None, beta=0.1, m_steps=1, lr=1e-3, device="cpu")
+    return est.accumulator_factory().make()
+
+
+def test_dpo_accumulator_carries_the_weight():
+    lo, hi = _dpo_accumulator(), _dpo_accumulator()
     lo.update((np.zeros(3), 0, 1), 0.01, None)
     hi.update((np.zeros(3), 0, 1), 100.0, None)
     # same triple, very different weight -> the sufficient statistics must differ now
-    assert lo.value()[3] != hi.value()[3]
+    assert lo.value()[3].tolist() != hi.value()[3].tolist()
 
 
 def test_dpo_seq_update_and_combine_preserve_weights():
-    from mixle.models.dpo_leaf import DPOAccumulator
-
     enc = (np.zeros((2, 3)), np.array([0, 0]), np.array([1, 1]))
-    a = DPOAccumulator()
+    a = _dpo_accumulator()
     a.seq_update(enc, np.array([2.0, 5.0]), None)
-    assert a.value()[3] == [2.0, 5.0]
+    assert a.value()[3].tolist() == [2.0, 5.0]
 
-    b = DPOAccumulator().from_value(a.value())  # round-trip the 4-tuple
-    b.combine(a.value())  # distributed merge extends every parallel list, weights included
-    assert len(b.value()[0]) == 4 and b.value()[3] == [2.0, 5.0, 2.0, 5.0]
+    b = _dpo_accumulator().from_value(a.value())  # round-trip the 4-tuple (x, chosen, rejected, w)
+    b.combine(a.value())  # distributed merge extends every parallel buffer, weights included
+    assert len(b.value()[0]) == 4 and b.value()[3].tolist() == [2.0, 5.0, 2.0, 5.0]
 
 
 def test_dpo_weighting_changes_the_fitted_policy():

--- a/mixle/tests/grad_control_test.py
+++ b/mixle/tests/grad_control_test.py
@@ -1,0 +1,95 @@
+"""The two remaining control receipts: gradient checkpointing and LoRA-style adapters.
+
+Checkpointing is a memory/compute trade, not a model change: the claim worth pinning is that the
+recompute path produces IDENTICAL gradients to the plain path on the same weights and batch.
+The adapter test pins the deeper claim behind "peft just works": an adapter-wrapped module is
+still just a module -- drop it into the bridge, the frozen base never moves, only the low-rank
+deltas train, and the fit genuinely improves the objective.
+"""
+
+import unittest
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from mixle.inference.estimation import optimize  # noqa: E402
+from mixle.models import GradLeaf  # noqa: E402
+from mixle.models.transformer import build_causal_lm  # noqa: E402
+
+
+class GradientCheckpointingTest(unittest.TestCase):
+    def test_checkpointing_gradients_are_identical(self):
+        torch.manual_seed(0)
+        plain = build_causal_lm(vocab=17, d_model=16, n_layer=2, n_head=2, block=8)
+        ckpt = build_causal_lm(vocab=17, d_model=16, n_layer=2, n_head=2, block=8, gradient_checkpointing=True)
+        ckpt.load_state_dict(plain.state_dict())
+
+        x = torch.randint(0, 17, (5, 8)).float()
+        y = torch.randint(0, 17, (5,))
+
+        def grads(model):
+            model.train()
+            model.zero_grad()
+            loss = torch.nn.functional.cross_entropy(model(x), y)
+            loss.backward()
+            return loss, {k: p.grad.clone() for k, p in model.named_parameters() if p.grad is not None}
+
+        loss_a, ga = grads(plain)
+        loss_b, gb = grads(ckpt)
+        self.assertTrue(ckpt.gradient_checkpointing)
+        np.testing.assert_allclose(float(loss_a), float(loss_b), rtol=0, atol=0)
+        self.assertEqual(set(ga), set(gb))
+        for k in ga:
+            np.testing.assert_allclose(ga[k].numpy(), gb[k].numpy(), atol=1.0e-6)
+
+    def test_flag_toggles_on_an_existing_model(self):
+        model = build_causal_lm(vocab=11, d_model=16, n_layer=1, n_head=2, block=4)
+        self.assertFalse(model.gradient_checkpointing)
+        model.gradient_checkpointing = True  # a plain attribute: no rebuild, no ctor round-trip
+        model.train()
+        out = model(torch.randint(0, 11, (3, 4)).float())
+        self.assertEqual(tuple(out.shape), (3, 11))
+
+
+class LoRAStyleAdapter(torch.nn.Module):
+    """The peft pattern, hand-rolled: a FROZEN base map plus a trainable low-rank delta. peft's
+    wrapped modules are exactly this shape -- torch modules with frozen base weights -- which is
+    why they drop into the bridge unchanged."""
+
+    def __init__(self, dim: int = 2, rank: int = 1, seed: int = 0):
+        super().__init__()
+        torch.manual_seed(seed)
+        self.base = torch.nn.Linear(dim, dim)
+        self.base.requires_grad_(False)  # the frozen backbone
+        self.lora_a = torch.nn.Parameter(torch.randn(dim, rank) * 0.1)
+        self.lora_b = torch.nn.Parameter(torch.zeros(rank, dim))
+        self.log_sigma = torch.nn.Parameter(torch.zeros(dim))
+
+    def log_density(self, x):
+        center = self.base(x) * 0.0 + self.base.bias + (self.lora_a @ self.lora_b).diag() + x * 0.0
+        # a learnable location built ONLY from frozen-base offsets + the low-rank delta
+        return torch.distributions.Normal(center, torch.exp(self.log_sigma)).log_prob(x).sum(-1)
+
+
+class AdapterThroughTheBridgeTest(unittest.TestCase):
+    def test_only_the_adapter_trains(self):
+        rng = np.random.RandomState(0)
+        data = rng.normal([2.0, -1.0], 0.5, size=(300, 2))
+
+        module = LoRAStyleAdapter(dim=2)
+        base_before = {k: v.clone() for k, v in module.base.state_dict().items()}
+        before_ll = float(np.mean(GradLeaf(module).seq_log_density(data)))
+
+        fitted = optimize([row for row in data], GradLeaf(module, m_steps=200, lr=0.05), max_its=3, out=None)
+
+        for k, v in fitted.module.base.state_dict().items():  # the backbone never moved
+            np.testing.assert_array_equal(v.numpy(), base_before[k].numpy())
+        self.assertGreater(float(fitted.module.lora_b.abs().sum()), 0.0)  # the delta did
+        after_ll = float(np.mean(fitted.seq_log_density(data)))
+        self.assertGreater(after_ll, before_ll + 1.0)  # and the fit is real
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mixle/tests/torch_parity_test.py
+++ b/mixle/tests/torch_parity_test.py
@@ -1,0 +1,76 @@
+"""The parity receipt: ``optimize(x, module)`` matches a hand-written PyTorch training loop.
+
+The claim this pins is the library's pitch for neural leaves — the few-line mixle fit reaches the
+same held-out performance as the raw torch loop it replaces (dataset prep, optimizer, epoch loop,
+eval), on the same module architecture and the same data. Not a benchmark of architectures: a
+CONTRACT that the manufactured training loop gives nothing away. If a change to the gradient
+M-step ever costs real likelihood against plain torch, this fails.
+"""
+
+import unittest
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from mixle.inference.estimation import optimize  # noqa: E402
+
+
+class AffineDensity(torch.nn.Module):
+    """A well-posed learnable density (an affine normalizing flow: diagonal Gaussian with free
+    location/scale). Deliberately CONVEX in its parameters' effect so both training paths provably
+    share one optimum -- this test pins that the manufactured loop REACHES it, not that a
+    particular architecture trains nicely."""
+
+    def __init__(self, dim: int = 3, seed: int = 0):
+        super().__init__()
+        torch.manual_seed(seed)
+        self.mu = torch.nn.Parameter(torch.zeros(dim))
+        self.log_sigma = torch.nn.Parameter(torch.zeros(dim))
+
+    def log_density(self, x):
+        return torch.distributions.Normal(self.mu, torch.exp(self.log_sigma)).log_prob(x).sum(-1)
+
+
+def _blobs(n, seed):
+    rng = np.random.RandomState(seed)
+    return rng.normal([1.5, -2.0, 0.3], [0.8, 1.2, 2.0], size=(n, 3))
+
+
+class TorchParityTest(unittest.TestCase):
+    def test_mixle_fit_matches_a_raw_torch_loop(self):
+        train, held = _blobs(400, seed=0), _blobs(200, seed=1)
+
+        # --- the raw torch loop: tensors, optimizer, epochs, eval -- written out honestly ---------
+        raw = AffineDensity(seed=3)
+        xt = torch.as_tensor(train, dtype=torch.float32)
+        opt = torch.optim.Adam(raw.parameters(), lr=5e-3)
+        raw.train()
+        for _ in range(600):
+            opt.zero_grad()
+            loss = -raw.log_density(xt).mean()
+            loss.backward()
+            opt.step()
+        raw.eval()
+        with torch.no_grad():
+            raw_held = float(raw.log_density(torch.as_tensor(held, dtype=torch.float32)).mean())
+
+        # --- the mixle spelling of the same fit -------------------------------------------------
+        fitted = optimize([row for row in train], AffineDensity(seed=3), max_its=10, out=None)
+        mixle_held = float(np.mean(fitted.seq_log_density(held)))
+
+        # same architecture, same data, same performance -- the manufactured loop gives nothing away
+        self.assertLess(abs(mixle_held - raw_held), 0.05)
+
+    def test_the_mixle_spelling_is_actually_the_short_one(self):
+        # the receipt behind the "few lines" claim: the mixle fit above is ONE call; everything the
+        # raw loop spells out (tensor prep, optimizer, epoch loop, train/eval mode, no_grad eval)
+        # is manufactured. This test exists so the doc claim points at executable code, not prose.
+        train = _blobs(200, seed=2)
+        fitted = optimize([row for row in train], AffineDensity(seed=4), max_its=5, out=None)
+        self.assertTrue(np.isfinite(fitted.log_density(train[0])))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Stacked on #120 (base: `neural-bridge`; retargets to the release branch when #120 merges). #120 built the bridge and collapsed `NeuralDensity`; this PR finishes the job across `mixle.models`.

**Migrated** — plumbing deleted, estimator math verbatim, serialization and public names untouched (the generic `DataBufferAccumulator` was generalized to tuple encodings like `(x, y)` pairs; dtype/shape quirks are preserved at tensor-prep time — class labels and action indices round-trip the float buffer exactly and cast back to `long`):

| Family | Net lines |
|---|---|
| NeuralGaussian + PINN factory | −55 |
| NeuralConditionalDensity | −59 |
| NeuralCategorical | −56 |
| EnergyModel | −51 |
| DPO | −47 |

Net **−225 lines** on top of #120's −116, and every future gradient family starts at zero plumbing.

**Deliberately NOT migrated** — three families where investigation showed the accumulator is architecture, not ceremony, each verified empirically:
- `feature_map`: a delegating adapter whose `value()` is the *inner* family's native (often closed-form) sufficient statistic — a buffer would break every closed-form inner family.
- `random_forest`: the label dtype is load-bearing — float64 coercion breaks string classes outright and **silently flips `task='auto'` from classification to regression** (dtype-based inference), and the `(n,1)` column reshape would corrupt the regression sigma via broadcasting.
- `streaming_transformer`: its `seq_update` **is** a training step (persistent AdamW state per shard), `value()` is telemetry (`loss_sum, tokens` — never the corpus, pinned by its own no-buffering test), and the FSDP2 handle's no-gather contract is precisely the anti-pattern a buffering accumulator would reintroduce.

**The parity receipt**: `torch_parity_test` pins the pitch — `optimize(x, module)` reaches the same held-out log-likelihood as an honestly written raw-torch training loop (tensors, Adam, epochs, eval) within 0.05 nats, same module, same data, on a convex fixture so both paths provably share one optimum. The README Quickstart gains the "a torch module is a distribution — the training code you didn't write" block (one-call fit, composition with classical families in one EM, freezing via `requires_grad_`, loss/optimizer hooks, `fitted.module` escape hatch), pointing at that test as the receipt instead of prose.

Verification: 135 tests across all touched and consumer suites (grad_leaf, parity, neural_density, serialization, composition grid, deep_set, pinn, mixture_density, energy ×2, feature_map, neural_ppl, dpo+registry, lm_serialization, streaming weights, random_forest, project_neural, modality routing, ppl_density) — all green; ruff clean across `mixle/models/`.