### PR TITLE
task: add CalibratedGenerator for conformal generation with abstention

### DIFF
--- a/mixle/task/calibrated_generator.py
+++ b/mixle/task/calibrated_generator.py
@@ -1,0 +1,159 @@
+"""``CalibratedGenerator`` -- conformal generation with honest abstention.
+
+The generation-side sibling of :class:`~mixle.task.calibrate.CalibratedTaskModel`. That class gates
+*classification*: it turns an uncalibrated softmax into conformal label sets and escalates on an
+ambiguous (empty or multi-label) set. This module gates *generation*: draw ``k`` candidates from any
+generator (a :class:`~mixle.task.llm.CallableLLM`, a sampler, a beam), score each candidate with any
+mixle-scoreable model, and calibrate a conformal threshold on a held-out set so that serving the
+best-scored candidate carries the same finite-sample coverage guarantee -- instead of always emitting
+whatever scored highest, regardless of whether the score means anything.
+
+The trick is treating the ``k`` candidates the way :class:`CalibratedTaskModel` treats classes: raw
+candidate scores are softmax-normalized per prompt into selection probabilities, and
+:func:`mixle.inference.conformal.conformal_label_threshold` / :func:`~mixle.inference.conformal.conformal_label_sets`
+calibrate + apply the exact LAC threshold the classification sibling uses. A singleton conformal set ->
+serve that candidate (covered at ``1 - alpha``); an empty or multi-candidate set -> honest "I'm not
+sure" (:data:`ABSTAIN`) rather than a silent guess. ``ABSTAIN`` is ``None``, the same sentinel value as
+:data:`mixle.task.calibrate.ESCALATE`, so a :class:`~mixle.task.cascade.Cascade` built on a
+``CalibratedGenerator`` escalates on abstention exactly the way it escalates on ``ESCALATE`` -- no
+special-casing needed on the cascade side.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Callable, Sequence
+from typing import Any
+
+import numpy as np
+
+from mixle.inference.conformal import conformal_label_sets, conformal_label_threshold
+
+ABSTAIN = None  # sentinel returned when no candidate clears the calibrated threshold; equals Cascade's ESCALATE
+
+
+def _softmax(x: np.ndarray) -> np.ndarray:
+    x = x - np.max(x, axis=-1, keepdims=True)
+    e = np.exp(x)
+    return e / np.sum(e, axis=-1, keepdims=True)
+
+
+def _derive_seed(base_seed: int, prompt: Any) -> int:
+    """A stable (cross-process) per-prompt seed derived from ``base_seed`` -- unlike builtin ``hash()``,
+    which is salted per-process by default, so it cannot be used to reproduce a draw across runs."""
+    digest = hashlib.sha256(f"{base_seed}:{prompt!r}".encode()).digest()
+    return int.from_bytes(digest[:8], "big") % (2**32)
+
+
+class CalibratedGenerator:
+    """Draw ``k`` scored candidates and serve the best one under a conformal accept-or-abstain guarantee.
+
+    Args:
+        generate: ``generate(prompt, k) -> Sequence[candidate]`` (an ``rng`` keyword is passed if the
+            callable accepts one; falls back to the two-argument form otherwise). Any generator that can
+            draw ``k`` candidates for a prompt works: a wrapped :class:`~mixle.task.llm.CallableLLM`
+            sampled ``k`` times, a beam, a stochastic sampler.
+        score: ``score(candidate) -> float``, any mixle-scoreable model. Higher is better; the score
+            need not be a calibrated probability -- that is exactly what conformal calibration fixes.
+        alpha: target miscoverage rate.
+        k: number of candidates to draw per prompt.
+        seed: base seed for candidate draws; combined with the prompt (see :func:`_derive_seed`) so
+            different prompts get different, but reproducible, draws.
+    """
+
+    def __init__(
+        self,
+        generate: Callable[..., Sequence[Any]],
+        score: Callable[[Any], float],
+        alpha: float = 0.1,
+        *,
+        k: int = 8,
+        qhat: float | None = None,
+        seed: int = 0,
+    ) -> None:
+        self.generate = generate
+        self.score = score
+        self.alpha = float(alpha)
+        self.k = int(k)
+        self.qhat = qhat
+        self.seed = int(seed)
+
+    def _draw(self, prompt: Any, *, seed: int) -> list[Any]:
+        rng = np.random.default_rng(seed)
+        try:
+            cands = self.generate(prompt, self.k, rng=rng)
+        except TypeError:
+            cands = self.generate(prompt, self.k)
+        cands = list(cands)
+        if not cands:
+            raise ValueError(f"generate(...) returned no candidates for prompt {prompt!r}")
+        return cands
+
+    def _scored(self, prompt: Any, *, seed: int) -> tuple[list[Any], np.ndarray]:
+        cands = self._draw(prompt, seed=seed)
+        scores = np.asarray([float(self.score(c)) for c in cands], dtype=float)
+        return cands, scores
+
+    def calibrate(
+        self, prompts: Sequence[Any], is_correct: Callable[[Any, Any], bool], *, seed: int | None = None
+    ) -> CalibratedGenerator:
+        """Fit the conformal threshold on a held-out set of prompts, given a correctness oracle.
+
+        For each held-out prompt, ``k`` candidates are drawn and scored; the scores are softmax-normalized
+        into per-prompt selection probabilities. The calibration score for that prompt is the probability
+        mass landing on whichever candidate(s) ``is_correct(prompt, candidate)`` accepts (``0`` if none of
+        the ``k`` draws is correct -- an honest miss that the calibration prices in, the same way a
+        held-out example whose true class never appears in a small candidate set prices into a wider
+        conformal set). :func:`mixle.inference.conformal.conformal_label_threshold` on those scores gives
+        the same LAC threshold :class:`~mixle.task.calibrate.CalibratedTaskModel` calibrates for label sets.
+        """
+        rng_seed = self.seed if seed is None else int(seed)
+        cal_prob_true = []
+        for i, prompt in enumerate(prompts):
+            cands, scores = self._scored(prompt, seed=_derive_seed(rng_seed, (i, prompt)))
+            probs = _softmax(scores)
+            mass = sum(p for c, p in zip(cands, probs) if is_correct(prompt, c))
+            cal_prob_true.append(mass)
+        if not cal_prob_true:
+            raise ValueError("calibrate(...) needs at least one held-out prompt")
+        self.qhat = conformal_label_threshold(np.asarray(cal_prob_true, dtype=float), alpha=self.alpha)
+        return self
+
+    def candidate_set(self, prompt: Any, *, seed: int | None = None) -> list[Any]:
+        """The conformal candidate set for ``prompt`` -- candidates whose selection probability clears
+        the calibrated threshold. A singleton set is what :meth:`serve` accepts; empty/multi abstains."""
+        if self.qhat is None:
+            raise RuntimeError("call calibrate(...) (or set qhat) before candidate_set(...)")
+        call_seed = _derive_seed(self.seed, prompt) if seed is None else int(seed)
+        cands, scores = self._scored(prompt, seed=call_seed)
+        probs = _softmax(scores)
+        sets, _ = conformal_label_sets(np.empty(0), probs[None, :], alpha=self.alpha, qhat=self.qhat)
+        return [cands[i] for i in np.flatnonzero(sets[0])]
+
+    def serve(self, prompt: Any, *, seed: int | None = None) -> Any:
+        """Draw ``k`` candidates and return the best one if it conformally clears the threshold, else
+        :data:`ABSTAIN`. ``ABSTAIN`` is returned for both an empty set (nothing confident enough) and a
+        multi-candidate set (genuinely ambiguous) -- the same honest-uncertainty split
+        :class:`~mixle.task.calibrate.CalibratedTaskModel` uses for classification."""
+        admitted = self.candidate_set(prompt, seed=seed)
+        return admitted[0] if len(admitted) == 1 else ABSTAIN
+
+    def decide(self, prompt: Any, *, seed: int | None = None) -> Any:
+        """Alias for :meth:`serve` with the same name as :meth:`CalibratedTaskModel.decide`, so a
+        ``CalibratedGenerator`` drops into :class:`~mixle.task.cascade.Cascade` unmodified."""
+        return self.serve(prompt, seed=seed)
+
+    def __call__(self, prompt: Any, *, seed: int | None = None) -> Any:
+        return self.serve(prompt, seed=seed)
+
+    def abstention_rate(self, prompts: Sequence[Any], *, seed: int | None = None) -> float:
+        """Empirical fraction of ``prompts`` that would abstain -- the generation analogue of
+        :meth:`CalibratedTaskModel.escalation_rate`."""
+        prompts = list(prompts)
+        if not prompts:
+            return 0.0
+        outcomes = [self.serve(p, seed=seed) for p in prompts]
+        return float(np.mean([o is ABSTAIN for o in outcomes]))
+
+
+__all__ = ["ABSTAIN", "CalibratedGenerator"]

--- a/mixle/tests/task_calibrated_generator_test.py
+++ b/mixle/tests/task_calibrated_generator_test.py
@@ -1,0 +1,155 @@
+"""Calibrated generator (mixle.task.calibrated_generator): conformal accept-or-abstain for generation.
+
+Coverage of the conformal accept decision must hold on held-out data the same way it does for
+CalibratedTaskModel's label sets; abstention (ABSTAIN) must compose with Cascade as an escalation
+signal; and serving must be reproducible given a seed.
+"""
+
+import hashlib
+import unittest
+
+import numpy as np
+
+from mixle.task.calibrated_generator import ABSTAIN, CalibratedGenerator
+from mixle.task.cascade import Cascade
+
+# --- synthetic "double the prompt" generation task -------------------------------------------------
+#
+# A candidate is (n, guess). The correct answer for prompt n is 2 * n. `generate` draws k candidates:
+# the correct answer is included with probability `hit_prob`, plus decoys at a random offset. `score`
+# is a pure function of the candidate alone (no access to ground truth beyond the same "double it" prior
+# a real verifier might encode) with a small deterministic jitter, so it ranks well but not perfectly.
+
+
+def _stable_unit(obj) -> float:
+    """Deterministic pseudo-noise in [0, 1) from a hash of `obj` -- keeps `score` a pure function."""
+    digest = hashlib.sha256(repr(obj).encode()).digest()
+    return int.from_bytes(digest[:8], "big") / 2**64
+
+
+def make_generate(hit_prob: float, decoy_spread: int = 6):
+    def generate(prompt, k, rng=None):
+        if rng is None:
+            rng = np.random.default_rng()
+        n = prompt
+        correct = 2 * n
+        cands = []
+        if rng.random() < hit_prob:
+            cands.append((n, correct))
+        while len(cands) < k:
+            offset = int(rng.integers(-decoy_spread, decoy_spread + 1))
+            if offset == 0:
+                continue
+            cands.append((n, correct + offset))
+        rng.shuffle(cands)
+        return cands
+
+    return generate
+
+
+def score(candidate) -> float:
+    n, guess = candidate
+    deviation = abs(guess - 2 * n)
+    jitter = _stable_unit(candidate) * 0.5
+    return -float(deviation) + jitter
+
+
+def is_correct(prompt, candidate) -> bool:
+    n, guess = candidate
+    return guess == 2 * n and n == prompt
+
+
+class CoverageTest(unittest.TestCase):
+    def test_accepted_error_rate_and_abstention_track_alpha(self):
+        alpha = 0.1
+        cal_prompts = list(range(0, 700))
+        test_prompts = list(range(10_000, 10_700))
+
+        # hit_prob's miss rate (5%) must stay below alpha (10%) for a selective threshold to exist at all --
+        # otherwise no candidate ever clears 1 - alpha coverage and the calibration saturates to "abstain always"
+        # (qhat pinned at its max), the same way CalibratedTaskModel's qhat saturates to +inf when the true class
+        # is missing from the candidate set more often than alpha tolerates.
+        gen = make_generate(hit_prob=0.95)
+        model = CalibratedGenerator(gen, score, alpha=alpha, k=5, seed=1).calibrate(cal_prompts, is_correct)
+
+        served = [model.serve(p) for p in test_prompts]
+        accepted = [(p, c) for p, c in zip(test_prompts, served) if c is not ABSTAIN]
+        abstain_rate = 1.0 - len(accepted) / len(test_prompts)
+
+        self.assertGreater(len(accepted), 0)
+        error_rate = np.mean([not is_correct(p, c) for p, c in accepted])
+        # finite-sample slack, mirroring task_calibrate_test.py's coverage tolerance
+        self.assertLessEqual(error_rate, alpha + 0.08)
+        # abstention is doing real, non-degenerate work: it neither accepts nor rejects everything
+        self.assertGreater(abstain_rate, 0.0)
+        self.assertLess(abstain_rate, 1.0)
+
+    def test_abstention_rate_decreases_as_alpha_relaxes(self):
+        cal_prompts = list(range(0, 700))
+        test_prompts = list(range(20_000, 20_700))
+        gen = make_generate(hit_prob=0.7)
+
+        tight = CalibratedGenerator(gen, score, alpha=0.05, k=5, seed=2).calibrate(cal_prompts, is_correct)
+        loose = CalibratedGenerator(gen, score, alpha=0.4, k=5, seed=2).calibrate(cal_prompts, is_correct)
+
+        tight_rate = tight.abstention_rate(test_prompts)
+        loose_rate = loose.abstention_rate(test_prompts)
+        # a larger alpha tolerates more risk, so it should abstain no more than a stricter alpha
+        self.assertLessEqual(loose_rate, tight_rate + 1e-9)
+
+
+class CascadeIntegrationTest(unittest.TestCase):
+    def test_abstention_escalates_through_cascade(self):
+        alpha = 0.1
+        cal_prompts = list(range(0, 500))
+        gen = make_generate(hit_prob=0.5, decoy_spread=8)  # frequent misses -> frequent abstention
+        model = CalibratedGenerator(gen, score, alpha=alpha, k=5, seed=3).calibrate(cal_prompts, is_correct)
+
+        def teacher(prompts):
+            return [(n, 2 * n) for n in prompts]
+
+        casc = Cascade(model, teacher)
+
+        probe_prompts = list(range(30_000, 30_300))
+        abstained_prompt = next((p for p in probe_prompts if model.decide(p) is ABSTAIN), None)
+        self.assertIsNotNone(abstained_prompt, "test setup should produce at least one abstention")
+
+        result = casc(abstained_prompt)  # must escalate, not raise
+        self.assertEqual(result, (abstained_prompt, 2 * abstained_prompt))
+        self.assertEqual(casc.stats.n_escalated, 1)
+
+        # serving a batch mixes accepted and escalated outcomes without error, and every escalation
+        # is answered correctly by the (perfect) teacher
+        results = casc.serve(probe_prompts)
+        self.assertEqual(len(results), len(probe_prompts))
+        self.assertGreater(casc.stats.n_escalated, 0)
+        self.assertTrue(all(is_correct(p, r) for p, r in zip(probe_prompts, results)))
+
+
+class DeterminismTest(unittest.TestCase):
+    def test_same_seed_same_outcome(self):
+        cal_prompts = list(range(0, 400))
+        gen = make_generate(hit_prob=0.75)
+
+        def build():
+            return CalibratedGenerator(gen, score, alpha=0.1, k=5, seed=42).calibrate(cal_prompts, is_correct)
+
+        model_a = build()
+        model_b = build()
+
+        self.assertAlmostEqual(model_a.qhat, model_b.qhat, places=12)
+
+        for prompt in range(40_000, 40_050):
+            out_a = model_a.serve(prompt)
+            out_b = model_b.serve(prompt)
+            self.assertEqual(out_a, out_b)
+
+        # repeated calls on the same instance/prompt are also stable
+        prompt = 40_100
+        first = model_a.serve(prompt)
+        second = model_a.serve(prompt)
+        self.assertEqual(first, second)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds `CalibratedGenerator` (`mixle/task/calibrated_generator.py`), the generation-side sibling of `CalibratedTaskModel`: draw k candidates from any generator, score each with any mixle-scoreable model, and calibrate a conformal threshold on a held-out set so serving the best candidate carries a finite-sample coverage guarantee.
- Reuses `conformal_label_threshold`/`conformal_label_sets` (`mixle/inference/conformal.py`) rather than reimplementing calibration, by treating the k candidates like classes: scores are softmax-normalized per prompt into selection probabilities, and the same LAC threshold logic `CalibratedTaskModel` uses for label sets applies directly.
- A singleton conformal set serves that candidate; an empty or multi-candidate set abstains (`ABSTAIN`, same `None` sentinel as `CalibratedTaskModel.ESCALATE`). A `decide()` alias lets a `CalibratedGenerator` drop into `Cascade` unmodified so abstention escalates instead of failing.
- Candidate draws are seeded deterministically per-prompt (stable hash of `seed` + prompt, not the process-salted builtin `hash()`), so `serve()` is reproducible given a seed.

## Test plan
New file `mixle/tests/task_calibrated_generator_test.py`:
- Coverage test on a synthetic "double the prompt" task: error rate among accepted (non-abstained) outputs stays within alpha plus finite-sample slack, and abstention is non-degenerate (neither 0 nor 1).
- Alpha-monotonicity test: a looser alpha abstains no more than a tighter one.
- Cascade integration test: wires a `CalibratedGenerator` into `Cascade` and confirms an abstained case escalates to the teacher and is answered correctly rather than raising.
- Determinism test: same seed produces the same qhat and the same served/abstained outcome across independent instances and repeated calls.

Ran:
```
python -m ruff check --fix mixle/task/calibrated_generator.py mixle/tests/task_calibrated_generator_test.py
python -m ruff format mixle/task/calibrated_generator.py mixle/tests/task_calibrated_generator_test.py
python -m pytest mixle/tests/task_calibrated_generator_test.py mixle/tests/task_calibrate_test.py mixle/tests/task_cascade_test.py mixle/tests/task_llm_test.py
```
All pass (one pre-existing skip in `task_calibrate_test.py` from a missing `safetensors` dependency in the local venv, unrelated to this change).