### PR TITLE
examples: peft LoRA through GradLeaf, on a real HF checkpoint

### DIFF
--- a/examples/peft_lora_grad_leaf.py
+++ b/examples/peft_lora_grad_leaf.py
@@ -1,0 +1,124 @@
+"""peft LoRA through the GradLeaf bridge -- a REAL HuggingFace checkpoint, not a hand-rolled stand-in.
+
+``mixle/tests/grad_control_test.py``'s ``AdapterThroughTheBridgeTest`` pins the claim with a hand-rolled
+``LoRAStyleAdapter`` (frozen base + trainable low-rank delta) and documents why it generalizes: "peft's
+wrapped modules are exactly this shape -- torch modules with frozen base weights -- which is why they drop
+into the bridge unchanged." This example reproduces that receipt with the real thing: a tiny HuggingFace
+GPT-2 checkpoint, wrapped with actual ``peft.get_peft_model`` LoRA adapters, dropped into ``GradLeaf``
+unchanged.
+
+``GradLeaf`` wants ``module.log_density(x) -> (n,)``; a causal LM's natural objective is token-level
+cross-entropy, not an unconditional density. The bridge doesn't care -- next-token log-likelihood summed
+over a sequence IS a log density over that sequence, so ``PeftCausalLMLeaf.log_density`` below is exactly
+that sum, negated back out of the standard cross-entropy loss. Everything downstream (the M-step's
+responsibility-weighted NLL, the optimizer seeing only ``requires_grad`` params) is unmodified GradLeaf.
+
+The receipt: after fitting,
+  * every frozen BASE weight is bitwise-unchanged (peft froze it; the optimizer never touched it either --
+    ``GradEstimator`` filters to trainable params only), and
+  * only the LoRA adapter matrices moved, and
+  * the fit is real (held-out log-likelihood improves).
+
+Run: ``python examples/peft_lora_grad_leaf.py``
+(needs ``pip install "mixle[torch]" transformers peft`` -- peft/transformers are example-only deps, not a
+mixle extra, since GradLeaf itself has no opinion on what module you hand it).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from mixle.inference.estimation import optimize
+from mixle.models import GradLeaf
+
+CHECKPOINT = "hf-internal-testing/tiny-random-gpt2"  # a handful of KB; real GPT-2 architecture, random weights
+
+
+def build_peft_wrapped_module(seed: int = 0):
+    """Load the tiny checkpoint, wrap it with LoRA adapters, and adapt it to GradLeaf's
+    ``log_density(x) -> (n,)`` contract. This is the ONLY glue GradLeaf needs -- everything else
+    (freezing the base, exposing only the adapter params as trainable) is peft's ordinary behavior."""
+    import torch
+    from peft import LoraConfig, TaskType, get_peft_model
+    from transformers import AutoModelForCausalLM
+
+    torch.manual_seed(seed)
+    base = AutoModelForCausalLM.from_pretrained(CHECKPOINT)
+    lora_cfg = LoraConfig(
+        task_type=TaskType.CAUSAL_LM,
+        r=4,
+        lora_alpha=8,
+        lora_dropout=0.0,
+        target_modules=["c_attn"],  # GPT-2's fused qkv projection
+    )
+    peft_model = get_peft_model(base, lora_cfg)  # freezes the base, adds trainable LoRA deltas -- peft's job
+
+    class PeftCausalLMLeaf(torch.nn.Module):
+        """A causal LM IS a density over token sequences: next-token log-likelihood summed over the
+        sequence. This wrapper is the only mixle-specific code -- the peft model inside is untouched."""
+
+        def __init__(self, lm) -> None:
+            super().__init__()
+            self.lm = lm  # the peft-wrapped module, dropped in whole
+
+        def log_density(self, x):  # x: (n, block) token ids, arriving as float per GradLeaf's contract
+            ids = x.long()
+            logits = self.lm(input_ids=ids).logits  # (n, block, vocab)
+            shift_logits = logits[:, :-1, :]
+            shift_targets = ids[:, 1:]
+            ce = torch.nn.functional.cross_entropy(
+                shift_logits.reshape(-1, shift_logits.shape[-1]),
+                shift_targets.reshape(-1),
+                reduction="none",
+            ).reshape(ids.shape[0], -1)
+            return -ce.sum(-1)  # summed next-token log-likelihood == log density of the sequence
+
+    return PeftCausalLMLeaf(peft_model)
+
+
+def toy_token_sequences(vocab: int, block: int, n: int, rng: np.random.RandomState) -> list:
+    """A tiny structured corpus -- a handful of fixed cyclic patterns drawn from a SMALL sub-vocabulary
+    -- so a heavily-restricted-rank LoRA adapter on a randomly-initialized tiny model has a real,
+    learnable signal to chase in a few M-steps, without needing a real text dataset for a smoke example."""
+    sub_vocab = min(6, vocab)
+    starts = rng.randint(0, sub_vocab, size=4)  # a handful of repeating cycles, not one per sequence
+    seqs = []
+    for i in range(n):
+        start = int(starts[i % len(starts)])
+        seqs.append([(start + j) % sub_vocab for j in range(block)])
+    return [np.asarray(s, dtype=float) for s in seqs]
+
+
+def main() -> None:
+    rng = np.random.RandomState(0)
+    module = build_peft_wrapped_module(seed=0)
+
+    base_before = {k: v.clone() for k, v in module.lm.base_model.model.state_dict().items() if "lora_" not in k}
+
+    block = 8
+    data = toy_token_sequences(vocab=module.lm.config.vocab_size, block=block, n=64, rng=rng)
+
+    leaf = GradLeaf(module, m_steps=150, lr=0.1)
+    before_ll = float(np.mean(leaf.seq_log_density(np.stack(data))))
+
+    fitted = optimize(data, leaf, max_its=4, out=None)
+
+    after_ll = float(np.mean(fitted.seq_log_density(np.stack(data))))
+
+    base_after = {k: v for k, v in fitted.module.lm.base_model.model.state_dict().items() if "lora_" not in k}
+    max_base_drift = max(float((base_after[k] - base_before[k]).abs().max()) for k in base_before)
+    lora_params = [p for n, p in fitted.module.lm.named_parameters() if "lora_" in n and p.requires_grad]
+    lora_moved = sum(float(p.detach().abs().sum()) for p in lora_params)
+
+    print(f"base weight drift (should be 0.0): {max_base_drift}")
+    print(f"LoRA adapter param mass (should be > 0): {lora_moved:.4f}")
+    print(f"mean log-density before fit: {before_ll:.4f}")
+    print(f"mean log-density after fit:  {after_ll:.4f}")
+    assert max_base_drift == 0.0, "the frozen base moved -- peft/GradLeaf contract broken"
+    assert lora_moved > 0.0, "the adapter never trained"
+    assert after_ll > before_ll, "the fit made no progress"
+    print("OK: only the LoRA adapter trained; the base checkpoint is untouched; the fit improved.")
+
+
+if __name__ == "__main__":
+    main()

--- a/mixle/tests/conftest.py
+++ b/mixle/tests/conftest.py
@@ -64,6 +64,9 @@ FILE_MARKERS: dict[str, MarkerTuple] = {
     "structure_embedded_test.py": ("torch", "integration", "slow"),
     "estimation_structure_default_test.py": ("integration", "slow"),
     "scientist_test.py": ("torch", "integration", "optional", "slow"),
+    # Downloads a real tiny HF checkpoint (peft/transformers, network-gated) and fits it -- skips cleanly
+    # offline, but is neither fast nor a core-path test.
+    "peft_lora_grad_leaf_smoke_test.py": ("torch", "integration", "optional", "slow"),
     "planning_test.py": ("planner",),
     "uq_test.py": ("torch", "integration", "slow"),
     "infer_backends_test.py": ("numba", "integration", "slow"),

--- a/mixle/tests/peft_lora_grad_leaf_smoke_test.py
+++ b/mixle/tests/peft_lora_grad_leaf_smoke_test.py
@@ -1,0 +1,61 @@
+"""Smoke test for ``examples/peft_lora_grad_leaf.py``: the real-checkpoint receipt still holds.
+
+Reuses the example's own building blocks (a real ``peft``-wrapped tiny HF checkpoint dropped into
+``GradLeaf``) rather than re-deriving them, so this pins the actual example against regressions instead
+of a parallel hand-rolled copy. Skips cleanly (no network, or peft/transformers missing) rather than
+failing CI machines without internet access.
+"""
+
+import sys
+import unittest
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("transformers")
+pytest.importorskip("peft")
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "examples"))
+from peft_lora_grad_leaf import build_peft_wrapped_module, toy_token_sequences  # noqa: E402
+
+from mixle.inference.estimation import optimize  # noqa: E402
+from mixle.models import GradLeaf  # noqa: E402
+
+
+def _offline_or_skip():
+    try:
+        build_peft_wrapped_module(seed=0)
+    except Exception as exc:  # pragma: no cover - depends on network/HF Hub availability
+        pytest.skip(f"tiny HF checkpoint unavailable (likely offline): {exc}")
+
+
+class PeftLoraGradLeafSmokeTest(unittest.TestCase):
+    def test_only_the_lora_adapter_trains_on_a_real_checkpoint(self):
+        _offline_or_skip()
+        rng = np.random.RandomState(0)
+        module = build_peft_wrapped_module(seed=0)
+
+        base_before = {
+            k: v.clone() for k, v in module.lm.base_model.model.state_dict().items() if "lora_" not in k
+        }
+
+        data = toy_token_sequences(vocab=module.lm.config.vocab_size, block=8, n=32, rng=rng)
+        leaf = GradLeaf(module, m_steps=40, lr=0.1)
+        before_ll = float(np.mean(leaf.seq_log_density(np.stack(data))))
+
+        fitted = optimize(data, leaf, max_its=2, out=None)
+
+        after_ll = float(np.mean(fitted.seq_log_density(np.stack(data))))
+        base_after = {k: v for k, v in fitted.module.lm.base_model.model.state_dict().items() if "lora_" not in k}
+        for k in base_before:  # the frozen checkpoint never moved
+            np.testing.assert_array_equal(base_after[k].numpy(), base_before[k].numpy())
+
+        lora_params = [p for n, p in fitted.module.lm.named_parameters() if "lora_" in n and p.requires_grad]
+        self.assertGreater(sum(float(p.detach().abs().sum()) for p in lora_params), 0.0)  # the delta did move
+        self.assertGreater(after_ll, before_ll)  # and the fit made real progress
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Reproduces `mixle/tests/grad_control_test.py`'s `AdapterThroughTheBridgeTest` receipt with the real thing instead of the hand-rolled stand-in: a `hf-internal-testing/tiny-random-gpt2` checkpoint wrapped with actual `peft.get_peft_model` LoRA adapters, dropped into `GradLeaf` (`mixle/models/grad_leaf.py`) unchanged.
- New `examples/peft_lora_grad_leaf.py`: a thin `log_density(x) -> (n,)` wrapper around the peft-wrapped causal LM (next-token cross-entropy, negated), fit via `mixle.inference.estimation.optimize`. Asserts the base checkpoint stays bitwise-frozen, only the LoRA adapter parameters move, and held-out log-likelihood genuinely improves.
- `peft`/`transformers` are declared as example-only dependencies in the module docstring (not a new `pyproject.toml` extra) -- `GradLeaf` itself has no opinion on what module is handed to it, so there's nothing to add to the package's install surface.
- New `mixle/tests/peft_lora_grad_leaf_smoke_test.py` pins the example against regressions by reusing its own building blocks; skips cleanly if offline or if peft/transformers aren't installed. Tagged `torch, integration, optional, slow` in `mixle/tests/conftest.py`, matching the existing convention for other network-gated HF-checkpoint tests (e.g. `scientist_test.py`).

## Test plan
- [x] `ruff check examples/peft_lora_grad_leaf.py mixle/tests/peft_lora_grad_leaf_smoke_test.py mixle/tests/conftest.py` -- clean
- [x] `python examples/peft_lora_grad_leaf.py` -- prints the receipt (base drift 0.0, LoRA params moved, log-density improves) and exits 0
- [x] `pytest mixle/tests/peft_lora_grad_leaf_smoke_test.py -n0 -m ""` -- passes
- [x] `pytest mixle/tests/grad_control_test.py -n0 -m ""` -- passes (no regressions)