### PR TITLE
data: lazy array-store sources (zarr/HDF5/memmap) + PatchSampler

### DIFF
--- a/mixle/data/sources/__init__.py
+++ b/mixle/data/sources/__init__.py
@@ -24,6 +24,9 @@ _KINDS: dict[str, tuple[str, str]] = {
     "pandas": ("pandas_source", "read_dataframe"),
     "mongo": ("mongo_source", "read_mongo"),
     "remote": ("hadoop_source", "read_remote"),
+    "zarr": ("array_source", "read_zarr"),
+    "hdf5": ("array_source", "read_hdf5"),
+    "memmap": ("array_source", "read_memmap"),
 }
 
 

--- a/mixle/data/sources/array_source.py
+++ b/mixle/data/sources/array_source.py
@@ -1,0 +1,280 @@
+"""Scientific-array data sources -- zarr / HDF5 / numpy-memmap volumes, plus a ``PatchSampler``.
+
+mixle's data model is records/tuples/sequences; a 40 GB array on disk has no first-class answer without
+this module. Each array-store connector is *lazy*: constructing it opens the store's metadata (shape,
+dtype, chunking) but never reads the full array into memory -- only requested slices are pulled off disk.
+
+``PatchSampler`` wraps any of these (or any N-D array-like object exposing ``.shape``/``__getitem__``)
+and yields ``(patch, coords)`` records -- fixed-size N-D patches at deterministic, seeded locations --
+without ever materializing the underlying volume. Because it also implements ``__len__``/``__getitem__``
+by index, it plugs directly into :class:`~mixle.utils.parallel.multiprocessing.MPEncodedData`: the driver
+shards by index (``data[j] for j in range(i, n, num_workers)``) and only *those* patches are read and
+pickled to worker ``i`` -- the full volume is never touched by the driver process.
+
+Optional: zarr and h5py are guarded behind ``mixle.utils.optional_deps`` (``pip install mixle[arrays]``);
+numpy-memmap needs no extra dependency. Every connector still constructs even when its dependency is
+uninstalled -- it defers the ``require(...)`` error to first use (matching ``sql_source``/``mongo_source``),
+except memmap, which never has a missing dependency to guard.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+from typing import Any
+
+import numpy as np
+
+from mixle.data.partition import encode_partitions
+from mixle.data.schema import Schema
+from mixle.data.structure import EXCHANGEABLE, SampleStructure
+from mixle.utils.optional_deps import HAS_H5PY, HAS_ZARR, require
+from mixle.utils.optional_deps import h5py as _h5py
+from mixle.utils.optional_deps import zarr as _zarr
+
+__all__ = [
+    "ZarrArraySource",
+    "HDF5ArraySource",
+    "MemmapArraySource",
+    "PatchSampler",
+    "read_zarr",
+    "read_hdf5",
+    "read_memmap",
+]
+
+
+class _ArrayVolumeSource:
+    """Shared base for the array-store connectors: a lazy, index-along-axis-0 ``DataSource``.
+
+    ``records()``/``encode()`` satisfy the ordinary :class:`~mixle.data.core.DataSource` protocol
+    (iterating row-by-row along the leading axis, each row read fresh off disk); ``.array`` exposes the
+    underlying lazy N-D object (a zarr array / h5py dataset / memmap) for :class:`PatchSampler`, which
+    needs full N-D slicing rather than row iteration.
+    """
+
+    array: Any
+
+    def __init__(self, structure: SampleStructure, schema: Schema | None) -> None:
+        self.structure = structure
+        self.schema = schema
+
+    @property
+    def shape(self) -> tuple[int, ...]:
+        return tuple(self.array.shape)
+
+    @property
+    def dtype(self) -> Any:
+        return self.array.dtype
+
+    def __len__(self) -> int:
+        return int(self.shape[0])
+
+    def __getitem__(self, i: int) -> np.ndarray:
+        return np.asarray(self.array[i])
+
+    def records(self) -> Iterable[Any]:
+        return (self[i] for i in range(len(self)))
+
+    def encode(self, encoder: Any, num_chunks: int = 1, chunk_size: int | None = None) -> list[tuple[int, Any]]:
+        return encode_partitions(list(self.records()), encoder, self.structure, num_chunks, chunk_size)
+
+
+class ZarrArraySource(_ArrayVolumeSource):
+    """Lazy connector over a zarr array (or a named array within a zarr group/store).
+
+    Optional: requires ``zarr`` (``pip install mixle[arrays]``). Opening a zarr store reads only its
+    metadata; ``self.array`` is the live zarr ``Array`` -- slicing it (row iteration here, or arbitrary
+    N-D slices via :class:`PatchSampler`) reads and decompresses only the requested chunks.
+    """
+
+    def __init__(
+        self,
+        path: str,
+        component: str | None = None,
+        *,
+        structure: SampleStructure = EXCHANGEABLE,
+        schema: Schema | None = None,
+    ) -> None:
+        super().__init__(structure, schema)
+        if not HAS_ZARR:
+            require("zarr", "arrays")
+        store = _zarr.open(path, mode="r")
+        self.array = store[component] if component is not None else store
+
+
+class HDF5ArraySource(_ArrayVolumeSource):
+    """Lazy connector over an HDF5 dataset within a file.
+
+    Optional: requires ``h5py`` (``pip install mixle[arrays]``). The file handle is opened read-only
+    and kept resident (h5py datasets are themselves lazy: indexing reads only the requested slice); call
+    :meth:`close` (or use as a context manager) to release it.
+    """
+
+    def __init__(
+        self,
+        path: str,
+        dataset: str,
+        *,
+        structure: SampleStructure = EXCHANGEABLE,
+        schema: Schema | None = None,
+    ) -> None:
+        super().__init__(structure, schema)
+        if not HAS_H5PY:
+            require("h5py", "arrays")
+        self._file = _h5py.File(path, "r")
+        self.array = self._file[dataset]
+
+    def close(self) -> None:
+        """Close the underlying HDF5 file handle. Idempotent."""
+        try:
+            self._file.close()
+        except Exception:
+            pass
+
+    def __enter__(self) -> HDF5ArraySource:
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
+    def __del__(self) -> None:
+        try:
+            self.close()
+        except Exception:
+            pass
+
+
+class MemmapArraySource(_ArrayVolumeSource):
+    """Lazy connector over a numpy ``memmap`` volume (no optional dependency: pure numpy).
+
+    ``np.memmap`` maps the file into the process's address space and only pages in the slices that are
+    actually indexed, so this never reads the full volume into resident memory either.
+    """
+
+    def __init__(
+        self,
+        path: str,
+        dtype: Any,
+        shape: tuple[int, ...],
+        *,
+        mode: str = "r",
+        structure: SampleStructure = EXCHANGEABLE,
+        schema: Schema | None = None,
+    ) -> None:
+        super().__init__(structure, schema)
+        self.array = np.memmap(path, dtype=dtype, mode=mode, shape=tuple(shape))
+
+
+def read_zarr(
+    path: str,
+    component: str | None = None,
+    *,
+    structure: SampleStructure = EXCHANGEABLE,
+    schema: Schema | None = None,
+) -> ZarrArraySource:
+    """Open a zarr array/store lazily as a :class:`~mixle.data.core.DataSource`."""
+    return ZarrArraySource(path, component, structure=structure, schema=schema)
+
+
+def read_hdf5(
+    path: str,
+    dataset: str,
+    *,
+    structure: SampleStructure = EXCHANGEABLE,
+    schema: Schema | None = None,
+) -> HDF5ArraySource:
+    """Open an HDF5 dataset lazily as a :class:`~mixle.data.core.DataSource`."""
+    return HDF5ArraySource(path, dataset, structure=structure, schema=schema)
+
+
+def read_memmap(
+    path: str,
+    dtype: Any,
+    shape: tuple[int, ...],
+    *,
+    mode: str = "r",
+    structure: SampleStructure = EXCHANGEABLE,
+    schema: Schema | None = None,
+) -> MemmapArraySource:
+    """Open a numpy-memmap volume lazily as a :class:`~mixle.data.core.DataSource`."""
+    return MemmapArraySource(path, dtype, shape, mode=mode, structure=structure, schema=schema)
+
+
+class PatchSampler:
+    """Yield ``(patch, coords)`` records -- fixed-size N-D patches sampled from an array -- lazily.
+
+    Wraps any N-D array-like object with a ``.shape`` and N-D ``__getitem__`` (a
+    :class:`ZarrArraySource`/``HDF5ArraySource``/``MemmapArraySource``'s ``.array``, a raw zarr/h5py/
+    memmap object, or a plain ``numpy.ndarray``). Patch placement is a deterministic function of
+    ``seed``: the top-left corner of each patch is drawn from a seeded ``numpy.random.Generator`` once,
+    up front (cheap -- it is only ``num_patches`` integer tuples), and never touches the underlying
+    array until a patch is actually indexed. Iterating/indexing therefore reads only the requested
+    patches off disk, never the full volume.
+
+    Args:
+        array: N-D array-like source (anything supporting ``.shape`` and N-D ``__getitem__``).
+        patch_size: the N-D patch extent; must have the same rank as ``array.shape``.
+        num_patches: how many ``(patch, coords)`` records to sample.
+        seed: seeds the corner-placement RNG; identical ``seed`` -> identical patch sequence.
+        stride: if given, corners are snapped to this stride along every axis (useful for aligning
+            patches to a chunk grid); default ``None`` samples arbitrary integer corners.
+        structure: the :class:`~mixle.data.structure.SampleStructure` of the patch stream (patches are
+            i.i.d. draws from the volume by default, hence ``EXCHANGEABLE``).
+    """
+
+    def __init__(
+        self,
+        array: Any,
+        patch_size: Sequence[int],
+        num_patches: int,
+        *,
+        seed: int = 0,
+        stride: int | None = None,
+        structure: SampleStructure = EXCHANGEABLE,
+        schema: Schema | None = None,
+    ) -> None:
+        self._array = array
+        self.shape = tuple(int(s) for s in array.shape)
+        self.patch_size = tuple(int(p) for p in patch_size)
+        if len(self.patch_size) != len(self.shape):
+            raise ValueError(
+                "patch_size rank %d does not match array rank %d" % (len(self.patch_size), len(self.shape))
+            )
+        for s, p in zip(self.shape, self.patch_size):
+            if p <= 0 or p > s:
+                raise ValueError("patch_size %r does not fit within array shape %r" % (self.patch_size, self.shape))
+        self.num_patches = int(num_patches)
+        self.seed = seed
+        self.stride = stride
+        self.structure = structure
+        self.schema = schema
+        self._coords = self._sample_coords()
+
+    def _sample_coords(self) -> list[tuple[int, ...]]:
+        rng = np.random.default_rng(self.seed)
+        coords: list[tuple[int, ...]] = []
+        highs = [s - p + 1 for s, p in zip(self.shape, self.patch_size)]
+        for _ in range(self.num_patches):
+            corner = tuple(int(rng.integers(0, h)) for h in highs)
+            if self.stride is not None:
+                corner = tuple((c // self.stride) * self.stride for c in corner)
+            coords.append(corner)
+        return coords
+
+    def __len__(self) -> int:
+        return self.num_patches
+
+    def __getitem__(self, i: int) -> tuple[np.ndarray, tuple[int, ...]]:
+        corner = self._coords[i]
+        slices = tuple(slice(c, c + p) for c, p in zip(corner, self.patch_size))
+        patch = np.asarray(self._array[slices])
+        return patch, corner
+
+    def coords(self) -> list[tuple[int, ...]]:
+        """Return the full, deterministic list of sampled patch corners (cheap -- no array I/O)."""
+        return list(self._coords)
+
+    def records(self) -> Iterable[tuple[np.ndarray, tuple[int, ...]]]:
+        return (self[i] for i in range(len(self)))
+
+    def encode(self, encoder: Any, num_chunks: int = 1, chunk_size: int | None = None) -> list[tuple[int, Any]]:
+        return encode_partitions(list(self.records()), encoder, self.structure, num_chunks, chunk_size)

--- a/mixle/tests/array_data_sources_test.py
+++ b/mixle/tests/array_data_sources_test.py
@@ -1,0 +1,286 @@
+"""Tests for the scientific-array data sources and PatchSampler (roadmap item A3).
+
+Covers: patch-streamed peak-RSS receipt against a synthetic zarr volume (slow), patch-sequence
+determinism given a seed, and PatchSampler working through MPEncodedData (round-robin sharding, each
+worker reads only its own patches). All tests skip cleanly when zarr/h5py are not installed.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import platform
+import resource
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+import numpy as np
+
+from mixle.data.sources.array_source import HDF5ArraySource, MemmapArraySource, PatchSampler, ZarrArraySource
+from mixle.inference.estimation import optimize
+from mixle.stats import (
+    GaussianDistribution,
+    GaussianEstimator,
+    MixtureDistribution,
+    MixtureEstimator,
+    seq_encode,
+    seq_log_density_sum,
+)
+from mixle.utils.optional_deps import HAS_H5PY, HAS_ZARR
+from mixle.utils.parallel.multiprocessing import MPEncodedData
+
+if HAS_ZARR:
+    import zarr
+
+REPO = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def _rss_bytes() -> int:
+    """Current process peak RSS in bytes (``ru_maxrss`` is bytes on macOS, KiB on Linux)."""
+    peak = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    return peak if platform.system() == "Darwin" else peak * 1024
+
+
+def _write_two_region_zarr_in_subprocess(
+    path: str, depth: int, height: int, width: int, *, block: int = 20, chunk_plane: int = 50
+) -> None:
+    """Write a ``(depth, height, width)`` float32 zarr volume in a throwaway child process.
+
+    The generation itself allocates ``block``-sized slabs; the writer's own resident memory (and any
+    zarr/blosc write-side buffering) is irrelevant to the peak-RSS *receipt*, which only cares about the
+    memory the *test* process uses to open the store and stream patches -- so generation is isolated to
+    a subprocess and never touches this process's ``ru_maxrss`` high-water mark.
+
+    The first half of the depth axis is drawn from N(-3, 1); the second half from N(3, 1), so a mixture
+    fit over patch-mean features has two well-separated components to recover. Chunks are kept small
+    (``chunk_plane`` per spatial axis) so that reading one small patch later only decompresses a few
+    small chunks, not an entire depth-spanning plane.
+    """
+    script = (
+        "import zarr, numpy as np\n"
+        "arr = zarr.open(r'%s', mode='w', shape=(%d, %d, %d), chunks=(%d, %d, %d), dtype='float32')\n"
+        "rng = np.random.default_rng(12345)\n"
+        "half = %d // 2\n"
+        "for start in range(0, %d, %d):\n"
+        "    stop = min(start + %d, %d)\n"
+        "    n = stop - start\n"
+        "    mean = -3.0 if start < half else 3.0\n"
+        "    arr[start:stop] = rng.normal(loc=mean, scale=1.0, size=(n, %d, %d)).astype('float32')\n"
+        % (
+            path,
+            depth,
+            height,
+            width,
+            block,
+            min(chunk_plane, height),
+            min(chunk_plane, width),
+            depth,
+            depth,
+            block,
+            block,
+            depth,
+            height,
+            width,
+        )
+    )
+    subprocess.run([sys.executable, "-c", script], check=True)
+
+
+class PeakRssPatchStreamingTest(unittest.TestCase):
+    """Acceptance test A3-1: fit a mixture over zarr patches without loading the volume, low peak RSS."""
+
+    @unittest.skipUnless(HAS_ZARR, "zarr not installed; pip install mixle[arrays]")
+    def test_patch_stream_fit_keeps_peak_rss_far_below_volume_size(self):
+        # 650x650x650 float32 ~= 1010 MiB uncompressed -- big enough that fully materializing it would
+        # visibly move peak RSS well past our threshold below, and still writes+reads in well under a
+        # minute given the small (block, 50, 50) write/storage chunking.
+        depth = height = width = 650
+        volume_bytes = depth * height * width * 4
+        tmpdir = tempfile.mkdtemp(prefix="mixle_array_rss_")
+        try:
+            path = tmpdir + "/volume.zarr"
+            _write_two_region_zarr_in_subprocess(path, depth, height, width)
+
+            # Baseline peak RSS after the volume is written (in a now-exited child process) and only
+            # its metadata has been opened in *this* process.
+            source = ZarrArraySource(path)
+            self.assertEqual(source.shape, (depth, height, width))
+            baseline_rss = _rss_bytes()
+
+            sampler = PatchSampler(source.array, patch_size=(8, 8, 8), num_patches=400, seed=7)
+            means = [float(np.mean(patch)) for patch, _coords in sampler.records()]
+
+            estimator = MixtureEstimator([GaussianEstimator()] * 2)
+            enc = seq_encode(means, estimator=estimator)
+            start = MixtureDistribution([GaussianDistribution(-1.0, 4.0), GaussianDistribution(1.0, 4.0)], [0.5, 0.5])
+            model = optimize(None, estimator, enc_data=enc, max_its=30, prev_estimate=start, out=io.StringIO())
+
+            peak_rss = _rss_bytes()
+
+            # Pinned floor/ceiling: the volume is ~1010 MiB uncompressed; patch-streamed fitting only
+            # ever holds `num_patches` small (8,8,8) patches plus interpreter/library baseline in
+            # memory (measured ~200-300 MiB total under the full test suite's import graph, incl.
+            # numpy/scipy/zarr/mixle.stats). We assert the peak stays under half the volume size --
+            # generous headroom above the measured baseline while still failing hard if the source
+            # ever materializes the full array (which would push peak RSS to within a few MiB of
+            # `volume_bytes`).
+            self.assertLess(
+                peak_rss,
+                volume_bytes // 2,
+                "peak RSS %.1f MiB was not far below the %.1f MiB volume -- patch sampling may have "
+                "materialized the full array" % (peak_rss / 2**20, volume_bytes / 2**20),
+            )
+            # The patch-streaming phase itself should add only a small increment over the
+            # already-open-source baseline, not volume-sized growth.
+            self.assertLess(peak_rss - baseline_rss, volume_bytes // 4)
+
+            mus = sorted(c.mu for c in model.components)
+            self.assertAlmostEqual(mus[0], -3.0, delta=0.75)
+            self.assertAlmostEqual(mus[1], 3.0, delta=0.75)
+        finally:
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+class PatchSamplerDeterminismTest(unittest.TestCase):
+    """Acceptance test A3-2: identical seed -> identical (patch, coords) sequence."""
+
+    def setUp(self):
+        self.rng = np.random.default_rng(0)
+        self.array = self.rng.normal(size=(40, 40, 40)).astype("float32")
+
+    def test_same_seed_reproduces_sequence(self):
+        s1 = PatchSampler(self.array, patch_size=(4, 4, 4), num_patches=25, seed=42)
+        s2 = PatchSampler(self.array, patch_size=(4, 4, 4), num_patches=25, seed=42)
+        self.assertEqual(s1.coords(), s2.coords())
+        for (p1, c1), (p2, c2) in zip(s1.records(), s2.records()):
+            self.assertEqual(c1, c2)
+            np.testing.assert_array_equal(p1, p2)
+
+    def test_different_seed_diverges(self):
+        s1 = PatchSampler(self.array, patch_size=(4, 4, 4), num_patches=25, seed=1)
+        s2 = PatchSampler(self.array, patch_size=(4, 4, 4), num_patches=25, seed=2)
+        self.assertNotEqual(s1.coords(), s2.coords())
+
+    def test_indexing_matches_records_order(self):
+        sampler = PatchSampler(self.array, patch_size=(3, 3, 3), num_patches=10, seed=5)
+        by_index = [sampler[i] for i in range(len(sampler))]
+        by_records = list(sampler.records())
+        self.assertEqual(len(by_index), len(by_records))
+        for (p1, c1), (p2, c2) in zip(by_index, by_records):
+            self.assertEqual(c1, c2)
+            np.testing.assert_array_equal(p1, p2)
+
+
+class _PatchMeanFeatureSource:
+    """Thin lazy adapter: index j -> the scalar mean of PatchSampler patch j (still reads on demand)."""
+
+    def __init__(self, sampler: PatchSampler) -> None:
+        self._sampler = sampler
+
+    def __len__(self) -> int:
+        return len(self._sampler)
+
+    def __getitem__(self, i: int) -> float:
+        patch, _coords = self._sampler[i]
+        return float(np.mean(patch))
+
+
+class PatchSamplerMPEncodedDataTest(unittest.TestCase):
+    """Acceptance test A3-3: PatchSampler works through MPEncodedData's round-robin sharding."""
+
+    @unittest.skipUnless(HAS_ZARR, "zarr not installed; pip install mixle[arrays]")
+    def test_mp_encoded_data_shards_patches_disjointly_and_matches_serial(self):
+        tmpdir = tempfile.mkdtemp(prefix="mixle_array_mp_")
+        try:
+            path = tmpdir + "/small.zarr"
+            _write_two_region_zarr_in_subprocess(path, depth=60, height=60, width=60, block=10, chunk_plane=20)
+            source = ZarrArraySource(path)
+            sampler = PatchSampler(source.array, patch_size=(4, 4, 4), num_patches=120, seed=3)
+            feature_source = _PatchMeanFeatureSource(sampler)
+
+            # Replicate MPEncodedData's own round-robin contract (data[j] for j in range(i, n, W)) to
+            # confirm it is a disjoint, complete cover of the patch indices before trusting the
+            # multiprocess run.
+            num_workers = 3
+            n = len(feature_source)
+            shard_indices = [list(range(i, n, num_workers)) for i in range(num_workers)]
+            covered = sorted(idx for shard in shard_indices for idx in shard)
+            self.assertEqual(covered, list(range(n)))
+            for a in range(num_workers):
+                for b in range(a + 1, num_workers):
+                    self.assertFalse(set(shard_indices[a]) & set(shard_indices[b]))
+
+            estimator = GaussianEstimator()
+            data = list(feature_source[i] for i in range(n))
+            enc_local = seq_encode(data, estimator=estimator)
+
+            with MPEncodedData(feature_source, estimator=estimator, num_workers=num_workers) as enc:
+                self.assertEqual(len(enc), n)
+                cnt_p, ll_p = enc.pysp_seq_log_density_sum(GaussianDistribution(0.0, 4.0))
+            cnt_s, ll_s = seq_log_density_sum(enc_local, GaussianDistribution(0.0, 4.0))
+            self.assertEqual(cnt_p, cnt_s)
+            self.assertAlmostEqual(ll_p, ll_s, places=6)
+        finally:
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+class ArrayStoreConnectorSmokeTest(unittest.TestCase):
+    """Smoke-tests the zarr / HDF5 / memmap connectors implement the shared lazy contract."""
+
+    @unittest.skipUnless(HAS_ZARR, "zarr not installed; pip install mixle[arrays]")
+    def test_zarr_source_is_lazy_and_row_iterable(self):
+        tmpdir = tempfile.mkdtemp(prefix="mixle_array_zarr_")
+        try:
+            path = tmpdir + "/rows.zarr"
+            data = np.arange(24, dtype="float32").reshape(6, 4)
+            zarr.open(path, mode="w", shape=data.shape, chunks=(2, 4), dtype="float32")[:] = data
+            source = ZarrArraySource(path)
+            self.assertEqual(len(source), 6)
+            np.testing.assert_array_equal(source[0], data[0])
+            rows = list(source.records())
+            self.assertEqual(len(rows), 6)
+            np.testing.assert_array_equal(np.stack(rows), data)
+        finally:
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+    @unittest.skipUnless(HAS_H5PY, "h5py not installed; pip install mixle[arrays]")
+    def test_hdf5_source_is_lazy_and_row_iterable(self):
+        import h5py
+
+        tmpdir = tempfile.mkdtemp(prefix="mixle_array_h5_")
+        try:
+            path = tmpdir + "/rows.h5"
+            data = np.arange(24, dtype="float32").reshape(6, 4)
+            with h5py.File(path, "w") as f:
+                f.create_dataset("vol", data=data, chunks=(2, 4))
+            with HDF5ArraySource(path, "vol") as source:
+                self.assertEqual(len(source), 6)
+                np.testing.assert_array_equal(source[0], data[0])
+                rows = list(source.records())
+            np.testing.assert_array_equal(np.stack(rows), data)
+        finally:
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+    def test_memmap_source_is_lazy_and_supports_patch_sampling(self):
+        tmpdir = tempfile.mkdtemp(prefix="mixle_array_memmap_")
+        try:
+            path = tmpdir + "/rows.dat"
+            data = np.arange(60, dtype="float32").reshape(3, 4, 5)
+            data.tofile(path)
+            source = MemmapArraySource(path, dtype="float32", shape=(3, 4, 5))
+            self.assertEqual(source.shape, (3, 4, 5))
+            np.testing.assert_array_equal(source[0], data[0])
+
+            sampler = PatchSampler(source.array, patch_size=(2, 2, 2), num_patches=5, seed=1)
+            for patch, coords in sampler.records():
+                sl = tuple(slice(c, c + 2) for c in coords)
+                np.testing.assert_array_equal(patch, data[sl])
+        finally:
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(unittest.main())

--- a/mixle/tests/conftest.py
+++ b/mixle/tests/conftest.py
@@ -255,6 +255,9 @@ NODEID_MARKERS: tuple[tuple[str, MarkerTuple], ...] = (
     ("MPS", ("torch", "optional")),
     ("numba", ("numba",)),
     ("umap", ("optional", "hvis")),
+    # PeakRssPatchStreamingTest writes+reads a ~476 MiB synthetic zarr volume to exercise the A3
+    # patch-streaming peak-RSS receipt; the rest of array_data_sources_test.py stays in the fast gate.
+    ("PeakRssPatchStreamingTest", ("optional", "slow")),
 )
 
 

--- a/mixle/utils/optional_deps.py
+++ b/mixle/utils/optional_deps.py
@@ -12,9 +12,29 @@ pyspark: `pyspark` is None when missing and RDD_TYPES is an empty tuple, so
 through to their local implementations. Install with:
 
     pip install mixle[spark]
+
+zarr / h5py: the array-store data sources (``mixle.data.sources.array_source``) read lazily from
+on-disk zarr and HDF5 volumes without materializing them. Both are ``None`` when missing and
+``HAS_ZARR`` / ``HAS_H5PY`` are ``False``, so the connectors raise the standard ``require(...)`` message
+instead of an ``ImportError`` on import. numpy-memmap volumes need no extra dependency. Install with:
+
+    pip install mixle[arrays]
 """
 
-__all__ = ["numba", "HAS_NUMBA", "pyspark", "HAS_PYSPARK", "RDD_TYPES", "gmpy2", "HAS_GMPY2", "require"]
+__all__ = [
+    "numba",
+    "HAS_NUMBA",
+    "pyspark",
+    "HAS_PYSPARK",
+    "RDD_TYPES",
+    "gmpy2",
+    "HAS_GMPY2",
+    "zarr",
+    "HAS_ZARR",
+    "h5py",
+    "HAS_H5PY",
+    "require",
+]
 
 
 def require(name: str, extra: str):
@@ -71,3 +91,21 @@ except ImportError:
     pyspark = None
     HAS_PYSPARK = False
     RDD_TYPES = ()
+
+
+try:
+    import zarr
+
+    HAS_ZARR = True
+except ImportError:
+    zarr = None
+    HAS_ZARR = False
+
+
+try:
+    import h5py
+
+    HAS_H5PY = True
+except ImportError:
+    h5py = None
+    HAS_H5PY = False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,9 @@ arrow = ["pyarrow>=14"]
 sql = ["sqlalchemy>=2.0"]
 mongo = ["pymongo>=4.3"]
 hadoop = ["pyarrow>=14", "fsspec>=2023.1.0"]
+# lazy N-D array-store connectors (mixle.data.sources.array_source): zarr + HDF5 volumes for
+# PatchSampler-style streaming reads. numpy-memmap needs no extra dependency, so it is not listed here.
+arrays = ["zarr>=2.16", "h5py>=3.10"]
 data = ["pandas>=2.0", "pyarrow>=14", "sqlalchemy>=2.0", "pymongo>=4.3", "fsspec>=2023.1.0"]
 # graph-grammar models (mixle.stats.sequences.grammar) are the only networkx user; lazy + optional.
 grammar = ["networkx>=3.0"]


### PR DESCRIPTION
## Summary
- Adds `mixle.data.sources.array_source`: lazy `DataSource` connectors over zarr arrays, HDF5 datasets, and numpy-memmap volumes (roadmap item A3). Constructing any of them opens only metadata; only requested slices are read off disk.
- Adds `PatchSampler`, which wraps any N-D array-like object (or one of the above) and yields `(patch, coords)` records -- fixed-size N-D patches at seeded, deterministic locations -- without materializing the underlying array. It implements `__len__`/`__getitem__` by index, so it plugs directly into `MPEncodedData`'s round-robin sharding: each worker only reads and pickles its own shard of patches, never the full volume.
- **A3a decision**: zarr + h5py land in a new `arrays` extra (`pip install mixle[arrays]`), matching the proposal in the roadmap doc. numpy-memmap needs no extra dependency (pure numpy) and is not listed there. Both `zarr`/`h5py` imports are guarded behind `mixle.utils.optional_deps` (new `HAS_ZARR`/`HAS_H5PY` flags), mirroring the existing `pyspark` guard, so the base install is untouched and connectors defer to `require(...)` at first use when the extra isn't installed.
- Registers `zarr` / `hdf5` / `memmap` connector kinds in the `mixle.data.sources` dispatch table alongside the existing pandas/arrow/sql/mongo kinds.

## Test plan
New `mixle/tests/array_data_sources_test.py`:
- [x] Peak-RSS receipt (slow-marked, `PeakRssPatchStreamingTest`): writes a synthetic ~1010 MiB two-region zarr volume in a throwaway subprocess (so its own write-side memory never touches the test process), fits a 2-component Gaussian mixture over `PatchSampler`-streamed patch-mean features, and asserts peak RSS stays under half the volume's uncompressed size (measured ~250-300 MiB peak vs. ~1010 MiB volume) while the mixture recovers both component means.
- [x] Patch determinism given seed (`PatchSamplerDeterminismTest`): identical seed -> identical `(patch, coords)` sequence; different seeds diverge; index access matches iteration order.
- [x] Works through `MPEncodedData` (`PatchSamplerMPEncodedDataTest`): confirms the round-robin shard contract is a disjoint, complete cover of patch indices, then runs a real 3-worker `MPEncodedData` over a `PatchSampler`-backed feature source and checks its aggregated stats match a serial encode.
- [x] Connector smoke tests for zarr / HDF5 / memmap lazy row iteration, plus PatchSampler-over-memmap patch correctness.
- [x] All zarr/h5py-dependent tests skip cleanly via `unittest.skipUnless(HAS_ZARR/HAS_H5PY, ...)` when the `arrays` extra isn't installed.

Ran locally (venv with `zarr`+`h5py` installed):
- `ruff check` / `ruff format --check` on all changed files: clean.
- `pytest mixle/tests/array_data_sources_test.py -n0 -m ""`: 8 passed.
- `pytest mixle/tests/array_data_sources_test.py` (default fast gate): 7 passed, `PeakRssPatchStreamingTest` correctly excluded as `slow`.
- `pytest mixle/tests/parallel_test.py mixle/tests/dataframe_adapter_test.py mixle/tests/data_layer_test.py mixle/tests/data_schema_test.py -m "" -n auto`: 33 passed, 2 skipped (pandas/mpi4py not installed) -- no regressions.