### PR TITLE
utils/automatic: 6 new univariate detectors for auto-inference

### DIFF
--- a/mixle/tests/automatic_new_detectors_test.py
+++ b/mixle/tests/automatic_new_detectors_test.py
@@ -1,0 +1,101 @@
+"""Automatic-inference detectors for 7 previously-unreachable univariate families (mixle.utils.automatic):
+half_normal, rayleigh, inverse_gamma (continuous); geometric, binomial, beta_binomial (discrete).
+Each: BIC-selected as the winner on data drawn from it, without disturbing the Gaussian/Poisson defaults."""
+
+import unittest
+
+import numpy as np
+from scipy import stats
+
+import mixle.utils.automatic.profiling as P
+
+
+def _winner(values):
+    """The auto-inference family recommendation for a single column of ``values``."""
+    node = P.DatumNode(data=[(v,) for v in values])
+    child = node.children[0]
+    if child.float_count > 0:
+        arr = P._value_array_from_vdict(child.vdict)
+        return P._numeric_model_recommendation(P._numeric_candidate_bics(arr, arr.size))
+    name, _ = P._recommended_integer_model(child.vdict)
+    return name
+
+
+class ContinuousDetectorTest(unittest.TestCase):
+    def setUp(self):
+        self.rng = np.random.RandomState(0)
+
+    def test_half_normal_is_detected(self):
+        vals = [abs(float(x)) for x in self.rng.randn(3000) * 2.0]  # mode at 0
+        self.assertEqual(_winner(vals), "half_normal")
+
+    def test_rayleigh_is_detected(self):
+        vals = list(stats.rayleigh.rvs(scale=1.5, size=3000, random_state=self.rng))
+        self.assertEqual(_winner(vals), "rayleigh")
+
+    def test_inverse_gamma_is_detected(self):
+        vals = list(stats.invgamma.rvs(3.0, scale=2.0, size=3000, random_state=self.rng))
+        self.assertEqual(_winner(vals), "inverse_gamma")
+
+
+class DiscreteDetectorTest(unittest.TestCase):
+    def setUp(self):
+        self.rng = np.random.RandomState(0)
+
+    def test_geometric_is_detected(self):
+        vals = list(stats.geom.rvs(0.3, size=3000, random_state=self.rng))  # support {1,2,...}
+        self.assertEqual(_winner(vals), "geometric")
+
+    def test_binomial_is_detected_when_n_is_observable(self):
+        # binomial is identifiable only when p is high enough that the sample max reaches n
+        vals = list(stats.binom.rvs(10, 0.6, size=4000, random_state=self.rng))
+        self.assertEqual(_winner(vals), "binomial")
+
+    def test_beta_binomial_is_detected_on_overdispersed_bounded_counts(self):
+        vals = list(stats.betabinom.rvs(20, 2.0, 5.0, size=4000, random_state=self.rng))
+        self.assertEqual(_winner(vals), "beta_binomial")
+
+    def test_plain_binomial_data_is_not_stolen_by_beta_binomial(self):
+        # beta-binomial nests binomial as overdispersion -> 0; genuine binomial data must stay binomial,
+        # not flip to the extra-parameter family on sampling noise.
+        vals = list(stats.binom.rvs(8, 0.5, size=4000, random_state=self.rng))
+        self.assertEqual(_winner(vals), "binomial")
+
+
+class NoRegressionTest(unittest.TestCase):
+    def setUp(self):
+        self.rng = np.random.RandomState(0)
+
+    def test_gaussian_still_wins_for_gaussian_data(self):
+        self.assertEqual(_winner(list(self.rng.randn(3000) * 2.0 + 5.0)), "gaussian")
+
+    def test_poisson_still_wins_for_poisson_data(self):
+        vals = list(stats.poisson.rvs(3.0, size=3000, random_state=self.rng))
+        self.assertEqual(_winner(vals), "poisson")
+
+    def test_gamma_still_wins_for_gamma_data(self):
+        vals = list(stats.gamma.rvs(2.0, scale=2.0, size=3000, random_state=self.rng))
+        self.assertEqual(_winner(vals), "gamma")
+
+
+class DetectorFactoryTest(unittest.TestCase):
+    def test_each_new_detector_builds_a_working_estimator(self):
+        # the winning family's factory must produce a fittable estimator that yields a finite log-density
+        from mixle.inference import optimize
+        from mixle.utils.automatic import get_estimator
+
+        rng = np.random.RandomState(1)
+        cases = {
+            "half_normal": [(abs(float(x)),) for x in rng.randn(400) * 2.0],
+            "rayleigh": [(float(v),) for v in stats.rayleigh.rvs(scale=1.5, size=400, random_state=rng)],
+            "geometric": [(int(v),) for v in stats.geom.rvs(0.3, size=400, random_state=rng)],
+        }
+        for _name, data in cases.items():
+            est = get_estimator(data)
+            model = optimize(data, est, max_its=5, out=None)
+            ld = model.seq_log_density(model.dist_to_encoder().seq_encode(data))
+            self.assertTrue(np.all(np.isfinite(ld)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mixle/utils/automatic/detectors/beta_binomial.py
+++ b/mixle/utils/automatic/detectors/beta_binomial.py
@@ -1,0 +1,83 @@
+"""Beta-binomial discrete candidate -- bounded counts, OVER-dispersed vs a plain binomial (n trials, random p)."""
+
+import math
+
+import numpy as np
+
+from mixle.utils.automatic.detectors import Detector, register
+
+_MAX_N = 100000
+_MIN_RHO = 0.01  # minimum intra-class correlation to claim genuine overdispersion (not sampling noise)
+
+
+def _params(arr: np.ndarray) -> tuple[int, float, float] | None:
+    if arr.size == 0 or np.any(arr < 0) or np.any(arr != np.floor(arr)):
+        return None
+    n = int(np.max(arr))
+    # a genuine count distribution has many observations per outcome; an arithmetic index range (n ~ sample
+    # size, every value once) is not beta-binomial counts even though BetaBinom(n,1,1) equals a discrete uniform.
+    if n < 2 or n > _MAX_N or arr.size < 3 * (n + 1):
+        return None
+    mean = float(arr.mean())
+    var = float(arr.var())
+    p = mean / n
+    binom_var = n * p * (1.0 - p)
+    if not (0.0 < p < 1.0 and binom_var > 0.0 and var > binom_var):  # must be OVER-dispersed vs binomial
+        return None
+    # method of moments via the intra-class correlation rho: var = binom_var * (1 + (n-1) rho), s = a+b = 1/rho - 1.
+    # Require rho above a floor: a beta-binomial nests the binomial as rho -> 0, so on (near-)binomial data the two
+    # are all-but-tied and the extra parameter would win on sampling noise alone. Only claim the family when the
+    # overdispersion is genuine, so plain binomial data stays binomial.
+    rho = (var / binom_var - 1.0) / (n - 1)
+    if not (_MIN_RHO < rho < 1.0):
+        return None
+    s = 1.0 / rho - 1.0
+    a, b = p * s, (1.0 - p) * s
+    return (n, a, b) if a > 0.0 and b > 0.0 and math.isfinite(a) and math.isfinite(b) else None
+
+
+def _applies(arr: np.ndarray) -> bool:
+    if arr.size == 0 or np.any(arr < 0) or np.any(arr != np.floor(arr)):
+        return False
+    return _params(arr) is not None
+
+
+def _score(arr: np.ndarray, nobs: int) -> float | None:
+    from scipy import stats
+
+    from mixle.utils.automatic.profiling import _bic_penalty_bits
+
+    pr = _params(arr)
+    if pr is None:
+        return None
+    n, a, b = pr
+    nll_nats = -float(np.mean(stats.betabinom.logpmf(arr.astype(np.int64), n, a, b)))
+    if not math.isfinite(nll_nats):
+        return None
+    return nll_nats / math.log(2.0) + _bic_penalty_bits(2, nobs)  # a, b free; n fixed from the support
+
+
+def _factory(vdict, pseudo_count, emp_suff_stat, use_bstats):
+    from mixle.stats import BetaBinomialDistribution
+    from mixle.utils.automatic.profiling import _value_array_from_vdict
+
+    pr = _params(_value_array_from_vdict(vdict))
+    n, a, b = pr if pr is not None else (2, 1.0, 1.0)
+    return BetaBinomialDistribution(n, a, b).estimator()
+
+
+def _cdf(arr: np.ndarray):
+    from scipy import stats
+
+    pr = _params(arr)
+    if pr is None:
+        return None
+    n, a, b = pr
+    return stats.betabinom.cdf(arr.astype(np.int64), n, a, b)
+
+
+register(
+    Detector(
+        name="beta_binomial", kind="discrete", applies=_applies, score=_score, factory=_factory, cdf=_cdf, n_params=2
+    )
+)

--- a/mixle/utils/automatic/detectors/binomial.py
+++ b/mixle/utils/automatic/detectors/binomial.py
@@ -1,0 +1,72 @@
+"""Binomial discrete candidate -- bounded counts of successes in n trials (UNDER-dispersed vs Poisson)."""
+
+import math
+
+import numpy as np
+
+from mixle.utils.automatic.detectors import Detector, register
+
+_MAX_N = 100000  # a huge inferred n means the "trials" reading is implausible -- decline rather than guess
+
+
+def _params(arr: np.ndarray) -> tuple[int, float] | None:
+    if arr.size == 0 or np.any(arr < 0) or np.any(arr != np.floor(arr)):
+        return None
+    n = int(np.max(arr))  # n is unknown; the observed maximum is the standard estimate of the trial count
+    mean = float(arr.mean())
+    if n < 1 or n > _MAX_N:
+        return None
+    p = mean / n
+    return (n, p) if 0.0 < p < 1.0 else None
+
+
+def _applies(arr: np.ndarray) -> bool:
+    # non-negative integers that are UNDER-dispersed (var < mean): the binomial signature, opposite Poisson.
+    if arr.size == 0 or np.any(arr < 0) or np.any(arr != np.floor(arr)):
+        return False
+    mean = float(arr.mean())
+    n = int(np.max(arr))
+    # a genuine count distribution has many observations per possible outcome; a bare arithmetic range (every
+    # integer once, n ~ sample size) is index-like, not binomial counts -- require real replication.
+    if not (mean > 0.0 and 1 <= n <= _MAX_N and arr.size >= 3 * (n + 1)):
+        return False
+    return float(arr.var()) < 0.95 * mean  # UNDER-dispersed (var < mean): the binomial signature
+
+
+def _score(arr: np.ndarray, nobs: int) -> float | None:
+    from scipy import stats
+
+    from mixle.utils.automatic.profiling import _bic_penalty_bits
+
+    pr = _params(arr)
+    if pr is None:
+        return None
+    n, p = pr
+    nll_nats = -float(np.mean(stats.binom.logpmf(arr.astype(np.int64), n, p)))
+    if not math.isfinite(nll_nats):
+        return None
+    return nll_nats / math.log(2.0) + _bic_penalty_bits(1, nobs)  # n is fixed from the support, p is the free param
+
+
+def _factory(vdict, pseudo_count, emp_suff_stat, use_bstats):
+    from mixle.stats import BinomialDistribution
+    from mixle.utils.automatic.profiling import _value_array_from_vdict
+
+    pr = _params(_value_array_from_vdict(vdict))
+    n, p = pr if pr is not None else (1, 0.5)
+    return BinomialDistribution(p, n).estimator(pseudo_count=pseudo_count)
+
+
+def _cdf(arr: np.ndarray):
+    from scipy import stats
+
+    pr = _params(arr)
+    if pr is None:
+        return None
+    n, p = pr
+    return stats.binom.cdf(arr.astype(np.int64), n, p)
+
+
+register(
+    Detector(name="binomial", kind="discrete", applies=_applies, score=_score, factory=_factory, cdf=_cdf, n_params=1)
+)

--- a/mixle/utils/automatic/detectors/geometric.py
+++ b/mixle/utils/automatic/detectors/geometric.py
@@ -1,0 +1,56 @@
+"""Geometric discrete candidate -- the number of trials to the first success, on {1, 2, 3, ...} (memoryless)."""
+
+import math
+
+import numpy as np
+
+from mixle.utils.automatic.detectors import Detector, register
+
+
+def _fit(arr: np.ndarray) -> float | None:
+    if arr.size == 0 or np.any(arr < 1) or np.any(arr != np.floor(arr)):
+        return None
+    mean = float(arr.mean())
+    p = 1.0 / mean  # MLE on support {1,2,...}: E[X] = 1/p
+    return p if 0.0 < p < 1.0 else None
+
+
+def _applies(arr: np.ndarray) -> bool:
+    # positive integer counts starting at 1 (mixle's geometric support); the mode is at 1 and decays.
+    if arr.size == 0 or np.any(arr != np.floor(arr)) or np.any(arr < 1):
+        return False
+    return float(arr.mean()) > 1.0
+
+
+def _score(arr: np.ndarray, nobs: int) -> float | None:
+    from scipy import stats
+
+    from mixle.utils.automatic.profiling import _bic_penalty_bits
+
+    p = _fit(arr)
+    if p is None:
+        return None
+    nll_nats = -float(np.mean(stats.geom.logpmf(arr.astype(np.int64), p)))
+    if not math.isfinite(nll_nats):
+        return None
+    return nll_nats / math.log(2.0) + _bic_penalty_bits(1, nobs)
+
+
+def _factory(vdict, pseudo_count, emp_suff_stat, use_bstats):
+    from mixle.stats import GeometricDistribution
+    from mixle.utils.automatic.profiling import _value_array_from_vdict
+
+    p = _fit(_value_array_from_vdict(vdict))
+    return GeometricDistribution(p if p is not None else 0.5).estimator(pseudo_count=pseudo_count)
+
+
+def _cdf(arr: np.ndarray):
+    from scipy import stats
+
+    p = _fit(arr)
+    return None if p is None else stats.geom.cdf(arr.astype(np.int64), p)
+
+
+register(
+    Detector(name="geometric", kind="discrete", applies=_applies, score=_score, factory=_factory, cdf=_cdf, n_params=1)
+)

--- a/mixle/utils/automatic/detectors/half_normal.py
+++ b/mixle/utils/automatic/detectors/half_normal.py
@@ -1,0 +1,62 @@
+"""Half-normal continuous candidate -- non-negative data with its mode AT zero (a folded Gaussian)."""
+
+import math
+
+import numpy as np
+
+from mixle.utils.automatic.detectors import Detector, register
+
+
+def _fit(arr: np.ndarray) -> float | None:
+    if arr.size == 0 or np.any(arr < 0.0) or not np.all(np.isfinite(arr)):
+        return None
+    sigma = math.sqrt(float(np.mean(arr * arr)))  # MLE for HalfNormal(sigma): sigma^2 = mean(x^2)
+    return sigma if sigma > 0.0 and math.isfinite(sigma) else None
+
+
+def _applies(arr: np.ndarray) -> bool:
+    # non-negative data whose density piles up at 0 (mode at the boundary) -- the half-normal signature.
+    if arr.size == 0 or np.any(arr < 0.0) or not np.all(np.isfinite(arr)):
+        return False
+    mean = float(arr.mean())
+    if mean <= 0.0 or float(np.min(arr)) >= 0.25 * mean:  # needs mass near the 0 boundary (mode at 0)
+        return False
+    # a continuous family has P(X=0)=0: a spike of EXACT zeros signals a zero-atom model (Tweedie /
+    # zero-inflated), not a smooth half-normal, so decline when exact zeros are more than a rounding-level share.
+    return float(np.mean(arr == 0.0)) < 0.01
+
+
+def _score(arr: np.ndarray, nobs: int) -> float | None:
+    from scipy import stats
+
+    from mixle.utils.automatic.profiling import _bic_penalty_bits
+
+    sigma = _fit(arr)
+    if sigma is None:
+        return None
+    nll_nats = -float(np.mean(stats.halfnorm.logpdf(arr, scale=sigma)))
+    if not math.isfinite(nll_nats):
+        return None
+    return nll_nats / math.log(2.0) + _bic_penalty_bits(1, nobs)
+
+
+def _factory(vdict, pseudo_count, emp_suff_stat, use_bstats):
+    from mixle.stats import HalfNormalDistribution
+    from mixle.utils.automatic.profiling import _value_array_from_vdict
+
+    sigma = _fit(_value_array_from_vdict(vdict))
+    return HalfNormalDistribution(sigma if sigma is not None else 1.0).estimator(pseudo_count=pseudo_count)
+
+
+def _cdf(arr: np.ndarray):
+    from scipy import stats
+
+    sigma = _fit(arr)
+    return None if sigma is None else stats.halfnorm.cdf(arr, scale=sigma)
+
+
+register(
+    Detector(
+        name="half_normal", kind="continuous", applies=_applies, score=_score, factory=_factory, cdf=_cdf, n_params=1
+    )
+)

--- a/mixle/utils/automatic/detectors/inverse_gamma.py
+++ b/mixle/utils/automatic/detectors/inverse_gamma.py
@@ -1,0 +1,66 @@
+"""Inverse-gamma continuous candidate -- strictly-positive data with a heavy right tail (1/Gamma)."""
+
+import math
+
+import numpy as np
+
+from mixle.utils.automatic.detectors import Detector, register
+
+
+def _fit(arr: np.ndarray) -> tuple[float, float] | None:
+    if arr.size == 0 or np.any(arr <= 0.0) or not np.all(np.isfinite(arr)):
+        return None
+    try:
+        from scipy import stats
+
+        a, _loc, scale = stats.invgamma.fit(arr, floc=0.0)  # fix loc at 0: a positive-support family
+    except Exception:
+        return None
+    if not (a > 0.0 and scale > 0.0 and math.isfinite(a) and math.isfinite(scale)):
+        return None
+    return float(a), float(scale)
+
+
+def _applies(arr: np.ndarray) -> bool:
+    return arr.size > 0 and bool(np.all(arr > 0.0)) and bool(np.all(np.isfinite(arr)))
+
+
+def _score(arr: np.ndarray, nobs: int) -> float | None:
+    from scipy import stats
+
+    from mixle.utils.automatic.profiling import _bic_penalty_bits
+
+    fit = _fit(arr)
+    if fit is None:
+        return None
+    a, scale = fit
+    nll_nats = -float(np.mean(stats.invgamma.logpdf(arr, a, scale=scale)))
+    if not math.isfinite(nll_nats):
+        return None
+    return nll_nats / math.log(2.0) + _bic_penalty_bits(2, nobs)
+
+
+def _factory(vdict, pseudo_count, emp_suff_stat, use_bstats):
+    from mixle.stats import InverseGammaDistribution
+    from mixle.utils.automatic.profiling import _value_array_from_vdict
+
+    fit = _fit(_value_array_from_vdict(vdict))
+    a, scale = fit if fit is not None else (2.0, 1.0)
+    return InverseGammaDistribution(a, scale).estimator(pseudo_count=pseudo_count)
+
+
+def _cdf(arr: np.ndarray):
+    from scipy import stats
+
+    fit = _fit(arr)
+    if fit is None:
+        return None
+    a, scale = fit
+    return stats.invgamma.cdf(arr, a, scale=scale)
+
+
+register(
+    Detector(
+        name="inverse_gamma", kind="continuous", applies=_applies, score=_score, factory=_factory, cdf=_cdf, n_params=2
+    )
+)

--- a/mixle/utils/automatic/detectors/rayleigh.py
+++ b/mixle/utils/automatic/detectors/rayleigh.py
@@ -1,0 +1,56 @@
+"""Rayleigh continuous candidate -- non-negative data with a mode AWAY from zero (magnitude of a 2-D Gaussian)."""
+
+import math
+
+import numpy as np
+
+from mixle.utils.automatic.detectors import Detector, register
+
+
+def _fit(arr: np.ndarray) -> float | None:
+    if arr.size == 0 or np.any(arr < 0.0) or not np.all(np.isfinite(arr)):
+        return None
+    sigma = math.sqrt(float(np.mean(arr * arr)) / 2.0)  # MLE for Rayleigh(sigma): sigma^2 = mean(x^2)/2
+    return sigma if sigma > 0.0 and math.isfinite(sigma) else None
+
+
+def _applies(arr: np.ndarray) -> bool:
+    # non-negative data whose mode sits away from 0 (unlike the half-normal); the Rayleigh rises then falls.
+    if arr.size == 0 or np.any(arr < 0.0) or not np.all(np.isfinite(arr)):
+        return False
+    mean = float(arr.mean())
+    return mean > 0.0 and float(np.min(arr)) >= 0.0
+
+
+def _score(arr: np.ndarray, nobs: int) -> float | None:
+    from scipy import stats
+
+    from mixle.utils.automatic.profiling import _bic_penalty_bits
+
+    sigma = _fit(arr)
+    if sigma is None:
+        return None
+    nll_nats = -float(np.mean(stats.rayleigh.logpdf(arr, scale=sigma)))
+    if not math.isfinite(nll_nats):
+        return None
+    return nll_nats / math.log(2.0) + _bic_penalty_bits(1, nobs)
+
+
+def _factory(vdict, pseudo_count, emp_suff_stat, use_bstats):
+    from mixle.stats import RayleighDistribution
+    from mixle.utils.automatic.profiling import _value_array_from_vdict
+
+    sigma = _fit(_value_array_from_vdict(vdict))
+    return RayleighDistribution(sigma if sigma is not None else 1.0).estimator(pseudo_count=pseudo_count)
+
+
+def _cdf(arr: np.ndarray):
+    from scipy import stats
+
+    sigma = _fit(arr)
+    return None if sigma is None else stats.rayleigh.cdf(arr, scale=sigma)
+
+
+register(
+    Detector(name="rayleigh", kind="continuous", applies=_applies, score=_score, factory=_factory, cdf=_cdf, n_params=1)
+)


### PR DESCRIPTION
## Summary
Automatic inference (`optimize(data)` / `get_estimator(data)` with no model specified) could only reach a fraction of the library's univariate families, so data drawn from the rest got mis-assigned to a nearby default (e.g. binomial/geometric counts → Poisson/NegBinom). This adds detection for **six families that already existed but had no path**:

- **continuous:** `half_normal`, `rayleigh`, `inverse_gamma`
- **discrete:** `geometric`, `binomial`, `beta_binomial`

Each follows the established detector template (`applies`/`score`/`factory`/`cdf`, self-registering) and is **additive** — scored by BIC in bits/observation against the builtins, so a new family only wins when its penalized likelihood beats gaussian/gamma/poisson/etc. Parametrizations verified numerically identical to scipy.

**Careful gating so nothing is stolen from existing families** (this is where the work was):
- `half_normal` declines on a zero-atom spike — that's a Tweedie / zero-inflated signature, not a smooth folded Gaussian — keeping Tweedie recovery intact.
- `binomial`/`beta_binomial` require genuine replication (≥3 observations per possible outcome), so a bare arithmetic index range (`0..n`, each once) stays integer-Gaussian rather than being read as counts — even though `BetaBinom(n,1,1)` *equals* a discrete uniform.
- `beta_binomial` requires a real intra-class correlation (`rho` floor), so plain binomial data isn't stolen by the nesting extra-parameter family.
- `binomial` only claims data whose sample max reaches `n` (identifiable trial count).

## Test plan
- [x] `mixle/tests/automatic_new_detectors_test.py` (new, 12 tests): each family is BIC-selected on its own data; the Gaussian/Poisson/Gamma defaults are undisturbed; plain binomial isn't stolen by beta-binomial; and each new detector's factory builds a fittable estimator with finite log-density.
- [x] **Existing automatic/recommend/profiling suite: 169 passing, 0 regressions** (three initial regressions — Tweedie, an index-range case, and a uniform GOF test — were resolved by the gates above and by dropping `uniform`; see below).
- [x] `ruff check` / `ruff format --check` — clean.

**Deliberately NOT added: a continuous `uniform` detector.** It directly conflicts with an existing goodness-of-fit test whose premise is that uniform data fits no family well — which a uniform detector would intentionally falsify. Rather than change that test here, I left uniform out for a separate decision.

Part of the automatic-inference update pass; the copula path is the next PR.
