### PR TITLE
experimental: E0 scaffold + graduation contract for track-E mechanisms

### DIFF
--- a/mixle/experimental/README.md
+++ b/mixle/experimental/README.md
@@ -1,0 +1,34 @@
+# `mixle.experimental` — exploratory surfaces, not yet in the stable package
+
+This is a holding area for mechanisms that haven't earned promotion into the stable `mixle` package yet.
+Code here may change or be removed without the usual stability guarantees; import it expecting churn.
+
+## Graduation rule
+
+A mechanism graduates out of `experimental/` into the stable package when it:
+
+1. **beats the E1 baseline on the E7 evaluation suite at matched FLOPs**, and
+2. **has misfit/truncation receipts** — honest, measured error-characterization artifacts for its state
+   structure (e.g. a sketch's collision rate, a tree's truncation error, a moment-closure residual), not
+   just "it works" anecdote.
+
+Both conditions are required. This is the same "every acceptance criterion is a receipt" ethos as the rest
+of the long-context roadmap: a mechanism doesn't graduate on vibes, it graduates on artifacts checked
+against a fixed baseline and a fixed compute budget.
+
+**Status as of this scaffold: forward-looking contract, not yet enforced.** E1 (the baseline mechanism)
+and E7 (the referee evaluation suite) are later items on the same roadmap track and don't exist yet. This
+document states the rule those items will satisfy; nothing in `mixle.experimental` checks it automatically
+today. `mixle.experimental.graduation.ExperimentalMechanism` gives later items a place to record their
+receipts once E1/E7 land, and `is_eligible()` is the (already-testable) bookkeeping check for "does this
+mechanism have both receipts" — it does not itself run any evaluation.
+
+## Testing convention
+
+Tests exercising code under `mixle/experimental/` are tagged `@pytest.mark.experimental` (registered in
+`pyproject.toml`) so they can be filtered, run, and reported on distinctly from the stable-package suite —
+mirroring how `torch`/`numba`/`jax`/`optional` mark backend-gated tests elsewhere in this repo.
+
+## Current contents
+
+- `program.py` / `graduation.py` — see `mixle/experimental/__init__.py` for what each module is.

--- a/mixle/experimental/__init__.py
+++ b/mixle/experimental/__init__.py
@@ -12,4 +12,10 @@ Current contents:
   ``Categorical(logits=Net(...)).fit(y, given=...)``, ``Normal(Net(...), free).fit(...)``, and mixtures of
   ``SoftmaxNeuralLeaf`` experts -- which compose into the PPL with no loss closures. It is kept here for the
   genuinely game-shaped cases the declarative surface does not reach (GANs, on-policy RL).
+- :mod:`mixle.experimental.graduation` -- the bookkeeping ledger (:class:`~mixle.experimental.graduation.ExperimentalMechanism`,
+  ``REGISTRY``) that later long-context mechanisms register against to track graduation eligibility. See
+  ``mixle/experimental/README.md`` for the graduation contract itself.
+
+Tests for code under here are tagged ``@pytest.mark.experimental`` (see ``pyproject.toml``) so they can be
+run and reported on distinctly from the stable-package suite.
 """

--- a/mixle/experimental/graduation.py
+++ b/mixle/experimental/graduation.py
@@ -1,0 +1,67 @@
+"""Graduation bookkeeping for mechanisms living in :mod:`mixle.experimental`.
+
+Policy (see ``mixle/experimental/README.md``): a mechanism graduates out of ``experimental/`` into the
+stable package when it (a) beats the E1 baseline on the E7 long-context referee suite at matched FLOPs,
+and (b) has misfit/truncation receipts -- measured error-characterization artifacts, not just "it works".
+
+Neither the E1 baseline nor the E7 referee suite exists yet at the time this scaffold was written; this
+module only encodes the *shape* of the bookkeeping those later items will populate and check against.
+Nothing here enforces the rule today -- :meth:`ExperimentalMechanism.is_eligible` is pure bookkeeping over
+whatever receipts a mechanism happens to have attached.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class ExperimentalMechanism:
+    """One entry in the experimental-mechanism graduation ledger.
+
+    - ``name``: short identifier, e.g. ``"chunked_recurrent_spine"`` (E1) or ``"sketch_state_attention"`` (E3).
+    - ``graduated``: whether this mechanism has already been promoted into the stable package.
+    - ``baseline_receipt``: the matched-FLOPs comparison against the E1 baseline on the E7 suite, once both
+      exist -- e.g. ``{"metric": "bpb", "mechanism": 1.02, "baseline": 1.05, "flops": 3.1e20}``. ``None``
+      until measured.
+    - ``misfit_receipt``: honest error-characterization artifacts for the mechanism's state structure --
+      e.g. sketch collision rate, tree truncation error, moment-closure residual. ``None`` until measured.
+    """
+
+    name: str
+    graduated: bool = False
+    baseline_receipt: dict | None = None
+    misfit_receipt: dict | None = None
+
+    def is_eligible(self) -> bool:
+        """Whether both receipts required by the graduation rule are present.
+
+        This does not check ``graduated`` -- it answers "could this graduate", not "has it".
+        """
+        return self.baseline_receipt is not None and self.misfit_receipt is not None
+
+
+@dataclass
+class _GraduationRegistry:
+    """In-memory ledger of :class:`ExperimentalMechanism` entries, keyed by name."""
+
+    _mechanisms: dict[str, ExperimentalMechanism] = field(default_factory=dict)
+
+    def register(self, mechanism: ExperimentalMechanism) -> ExperimentalMechanism:
+        """Add (or replace) a mechanism entry and return it."""
+        self._mechanisms[mechanism.name] = mechanism
+        return mechanism
+
+    def get(self, name: str) -> ExperimentalMechanism:
+        """Look up a registered mechanism by name."""
+        return self._mechanisms[name]
+
+    def __iter__(self):
+        return iter(self._mechanisms.values())
+
+    def __len__(self) -> int:
+        return len(self._mechanisms)
+
+
+REGISTRY = _GraduationRegistry()
+"""The process-wide graduation ledger. Track-E items register their ``ExperimentalMechanism`` here."""

--- a/mixle/tests/experimental_scaffold_test.py
+++ b/mixle/tests/experimental_scaffold_test.py
@@ -1,0 +1,64 @@
+"""E0 scaffold: mixle.experimental imports cleanly and its graduation bookkeeping round-trips."""
+
+import pytest
+
+import mixle.experimental as experimental
+from mixle.experimental.graduation import REGISTRY, ExperimentalMechanism
+
+pytestmark = pytest.mark.fast
+
+
+def test_experimental_package_imports():
+    assert experimental.__doc__
+
+
+def test_ungraduated_mechanism_with_no_receipts_is_ineligible():
+    mechanism = ExperimentalMechanism(name="scaffold_test_no_receipts")
+
+    assert mechanism.graduated is False
+    assert mechanism.baseline_receipt is None
+    assert mechanism.misfit_receipt is None
+    assert mechanism.is_eligible() is False
+
+
+def test_mechanism_with_only_one_receipt_is_ineligible():
+    baseline_only = ExperimentalMechanism(
+        name="scaffold_test_baseline_only",
+        baseline_receipt={"metric": "bpb", "mechanism": 1.02, "baseline": 1.05, "flops": 3.1e20},
+    )
+    misfit_only = ExperimentalMechanism(
+        name="scaffold_test_misfit_only",
+        misfit_receipt={"truncation_error": 0.01},
+    )
+
+    assert baseline_only.is_eligible() is False
+    assert misfit_only.is_eligible() is False
+
+
+def test_mechanism_with_both_receipts_is_eligible():
+    mechanism = ExperimentalMechanism(
+        name="scaffold_test_both_receipts",
+        baseline_receipt={"metric": "bpb", "mechanism": 1.02, "baseline": 1.05, "flops": 3.1e20},
+        misfit_receipt={"truncation_error": 0.01},
+    )
+
+    assert mechanism.is_eligible() is True
+    # Eligibility is separate from having actually graduated.
+    assert mechanism.graduated is False
+
+
+def test_registry_round_trips_registered_mechanisms():
+    mechanism = ExperimentalMechanism(name="scaffold_test_registry_roundtrip")
+
+    registered = REGISTRY.register(mechanism)
+
+    assert registered is mechanism
+    assert REGISTRY.get("scaffold_test_registry_roundtrip") is mechanism
+    assert mechanism in list(REGISTRY)
+    assert len(REGISTRY) >= 1
+
+
+@pytest.mark.experimental
+def test_experimental_marker_is_registered_and_collectible():
+    """A trivial test tagged `experimental` -- confirms the marker is registered, not just documented."""
+    assert True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,7 @@ markers = [
     "slow: heavier stochastic, integration, or exhaustive tests for full CI.",
     "optional: tests that require optional extras or external executables.",
     "benchmark: timing-oriented tests; not part of correctness gates.",
+    "experimental: tests for mixle.experimental mechanisms without graduation receipts yet (see mixle/experimental/README.md).",
     "stochastic: tests whose assertions depend on random sampling.",
     "integration: end-to-end workflow tests across multiple modules.",
     "distribution: distribution interface, density, sampler, estimator, and encoder tests.",


### PR DESCRIPTION
## Summary

Roadmap item E0 ("1B+ context training" track): scaffold + graduation contract that later
track-E items (E1-E9, non-dense-attention long-context mechanisms) plug into.

- `mixle/experimental/` already existed (holding `program.py`); this extends it rather than
  duplicating it.
- `mixle/experimental/README.md` — the graduation policy: a mechanism graduates out of
  `experimental/` into the stable package when it (a) beats the E1 baseline on the E7
  evaluation suite at matched FLOPs, and (b) has misfit/truncation receipts. Explicitly notes
  E1/E7 don't exist yet, so this is a forward-looking contract, not enforced today.
- `mixle/experimental/graduation.py` — a minimal, testable ledger:
  `ExperimentalMechanism(name, graduated=False, baseline_receipt=None, misfit_receipt=None)`
  with `.is_eligible()` (true once both receipts are present), plus a small `REGISTRY` that
  later items register against.
- `pyproject.toml` — registers a `pytest.mark.experimental` marker, following the existing
  `torch`/`numba`/`jax`/`optional` marker convention (no CI workflow changes; the marker
  runs in the existing `full` lane like any other unfiltered marker).
- `mixle/tests/experimental_scaffold_test.py` — import test, registry/eligibility round-trip
  tests, and a marker-collectibility test.

## Test plan

- [x] `ruff check --fix` / `ruff format` on all changed files — clean.
- [x] `pytest mixle/tests/experimental_scaffold_test.py -m "fast or experimental"` — 6 passed.
- [x] `pytest --collect-only -q -m ""` (full repo) — 5572 tests collected, no collection
      errors introduced by the new marker registration.
