### PR TITLE
inference/automatic: reach a copula for dependent continuous records

### DIFF
--- a/mixle/inference/estimation.py
+++ b/mixle/inference/estimation.py
@@ -96,25 +96,66 @@ def _maybe_structured_model(data: Any, max_its: int, out: Any, rng: RandomState 
         from mixle.inference.structure import _num_free_params
         from mixle.utils.automatic import get_estimator
 
+        # all-continuous records get a second dependence candidate below (a copula), which models
+        # heterogeneous marginals + dependence a linear-Gaussian network cannot; other records only try the BN.
+        all_continuous = all(isinstance(v, (float, np.floating)) for v in first)
         net = learn_bayesian_network(rows)
-        if not net.edges():
+        if not net.edges() and not all_continuous:
             return None  # independence is what the composite already models; keep the automatic families
 
         composite = optimize(rows, get_estimator(rows), max_its=max_its, rng=rng, out=None)
         enc = composite.dist_to_encoder().seq_encode(rows)
         comp_ll = float(np.sum(composite.seq_log_density(enc)))
-        comp_bic = -2.0 * comp_ll + _num_free_params(composite) * float(np.log(max(len(rows), 2)))
-        net_bic = bayesian_network_bic(net, rows)
-        if net_bic >= comp_bic:
+        n_log = float(np.log(max(len(rows), 2)))
+        comp_params = _num_free_params(composite)
+        comp_bic = -2.0 * comp_ll + comp_params * n_log
+
+        # candidate dependence models, each scored by BIC on the same data; the independent composite is the
+        # baseline and wins ties, so this never returns a worse model than the historical default.
+        candidates: list[tuple[float, Any, str]] = []
+        if net.edges():
+            candidates.append((bayesian_network_bic(net, rows), net, "bayesian-network"))
+        if all_continuous:
+            cop = _maybe_copula_model(rows, composite, comp_params, n_log, max_its, rng)
+            if cop is not None:
+                candidates.append(cop)
+        if not candidates:
+            return None
+        best_bic, best_model, desc = min(candidates, key=lambda u: u[0])
+        if best_bic >= comp_bic:
             return None
         if out is not None:
-            edges = ", ".join(f"{p}->{c}" for p, c in net.edges())
             out.write(
-                f"structure: discovered cross-field dependencies [{edges}] (BIC {net_bic:.1f} < {comp_bic:.1f})\n"
+                "structure: %s dependence beats independent fields (BIC %.1f < %.1f)\n" % (desc, best_bic, comp_bic)
             )
-        return net
+        return best_model
     except Exception:  # noqa: BLE001 - the structure default must never break the historical path
         return None
+
+
+def _maybe_copula_model(
+    rows: Any, composite: Any, comp_params: int, n_log: float, max_its: int, rng: RandomState | None
+) -> tuple[float, Any, str] | None:
+    """A copula over the composite's per-field marginals: heterogeneous margins + a Gaussian dependence core.
+
+    Reuses the independently-detected marginals (which the composite already fitted) and adds ONE dependence
+    object -- a Gaussian copula's correlation matrix, ``d(d-1)/2`` parameters on top of the marginals -- so the
+    BIC comparison against the composite is exactly "does the dependence pay for those correlation params". The
+    copula reaches joints a linear-Gaussian Bayesian network cannot: e.g. a Gamma margin and a Student-t margin
+    coupled by rank correlation. Returns ``(bic, model, "copula")`` or ``None`` if inapplicable.
+    """
+    marginals = list(getattr(composite, "dists", []) or [])
+    if len(marginals) < 2 or any(not callable(getattr(m, "cdf", None)) for m in marginals):
+        return None  # a copula needs each marginal's CDF for the probability-integral transform
+    from mixle.stats.combinator.copula import CopulaDistribution
+    from mixle.stats.multivariate.gaussian_copula import GaussianCopulaDistribution
+
+    d = len(marginals)
+    proto = CopulaDistribution(marginals, GaussianCopulaDistribution(np.eye(d)))
+    copula = optimize(rows, proto.estimator(), prev_estimate=proto, max_its=max_its, rng=rng, out=None)
+    ll = float(np.sum(copula.seq_log_density(copula.dist_to_encoder().seq_encode(rows))))
+    params = comp_params + d * (d - 1) // 2  # marginals (as in the composite) + the correlation off-diagonals
+    return (-2.0 * ll + params * n_log, copula, "copula")
 
 
 # --- data-encoding helpers --------------------------------------------------

--- a/mixle/tests/automatic_copula_structure_test.py
+++ b/mixle/tests/automatic_copula_structure_test.py
@@ -1,0 +1,73 @@
+"""Automatic inference reaches a COPULA for dependent continuous records (mixle.inference.estimation).
+
+When flat all-continuous records have dependence and heterogeneous marginals, optimize(data) with no
+estimator recommends a CopulaDistribution over the auto-detected marginals + a Gaussian dependence core --
+but only when it beats the independent composite by BIC. Independent data stays a composite; the historical
+Bayesian-network path for non-continuous records is untouched."""
+
+import unittest
+
+import numpy as np
+from scipy.stats import gamma as spgamma
+from scipy.stats import norm
+
+from mixle.inference import optimize
+from mixle.stats.combinator.copula import CopulaDistribution
+from mixle.stats.combinator.composite import CompositeDistribution
+
+
+def _dependent_heterogeneous(seed, n=1500, r=0.75):
+    rng = np.random.RandomState(seed)
+    z = rng.multivariate_normal([0.0, 0.0], [[1.0, r], [r, 1.0]], size=n)
+    u = norm.cdf(z)
+    x0 = spgamma.ppf(u[:, 0], a=2.0, scale=2.0)  # Gamma marginal
+    x1 = norm.ppf(u[:, 1], loc=5.0, scale=2.0)  # Gaussian marginal
+    return [(float(a), float(b)) for a, b in zip(x0, x1)]
+
+
+class AutomaticCopulaTest(unittest.TestCase):
+    def test_dependent_continuous_records_get_a_copula(self):
+        model = optimize(_dependent_heterogeneous(0), out=None)
+        self.assertIsInstance(model, CopulaDistribution)
+        self.assertAlmostEqual(float(model.copula.corr[0, 1]), 0.75, delta=0.1)  # recovers the dependence
+        # marginals are the auto-detected families, not forced Gaussian
+        self.assertEqual(type(model.marginals[0]).__name__, "GammaDistribution")
+        self.assertEqual(type(model.marginals[1]).__name__, "GaussianDistribution")
+
+    def test_the_copula_beats_the_independent_composite_on_dependent_data(self):
+        data = _dependent_heterogeneous(1)
+        cop = optimize(data, out=None)
+        comp = optimize(data, structure="off", out=None)  # forces the historical independent composite
+        enc_c = cop.dist_to_encoder().seq_encode(data)
+        enc_i = comp.dist_to_encoder().seq_encode(data)
+        ll_cop = float(np.sum(cop.seq_log_density(enc_c)))
+        ll_comp = float(np.sum(comp.seq_log_density(enc_i)))
+        self.assertGreater(ll_cop, ll_comp + 50.0)  # dependence is real and worth many nats
+
+    def test_independent_continuous_records_stay_a_composite(self):
+        # no dependence -> the copula's correlation params don't pay for themselves -> composite wins.
+        rng = np.random.RandomState(2)
+        x0 = spgamma.rvs(2.0, scale=2.0, size=1500, random_state=rng)
+        x1 = norm.rvs(5.0, 2.0, size=1500, random_state=rng)
+        data = [(float(a), float(b)) for a, b in zip(x0, x1)]
+        model = optimize(data, out=None)
+        self.assertNotIsInstance(model, CopulaDistribution)
+        self.assertIsInstance(model, CompositeDistribution)
+
+    def test_structure_off_restores_the_composite(self):
+        model = optimize(_dependent_heterogeneous(3), structure="off", out=None)
+        self.assertIsInstance(model, CompositeDistribution)
+
+    def test_discrete_records_do_not_get_a_copula(self):
+        # integer/categorical records are not continuous margins; the copula path must not fire (the
+        # historical Bayesian-network-vs-composite behavior is unchanged for them).
+        rng = np.random.RandomState(4)
+        a = rng.randint(0, 5, size=800)
+        b = (a + rng.randint(0, 2, size=800)) % 5  # dependent discrete
+        data = [(int(x), int(y)) for x, y in zip(a, b)]
+        model = optimize(data, out=None)
+        self.assertNotIsInstance(model, CopulaDistribution)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
The headline automatic-inference update: `optimize(data)` / `fit(data)` with no estimator now **considers a copula** as a dependence candidate for flat all-continuous records, alongside the existing Bayesian-network structure discovery. When continuous columns are dependent with **heterogeneous marginals**, the copula models a joint a linear-Gaussian network can't — e.g. a Gamma margin and a Gaussian margin coupled by rank correlation.

This closes the loop on the whole copula toolkit built earlier: auto-inference could reach *none* of it before.

**Mechanism** (fully principled, same BIC gate as everything else):
- Reuse the marginals the independent composite **already fitted** — the auto-detected per-column families, which expose the `cdf` a copula needs for the probability-integral transform.
- Add exactly **one** dependence object: a Gaussian copula's correlation matrix, `d(d-1)/2` params on top of the marginals.
- Score every dependence candidate (BN, copula) by **BIC against the independent composite**; the composite is the baseline and wins ties, so the default is never worse. `_maybe_structured_model` generalized from a single BN candidate to a min-BIC selection.

**Behavior preserved:**
- Discrete/mixed records only try the BN — historical behavior unchanged.
- Independent continuous data stays a composite (the correlation params don't pay for themselves).
- `structure='off'` restores the historical composite.

## Test plan
- [x] `mixle/tests/automatic_copula_structure_test.py` (new, 5 tests): dependent heterogeneous continuous records get a `CopulaDistribution` that recovers the correlation (0.75) and the auto-detected Gamma/Gaussian marginals; the copula beats the independent composite by >50 nats; **independent** continuous data stays a composite; `structure='off'` restores the composite; **discrete** records never get a copula.
- [x] **Existing structure/BN/estimation/automatic suite: 270 passing, 0 regressions** (incl. the 8 `estimation_structure_default` BN tests).
- [x] `ruff check` / `ruff format --check` — clean.

Second of the two automatic-inference updates (the 6 univariate detectors were #133). Uses the Gaussian copula as the dependence core; a vine core (per-edge selection) is a natural follow-on.
