### PR TITLE
inference: D1 node report protocol over the estimator tree

### DIFF
--- a/mixle/inference/node_report.py
+++ b/mixle/inference/node_report.py
@@ -1,0 +1,362 @@
+"""Node report protocol -- per-subtree diagnostics over a composed distribution tree (workstream D1).
+
+Frame (see the ConditionalJIT track, D1-D6): **the estimator tree is an IR**. Every node -- a leaf
+distribution or a combinator subtree (Composite/Mixture/Sequence/Conditional/Optional/...) -- can
+report its own residual, its Q-gain (Neal-Hinton free-energy lower-bound improvement), its E/M cost,
+its update kind, and cheap health receipts. Later track items (freeze/roll-up caching, a block-EM
+scheduler, leaf hot-swapping, backend re-specialization, a learned controller) all read these reports;
+none of them may change what a fit computes -- only how it is scheduled -- so this module never runs
+its own EM, it only instruments/observes the existing machinery in :mod:`mixle.inference.em` and
+:mod:`mixle.inference.estimation`.
+
+Design choices (documented here because later D-track items depend on this interface):
+
+* **residual** -- a Monte-Carlo estimate of this node's own negative log-density,
+  ``-mean(log_density(x))`` over samples drawn from the node's *own current fit*
+  (``node.sampler().sample(n)``). This is available at EVERY node generically (every
+  ``ProbabilityDistribution`` has ``sampler`` and ``log_density``) without needing per-combinator data
+  slicing (a leaf under a ``CompositeDistribution`` never sees the top-level tuple directly, so an
+  exact real-data residual cannot be computed generically for an arbitrary subtree without
+  reimplementing every combinator's data-projection rule -- out of scope for an S-effort generic
+  dispatcher). For an exponential-family leaf this MC residual converges to the differential/Shannon
+  entropy of the fit; it is a legitimate "how much spread/uncertainty is still in this subtree's fit"
+  signal, not a real-data fit residual. Callers who want a real-data top-level residual can pass
+  ``data``/``enc_data`` and read the *root* row, whose residual/Q-gain instead comes from the actual
+  EM objective (see :func:`root_em_report`).
+* **Q-gain** -- ``residual_before - residual_after`` for the SAME field path across two
+  :func:`flat_report_table` calls that bracket one EM update (pass the earlier table as
+  ``prev_table``). This is a genuine before/after delta of the tracked residual, not invented. The
+  Neal-Hinton guarantee (coordinate ascent on one computable free energy F) is proven only for the
+  actual tracked EM objective at the TOP level (see :mod:`mixle.inference.em`'s ``run_em`` /
+  :mod:`mixle.inference.estimation`'s ``optimize``, whose ``delta``-gated loop never accepts a
+  decreasing step); per-node Q-gain is a diagnostic decomposition, not individually guaranteed
+  non-negative (a mixture EM step can, e.g., grow one component's spread while improving the joint
+  objective). :func:`root_em_report` verifies the real, provably-monotone quantity.
+* **E/M cost** -- a parameter-count x dataset-size proxy (``nobs`` if supplied, else 1): E-step cost
+  ``~ param_count * nobs`` (every observation is scored against every parameter once), M-step cost
+  ``~ param_count`` for a closed-form/conjugate update, ``~ param_count * _GRADIENT_STEPS`` for a
+  gradient-based estimator, ``0`` for a frozen/no-op node. Proxy, not wall-clock -- documented so D2's
+  freeze/roll-up cache and D3's scheduler can decide whether to replace it with a measured cost later.
+* **update kind** -- derived from the node's own estimator/capabilities: ``"frozen"`` (the ``Neutral``
+  capability -- a Null distribution/accumulator/encoder), ``"em"`` (latent-variable nodes exposing
+  ``seq_posterior`` or the ``LatentStructured`` capability -- the same duck-type
+  :mod:`mixle.inference.em` itself uses for ``PosteriorTransformEM``), ``"conjugate_closed_form"``
+  (the ``ConjugateUpdatable`` capability), ``"gradient"`` (estimator class name signals a
+  gradient/neural/torch optimizer), else ``"closed_form"`` (the common one-shot M-step case).
+* **health receipts** -- reuses the near-degenerate-variance check already used by
+  :mod:`mixle.inference.precision_plan` (``sigma2``/``variance`` below a floor), adds a generic NaN
+  sweep over the node's own numeric attributes (``-inf`` is deliberately NOT flagged -- it is a
+  legitimate log-space encoding of a zero-probability event, e.g. a categorical's
+  ``log_default_value``; only NaN is never a legitimate parameter value), and an ill-conditioning
+  check (``cond`` on any square 2D numeric attribute whose name suggests a covariance/precision
+  matrix) -- a minimal, honest version where nothing richer already exists in the codebase for a
+  given family.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+
+from mixle.stats.compute.pdist import ProbabilityDistribution
+
+_DEFAULT_MC_SAMPLES = 64
+_GRADIENT_STEPS = 50.0  # proxy M-step iteration count for gradient-based estimators
+_EM_ITERS = 10.0  # proxy outer-iteration count for latent (E/M) nodes
+_NEAR_DEGENERATE_VARIANCE = 1e-10
+_ILL_CONDITIONED_COND_NUMBER = 1e8
+
+
+@dataclass
+class NodeReport:
+    """Per-node diagnostics for one point in a composed distribution tree.
+
+    ``field_path`` follows the existing ``EnumerationError`` path convention used throughout the
+    combinators (e.g. ``"MixtureDistribution.components[0] -> CompositeDistribution.dists[1]"``), so
+    reports compose with the rest of the codebase's structural-error/debugging vocabulary.
+    """
+
+    field_path: str
+    node_type: str
+    update_kind: str
+    residual: float
+    q_gain: float | None
+    e_step_cost: float
+    m_step_cost: float
+    param_count: int
+    health: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def is_healthy(self) -> bool:
+        """True iff every boolean health receipt that flags a problem is False."""
+        return not any(bool(v) for k, v in self.health.items() if k != "finite_params") and self.health.get(
+            "finite_params", True
+        )
+
+
+def _param_count(dist: ProbabilityDistribution) -> int:
+    """Return a parameter-count proxy for ``dist``: declared params if known, else numeric-leaf count."""
+    from mixle.stats.compute.declarations import declaration_for
+
+    declaration = declaration_for(dist)
+    if declaration is not None and declaration.parameters:
+        total = 0
+        for spec in declaration.parameters:
+            value = getattr(dist, spec.name, None)
+            if isinstance(value, np.ndarray):
+                total += int(value.size)
+            elif value is not None:
+                total += 1
+        return max(total, 1)
+
+    total = 0
+    for name, value in vars(dist).items():
+        if name.startswith("_"):
+            continue
+        if isinstance(value, np.ndarray) and np.issubdtype(value.dtype, np.number):
+            total += int(value.size)
+        elif isinstance(value, (int, float)) and not isinstance(value, bool):
+            total += 1
+    return max(total, 1)
+
+
+def _update_kind(dist: ProbabilityDistribution) -> str:
+    """Classify how ``dist`` gets re-estimated: frozen / em / conjugate_closed_form / gradient / closed_form."""
+    from mixle.capability import ConjugateUpdatable, LatentStructured, Neutral, supports
+
+    if supports(dist, Neutral):
+        return "frozen"
+    if callable(getattr(dist, "seq_posterior", None)) or supports(dist, LatentStructured):
+        return "em"
+    if supports(dist, ConjugateUpdatable):
+        return "conjugate_closed_form"
+
+    try:
+        estimator = dist.estimator()
+    except Exception:
+        estimator = None
+    if estimator is not None:
+        est_name = type(estimator).__name__.lower()
+        if any(tok in est_name for tok in ("grad", "torch", "neural", "sgd", "adam")):
+            return "gradient"
+    return "closed_form"
+
+
+def _em_cost(update_kind: str, param_count: int, nobs: float) -> tuple[float, float]:
+    """Return ``(e_step_cost, m_step_cost)`` proxy units for ``update_kind`` (see module docstring)."""
+    if update_kind == "frozen":
+        return 0.0, 0.0
+    e_cost = float(param_count) * float(nobs)
+    if update_kind == "gradient":
+        m_cost = float(param_count) * _GRADIENT_STEPS
+    elif update_kind == "em":
+        m_cost = float(param_count) * _EM_ITERS
+    else:
+        m_cost = float(param_count)
+    return e_cost, m_cost
+
+
+def _residual_mc(dist: ProbabilityDistribution, n_mc: int, seed: int) -> float:
+    """Monte-Carlo self-NLL: ``-mean(log_density(x))`` over ``n_mc`` self-samples (see module docstring)."""
+    try:
+        samples = dist.sampler(seed).sample(int(n_mc))
+    except Exception:
+        return float("nan")
+    if samples is None:
+        # A Neutral/no-op node (e.g. NullDistribution) legitimately samples nothing.
+        return float("nan")
+
+    total = 0.0
+    count = 0
+    for x in samples:
+        try:
+            lp = float(dist.log_density(x))
+        except Exception:
+            continue
+        if np.isfinite(lp):
+            total += -lp
+            count += 1
+    if count == 0:
+        return float("nan")
+    return total / count
+
+
+def _health_receipts(dist: ProbabilityDistribution) -> dict[str, Any]:
+    """Cheap, generic health diagnostics: NaN/Inf params, near-degenerate variance, ill-conditioning.
+
+    Reuses the near-degenerate-variance convention from
+    :func:`mixle.inference.precision_plan.recommend_compute_precision` (a ``sigma2``/``variance``
+    attribute below a small floor); the NaN/Inf sweep and covariance-conditioning check are the
+    minimal honest additions for families with no richer diagnostic already registered.
+    """
+    receipts: dict[str, Any] = {"finite_params": True, "near_degenerate": False, "ill_conditioned": False}
+    for name, value in vars(dist).items():
+        if name.startswith("_"):
+            continue
+        arr: np.ndarray | None = None
+        if isinstance(value, np.ndarray) and np.issubdtype(value.dtype, np.number):
+            arr = value
+        elif isinstance(value, (int, float)) and not isinstance(value, bool):
+            arr = np.asarray([value], dtype=np.float64)
+
+        if arr is not None:
+            # NaN is never a legitimate parameter value. -inf is excluded from this check on purpose:
+            # log-space parameters (e.g. a zero-probability category's log_default_value) legitimately
+            # carry -inf, so flagging it here would be a false positive on perfectly healthy models.
+            if arr.size and np.any(np.isnan(arr)):
+                receipts["finite_params"] = False
+            if "sigma2" in name or "variance" in name or "scale2" in name:
+                if np.any(arr < _NEAR_DEGENERATE_VARIANCE):
+                    receipts["near_degenerate"] = True
+
+        if (
+            isinstance(value, np.ndarray)
+            and value.ndim == 2
+            and value.shape[0] == value.shape[1]
+            and value.shape[0] > 0
+            and any(tok in name.lower() for tok in ("cov", "sigma", "precision"))
+        ):
+            try:
+                if np.all(np.isfinite(value)) and np.linalg.cond(value) > _ILL_CONDITIONED_COND_NUMBER:
+                    receipts["ill_conditioned"] = True
+            except Exception:
+                pass
+    return receipts
+
+
+def node_report(
+    dist: ProbabilityDistribution,
+    *,
+    field_path: str = "root",
+    n_mc: int = _DEFAULT_MC_SAMPLES,
+    seed: int = 0,
+    nobs: float | None = None,
+    prev_residual: float | None = None,
+) -> NodeReport:
+    """Return a :class:`NodeReport` for a single node (leaf or combinator subtree).
+
+    Dispatches generically over the five-piece contract / capability lens -- no per-family branching.
+    """
+    node_type = type(dist).__name__
+    update_kind = _update_kind(dist)
+    # A frozen/no-op node (the Neutral capability, e.g. NullDistribution) contributes nothing to be
+    # fit and typically cannot even sample -- report an exact 0.0 residual rather than NaN.
+    residual = 0.0 if update_kind == "frozen" else _residual_mc(dist, n_mc=n_mc, seed=seed)
+    param_count = _param_count(dist)
+    e_step_cost, m_step_cost = _em_cost(update_kind, param_count, 1.0 if nobs is None else float(nobs))
+    health = _health_receipts(dist)
+
+    q_gain: float | None = None
+    if prev_residual is not None and np.isfinite(prev_residual) and np.isfinite(residual):
+        q_gain = float(prev_residual - residual)
+
+    return NodeReport(
+        field_path=field_path,
+        node_type=node_type,
+        update_kind=update_kind,
+        residual=residual,
+        q_gain=q_gain,
+        e_step_cost=e_step_cost,
+        m_step_cost=m_step_cost,
+        param_count=param_count,
+        health=health,
+    )
+
+
+def _child_distributions(dist: ProbabilityDistribution) -> list[tuple[str, ProbabilityDistribution]]:
+    """Generic duck-typed child discovery: any attribute holding a distribution (or a list/tuple/dict
+    of distributions) is a structural child. Mirrors the ``ClassName.attr[idx]`` path convention
+    already used by ``EnumerationError``/``child_enumerator`` in :mod:`mixle.stats.compute.pdist`, and
+    the list/tuple/dict child-walk already used by ``_collect_estimator_keys`` in the same module --
+    no per-combinator-family special-casing.
+    """
+    node_type = type(dist).__name__
+    out: list[tuple[str, ProbabilityDistribution]] = []
+    for name, value in sorted(vars(dist).items()):
+        if name.startswith("_"):
+            continue
+        if isinstance(value, ProbabilityDistribution):
+            out.append(("%s.%s" % (node_type, name), value))
+        elif isinstance(value, (list, tuple)):
+            for i, child in enumerate(value):
+                if isinstance(child, ProbabilityDistribution):
+                    out.append(("%s.%s[%d]" % (node_type, name, i), child))
+        elif isinstance(value, dict):
+            for key, child in value.items():
+                if isinstance(child, ProbabilityDistribution):
+                    out.append(("%s.%s[%r]" % (node_type, name, key), child))
+    return out
+
+
+def walk_tree(dist: ProbabilityDistribution, *, path: str = "root") -> list[tuple[str, ProbabilityDistribution]]:
+    """Return ``(field_path, node)`` for every node in the tree, pre-order, deduplicated by identity."""
+    out: list[tuple[str, ProbabilityDistribution]] = []
+    visited: set[int] = set()
+
+    def _visit(node: ProbabilityDistribution, node_path: str) -> None:
+        if id(node) in visited:
+            return
+        visited.add(id(node))
+        out.append((node_path, node))
+        for child_label, child in _child_distributions(node):
+            child_path = "%s -> %s" % (node_path, child_label)
+            _visit(child, child_path)
+
+    _visit(dist, path)
+    return out
+
+
+def flat_report_table(
+    dist: ProbabilityDistribution,
+    *,
+    nobs: float | None = None,
+    prev_table: list[NodeReport] | None = None,
+    n_mc: int = _DEFAULT_MC_SAMPLES,
+    seed: int = 0,
+) -> list[NodeReport]:
+    """Walk a composed tree and return one :class:`NodeReport` per node, in traversal order.
+
+    Satisfies "composed tree -> flat table": every leaf and every combinator subtree gets exactly one
+    row, keyed by its ``field_path``. Pass the previous call's return value as ``prev_table`` to
+    populate each row's ``q_gain`` as the residual improvement across an intervening EM update.
+    """
+    prev_by_path = {r.field_path: r.residual for r in prev_table} if prev_table else {}
+    rows: list[NodeReport] = []
+    for i, (node_path, node) in enumerate(walk_tree(dist)):
+        rows.append(
+            node_report(
+                node,
+                field_path=node_path,
+                n_mc=n_mc,
+                seed=seed + i,
+                nobs=nobs,
+                prev_residual=prev_by_path.get(node_path),
+            )
+        )
+    return rows
+
+
+def root_em_report(
+    enc_data: Any,
+    estimator: Any,
+    model: ProbabilityDistribution,
+    *,
+    engine: Any | None = None,
+    max_its: int = 1,
+) -> tuple[ProbabilityDistribution, float, float]:
+    """Run ``max_its`` real EM steps (via :func:`mixle.inference.em.run_em`) and return
+    ``(new_model, objective_before, objective_after)`` on the ACTUAL tracked Neal-Hinton objective
+    (observed log-likelihood / MAP / VB, whichever ``run_em`` resolves) -- the one quantity this
+    module does not approximate. ``objective_after >= objective_before`` is the real, provably
+    monotone Q-gain guarantee; :class:`NodeReport`'s per-node ``q_gain`` is a diagnostic decomposition,
+    not individually guaranteed non-negative (see module docstring).
+    """
+    from mixle.inference.em import _resolve_run_em_objective, run_em
+
+    objective = _resolve_run_em_objective(None, enc_data, estimator, model, engine)
+    before = float(objective(model))
+    new_model = run_em(enc_data, estimator, model, max_its=max_its, delta=None, engine=engine)
+    after = float(objective(new_model))
+    return new_model, before, after

--- a/mixle/tests/node_report_test.py
+++ b/mixle/tests/node_report_test.py
@@ -1,0 +1,184 @@
+"""Tests for the D1 node report protocol (mixle.inference.node_report)."""
+
+import io
+import math
+import unittest
+
+import numpy as np
+
+from mixle.inference.em import run_em
+from mixle.inference.estimation import optimize
+from mixle.inference.node_report import (
+    NodeReport,
+    flat_report_table,
+    node_report,
+    root_em_report,
+    walk_tree,
+)
+from mixle.stats import (
+    BernoulliDistribution,
+    CategoricalDistribution,
+    CompositeDistribution,
+    CompositeEstimator,
+    ExponentialDistribution,
+    GaussianDistribution,
+    GaussianEstimator,
+    MixtureDistribution,
+    MixtureEstimator,
+    OptionalDistribution,
+    PoissonDistribution,
+    SequenceDistribution,
+    seq_encode,
+)
+
+
+def _representative_family_catalog():
+    """A small, deliberately representative subset of stock families -- one leaf per common shape
+    (continuous/discrete/count/binary), one wrapper (Optional), and one of each combinator
+    (Composite/Mixture/Sequence) -- rather than this repo's full ~100-family catalog (see
+    ``mixle.tests.sampler_seed_test``), which is unnecessarily large for exercising the GENERIC
+    dispatcher this module adds (it is not per-family logic, so one representative of each structural
+    shape is what actually exercises new code paths).
+    """
+    return {
+        "GaussianDistribution": GaussianDistribution(0.0, 1.0),
+        "ExponentialDistribution": ExponentialDistribution(1.5),
+        "BernoulliDistribution": BernoulliDistribution(0.3),
+        "PoissonDistribution": PoissonDistribution(3.0),
+        "CategoricalDistribution": CategoricalDistribution({"a": 0.4, "b": 0.6}),
+        "OptionalDistribution": OptionalDistribution(GaussianDistribution(0.0, 1.0), p=0.1),
+        "CompositeDistribution": CompositeDistribution([GaussianDistribution(0.0, 1.0), PoissonDistribution(2.0)]),
+        "MixtureDistribution": MixtureDistribution(
+            [GaussianDistribution(-2.0, 1.0), GaussianDistribution(2.0, 1.0)], [0.5, 0.5]
+        ),
+        "SequenceDistribution": SequenceDistribution(
+            GaussianDistribution(0.0, 1.0), len_dist=CategoricalDistribution({3: 1.0})
+        ),
+    }
+
+
+class NodeReportProtocolTestCase(unittest.TestCase):
+    # -- 1. every stock family reports -----------------------------------------------------------
+    def test_every_stock_family_reports(self):
+        catalog = _representative_family_catalog()
+        for name, dist in sorted(catalog.items()):
+            with self.subTest(family=name):
+                report = node_report(dist, seed=7)
+                self.assertIsInstance(report, NodeReport)
+                self.assertEqual(report.field_path, "root")
+                self.assertEqual(report.node_type, type(dist).__name__)
+                self.assertIn(
+                    report.update_kind,
+                    {"frozen", "em", "conjugate_closed_form", "gradient", "closed_form"},
+                )
+                self.assertTrue(math.isfinite(report.residual), "%s residual not finite" % name)
+                self.assertGreaterEqual(report.param_count, 1)
+                self.assertGreaterEqual(report.e_step_cost, 0.0)
+                self.assertGreaterEqual(report.m_step_cost, 0.0)
+                self.assertIn("finite_params", report.health)
+                self.assertTrue(report.health["finite_params"], "%s reported non-finite params" % name)
+
+    # -- 2. composed tree -> flat table -----------------------------------------------------------
+    def test_composed_tree_flat_table(self):
+        # A genuinely nested tree: a mixture of composites of (leaf, sequence-of-leaf).
+        def make_component(mu):
+            return CompositeDistribution(
+                [
+                    GaussianDistribution(mu, 1.0),
+                    SequenceDistribution(PoissonDistribution(2.0), len_dist=CategoricalDistribution({3: 1.0})),
+                ]
+            )
+
+        tree = MixtureDistribution([make_component(-2.0), make_component(2.0)], [0.5, 0.5])
+
+        # Fit it so the report reflects a real (post-EM) model, not just an initial guess.
+        data = tree.sampler(1).sample(500)
+        # Build the sequence estimator FROM a SequenceDistribution that carries the real len_dist
+        # (a fresh ``SequenceDistribution(PoissonDistribution(2.0))`` defaults ``len_dist`` to a
+        # NullDistribution, whose estimator is a no-op NullEstimator -- the fitted model would then
+        # keep a NullDistribution len_dist and be unsamplable; see SequenceEstimator.estimate).
+        estimator = MixtureEstimator(
+            [
+                CompositeEstimator(
+                    [
+                        GaussianEstimator(),
+                        SequenceDistribution(
+                            PoissonDistribution(2.0), len_dist=CategoricalDistribution({3: 1.0})
+                        ).estimator(),
+                    ]
+                )
+            ]
+            * 2
+        )
+        fitted = optimize(data, estimator, max_its=5, rng=np.random.RandomState(0), out=io.StringIO())
+
+        nodes = walk_tree(fitted)
+        table = flat_report_table(fitted, nobs=float(len(data)))
+
+        # One row per node, same order and count as the raw walk.
+        self.assertEqual(len(table), len(nodes))
+        self.assertEqual([r.field_path for r in table], [path for path, _ in nodes])
+
+        # Field paths are unique and every node in the nested structure is present.
+        paths = {r.field_path for r in table}
+        self.assertEqual(len(paths), len(table))
+        self.assertTrue(any("MixtureDistribution.components[0]" in p for p in paths))
+        self.assertTrue(any("MixtureDistribution.components[1]" in p for p in paths))
+        self.assertTrue(any("CompositeDistribution.dists[0]" in p for p in paths))
+        self.assertTrue(any("CompositeDistribution.dists[1]" in p for p in paths))
+        self.assertTrue(any("SequenceDistribution.dist" in p for p in paths))
+
+        # Sane, non-NaN values; residual/e_step_cost/m_step_cost/param_count are all non-negative.
+        for row in table:
+            self.assertTrue(math.isfinite(row.residual), row.field_path)
+            self.assertGreaterEqual(row.e_step_cost, 0.0)
+            self.assertGreaterEqual(row.m_step_cost, 0.0)
+            self.assertGreaterEqual(row.param_count, 1)
+
+        # A second table with the first as prev_table populates q_gain (diagnostic, per-node delta).
+        table2 = flat_report_table(fitted, nobs=float(len(data)), prev_table=table)
+        self.assertEqual(len(table2), len(table))
+        # Same field paths -> every row's q_gain is computable (residual is finite before and after).
+        for row in table2:
+            self.assertIsNotNone(row.q_gain)
+            self.assertTrue(math.isfinite(row.q_gain))
+
+    # -- 3. Q-gain sanity check on the real, tracked EM objective ---------------------------------
+    def test_root_em_objective_is_non_decreasing(self):
+        """Neal-Hinton coordinate ascent: the ACTUAL tracked EM objective (here, observed
+        log-likelihood via ``run_em``'s resolved objective) never decreases across a real EM step
+        on a non-degenerate model/dataset. This is the one quantity this module does not
+        approximate (see ``root_em_report``'s docstring) -- per-node ``NodeReport.q_gain`` is a
+        diagnostic residual-delta decomposition and is NOT individually guaranteed non-negative
+        (a mixture step can grow one component's spread while improving the joint objective), so we
+        verify monotonicity on the real global objective instead of faking a per-node assertion.
+        """
+        truth = MixtureDistribution([GaussianDistribution(-3.0, 1.0), GaussianDistribution(3.0, 1.0)], [0.5, 0.5])
+        data = truth.sampler(3).sample(2000)
+        estimator = MixtureEstimator([GaussianEstimator(), GaussianEstimator()])
+        enc_data = seq_encode(data, model=truth)
+
+        # Deliberately off-center initial model so the first EM step makes real progress.
+        init_model = MixtureDistribution([GaussianDistribution(-1.0, 4.0), GaussianDistribution(1.0, 4.0)], [0.5, 0.5])
+
+        model = init_model
+        for _ in range(5):
+            model, before, after = root_em_report(enc_data, estimator, model, max_its=1)
+            self.assertGreaterEqual(after, before - 1e-9, "EM objective decreased: %r -> %r" % (before, after))
+
+    def test_root_em_report_matches_run_em(self):
+        """root_em_report's returned model matches a plain run_em call with the same inputs."""
+        truth = GaussianDistribution(0.0, 1.0)
+        data = truth.sampler(5).sample(300)
+        estimator = GaussianEstimator()
+        enc_data = seq_encode(data, model=truth)
+        init_model = GaussianDistribution(1.0, 2.0)
+
+        expected = run_em(enc_data, estimator, init_model, max_its=3, delta=None)
+        got, _before, _after = root_em_report(enc_data, estimator, init_model, max_its=3)
+        self.assertAlmostEqual(got.mu, expected.mu, places=10)
+        self.assertAlmostEqual(got.sigma2, expected.sigma2, places=10)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Item D1 of the ConditionalJIT track (D1→D2→D3→D4→D6→D5): "the estimator tree is an IR" (update kind / additivity / cost per node), with correctness anchored to the Neal-Hinton free-energy view (any interleaving of partial E-steps and per-block conditional M-steps is coordinate ascent on one computable F; a learned scheduler can only affect speed, never correctness).

- Adds `mixle/inference/node_report.py`:
  - `NodeReport` dataclass: `field_path`, `node_type`, `update_kind`, `residual`, `q_gain`, `e_step_cost`, `m_step_cost`, `param_count`, `health` (dict), plus an `is_healthy` property.
  - `node_report(dist, ...)` — produces a report for any single leaf or combinator subtree, dispatched generically over the five-piece contract via duck-typing / the capability lens (`Neutral`, `LatentStructured`, `ConjugateUpdatable`), not hardcoded per family.
  - `walk_tree(dist)` — generic pre-order traversal discovering structural children (any attribute holding a `ProbabilityDistribution`, or a list/tuple/dict of them), deduplicated by identity, with `ClassName.attr[idx]` field paths.
  - `flat_report_table(dist, ...)` — walks a composed tree and returns one `NodeReport` per node in traversal order ("composed tree → flat table"); pass a previous table as `prev_table` to populate each row's `q_gain`.
  - `root_em_report(enc_data, estimator, model, ...)` — wraps the real `mixle.inference.em.run_em` loop and returns `(new_model, objective_before, objective_after)` on the actual tracked Neal-Hinton objective.

## Design choices D2-D6/D5 will depend on

- **residual** — a Monte-Carlo self-NLL, `-mean(log_density(x))` over samples drawn from the node's *own current fit* (`node.sampler(seed).sample(n)`). This is available generically at every node without reimplementing each combinator's data-projection rule (an arbitrary subtree can't generically recover the slice of real data it was fit against). For an exponential-family leaf this converges to differential/Shannon entropy — a legitimate "how much uncertainty is left in this subtree's fit" signal, not a real-data residual. Callers who want the real top-level fit residual should use `root_em_report`, whose `objective_before`/`objective_after` come from the actual EM objective.
- **Q-gain** — `residual_before - residual_after` for the same field path across two `flat_report_table()` calls bracketing one EM update. This is a genuine per-node diagnostic decomposition, but it is **not** individually guaranteed non-negative (e.g. a mixture step can grow one component's spread while improving the joint objective) — only the real, tracked top-level EM objective (verified via `root_em_report`, whose delta-gated loop never accepts a decreasing step) has the Neal-Hinton monotonicity guarantee.
- **E/M cost** — a `param_count × nobs` proxy: E-step ~ `param_count * nobs`, M-step ~ `param_count` (closed-form), `param_count * 50` (gradient), `param_count * 10` (latent/EM), `0` (frozen). Documented as a proxy, not wall-clock, so D2's freeze/roll-up cache and D3's scheduler can swap in a measured cost later if needed.
- **update kind** — derived from the node's own estimator/capabilities: `frozen` (`Neutral`), `em` (`seq_posterior` / `LatentStructured`), `conjugate_closed_form` (`ConjugateUpdatable`), `gradient` (estimator class name signals a gradient/neural/torch optimizer), else `closed_form`.
- **health receipts** — reuses the near-degenerate-variance check from `mixle.inference.precision_plan`, adds a generic NaN sweep (deliberately *not* flagging `-inf`, which is a legitimate log-space encoding, e.g. a categorical's `log_default_value`) and an ill-conditioning check (`np.linalg.cond` on any square 2D numeric attribute whose name suggests a covariance/precision matrix).

## Test plan

New `mixle/tests/node_report_test.py`:
1. `test_every_stock_family_reports` — a representative subset of stock families (continuous/discrete/count/binary leaves, `Optional`, `Composite`/`Mixture`/`Sequence`) each produce a valid `NodeReport` with finite residual, non-negative costs/param_count, and clean health.
2. `test_composed_tree_flat_table` — a genuinely nested tree (mixture of composites of leaf + sequence-of-leaf), fit via real EM, `flat_report_table` produces one row per node matching `walk_tree`'s traversal, with correct/unique field paths and sane (finite, non-negative) values; a second call with `prev_table` populates `q_gain`.
3. `test_root_em_objective_is_non_decreasing` — the real, tracked EM objective (via `root_em_report`) is non-decreasing across 5 successive real EM steps on a non-degenerate mixture-of-Gaussians fit — the actual Neal-Hinton guarantee, verified on the one quantity this module doesn't approximate (per-node `q_gain` is documented as NOT individually guaranteed non-negative, with the reasoning above).
4. `test_root_em_report_matches_run_em` — `root_em_report`'s returned model is byte-identical to a plain `run_em` call with the same inputs (pure wrapper, no side effects on the fit).

Ran:
- `python -m ruff check --fix mixle/inference/node_report.py mixle/tests/node_report_test.py` — clean.
- `python -m ruff format mixle/inference/node_report.py mixle/tests/node_report_test.py` — formatted, tests re-verified green after.
- `python -m pytest mixle/tests/node_report_test.py` — 4 passed, 9 subtests passed.
- `python -m pytest mixle/tests/em_nonfinite_guard_test.py mixle/tests/em_strategies_test.py mixle/tests/estimation_structure_default_test.py mixle/tests/estimator_stability_test.py mixle/tests/fused_em_test.py mixle/tests/fused_em_mixtures_test.py mixle/tests/node_report_test.py` — 50 passed, zero regressions.
