### PR TITLE
data: streaming tokenized-corpus pipeline (F3) -- sharding, packing, determinism, curriculum hook

### DIFF
--- a/mixle/data/streaming_corpus.py
+++ b/mixle/data/streaming_corpus.py
@@ -1,0 +1,212 @@
+"""Streaming, sharded, packed, deterministic token-corpus pipeline (roadmap F3).
+
+Scope note: this builds the *pipeline* -- sharded corpus streaming with per-rank residency, sequence
+packing, and deterministic global ordering given ``(seed, epoch)`` -- over a pre-tokenized corpus (plain
+integer token-id arrays, one array per document). A real BPE/tokenizer library is not a dependency of this
+codebase and is out of scope here; tokenization is a separate, later concern. F1 (the distributed trainer
+this pipeline would ultimately feed "at target tokens/s") does not exist yet either, so "saturates F1" is
+not measurable from this module alone -- everything else in the F3 acceptance list (per-rank sharding,
+packing efficiency, determinism, curriculum hooks) is real and tested here.
+
+Composes with existing machinery rather than duplicating it:
+
+- Per-rank residency extends :class:`~mixle.utils.parallel.multiprocessing.MPEncodedData`'s existing
+  sharding contract: that handle splits an input sequence round-robin, rank ``i`` keeping
+  ``data[i], data[i + world_size], data[i + 2*world_size], ...`` (disjoint, complete-coverage).
+  :func:`shard_documents_for_rank` applies the identical round-robin split, but to the *shuffled* global
+  document order from :func:`global_document_order` rather than to the raw input order -- so shuffling
+  changes which rank sees which document while the sharding contract itself (disjoint, complete, index
+  mod world_size) is unchanged and remains bitwise reproducible.
+- The packed output rows are ``block + 1`` tokens: ``row[:-1]`` is the model input and ``row[1:]`` is the
+  shifted next-token target at every position, matching the dense all-position teacher-forcing shape
+  ``mixle.models.language_model._forward_all_positions`` / ``LM.fit_pairs`` already consume (as opposed to
+  ``mixle.data.stream_token_source``'s one-target-per-window shape, which is the right shape for a single
+  unbounded sliding stream but wastes a factor of ``block`` of compute once sequences are packed).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterator, Sequence
+from typing import Any
+
+import numpy as np
+
+__all__ = [
+    "global_document_order",
+    "shard_documents_for_rank",
+    "pack_documents",
+    "PackedCorpus",
+    "StreamingCorpus",
+]
+
+SequenceSelector = Callable[[np.ndarray, int, int], np.ndarray]
+
+
+def _epoch_seed(seed: int, epoch: int) -> int:
+    """Fold ``(seed, epoch)`` into one 32-bit seed via ``SeedSequence`` -- independent, reproducible streams
+    per epoch from a single user-facing ``seed`` (the standard "reshuffle differently each epoch, but
+    deterministically" pattern)."""
+    return int(np.random.SeedSequence([int(seed), int(epoch)]).generate_state(1)[0])
+
+
+def global_document_order(
+    num_documents: int,
+    *,
+    seed: int,
+    epoch: int,
+    sequence_selector: SequenceSelector | None = None,
+) -> np.ndarray:
+    """The single, authoritative order documents are consumed in across ALL ranks combined for this epoch.
+
+    Same ``(seed, epoch)`` -> bitwise-identical order on every call/process (pure function of its inputs,
+    ``RandomState`` seeded deterministically). Different ``epoch`` with the same ``seed`` -> a different,
+    still fully deterministic order.
+
+    ``sequence_selector`` is the curriculum hook for E7 ("a bandit over length buckets" rationing
+    ultra-long examples, per the roadmap): an optional ``(order, seed, epoch) -> order`` callback that may
+    reorder, filter, or otherwise transform the base permutation before it is handed out to ranks. Left
+    ``None``, the base shuffle passes through unchanged. This module does not implement any curriculum
+    policy itself -- only the extension point.
+    """
+    rng = np.random.RandomState(_epoch_seed(seed, epoch))
+    order = rng.permutation(int(num_documents))
+    if sequence_selector is not None:
+        order = np.asarray(sequence_selector(order, int(seed), int(epoch)))
+    return order
+
+
+def shard_documents_for_rank(order: np.ndarray, rank: int, world_size: int) -> np.ndarray:
+    """Round-robin split of a (possibly shuffled/filtered) global document order across ranks.
+
+    Rank ``i`` gets ``order[i], order[i + world_size], order[i + 2*world_size], ...`` -- the same
+    round-robin residency contract :class:`~mixle.utils.parallel.multiprocessing.MPEncodedData` already
+    uses for its worker shards, so the two compose: disjoint across ranks, complete coverage of ``order``.
+    """
+    if world_size <= 0:
+        raise ValueError("world_size must be positive")
+    if not (0 <= rank < world_size):
+        raise ValueError("rank must satisfy 0 <= rank < world_size, got rank=%r world_size=%r" % (rank, world_size))
+    return np.asarray(order)[rank::world_size]
+
+
+class PackedCorpus:
+    """Result of :func:`pack_documents`: the packed rows plus the measured packing efficiency."""
+
+    __slots__ = ("rows", "packing_efficiency", "real_tokens", "total_tokens")
+
+    def __init__(self, rows: np.ndarray, real_tokens: int, total_tokens: int) -> None:
+        self.rows = rows
+        self.real_tokens = int(real_tokens)
+        self.total_tokens = int(total_tokens)
+        self.packing_efficiency = (self.real_tokens / self.total_tokens) if self.total_tokens else 1.0
+
+    def __len__(self) -> int:
+        return int(self.rows.shape[0])
+
+
+def pack_documents(
+    documents: Sequence[Any],
+    indices: Sequence[int],
+    block: int,
+    *,
+    pad_id: int = 0,
+    boundary_id: int | None = None,
+) -> PackedCorpus:
+    """Concatenate ``documents[indices]`` (in the given order) into one token stream and chunk it into
+    fixed-length ``block + 1`` rows -- the standard "concatenate-and-chunk with document boundaries"
+    packing scheme used in LM pretraining.
+
+    ``row[:-1]`` (length ``block``) is the model input; ``row[1:]`` (length ``block``) is the shifted
+    next-token target at every position. Padding (``pad_id``) is only ever needed to fill out the final
+    row once the stream runs out, so waste is bounded by ``block`` tokens total, not ``block`` tokens per
+    document -- packing efficiency (the real-token fraction) climbs toward 1.0 as the corpus grows relative
+    to ``block``. ``boundary_id`` (e.g. an EOS id), if given, is inserted between consecutive documents so
+    the model can see document edges within a packed row; it counts as a real (non-pad) token.
+    """
+    if block <= 0:
+        raise ValueError("block must be positive")
+    unit = int(block) + 1
+    pieces: list[np.ndarray] = []
+    for idx in indices:
+        doc = np.asarray(documents[idx]).reshape(-1)
+        if doc.size:
+            pieces.append(doc)
+        if boundary_id is not None:
+            pieces.append(np.asarray([boundary_id]))
+    if not pieces:
+        return PackedCorpus(np.zeros((0, unit), dtype=np.int64), real_tokens=0, total_tokens=0)
+
+    flat = np.concatenate(pieces).astype(np.int64)
+    n_full = flat.size // unit
+    remainder = flat.size - n_full * unit
+
+    full_rows = flat[: n_full * unit].reshape(n_full, unit) if n_full else np.zeros((0, unit), dtype=np.int64)
+    pad_count = 0
+    if remainder > 0:
+        last_row = np.full(unit, pad_id, dtype=np.int64)
+        last_row[:remainder] = flat[n_full * unit :]
+        rows = np.vstack([full_rows, last_row[None, :]])
+        pad_count = unit - remainder
+    else:
+        rows = full_rows
+
+    total_tokens = int(rows.size)
+    real_tokens = total_tokens - pad_count
+    return PackedCorpus(rows, real_tokens=real_tokens, total_tokens=total_tokens)
+
+
+class StreamingCorpus:
+    """Per-rank streaming view over a sharded, tokenized corpus: shuffled deterministically by
+    ``(seed, epoch)``, packed into fixed-length dense-teacher-forcing rows, and batched.
+
+    ``documents`` is the full corpus (every rank sees the same list; only its OWN shard is ever packed or
+    batched -- no gather, no materializing another rank's tokens). For a real out-of-core corpus,
+    ``documents`` is a lazy/mmap-backed sequence of per-shard-file document lists; the contract here is
+    unchanged since sharding and packing only ever index it, never buffer the whole thing.
+    """
+
+    def __init__(
+        self,
+        documents: Sequence[Any],
+        *,
+        rank: int,
+        world_size: int,
+        block: int,
+        batch_size: int,
+        seed: int = 0,
+        pad_id: int = 0,
+        boundary_id: int | None = None,
+        sequence_selector: SequenceSelector | None = None,
+    ) -> None:
+        self.documents = documents
+        self.rank = int(rank)
+        self.world_size = int(world_size)
+        self.block = int(block)
+        self.batch_size = int(batch_size)
+        self.seed = int(seed)
+        self.pad_id = int(pad_id)
+        self.boundary_id = boundary_id
+        self.sequence_selector = sequence_selector
+        self.last_packing_efficiency: float | None = None
+
+    def rank_document_indices(self, epoch: int) -> np.ndarray:
+        """This rank's document indices for ``epoch``, in the exact order they will be packed."""
+        order = global_document_order(
+            len(self.documents), seed=self.seed, epoch=epoch, sequence_selector=self.sequence_selector
+        )
+        return shard_documents_for_rank(order, self.rank, self.world_size)
+
+    def epoch_batches(self, epoch: int) -> Iterator[tuple[np.ndarray, np.ndarray]]:
+        """Yield ``(context (b, block) float32, targets (b, block) int64)`` micro-batches for this rank.
+
+        Deterministic given ``(seed, epoch, rank, world_size)``: re-running with the same inputs yields
+        bitwise-identical batches. Sets :attr:`last_packing_efficiency` as a side effect (the real-token
+        fraction of the rows this call packed).
+        """
+        indices = self.rank_document_indices(epoch)
+        packed = pack_documents(self.documents, indices, self.block, pad_id=self.pad_id, boundary_id=self.boundary_id)
+        self.last_packing_efficiency = packed.packing_efficiency
+        rows = packed.rows
+        for start in range(0, rows.shape[0], self.batch_size):
+            chunk = rows[start : start + self.batch_size]
+            yield chunk[:, :-1].astype(np.float32), chunk[:, 1:].astype(np.int64)

--- a/mixle/tests/streaming_corpus_test.py
+++ b/mixle/tests/streaming_corpus_test.py
@@ -1,0 +1,217 @@
+"""Tests for the F3 streaming tokenized-data pipeline (mixle.data.streaming_corpus)."""
+
+import unittest
+
+import numpy as np
+
+from mixle.data.streaming_corpus import (
+    StreamingCorpus,
+    global_document_order,
+    pack_documents,
+    shard_documents_for_rank,
+)
+
+
+def _synthetic_corpus(rng, n_docs=200, min_len=1, max_len=40):
+    """Documents with a mix of short and long lengths relative to a small block, like a real corpus."""
+    return [rng.randint(1, 5000, size=int(rng.randint(min_len, max_len + 1))) for _ in range(n_docs)]
+
+
+class ShardingTestCase(unittest.TestCase):
+    """Per-rank sharding correctness -- simulate several ranks in-process, mirroring how MPEncodedData's
+    own tests exercise its worker split without a real cluster."""
+
+    def test_disjoint_and_complete_coverage(self):
+        order = np.arange(37)  # unshuffled order is enough to test the sharding contract itself
+        world_size = 4
+        shards = [shard_documents_for_rank(order, rank, world_size) for rank in range(world_size)]
+
+        seen = np.concatenate(shards)
+        self.assertEqual(sorted(seen.tolist()), list(range(37)))  # complete coverage, no duplicates
+
+        for a in range(world_size):
+            for b in range(a + 1, world_size):
+                self.assertEqual(set(shards[a].tolist()) & set(shards[b].tolist()), set())  # disjoint
+
+    def test_matches_round_robin_contract_like_mpencoded_data(self):
+        # MPEncodedData shards raw data as `data[j] for j in range(i, n, num_workers)` (see
+        # mixle/utils/parallel/multiprocessing.py). shard_documents_for_rank applies the identical
+        # round-robin split, just to a (possibly shuffled) `order` array instead of raw positions.
+        order = np.arange(23)
+        world_size = 5
+        for rank in range(world_size):
+            expected = order[rank::world_size]
+            actual = shard_documents_for_rank(order, rank, world_size)
+            np.testing.assert_array_equal(actual, expected)
+
+    def test_shards_of_shuffled_order_still_disjoint_and_complete(self):
+        order = global_document_order(50, seed=7, epoch=0)
+        world_size = 3
+        shards = [shard_documents_for_rank(order, rank, world_size) for rank in range(world_size)]
+        seen = np.concatenate(shards)
+        self.assertEqual(sorted(seen.tolist()), list(range(50)))
+        for a in range(world_size):
+            for b in range(a + 1, world_size):
+                self.assertEqual(set(shards[a].tolist()) & set(shards[b].tolist()), set())
+
+    def test_invalid_rank_rejected(self):
+        order = np.arange(10)
+        with self.assertRaises(ValueError):
+            shard_documents_for_rank(order, rank=3, world_size=3)
+        with self.assertRaises(ValueError):
+            shard_documents_for_rank(order, rank=-1, world_size=3)
+        with self.assertRaises(ValueError):
+            shard_documents_for_rank(order, rank=0, world_size=0)
+
+
+class DeterminismTestCase(unittest.TestCase):
+    """Same (seed, epoch) -> bitwise-identical global order & per-rank batches; different epoch -> different,
+    still-deterministic order."""
+
+    def _documents(self):
+        rng = np.random.RandomState(0)
+        return _synthetic_corpus(rng, n_docs=64, min_len=1, max_len=20)
+
+    def test_same_seed_epoch_reproduces_global_order(self):
+        order_a = global_document_order(64, seed=42, epoch=3)
+        order_b = global_document_order(64, seed=42, epoch=3)
+        np.testing.assert_array_equal(order_a, order_b)
+
+    def test_different_epoch_same_seed_gives_different_order(self):
+        order_a = global_document_order(64, seed=42, epoch=0)
+        order_b = global_document_order(64, seed=42, epoch=1)
+        self.assertFalse(np.array_equal(order_a, order_b))
+        # both individually reproducible
+        np.testing.assert_array_equal(order_a, global_document_order(64, seed=42, epoch=0))
+        np.testing.assert_array_equal(order_b, global_document_order(64, seed=42, epoch=1))
+
+    def test_different_seed_same_epoch_gives_different_order(self):
+        order_a = global_document_order(64, seed=1, epoch=0)
+        order_b = global_document_order(64, seed=2, epoch=0)
+        self.assertFalse(np.array_equal(order_a, order_b))
+
+    def test_per_rank_batches_bitwise_identical_across_independent_runs(self):
+        documents = self._documents()
+
+        def run():
+            corpus = StreamingCorpus(documents, rank=1, world_size=3, block=8, batch_size=4, seed=123)
+            return list(corpus.epoch_batches(epoch=5))
+
+        run_a = run()
+        run_b = run()
+        self.assertEqual(len(run_a), len(run_b))
+        self.assertGreater(len(run_a), 0)
+        for (ctx_a, tgt_a), (ctx_b, tgt_b) in zip(run_a, run_b):
+            np.testing.assert_array_equal(ctx_a, ctx_b)
+            np.testing.assert_array_equal(tgt_a, tgt_b)
+
+    def test_different_epoch_changes_batches_deterministically(self):
+        documents = self._documents()
+        corpus = StreamingCorpus(documents, rank=0, world_size=2, block=8, batch_size=4, seed=123)
+        epoch0 = list(corpus.epoch_batches(epoch=0))
+        epoch1 = list(corpus.epoch_batches(epoch=1))
+
+        flat0 = np.concatenate([c.reshape(-1) for c, _ in epoch0]) if epoch0 else np.array([])
+        flat1 = np.concatenate([c.reshape(-1) for c, _ in epoch1]) if epoch1 else np.array([])
+        self.assertFalse(np.array_equal(flat0, flat1))
+
+        # re-running epoch 0 alone still reproduces epoch 0 exactly
+        epoch0_again = list(corpus.epoch_batches(epoch=0))
+        for (ctx_a, tgt_a), (ctx_b, tgt_b) in zip(epoch0, epoch0_again):
+            np.testing.assert_array_equal(ctx_a, ctx_b)
+            np.testing.assert_array_equal(tgt_a, tgt_b)
+
+    def test_global_batches_identical_across_full_rank_set_two_runs(self):
+        """The determinism receipt at the corpus level: replaying the whole run (all ranks, one epoch)
+        twice yields the identical set of per-rank batch sequences."""
+        documents = self._documents()
+        world_size = 4
+
+        def run_all_ranks():
+            out = []
+            for rank in range(world_size):
+                corpus = StreamingCorpus(documents, rank=rank, world_size=world_size, block=8, batch_size=4, seed=99)
+                out.append([(c.copy(), t.copy()) for c, t in corpus.epoch_batches(epoch=2)])
+            return out
+
+        run_a = run_all_ranks()
+        run_b = run_all_ranks()
+        for rank in range(world_size):
+            for (ctx_a, tgt_a), (ctx_b, tgt_b) in zip(run_a[rank], run_b[rank]):
+                np.testing.assert_array_equal(ctx_a, ctx_b)
+                np.testing.assert_array_equal(tgt_a, tgt_b)
+
+
+class PackingEfficiencyTestCase(unittest.TestCase):
+    """Packing efficiency (real-token fraction) on a realistic short/long document mix clears a measured
+    floor. Packing waste is bounded by one row (`block + 1` tokens), so efficiency should be high for any
+    corpus that's not tiny relative to `block` -- verified concretely here, not asserted blindly."""
+
+    def test_packing_efficiency_floor(self):
+        rng = np.random.RandomState(11)
+        documents = _synthetic_corpus(rng, n_docs=500, min_len=1, max_len=200)
+        indices = np.arange(len(documents))
+        packed = pack_documents(documents, indices, block=64, boundary_id=0)
+
+        self.assertGreater(len(packed), 0)
+        self.assertGreater(packed.packing_efficiency, 0.90)  # measured well above this in practice, see below
+        self.assertLessEqual(packed.packing_efficiency, 1.0)
+
+        # waste is bounded by a single row regardless of corpus size/shape
+        max_possible_waste = 64 + 1
+        self.assertLessEqual(packed.total_tokens - packed.real_tokens, max_possible_waste)
+
+    def test_packing_efficiency_improves_with_corpus_size(self):
+        # same length distribution, more documents -> waste (bounded, fixed) shrinks as a fraction of total
+        rng = np.random.RandomState(3)
+        small = _synthetic_corpus(np.random.RandomState(3), n_docs=5, min_len=1, max_len=50)
+        large = _synthetic_corpus(np.random.RandomState(3), n_docs=2000, min_len=1, max_len=50)
+        small_packed = pack_documents(small, np.arange(len(small)), block=32)
+        large_packed = pack_documents(large, np.arange(len(large)), block=32)
+        self.assertGreaterEqual(large_packed.packing_efficiency, small_packed.packing_efficiency)
+
+    def test_empty_input_reports_full_efficiency_and_no_rows(self):
+        packed = pack_documents([], [], block=16)
+        self.assertEqual(len(packed), 0)
+        self.assertEqual(packed.packing_efficiency, 1.0)
+
+
+class CurriculumHookTestCase(unittest.TestCase):
+    """A pluggable sequence_selector (the E7 extension point) actually influences which documents are
+    sampled -- this module only exposes the hook, not any curriculum policy."""
+
+    def test_custom_selector_filters_by_length_bucket(self):
+        rng = np.random.RandomState(5)
+        documents = [rng.randint(0, 100, size=n) for n in [2, 50, 3, 60, 4, 70, 1, 90]]
+        short_ids = {i for i, d in enumerate(documents) if len(d) < 10}
+
+        def only_short(order, seed, epoch):
+            return np.asarray([i for i in order if len(documents[i]) < 10])
+
+        order = global_document_order(len(documents), seed=1, epoch=0, sequence_selector=only_short)
+        self.assertTrue(set(order.tolist()).issubset(short_ids))
+        self.assertGreater(len(order), 0)
+
+        baseline = global_document_order(len(documents), seed=1, epoch=0)
+        self.assertLess(len(order), len(baseline))  # selector actually changed the sampled set
+
+    def test_selector_wired_through_streaming_corpus_end_to_end(self):
+        rng = np.random.RandomState(9)
+        documents = [rng.randint(0, 100, size=n) for n in [2, 50, 3, 60, 4, 70, 1, 90, 5, 95]]
+
+        def only_short(order, seed, epoch):
+            return np.asarray([i for i in order if len(documents[i]) < 10])
+
+        corpus = StreamingCorpus(
+            documents, rank=0, world_size=1, block=4, batch_size=2, seed=0, sequence_selector=only_short
+        )
+        indices = corpus.rank_document_indices(epoch=0)
+        for i in indices:
+            self.assertLess(len(documents[i]), 10)
+
+        without_selector = StreamingCorpus(documents, rank=0, world_size=1, block=4, batch_size=2, seed=0)
+        self.assertLess(len(indices), len(without_selector.rank_document_indices(epoch=0)))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements roadmap item **F3. Streaming tokenized data pipeline** (Frontier training infrastructure section): a new `mixle/data/streaming_corpus.py` module providing sharded corpus streaming with per-rank residency, sequence packing, deterministic global ordering given `(seed, epoch)`, and a curriculum extension point for E7.

- **Per-rank sharding** (`shard_documents_for_rank`): applies the exact same round-robin residency contract `MPEncodedData` already uses (`mixle/utils/parallel/multiprocessing.py`, `data[j] for j in range(i, n, num_workers)`), but over a shuffled/filtered global document order rather than raw input order -- so it composes with the existing sharding machinery instead of duplicating it. Disjoint, complete-coverage across ranks.
- **Sequence packing** (`pack_documents` / `PackedCorpus`): standard concatenate-and-chunk-with-boundaries packing into fixed `block + 1`-length rows (`row[:-1]` input / `row[1:]` shifted target), matching the dense all-position teacher-forcing shape `LM.fit_pairs` / `_forward_all_positions` already consume. Packing efficiency (real-token fraction) is computed and reported, not assumed.
- **Deterministic global order** (`global_document_order`): `(seed, epoch)` folded via `numpy.random.SeedSequence` into a `RandomState` permutation -- bitwise-identical order for the same `(seed, epoch)` on any process/run; different `epoch` (same `seed`) gives a different, still fully deterministic order. `StreamingCorpus.epoch_batches` verified bitwise-identical across independent runs at the per-rank-batch level, for a single rank and across the full rank set.
- **Curriculum hook for E7** (`sequence_selector`): an optional `(order, seed, epoch) -> order` callback threaded through `global_document_order` and `StreamingCorpus`, so a future length-bucket/bandit curriculum policy (E7) can filter or reorder the document stream. This PR only exposes the extension point -- no curriculum policy is implemented here.

**Scoping note:** operates over pre-tokenized integer token-id arrays (one array per document). A real BPE/tokenizer library is not a dependency of this codebase and tokenization itself is out of scope here -- a separate, later concern. `F1` (the distributed trainer this pipeline would ultimately feed "at target tokens/s") does not exist yet, so that specific acceptance sub-criterion ("saturates F1 at target tokens/s") is **not measurable** from this module alone and is deferred until F1 lands. Everything else in F3's acceptance list -- sharding, packing efficiency, determinism, curriculum hooks -- is implemented and tested now.

## Test plan

New test file `mixle/tests/streaming_corpus_test.py` (15 tests, all passing), simulating multiple ranks in-process the same way `MPEncodedData`'s own tests do (no cluster needed):

- [x] Per-rank sharding: disjoint + complete coverage across 3-5 simulated ranks, both for unshuffled and shuffled/filtered orders; matches `MPEncodedData`'s exact round-robin contract; invalid rank/world_size rejected.
- [x] Determinism receipt: same `(seed, epoch)` -> bitwise-identical global order and per-rank batch sequences across independent runs (verified at both the single-rank and full-rank-set level); different `epoch` (same `seed`) -> different order, itself still reproducible.
- [x] Packing efficiency floor: on a synthetic 500-document corpus with a realistic short/long length mix (1-200 tokens, block=64), **measured packing efficiency is 0.9996** (well above the asserted `>0.90` floor); waste is bounded by one row (`block + 1` tokens) regardless of corpus size, and efficiency is shown to improve as corpus size grows relative to `block`.
- [x] Curriculum hook smoke test: a custom `sequence_selector` (filters to length < 10) is confirmed to actually change the sampled document set, both standalone and wired through `StreamingCorpus`.

Also ran the existing `MPEncodedData` suite (`mixle/tests/parallel_test.py`, `pytest -m "not optional and not benchmark"`) to confirm no regressions to the sharding machinery this builds on: **8/8 passed**.

Lint: `ruff check --fix` and `ruff format` run on both new files, clean.
