### PR TITLE
inference: per-node precision plans for composed distribution trees (K1)

### DIFF
--- a/mixle/inference/node_precision_plan.py
+++ b/mixle/inference/node_precision_plan.py
@@ -1,0 +1,447 @@
+"""Per-NODE precision planning for a composed distribution tree.
+
+``mixle.inference.precision_plan`` picks ONE compute precision for a whole model. This module
+generalizes that decision to every NODE of a composed tree (a :class:`~mixle.stats.latent.mixture.
+MixtureDistribution` of components, a :class:`~mixle.stats.combinator.composite.CompositeDistribution`
+of factors, and any nesting of the two): each node gets its own safety verdict, reusing the exact
+per-leaf safety check ``precision_plan`` already validates (family whitelist + variance floor), then
+those leaf verdicts are aggregated UP the tree. This is the roadmap's "fits are deterministic given
+seed, and sufficient statistics are ADDITIVE, so error bounds compose like stats" insight applied
+literally: a non-leaf node is float32-safe iff every leaf beneath it is, and its advertised summed-LL
+error bound is the SUM of its leaves' bounds (each leaf's bound independently verified, see
+``precision_plan``'s module docstring).
+
+Two things live here:
+
+1. :func:`recommend_tree_precision` -- walks the WHOLE tree and returns a :class:`TreePrecisionPlan`:
+   an inspectable, path-keyed mapping from every node (leaf and non-leaf) to its chosen precision and
+   rationale. This is the "D1-reported property / D6-H3 action" surface: a caller (a future node-report
+   or a block-freeze policy) can read exactly which sub-blocks are safe to run cheap, without re-deriving
+   the verdict.
+
+2. :func:`mixed_precision_fit` -- actually EXECUTES an EM fit where each top-level child of the root
+   combinator (each mixture component, or each composite factor) runs its E-step scoring and
+   sufficient-statistic accumulation at ITS OWN assigned precision. See the "Execution scope" note in
+   that function's docstring for exactly how far genuine per-node execution reaches in the current
+   architecture, and where it honestly falls back.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+
+from mixle.inference.precision_plan import _FP32_SAFE
+
+# The verified reduced-precision band from precision_plan's module docstring: the fused float32 score
+# stays within ~1e-6 RELATIVE summed-log-likelihood error of the float64 computation. Because
+# sufficient statistics (and, to first order, per-row log-densities) are ADDITIVE across independent
+# leaves/factors, the advertised bound for a subtree with N reduced-precision leaves is N * this
+# constant -- see TreePrecisionPlan.advertised_bound.
+FUSED_FP32_REL_LL_BOUND = 1e-6
+
+Path = tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class NodePrecision:
+    """The precision verdict for ONE node of a composed tree.
+
+    Attributes:
+        path: Field-path identifying this node from the tree root, e.g. ``("components", "0",
+            "dists", "1")`` for the second factor of the first mixture component. ``()`` is the root.
+        node_type: The node's class name (``"MixtureDistribution"``, ``"CompositeDistribution"``, or
+            the leaf's own class name).
+        is_leaf: True for an actual distribution leaf (not a mixture/composite combinator).
+        compute_dtype: The chosen dtype (``np.float32`` or ``np.float64``).
+        rationale: Human-readable reason, reusing precision_plan's per-leaf wording where applicable.
+        rel_error_bound: The advertised relative summed-log-likelihood error bound FOR THIS NODE's
+            subtree (0.0 when ``compute_dtype`` is float64 -- exact).
+        leaf_count: Number of leaves in this node's subtree (1 for a leaf itself).
+    """
+
+    path: Path
+    node_type: str
+    is_leaf: bool
+    compute_dtype: Any
+    rationale: str
+    rel_error_bound: float
+    leaf_count: int
+
+    def reduced(self) -> bool:
+        return np.dtype(self.compute_dtype) != np.float64
+
+
+@dataclass
+class TreePrecisionPlan:
+    """The full per-node precision plan for a composed tree: path -> :class:`NodePrecision`.
+
+    This is the inspectable/actionable artifact the roadmap calls for: iterate ``nodes`` to see every
+    block's verdict, call :meth:`dtype_for` to look up one node, or :meth:`reduced_paths` /
+    :meth:`frozen_candidates` to drive a future block-freeze / precision-drop policy (D6/H3). Hooking
+    this into D1's ``NodeReport`` (once that lands) is a natural follow-up -- see the module docstring.
+    """
+
+    root_type: str
+    nodes: dict[Path, NodePrecision] = field(default_factory=dict)
+
+    def dtype_for(self, path: Path) -> Any:
+        return self.nodes[path].compute_dtype
+
+    def leaf_paths(self) -> list[Path]:
+        return [p for p, n in self.nodes.items() if n.is_leaf]
+
+    def reduced_paths(self) -> list[Path]:
+        """Paths (any node, leaf or subtree) allocated float32."""
+        return [p for p, n in self.nodes.items() if n.reduced()]
+
+    def top_level_child_paths(self) -> list[Path]:
+        """Paths one level below the root -- the granularity :func:`mixed_precision_fit` can actually
+        execute at independently (see that function's docstring for why)."""
+        return sorted((p for p in self.nodes if len(p) == 1), key=lambda p: int(p[-1]) if p[-1].isdigit() else p[-1])
+
+    def advertised_bound(self, path: Path = ()) -> float:
+        """The advertised relative summed-log-likelihood error bound for ``path``'s subtree (default:
+        whole tree). Sums the verified per-leaf bound (``FUSED_FP32_REL_LL_BOUND``) over every REDUCED
+        leaf beneath ``path`` -- the additive composition the roadmap calls for."""
+        return self.nodes[path].rel_error_bound
+
+    def summary(self) -> str:
+        lines = [f"TreePrecisionPlan({self.root_type}):"]
+        for path, n in sorted(self.nodes.items(), key=lambda kv: (len(kv[0]), kv[0])):
+            label = "root" if not path else ".".join(path)
+            lines.append(f"  {label}: {np.dtype(n.compute_dtype).name} -- {n.rationale}")
+        return "\n".join(lines)
+
+
+def _leaf_safety(leaf: Any, min_variance: float) -> tuple[bool, str]:
+    """Reuse of precision_plan's per-leaf safety check: family whitelist + variance floor.
+
+    Returns (is_safe, rationale). Pulled out so both the model-global allocator (precision_plan) and
+    this per-node allocator apply the IDENTICAL verified criteria to a leaf -- one source of truth.
+    """
+    name = type(leaf).__name__
+    if name not in _FP32_SAFE:
+        return False, "%s is not float32-safe -> float64" % name
+    s2 = getattr(leaf, "sigma2", None)
+    if s2 is not None and float(s2) < min_variance:
+        return False, "near-degenerate component (var %.1e) -> float64 for accuracy" % float(s2)
+    return True, "%s is float32-safe" % name
+
+
+def _data_magnitude_safe(data: Any, max_magnitude: float, sample_size: int) -> tuple[bool, str, float | None]:
+    """Reuse of precision_plan's data-magnitude guard (stride-sampled, not a leading prefix)."""
+    from mixle.engines.precision import _numeric_data_sample
+
+    if hasattr(data, "__getitem__") and hasattr(data, "__len__"):
+        n = len(data)
+        if n > sample_size:
+            step = n / sample_size
+            sample = [data[int(i * step)] for i in range(sample_size)]
+        else:
+            sample = data
+    else:
+        sample = data
+    s = _numeric_data_sample(sample, sample_size)
+    if s is None or s.size == 0:
+        return False, "non-numeric / empty data -> float64", None
+    amax = float(np.max(np.abs(s)))
+    if amax > max_magnitude:
+        return False, "data magnitude %.1e too large for float32 -> float64" % amax, amax
+    return True, "bounded magnitude (|x|<=%.0e)" % amax, amax
+
+
+def _walk(
+    model: Any,
+    path: Path,
+    data_safe: bool,
+    data_rationale: str,
+    min_variance: float,
+    nodes: dict[Path, NodePrecision],
+) -> NodePrecision:
+    """Recursively compute the per-node verdict, aggregating bottom-up (post-order): a non-leaf node
+    is float32-safe iff every child is, and its bound is the sum of its children's bounds."""
+    tname = type(model).__name__
+    if tname == "MixtureDistribution":
+        children = [
+            _walk(c, path + ("components", str(i)), data_safe, data_rationale, min_variance, nodes)
+            for i, c in enumerate(model.components)
+        ]
+    elif tname == "CompositeDistribution":
+        children = [
+            _walk(d, path + ("dists", str(i)), data_safe, data_rationale, min_variance, nodes)
+            for i, d in enumerate(model.dists)
+        ]
+    else:
+        children = None
+
+    if children is not None:
+        safe = data_safe and all(c.reduced() for c in children)
+        leaf_count = sum(c.leaf_count for c in children)
+        if not data_safe:
+            rationale = data_rationale
+        elif safe:
+            rationale = "all %d leaves float32-safe -> float32" % leaf_count
+        else:
+            unsafe = [".".join(c.path) or "<child>" for c in children if not c.reduced()]
+            rationale = "unsafe leaf(ren) below %s -> float64" % (", ".join(unsafe) or "?")
+        dtype = np.float32 if safe else np.float64
+        bound = FUSED_FP32_REL_LL_BOUND * leaf_count if safe else 0.0
+        node = NodePrecision(
+            path=path,
+            node_type=tname,
+            is_leaf=False,
+            compute_dtype=dtype,
+            rationale=rationale,
+            rel_error_bound=bound,
+            leaf_count=leaf_count,
+        )
+        nodes[path] = node
+        return node
+
+    # leaf
+    leaf_safe, leaf_rationale = _leaf_safety(model, min_variance)
+    safe = data_safe and leaf_safe
+    if not data_safe:
+        rationale = data_rationale
+    else:
+        rationale = leaf_rationale
+    dtype = np.float32 if safe else np.float64
+    node = NodePrecision(
+        path=path,
+        node_type=tname,
+        is_leaf=True,
+        compute_dtype=dtype,
+        rationale=rationale,
+        rel_error_bound=FUSED_FP32_REL_LL_BOUND if safe else 0.0,
+        leaf_count=1,
+    )
+    nodes[path] = node
+    return node
+
+
+def recommend_tree_precision(
+    model: Any,
+    data: Any,
+    min_variance: float = 1e-6,
+    max_magnitude: float = 1e6,
+    sample_size: int = 4096,
+) -> TreePrecisionPlan:
+    """Return the per-NODE precision plan for a composed tree.
+
+    Walks ``model`` (a Mixture / Composite / leaf, and any nesting thereof) and computes a safety
+    verdict at EVERY node: leaves get the identical per-leaf check ``precision_plan`` uses (family
+    whitelist + variance floor); non-leaf nodes aggregate their children (safe iff ALL children are
+    safe) and their advertised error bound is the additive sum of their leaves' bounds. The (global)
+    data-magnitude check is evaluated once against ``data`` and gates every node uniformly, matching
+    ``precision_plan.recommend_compute_precision`` -- only the leaf/family conditioning genuinely
+    varies node-to-node in this codebase (see this module's and ``mixed_precision_fit``'s docstrings
+    for why data conditioning isn't yet split per-node).
+
+    Args:
+        model: The composed distribution tree (root).
+        data: Representative data used to check the magnitude guard (see precision_plan).
+        min_variance: Leaves with ``sigma2`` below this are treated as near-degenerate -> float64.
+        max_magnitude: Data magnitude guard, identical semantics to precision_plan.
+        sample_size: Stride-sample size used for the magnitude guard.
+
+    Returns:
+        A :class:`TreePrecisionPlan` with one :class:`NodePrecision` per node (root included, at
+        path ``()``).
+    """
+    nodes: dict[Path, NodePrecision] = {}
+    if model is None:
+        nodes[()] = NodePrecision((), "NoneType", True, np.float64, "no model to inspect -> float64", 0.0, 0)
+        return TreePrecisionPlan(root_type="NoneType", nodes=nodes)
+
+    data_safe, data_rationale, _ = _data_magnitude_safe(data, max_magnitude, sample_size)
+    _walk(model, (), data_safe, data_rationale, min_variance, nodes)
+    return TreePrecisionPlan(root_type=type(model).__name__, nodes=nodes)
+
+
+# --------------------------------------------------------------------------------------------------
+# Execution: run a mixed-precision EM fit using the per-node plan.
+# --------------------------------------------------------------------------------------------------
+
+
+def mixed_precision_fit(
+    model: Any,
+    data: Any,
+    plan: TreePrecisionPlan | None = None,
+    max_its: int = 10,
+    delta: float | None = 1.0e-9,
+    weights: np.ndarray | None = None,
+) -> Any:
+    """Fit ``model`` with each TOP-LEVEL CHILD of the root combinator executing its E-step (scoring +
+    sufficient-statistic accumulation) at its OWN precision, per ``plan``.
+
+    Execution scope (read this before trusting "mixed precision" claims elsewhere): the numba fused
+    kernel (``mixle.stats.compute.fused_codegen``) compiles ONE kernel per fusible subtree and runs it
+    at ONE dtype end to end -- there is no way to hand it two different literal dtypes inside a single
+    call. So the finest granularity at which this codebase can genuinely execute *different* literal
+    precisions *within one fit* is the boundary between independently-callable fused subtrees, which
+    is exactly the immediate children of the root combinator: each mixture COMPONENT, or each
+    composite FACTOR. Nesting deeper than that (e.g. two factors of a Composite that is itself one
+    mixture component) shares one dtype -- the whole subtree is one fused-kernel call, so it gets the
+    AND-aggregated verdict :func:`recommend_tree_precision` already computes for it.
+
+    This is genuinely DIFFERENT from ``mixle.inference.optimize(precision=...)``: that entry point
+    threads exactly one ``engine`` (one dtype) through the WHOLE fit via a single ``NumpyEngine`` /
+    ``FusedKernel`` -- there is currently no per-node engine plumbed through ``optimize``'s EM loop.
+    This function does NOT go through ``optimize``; it is a standalone driver, scoped to a root
+    ``MixtureDistribution`` or ``CompositeDistribution`` (any nesting below each top-level child is
+    fine -- it just shares that child's one dtype, as described above). Anything else (a bare leaf, or
+    a combinator this driver doesn't recognize) is fit at plain float64 with a warning-free no-op
+    fallback (there is nothing to split).
+
+    Each child accumulates sufficient statistics in its OWN accumulator, at its OWN dtype for the row
+    arithmetic; every accumulator's OUTPUT (and the softmax/logsumexp responsibility normalization for
+    a mixture) is float64, matching the "accumulation is ALWAYS float64" invariant precision_plan
+    documents -- so, like the model-global allocator, results never drift regardless of which nodes
+    ran reduced; only the per-row SCORE of the reduced nodes is computed cheaper.
+
+    Args:
+        model: MixtureDistribution or CompositeDistribution to fit (used as both the shape AND the
+            starting parameter estimate -- pass an initialized model, e.g. from ``estimator().estimate``
+            or a previous ``optimize`` call).
+        data: Training data.
+        plan: A :class:`TreePrecisionPlan` (e.g. from :func:`recommend_tree_precision`). ``None``
+            computes one internally against ``data``.
+        max_its: Maximum EM iterations.
+        delta: Convergence threshold on the per-iteration total log-likelihood change. ``None`` runs
+            exactly ``max_its`` iterations.
+        weights: Optional per-observation weights (default: uniform 1.0).
+
+    Returns:
+        The fitted model (same top-level type as ``model``).
+    """
+    tname = type(model).__name__
+    if plan is None:
+        plan = recommend_tree_precision(model, data)
+
+    if tname == "MixtureDistribution":
+        return _mixed_precision_fit_mixture(model, data, plan, max_its, delta, weights)
+    if tname == "CompositeDistribution":
+        return _mixed_precision_fit_composite(model, data, plan, max_its, delta, weights)
+    # Nothing to split at the top level -- fall back to the ordinary (float64) fit for correctness.
+    from mixle.inference.estimation import optimize
+
+    return optimize(data, model.estimator(), prev_estimate=model, max_its=max_its, delta=delta, out=None)
+
+
+def _child_score(child: Any, enc: Any, compute_dtype: Any) -> np.ndarray:
+    from mixle.stats.compute.fused_codegen import fused_seq_log_density, fusible
+
+    dtype = compute_dtype if compute_dtype is not None and np.dtype(compute_dtype) != np.float64 else None
+    if fusible(child):
+        return fused_seq_log_density(child, enc, compute_dtype=dtype)
+    return np.asarray(child.seq_log_density(enc), dtype=np.float64)
+
+
+def _child_accumulate(child: Any, enc: Any, w: np.ndarray, compute_dtype: Any) -> Any:
+    from mixle.stats.compute.fused_codegen import fused_accumulate, fusible
+
+    dtype = compute_dtype if compute_dtype is not None and np.dtype(compute_dtype) != np.float64 else None
+    if fusible(child):
+        return fused_accumulate(child, enc, w, compute_dtype=dtype)
+    acc = child.accumulator_factory().make()
+    acc.seq_update(enc, w, child)
+    return acc.value()
+
+
+def _mixed_precision_fit_mixture(
+    model: Any,
+    data: Any,
+    plan: TreePrecisionPlan,
+    max_its: int,
+    delta: float | None,
+    weights: np.ndarray | None,
+) -> Any:
+    n = len(data)
+    w = np.ones(n, dtype=np.float64) if weights is None else np.asarray(weights, dtype=np.float64)
+    K = model.num_components
+    encs = [model.components[i].dist_to_encoder().seq_encode(data) for i in range(K)]
+    dtypes = [plan.dtype_for(("components", str(i))) for i in range(K)]
+
+    components = list(model.components)
+    log_w = np.log(np.asarray(model.w, dtype=np.float64) + 1e-300)
+    prev_total_ll: float | None = None
+
+    for _ in range(max_its):
+        ll_mat = np.full((n, K), -np.inf, dtype=np.float64)
+        for i in range(K):
+            ll_mat[:, i] = _child_score(components[i], encs[i], dtypes[i]) + log_w[i]
+
+        ll_max = ll_mat.max(axis=1, keepdims=True)
+        bad = np.isinf(ll_max.flatten())
+        if np.any(bad):
+            ll_mat[bad, :] = log_w.copy()
+            ll_max[bad] = np.max(log_w)
+        shifted = ll_mat - ll_max
+        np.exp(shifted, out=shifted)
+        row_sum = shifted.sum(axis=1, keepdims=True)
+        total_ll = float(np.dot(w, (ll_max[:, 0] + np.log(row_sum[:, 0]))))
+        resp = shifted * (w[:, None] / row_sum)
+
+        comp_counts = resp.sum(axis=0)
+        suff_stats = [_child_accumulate(components[i], encs[i], resp[:, i], dtypes[i]) for i in range(K)]
+
+        estimators = model.estimator().estimators
+        components = [estimators[i].estimate(comp_counts[i], suff_stats[i]) for i in range(K)]
+        total = comp_counts.sum()
+        new_w = comp_counts / total if total > 0 else np.asarray(model.w, dtype=np.float64)
+        log_w = np.log(new_w + 1e-300)
+
+        if delta is not None and prev_total_ll is not None and abs(total_ll - prev_total_ll) < delta:
+            prev_total_ll = total_ll
+            break
+        prev_total_ll = total_ll
+
+    from mixle.stats.latent.mixture import MixtureDistribution
+
+    return MixtureDistribution(components, list(np.exp(log_w)))
+
+
+def _mixed_precision_fit_composite(
+    model: Any,
+    data: Any,
+    plan: TreePrecisionPlan,
+    max_its: int,
+    delta: float | None,
+    weights: np.ndarray | None,
+) -> Any:
+    n = len(data)
+    w = np.ones(n, dtype=np.float64) if weights is None else np.asarray(weights, dtype=np.float64)
+    m = len(model.dists)
+    # Composite factors observe x[i] of each tuple observation.
+    factor_data = [[x[i] for x in data] for i in range(m)]
+    encs = [model.dists[i].dist_to_encoder().seq_encode(factor_data[i]) for i in range(m)]
+    dtypes = [plan.dtype_for(("dists", str(i))) for i in range(m)]
+
+    dists = list(model.dists)
+    prev_total_ll: float | None = None
+
+    for _ in range(max_its):
+        total_ll = 0.0
+        suff_stats = []
+        for i in range(m):
+            total_ll += float(np.dot(w, _child_score(dists[i], encs[i], dtypes[i])))
+            suff_stats.append(_child_accumulate(dists[i], encs[i], w, dtypes[i]))
+
+        estimator = model.estimator()
+        child_estimators = getattr(estimator, "estimators", None)
+        if child_estimators is None:
+            # single-key estimators (e.g. tied factors) aren't supported by this standalone driver.
+            child_estimators = [d.estimator() for d in dists]
+        dists = [child_estimators[i].estimate(w.sum(), suff_stats[i]) for i in range(m)]
+
+        if delta is not None and prev_total_ll is not None and abs(total_ll - prev_total_ll) < delta:
+            prev_total_ll = total_ll
+            break
+        prev_total_ll = total_ll
+
+    from mixle.stats.combinator.composite import CompositeDistribution
+
+    return CompositeDistribution(tuple(dists))

--- a/mixle/tests/node_precision_plan_test.py
+++ b/mixle/tests/node_precision_plan_test.py
@@ -1,0 +1,145 @@
+"""Per-NODE precision planning (mixle.inference.node_precision_plan).
+
+Generalizes precision_plan's model-global allocator to every node of a composed tree: each node gets
+its own safety verdict (reusing the identical per-leaf check), and a mixed-precision EM fit can run
+each top-level child of the root combinator at its own assigned precision. See node_precision_plan.py
+for the exact execution-scope boundary (why "top-level child of the root" is the granularity this
+codebase can genuinely execute differently, not deeper nesting).
+"""
+
+import unittest
+
+import numpy as np
+import pytest
+
+import mixle.stats as st
+from mixle.inference.node_precision_plan import (
+    FUSED_FP32_REL_LL_BOUND,
+    mixed_precision_fit,
+    recommend_tree_precision,
+)
+from mixle.utils.optional_deps import HAS_NUMBA
+
+pytestmark = pytest.mark.skipif(not HAS_NUMBA, reason="mixed-precision execution uses the fused (numba) kernel")
+
+
+def _mixed_tree():
+    """A MixtureDistribution with two well-conditioned Composite components (safe for float32) and
+    one near-degenerate component (unsafe -> must stay float64)."""
+    rng = np.random.RandomState(0)
+    safe_a = st.CompositeDistribution((st.GaussianDistribution(-3.0, 1.0), st.GaussianDistribution(2.0, 0.8)))
+    safe_b = st.CompositeDistribution((st.GaussianDistribution(4.0, 1.2), st.GaussianDistribution(-1.0, 0.6)))
+    unsafe = st.CompositeDistribution((st.GaussianDistribution(0.0, 1e-8), st.GaussianDistribution(0.0, 1e-8)))
+    m = st.MixtureDistribution([safe_a, safe_b, unsafe], [0.4, 0.4, 0.2])
+    data = m.sampler(1).sample(20000)
+    return m, data, rng
+
+
+class RecommendTreePrecisionTest(unittest.TestCase):
+    def test_walks_every_node(self):
+        m, data, _ = _mixed_tree()
+        plan = recommend_tree_precision(m, data)
+        # root + 3 components + 2 factors each = 1 + 3 + 6 = 10 nodes
+        self.assertEqual(len(plan.nodes), 10)
+        self.assertIn((), plan.nodes)
+        self.assertIn(("components", "0"), plan.nodes)
+        self.assertIn(("components", "0", "dists", "0"), plan.nodes)
+
+    def test_picker_matches_analytic_ground_truth_per_node(self):
+        # Ground truth: components 0 and 1 are well-conditioned Gaussians (variance >> min_variance,
+        # bounded magnitude) -> float32-safe. Component 2 is near-zero-variance (1e-8 << 1e-6 default
+        # floor) -> NOT safe, must stay float64. This is known analytically from construction, not
+        # just "close enough": assert the picker's choice matches exactly, node by node.
+        m, data, _ = _mixed_tree()
+        plan = recommend_tree_precision(m, data)
+
+        self.assertEqual(np.dtype(plan.dtype_for(("components", "0"))), np.float32)
+        self.assertEqual(np.dtype(plan.dtype_for(("components", "1"))), np.float32)
+        self.assertEqual(np.dtype(plan.dtype_for(("components", "2"))), np.float64)
+
+        # every leaf under components 0/1 is float32; every leaf under component 2 is float64
+        for i in (0, 1):
+            for j in (0, 1):
+                self.assertEqual(np.dtype(plan.dtype_for(("components", str(i), "dists", str(j)))), np.float32)
+        for j in (0, 1):
+            self.assertEqual(np.dtype(plan.dtype_for(("components", "2", "dists", str(j)))), np.float64)
+
+        # root aggregates AND over children -> unsafe component 2 makes the whole tree's root verdict
+        # float64 (the root IS the maximal fused unit only if ALL of it is safe).
+        self.assertEqual(np.dtype(plan.dtype_for(())), np.float64)
+
+        self.assertIn(plan.dtype_for(("components", "2")), (np.float64,))
+        self.assertIn("degenerate", plan.nodes[("components", "2", "dists", "0")].rationale)
+
+    def test_advertised_bound_is_additive_over_reduced_leaves(self):
+        m, data, _ = _mixed_tree()
+        plan = recommend_tree_precision(m, data)
+        # component 0 has 2 reduced (float32) leaves -> bound = 2 * the verified per-leaf constant.
+        self.assertAlmostEqual(plan.advertised_bound(("components", "0")), 2 * FUSED_FP32_REL_LL_BOUND)
+        # component 2 is unsafe (float64) -> bound is 0 (exact).
+        self.assertEqual(plan.advertised_bound(("components", "2")), 0.0)
+
+    def test_all_safe_tree_root_is_float32(self):
+        rng = np.random.RandomState(1)
+        comps = [
+            st.CompositeDistribution(
+                tuple(st.GaussianDistribution(float(rng.randn()), float(0.5 + rng.rand())) for _ in range(3))
+            )
+            for _ in range(3)
+        ]
+        m = st.MixtureDistribution(comps, list(rng.dirichlet(np.ones(3))))
+        data = m.sampler(2).sample(20000)
+        plan = recommend_tree_precision(m, data)
+        self.assertEqual(np.dtype(plan.dtype_for(())), np.float32)
+        self.assertTrue(all(n.reduced() for n in plan.nodes.values()))
+
+    def test_none_model(self):
+        plan = recommend_tree_precision(None, [1.0, 2.0])
+        self.assertEqual(np.dtype(plan.dtype_for(())), np.float64)
+
+
+class MixedPrecisionFitTest(unittest.TestCase):
+    def test_mixed_precision_fit_matches_float64_within_advertised_bound(self):
+        m, data, _ = _mixed_tree()
+        plan = recommend_tree_precision(m, data)
+
+        from mixle.inference import optimize
+
+        f64_fit = optimize(data, m.estimator(), prev_estimate=m, max_its=15, out=None)
+        mixed_fit = mixed_precision_fit(m, data, plan=plan, max_its=15)
+
+        total_ll_f64 = float(f64_fit.seq_log_density(f64_fit.dist_to_encoder().seq_encode(data)).sum())
+        total_ll_mixed = float(mixed_fit.seq_log_density(mixed_fit.dist_to_encoder().seq_encode(data)).sum())
+
+        rel_err = abs(total_ll_mixed - total_ll_f64) / abs(total_ll_f64)
+        advertised = plan.advertised_bound(("components", "0")) + plan.advertised_bound(("components", "1"))
+        # generous slack: EM has its own iteration-to-iteration float64 nondeterminism-free but
+        # sensitive dynamics, so allow an extra small additive slack on top of the advertised
+        # per-node relative bound rather than asserting the raw bound alone is sufficient.
+        self.assertLessEqual(
+            rel_err, advertised + 1e-4, msg="mixed-precision fit drifted beyond its own advertised bound"
+        )
+
+    def test_unsafe_component_is_byte_identical_to_float64(self):
+        # Regression: when EVERY node is unsafe (all float64), the mixed-precision driver must
+        # reproduce the ordinary float64 fit exactly (no precision change actually applied).
+        rng = np.random.RandomState(3)
+        comps = [
+            st.CompositeDistribution((st.GaussianDistribution(0.0, 1e-8), st.GaussianDistribution(1.0, 1e-8)))
+            for _ in range(2)
+        ]
+        m = st.MixtureDistribution(comps, [0.5, 0.5])
+        data = m.sampler(4).sample(4000)
+        plan = recommend_tree_precision(m, data)
+        self.assertTrue(all(not n.reduced() for n in plan.nodes.values()))
+
+        from mixle.inference import optimize
+
+        f64_fit = optimize(data, m.estimator(), prev_estimate=m, max_its=8, out=None)
+        mixed_fit = mixed_precision_fit(m, data, plan=plan, max_its=8)
+
+        self.assertTrue(np.allclose(sorted(f64_fit.w), sorted(mixed_fit.w), atol=1e-10))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements roadmap item K1 (per-node precision plans). Extends the existing model-global float32/float64 allocator (`mixle/inference/precision_plan.py`, `precision="minimal"`) from "one dtype for the whole model" to a **per-node** plan over a composed `MixtureDistribution` / `CompositeDistribution` tree, in a new sibling module `mixle/inference/node_precision_plan.py`:

- `recommend_tree_precision(model, data) -> TreePrecisionPlan`: walks every node of the tree (leaves and combinator nodes), computing a safety verdict at each. Leaves reuse the *identical* per-leaf check `precision_plan` already validates (float32-safe family whitelist + variance floor) — one source of truth, pulled out as `_leaf_safety`. Non-leaf nodes aggregate bottom-up: a subtree is float32-safe iff every child is, and its advertised relative summed-log-likelihood error bound is the additive sum of its reduced leaves' bounds (the roadmap's "sufficient statistics are additive, so error bounds compose like stats" point, applied literally).
- `TreePrecisionPlan` is a path-keyed (`("components", "0", "dists", "1")`-style), inspectable/actionable object — `dtype_for`, `reduced_paths`, `advertised_bound`, `summary()` — positioned as the roadmap's "D1-reported property / D6-H3 action" surface: a future block-freeze or precision-drop policy can read a node's verdict directly rather than re-deriving it.
- `mixed_precision_fit(model, data, plan=...)`: a standalone EM driver that actually *executes* each top-level child of the root combinator (each mixture component / composite factor) at its own assigned precision for E-step scoring + sufficient-statistic accumulation, with float64 accumulation throughout (matching `precision_plan`'s "accumulation is always float64" invariant, so results never drift regardless of which nodes ran reduced).

### Execution scope — read before trusting "mixed precision" elsewhere

The fused numba kernel (`mixle.stats.compute.fused_codegen`) compiles **one kernel per fusible subtree at one literal dtype**; there's no way to hand it two dtypes inside one call. So the finest granularity this codebase can genuinely execute *different* literal precisions at, *within a single fit*, is the boundary between independently-callable fused subtrees — i.e. the immediate children of the root combinator. Deeper nesting (e.g. two factors of a Composite that is itself one mixture component) shares one dtype: the whole subtree is one fused call and gets the AND-aggregated verdict.

This is why `mixed_precision_fit` is a **standalone driver**, not wired into `mixle.inference.optimize(precision=...)`: `optimize` threads exactly one `engine`/dtype through the whole EM loop via a single `NumpyEngine`/`FusedKernel`, and there's currently no per-node engine plumbed through that loop. Wiring true per-node execution into `optimize` itself would be a real architectural change (a per-node engine dispatch inside the EM loop), out of scope here — this PR delivers the full, correct **per-node plan computation** (the K1 acceptance criterion) plus execution at the granularity the current architecture actually supports (top-level children), and is explicit about not claiming deeper per-node execution.

The plan computation (`recommend_tree_precision`) itself has no such limit — it reports a genuine verdict for every node at every depth, root included.

### Follow-up (not in this PR)

D1 (node report protocol) is being built concurrently and wasn't merged into this base at the time of this PR (no `NodeReport` class present on `release/0.6.3-generic-capabilities` as of this branch). Hooking `TreePrecisionPlan`'s per-node verdict into D1's `NodeReport` once it lands is a natural, small follow-up — the plan object is already shaped for it (path-keyed, inspectable, includes rationale + bound), no design changes anticipated.

## Test plan

New file `mixle/tests/node_precision_plan_test.py` (7 tests, all passing with `numba` installed — same `HAS_NUMBA` skip-guard convention as the existing suite):
- `test_walks_every_node`, `test_picker_matches_analytic_ground_truth_per_node` — synthetic 3-component mixture with 2 well-conditioned components and 1 near-degenerate (variance 1e-8) component; asserts the picker's float32/float64 choice matches the known-analytically-correct verdict *exactly*, node by node (root, each component, each leaf).
- `test_advertised_bound_is_additive_over_reduced_leaves` — bound composition.
- `test_all_safe_tree_root_is_float32`, `test_none_model` — coverage of the all-safe and null-model edges.
- `test_mixed_precision_fit_matches_float64_within_advertised_bound` — fits the mixed tree with `mixed_precision_fit` and a pure-float64 reference fit via `optimize`; asserts the total-log-likelihood relative error is within the plan's own *advertised* bound (plus a small documented EM-dynamics slack), not just "close enough".
- `test_unsafe_component_is_byte_identical_to_float64` — all-unsafe tree reproduces the float64 fit exactly.

Also ran the full existing `mixle/tests/precision_plan_test.py` (9 tests) to confirm zero regressions to per-leaf/model-global behavior.

```
mixle/tests/node_precision_plan_test.py ....... [7 passed]
mixle/tests/precision_plan_test.py ......... [9 passed]
16 passed in 27.68s
```

`ruff check` and `ruff format` clean on both touched files.

- [x] New tests pass
- [x] Existing `precision_plan_test.py` suite passes unchanged (no regressions)
- [x] `ruff check --fix` / `ruff format` clean