### PR TITLE
inference/automatic: try a vine copula core, so auto-inference reaches tail dependence

### DIFF
--- a/mixle/inference/estimation.py
+++ b/mixle/inference/estimation.py
@@ -116,9 +116,7 @@ def _maybe_structured_model(data: Any, max_its: int, out: Any, rng: RandomState 
         if net.edges():
             candidates.append((bayesian_network_bic(net, rows), net, "bayesian-network"))
         if all_continuous:
-            cop = _maybe_copula_model(rows, composite, comp_params, n_log, max_its, rng)
-            if cop is not None:
-                candidates.append(cop)
+            candidates.extend(_copula_candidates(rows, composite, comp_params, comp_bic, n_log, max_its, rng))
         if not candidates:
             return None
         best_bic, best_model, desc = min(candidates, key=lambda u: u[0])
@@ -133,29 +131,61 @@ def _maybe_structured_model(data: Any, max_its: int, out: Any, rng: RandomState 
         return None
 
 
-def _maybe_copula_model(
-    rows: Any, composite: Any, comp_params: int, n_log: float, max_its: int, rng: RandomState | None
-) -> tuple[float, Any, str] | None:
-    """A copula over the composite's per-field marginals: heterogeneous margins + a Gaussian dependence core.
+# pair-copula free-parameter counts, for BIC when a vine is a candidate (independence adds nothing).
+_PAIR_COPULA_PARAMS = {"independence": 0, "gaussian": 1, "clayton": 1, "frank": 1, "gumbel": 1, "student_t": 2}
 
-    Reuses the independently-detected marginals (which the composite already fitted) and adds ONE dependence
-    object -- a Gaussian copula's correlation matrix, ``d(d-1)/2`` parameters on top of the marginals -- so the
-    BIC comparison against the composite is exactly "does the dependence pay for those correlation params". The
-    copula reaches joints a linear-Gaussian Bayesian network cannot: e.g. a Gamma margin and a Student-t margin
-    coupled by rank correlation. Returns ``(bic, model, "copula")`` or ``None`` if inapplicable.
+
+def _vine_param_count(vine: Any) -> int:
+    """Total free parameters of a fitted R-vine: sum of its per-edge pair-copula parameters."""
+    return sum(_PAIR_COPULA_PARAMS.get(e.copula.family, 1) for tree in getattr(vine, "trees", []) for e in tree)
+
+
+def _copula_candidates(
+    rows: Any, composite: Any, comp_params: int, comp_bic: float, n_log: float, max_its: int, rng: RandomState | None
+) -> list[tuple[float, Any, str]]:
+    """Copula dependence candidates over the composite's per-field marginals, each scored by BIC.
+
+    Reuses the independently-detected marginals (which the composite already fitted, and which expose the CDF a
+    copula needs for the probability-integral transform) and tries dependence cores that a linear-Gaussian
+    Bayesian network cannot represent:
+
+    * a **Gaussian copula** -- one correlation matrix, ``d(d-1)/2`` params on top of the marginals; the
+      elliptical, tail-independent default.
+    * a **regular vine** with Dißmann structure + per-edge family selection -- tried only when the Gaussian
+      copula already shows dependence pays (so a vine is never fit on independent data), and kept only if its
+      per-edge tail-dependence structure beats the Gaussian core by BIC. This is what lets automatic inference
+      recognize joint tail dependence (a Clayton-style joint-crash coupling) instead of forcing it elliptical.
+
+    Returns a list of ``(bic, model, description)`` candidates (possibly empty).
     """
     marginals = list(getattr(composite, "dists", []) or [])
     if len(marginals) < 2 or any(not callable(getattr(m, "cdf", None)) for m in marginals):
-        return None  # a copula needs each marginal's CDF for the probability-integral transform
+        return []  # a copula needs each marginal's CDF for the probability-integral transform
     from mixle.stats.combinator.copula import CopulaDistribution
     from mixle.stats.multivariate.gaussian_copula import GaussianCopulaDistribution
+    from mixle.stats.multivariate.rvine_copula import RVineCopulaDistribution
 
     d = len(marginals)
-    proto = CopulaDistribution(marginals, GaussianCopulaDistribution(np.eye(d)))
-    copula = optimize(rows, proto.estimator(), prev_estimate=proto, max_its=max_its, rng=rng, out=None)
-    ll = float(np.sum(copula.seq_log_density(copula.dist_to_encoder().seq_encode(rows))))
-    params = comp_params + d * (d - 1) // 2  # marginals (as in the composite) + the correlation off-diagonals
-    return (-2.0 * ll + params * n_log, copula, "copula")
+
+    def _fit_bic(core: Any, extra_params: int) -> tuple[float, Any]:
+        proto = CopulaDistribution(marginals, core)
+        fitted = optimize(rows, proto.estimator(), prev_estimate=proto, max_its=max_its, rng=rng, out=None)
+        ll = float(np.sum(fitted.seq_log_density(fitted.dist_to_encoder().seq_encode(rows))))
+        return -2.0 * ll + (comp_params + extra_params) * n_log, fitted
+
+    g_bic, gauss = _fit_bic(GaussianCopulaDistribution(np.eye(d)), d * (d - 1) // 2)
+    out: list[tuple[float, Any, str]] = [(g_bic, gauss, "copula")]
+
+    # only fit a vine when the (cheaper) Gaussian copula already beat independence -- if there is no dependence
+    # to model, the more-flexible vine cannot help and would just cost time. Its per-edge tail-dependence
+    # structure then earns its keep only if BIC prefers it over the elliptical Gaussian core.
+    if g_bic < comp_bic:
+        vproto = CopulaDistribution(marginals, RVineCopulaDistribution(d, []))
+        vine = optimize(rows, vproto.estimator(), prev_estimate=vproto, max_its=max_its, rng=rng, out=None)
+        v_ll = float(np.sum(vine.seq_log_density(vine.dist_to_encoder().seq_encode(rows))))
+        v_bic = -2.0 * v_ll + (comp_params + _vine_param_count(vine.copula)) * n_log
+        out.append((v_bic, vine, "vine-copula"))
+    return out
 
 
 # --- data-encoding helpers --------------------------------------------------

--- a/mixle/tests/automatic_vine_core_test.py
+++ b/mixle/tests/automatic_vine_core_test.py
@@ -1,0 +1,68 @@
+"""Automatic inference picks the right copula CORE by BIC (mixle.inference.estimation): a regular vine when
+the joint has tail dependence (a Clayton-style joint-crash coupling), the elliptical Gaussian copula when it
+doesn't, and neither when the columns are independent -- all decided by BIC, never forced."""
+
+import unittest
+
+import numpy as np
+from scipy.stats import gamma as spgamma
+from scipy.stats import norm
+
+from mixle.inference import optimize
+from mixle.stats.combinator.composite import CompositeDistribution
+from mixle.stats.combinator.copula import CopulaDistribution
+from mixle.stats.multivariate.clayton_copula import ClaytonCopulaDistribution
+from mixle.stats.multivariate.gaussian_copula import GaussianCopulaDistribution
+from mixle.stats.multivariate.rvine_copula import RVineCopulaDistribution
+
+
+def _heterogeneous(u):
+    """Push copula scores u through a Gamma marginal and a Gaussian marginal."""
+    x0 = spgamma.ppf(np.clip(u[:, 0], 1e-9, 1 - 1e-9), a=2.0, scale=2.0)
+    x1 = norm.ppf(np.clip(u[:, 1], 1e-9, 1 - 1e-9), loc=5.0, scale=2.0)
+    return [(float(a), float(b)) for a, b in zip(x0, x1)]
+
+
+class AutomaticVineCoreTest(unittest.TestCase):
+    def test_tail_dependent_data_gets_a_vine(self):
+        # Clayton coupling has strong LOWER-tail dependence the elliptical Gaussian copula cannot represent;
+        # the vine's per-edge family selection should recover it and win on BIC.
+        u = ClaytonCopulaDistribution(2, theta=3.0).sampler(0).sample(2000)
+        model = optimize(_heterogeneous(u), out=None)
+        self.assertIsInstance(model, CopulaDistribution)
+        self.assertIsInstance(model.copula, RVineCopulaDistribution)
+        fams = [e.copula.family for tree in model.copula.trees for e in tree]
+        self.assertIn("clayton", fams)  # the tail-dependence family was selected, not forced Gaussian
+
+    def test_elliptical_data_keeps_the_gaussian_copula(self):
+        # Gaussian coupling is tail-independent: the vine's extra per-edge parameters don't pay for themselves,
+        # so BIC keeps the simpler Gaussian copula core.
+        rng = np.random.RandomState(0)
+        z = rng.multivariate_normal([0.0, 0.0], [[1.0, 0.7], [0.7, 1.0]], size=2000)
+        model = optimize(_heterogeneous(norm.cdf(z)), out=None)
+        self.assertIsInstance(model, CopulaDistribution)
+        self.assertIsInstance(model.copula, GaussianCopulaDistribution)
+
+    def test_independent_data_gets_no_copula_and_no_vine(self):
+        rng = np.random.RandomState(1)
+        x0 = spgamma.rvs(2.0, scale=2.0, size=2000, random_state=rng)
+        x1 = norm.rvs(5.0, 2.0, size=2000, random_state=rng)
+        model = optimize([(float(a), float(b)) for a, b in zip(x0, x1)], out=None)
+        self.assertIsInstance(model, CompositeDistribution)  # no dependence -> no vine even attempted
+
+    def test_vine_captures_tail_dependence_a_gaussian_copula_misses(self):
+        # sanity that the vine is genuinely better here: on Clayton data it out-scores the Gaussian copula.
+        u = ClaytonCopulaDistribution(2, theta=4.0).sampler(0).sample(2000)
+        data = _heterogeneous(u)
+        vine = optimize(data, out=None)
+        # refit a Gaussian-copula-cored model on the same marginals for comparison
+        marg = list(vine.marginals)
+        gc = CopulaDistribution(marg, GaussianCopulaDistribution(np.eye(2)))
+        gc = optimize(data, gc.estimator(), prev_estimate=gc, out=None)
+        ll_vine = float(np.sum(vine.seq_log_density(vine.dist_to_encoder().seq_encode(data))))
+        ll_gc = float(np.sum(gc.seq_log_density(gc.dist_to_encoder().seq_encode(data))))
+        self.assertGreater(ll_vine, ll_gc)  # the tail-dependence core fits the joint-crash coupling better
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Follow-on to the auto-copula path (#136), flagged there as the natural next step. For dependent all-continuous records, automatic inference now scores **two copula cores** by BIC instead of one:

- a **Gaussian copula** — elliptical, tail-independent (the existing default core);
- a **regular vine** — Dißmann structure selection + per-edge family selection.

The vine lets `optimize(data)` recognize joint **tail dependence** — a Clayton-style joint-crash coupling the Gaussian copula structurally cannot represent — and pick the right per-edge family (clayton / gumbel / frank / …) from the data.

**Principled and cheap-by-default:**
- The vine is fit **only when the cheaper Gaussian copula already beat the independent composite** (i.e. dependence actually exists) — on independent data no vine is ever attempted.
- It's kept only if its per-edge structure **beats the Gaussian core by BIC** (params = sum of per-edge pair-copula parameters), so the extra flexibility must earn its place.

## Test plan
- [x] `mixle/tests/automatic_vine_core_test.py` (new, 4 tests): Clayton-coupled heterogeneous margins → a vine with a recovered `clayton` edge; Gaussian-coupled → the Gaussian copula core (vine doesn't pay); independent → a plain composite (no vine even attempted); and a sanity check that the vine out-scores the Gaussian copula on tail-dependent data.
- [x] **Existing structure/BN/estimation/automatic suite: 279 passing, 0 regressions** (incl. the #136 copula-structure tests and the BN structured-default tests).
- [x] `ruff check` / `ruff format --check` — clean.

This completes the automatic-inference copula story: heterogeneous marginals (auto-detected per column) + automatic dependence-core selection (independent / Gaussian copula / tail-dependent vine), all BIC-gated.
