### PR TITLE
experimental: tying discovery via arrangement similarity (H4)

### DIFF
--- a/mixle/experimental/tying_discovery.py
+++ b/mixle/experimental/tying_discovery.py
@@ -1,0 +1,314 @@
+"""Tying discovery via arrangement similarity -- the neural half of ConditionalJIT (H4).
+
+The R1 copula note (see the roadmap doc, R1 -> G4, F6, I2, H4) observes that any weight tensor's flattened
+value vector ``v`` decomposes as ``v = P . s``: a sorted **profile** ``s`` (the empirical quantile function --
+the values in sorted order) composed with a **permutation** ``P`` (the arrangement -- which sorted rank each
+original position maps to). That is exactly Sklar's theorem one level down: a joint distribution factors into
+marginals (here: the profile / value distribution) and a dependence structure (here: the arrangement). This
+module uses only the marginal half of that decomposition as a *discovery signal*: two tensors whose PROFILES
+are close are, value-distribution-wise, "the same numbers, differently arranged" -- exactly the situation a
+weight tie (two module attributes sharing one ``nn.Parameter``, the tensor analogue of this codebase's
+``keys=`` mechanism for tying distribution parameters across combinator children, see
+``mixle.stats.combinator``) can exploit for a real, measurable parameter reduction.
+
+This module deliberately stays on the "discovery" side of the R1 note. Training a permutation (differentiable
+OT / Sinkhorn / torchsort) is explicitly out of scope here -- profile comparison via sorted-vector L2 distance
+is closed-form and needs no optimization loop. See :func:`profile_distance` for why sorted-vector L2 already
+*is* the right 1-D optimal-transport quantity for this purpose.
+
+Workflow:
+
+1. :func:`tensor_profile` -- extract a fixed-length quantile-function profile from a weight tensor.
+2. :func:`profile_distance` -- an L2 distance between two profiles (= 1-D Wasserstein-2 distance between the
+   corresponding empirical distributions).
+3. :func:`propose_ties` -- rank all pairs of named tensors by profile distance and return the most promising
+   tying candidates.
+4. :func:`apply_tie` -- actually replace two tensors with one shared ``nn.Parameter`` and report a measured
+   output-parity receipt (the model is NOT guaranteed function-preserving by a tie; the receipt is the honest,
+   measured delta, not an assumed zero).
+
+Everything here lives in ``mixle/experimental/`` per F7: it graduates out once the mechanism has field mileage
+and (once merged) should be registered against E0's graduation ledger -- a trivial follow-up, not done here
+since ``mixle/experimental/graduation.py`` does not yet exist on this branch.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+try:
+    import torch
+
+    _HAS_TORCH = True
+except ImportError:  # pragma: no cover - torch is optional
+    _HAS_TORCH = False
+
+
+def tensor_profile(tensor: Any, n_quantiles: int = 256) -> Any:
+    """Return the fixed-length quantile-function **profile** of a tensor's values.
+
+    The profile is the empirical quantile function of the tensor's flattened values: sort the values, then
+    resample that sorted curve onto ``n_quantiles`` evenly spaced quantile positions in ``[0, 1]`` by linear
+    interpolation. Fixing ``n_quantiles`` makes profiles from differently shaped/sized tensors directly
+    comparable (a ``(64, 64)`` weight and a ``(32, 128)`` weight both reduce to a length-``n_quantiles`` curve).
+
+    This throws away the ARRANGEMENT entirely (sorting is exactly "forget the permutation P in v = P . s") and
+    keeps only the value distribution -- by design, since arrangement similarity is not what tying discovery
+    is asking about here: two tensors that hold "the same numbers" but scattered into different spatial slots
+    are still excellent tying candidates once one of them is permuted (or once the model is simply insensitive
+    to which of the two arrangements it uses, which the parity receipt in :func:`apply_tie` checks directly).
+
+    Args:
+        tensor: A torch tensor of any shape (or anything ``torch.as_tensor`` accepts).
+        n_quantiles (int): Number of fixed quantile positions to resample the sorted values onto. Must be
+            >= 2. Default 256 is small enough to be cheap and large enough that two profiles from
+            differently-shaped tensors compare fairly.
+
+    Returns:
+        A 1-D torch tensor of length ``n_quantiles``, dtype float32, containing the interpolated quantile
+        function.
+    """
+    if not _HAS_TORCH:  # pragma: no cover - torch is optional
+        raise ImportError("tensor_profile requires torch")
+    if n_quantiles < 2:
+        raise ValueError("n_quantiles must be >= 2, got %r" % (n_quantiles,))
+
+    flat = torch.as_tensor(tensor).detach().reshape(-1).to(torch.float32)
+    n = flat.numel()
+    if n == 0:
+        raise ValueError("tensor_profile requires a non-empty tensor")
+    sorted_vals, _ = torch.sort(flat)
+    if n == 1:
+        return sorted_vals.expand(n_quantiles).clone()
+
+    # Sample positions of the n sorted values along [0, 1], then linearly interpolate onto n_quantiles
+    # evenly spaced query points -- torch.nn.functional.interpolate wants a batch/channel axis.
+    source_positions = torch.linspace(0.0, 1.0, n)
+    query_positions = torch.linspace(0.0, 1.0, n_quantiles)
+    idx = torch.searchsorted(source_positions, query_positions, right=False).clamp(1, n - 1)
+    lo, hi = idx - 1, idx
+    lo_pos, hi_pos = source_positions[lo], source_positions[hi]
+    span = (hi_pos - lo_pos).clamp_min(1e-12)
+    frac = (query_positions - lo_pos) / span
+    return sorted_vals[lo] + frac * (sorted_vals[hi] - sorted_vals[lo])
+
+
+def profile_distance(profile_a: Any, profile_b: Any) -> float:
+    """L2 distance between two equal-length quantile-function profiles.
+
+    Sorted-vector-vs-sorted-vector L2 distance between two empirical quantile functions IS the (discretized)
+    1-D Wasserstein-2 distance between the two underlying empirical distributions -- a standard, well-known
+    fact worth stating explicitly rather than leaning on silently: for 1-D distributions, the optimal
+    transport coupling between two empirical measures is exactly the sorted-to-sorted (rank-to-rank) matching,
+    so ``W2(mu, nu) = ||sort(x) - sort(y)||_2`` up to the ``1/sqrt(n_quantiles)`` normalization used here. That
+    is also the ``v = P . s`` decomposition's marginal half compared directly: two tensors with identical
+    profiles (``profile_distance == 0``) hold the same multiset of values up to arrangement, i.e. one is some
+    permutation of the other -- the exact condition a weight tie wants.
+
+    Args:
+        profile_a: A 1-D tensor, as returned by :func:`tensor_profile`.
+        profile_b: A 1-D tensor of the same length as ``profile_a``.
+
+    Returns:
+        float: The (root-mean-square-normalized) L2 distance between the two profiles, >= 0.
+    """
+    if not _HAS_TORCH:  # pragma: no cover - torch is optional
+        raise ImportError("profile_distance requires torch")
+    a = torch.as_tensor(profile_a).to(torch.float32)
+    b = torch.as_tensor(profile_b).to(torch.float32)
+    if a.shape != b.shape:
+        raise ValueError("profile_distance requires equal-length profiles, got %r vs %r" % (a.shape, b.shape))
+    return float(torch.sqrt(torch.mean((a - b) ** 2)).item())
+
+
+@dataclass(frozen=True)
+class TyingCandidate:
+    """A single proposed weight tie between two named tensors.
+
+    Attributes:
+        name_a (str): Name of the first tensor (as passed into :func:`propose_ties`).
+        name_b (str): Name of the second tensor.
+        distance (float): Profile distance between the two tensors (lower = more similar = better candidate).
+        shape_a (tuple[int, ...]): Shape of the first tensor.
+        shape_b (tuple[int, ...]): Shape of the second tensor.
+    """
+
+    name_a: str
+    name_b: str
+    distance: float
+    shape_a: tuple
+    shape_b: tuple
+
+
+def propose_ties(
+    named_tensors: dict,
+    n_quantiles: int = 256,
+    max_distance: float | None = None,
+    top_k: int | None = None,
+) -> list:
+    """Propose weight-tying candidates by pairwise profile similarity across a set of named tensors.
+
+    Computes a :func:`tensor_profile` for every tensor, then ranks all pairs by :func:`profile_distance`
+    (ascending -- most similar first). This is the discovery step of H4: the analogue of scanning distribution
+    combinators for parameters that could share a ``keys=`` tag, applied to torch tensors instead.
+
+    Args:
+        named_tensors (dict[str, Any]): Mapping from a tensor name (e.g. ``"layer0.head2.q"``) to the tensor
+            itself. Tensors may have different shapes -- profiles fix that via resampling.
+        n_quantiles (int): Passed through to :func:`tensor_profile`.
+        max_distance (float | None): If given, only pairs with ``distance <= max_distance`` are returned. Left
+            unset (``None``) by default so callers can inspect the full ranked list and pick a threshold.
+        top_k (int | None): If given, only the ``top_k`` closest pairs are returned (after ``max_distance``
+            filtering, if any).
+
+    Returns:
+        list[TyingCandidate]: Candidates sorted by ascending distance (most similar / best tying candidate
+            first).
+    """
+    if not _HAS_TORCH:  # pragma: no cover - torch is optional
+        raise ImportError("propose_ties requires torch")
+    names = list(named_tensors.keys())
+    profiles = {name: tensor_profile(named_tensors[name], n_quantiles=n_quantiles) for name in names}
+    shapes = {name: tuple(torch.as_tensor(named_tensors[name]).shape) for name in names}
+
+    candidates = []
+    for i in range(len(names)):
+        for j in range(i + 1, len(names)):
+            name_a, name_b = names[i], names[j]
+            distance = profile_distance(profiles[name_a], profiles[name_b])
+            if max_distance is not None and distance > max_distance:
+                continue
+            candidates.append(
+                TyingCandidate(
+                    name_a=name_a,
+                    name_b=name_b,
+                    distance=distance,
+                    shape_a=shapes[name_a],
+                    shape_b=shapes[name_b],
+                )
+            )
+    candidates.sort(key=lambda c: c.distance)
+    if top_k is not None:
+        candidates = candidates[:top_k]
+    return candidates
+
+
+@dataclass(frozen=True)
+class ParityReceipt:
+    """Measured output-parity receipt for a function-preserving-edit attempt.
+
+    Attributes:
+        max_abs_diff (float): Max absolute elementwise difference between pre- and post-edit outputs.
+        relative_l2 (float): ``||after - before||_2 / ||before||_2`` (0 if ``before`` is identically zero).
+        params_before (int): Total parameter count before the edit.
+        params_after (int): Total parameter count after the edit.
+    """
+
+    max_abs_diff: float
+    relative_l2: float
+    params_before: int
+    params_after: int
+
+    @property
+    def params_reduced(self) -> int:
+        """Absolute parameter-count reduction (>= 0 for a real tie; can be 0 if no sharing occurred)."""
+        return self.params_before - self.params_after
+
+    @property
+    def params_reduced_fraction(self) -> float:
+        """Fractional parameter-count reduction, in ``[0, 1]``."""
+        if self.params_before == 0:
+            return 0.0
+        return self.params_reduced / self.params_before
+
+
+def _get_param(module: Any, dotted_name: str) -> Any:
+    obj = module
+    parts = dotted_name.split(".")
+    for part in parts[:-1]:
+        obj = getattr(obj, part)
+    return obj, parts[-1]
+
+
+def apply_tie(
+    module: Any,
+    name_a: str,
+    name_b: str,
+    inputs: Any,
+    strategy: str = "average",
+) -> ParityReceipt:
+    """Apply a proposed weight tie to two ``nn.Parameter`` attributes on ``module`` and measure the parity cost.
+
+    Replaces the two named parameters with ONE shared ``nn.Parameter`` (both attributes point at the same
+    tensor object afterward, so a gradient step on either updates both -- an actual, literal tie, not merely
+    initializing them equal). ``strategy`` picks the shared value:
+
+    - ``"average"`` (default): elementwise mean of the two original tensors. Requires identical shapes. This
+      is the natural choice when the two tensors are similar-valued-but-not-identical (the realistic case
+      tying discovery is meant to catch, per the H4 acceptance note) -- it minimizes the summed squared
+      perturbation to both tensors simultaneously.
+    - ``"keep_a"``: keep ``name_a``'s tensor verbatim and point ``name_b`` at it. Useful when one tensor is
+      trusted more (e.g. it trained longer, or ``name_a`` is canonical by convention).
+
+    Weight tying is NOT assumed to be output-preserving -- it is exactly a bet that it will be nearly so, which
+    is what the profile-similarity threshold in :func:`propose_ties` is for. This function does not enforce
+    any tolerance itself; it measures and returns the actual delta via a forward pass on ``inputs`` before and
+    after the edit, so the caller can decide whether the receipt is acceptable.
+
+    Args:
+        module: A ``torch.nn.Module`` whose forward pass is deterministic given ``inputs`` (caller should
+            ``.eval()`` it first if it contains dropout/batchnorm-type layers).
+        name_a (str): Dotted attribute path to the first ``nn.Parameter`` (e.g. ``"blocks.0.attn.qkv.weight"``).
+        name_b (str): Dotted attribute path to the second ``nn.Parameter``. Must have the same shape as
+            ``name_a``.
+        inputs: Whatever ``module(inputs)`` accepts; used for the before/after forward pass.
+        strategy (str): ``"average"`` or ``"keep_a"``; see above.
+
+    Returns:
+        ParityReceipt: measured output delta and parameter-count change.
+    """
+    if not _HAS_TORCH:  # pragma: no cover - torch is optional
+        raise ImportError("apply_tie requires torch")
+    if strategy not in ("average", "keep_a"):
+        raise ValueError("strategy must be 'average' or 'keep_a', got %r" % (strategy,))
+
+    owner_a, attr_a = _get_param(module, name_a)
+    owner_b, attr_b = _get_param(module, name_b)
+    param_a = getattr(owner_a, attr_a)
+    param_b = getattr(owner_b, attr_b)
+    if param_a.shape != param_b.shape:
+        raise ValueError("apply_tie requires equal-shape tensors, got %r vs %r" % (param_a.shape, param_b.shape))
+
+    params_before = sum(p.numel() for p in module.parameters())
+
+    module.eval()
+    with torch.no_grad():
+        outputs_before = module(inputs)
+        if isinstance(outputs_before, torch.Tensor):
+            outputs_before = outputs_before.clone()
+
+        if strategy == "average":
+            shared_value = (param_a.detach() + param_b.detach()) / 2.0
+        else:  # "keep_a"
+            shared_value = param_a.detach().clone()
+        shared_param = torch.nn.Parameter(shared_value, requires_grad=param_a.requires_grad)
+
+        setattr(owner_a, attr_a, shared_param)
+        setattr(owner_b, attr_b, shared_param)
+
+        outputs_after = module(inputs)
+
+    max_abs_diff = float((outputs_after - outputs_before).abs().max().item())
+    before_norm = float(outputs_before.norm().item())
+    diff_norm = float((outputs_after - outputs_before).norm().item())
+    relative_l2 = diff_norm / before_norm if before_norm > 0 else 0.0
+
+    params_after = sum(p.numel() for p in module.parameters())
+
+    return ParityReceipt(
+        max_abs_diff=max_abs_diff,
+        relative_l2=relative_l2,
+        params_before=params_before,
+        params_after=params_after,
+    )

--- a/mixle/tests/tying_discovery_test.py
+++ b/mixle/tests/tying_discovery_test.py
@@ -1,0 +1,224 @@
+"""Tests for H4 tying discovery: profile similarity, candidate proposal, and apply-with-receipts.
+
+These are the acceptance tests for H4: "discovered ties on a trained small LM give stated param reduction
+within a loss budget." Test 2 trains a tiny causal LM briefly, plants a known tying opportunity (one head's Q
+weight copied -- with noise -- into another head's slot), and confirms discovery surfaces exactly that pair.
+Test 3 applies the discovered tie and asserts both a bounded output-parity delta and a strictly non-zero
+parameter reduction, printing the actual measured numbers.
+"""
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from mixle.experimental.tying_discovery import (
+    apply_tie,
+    profile_distance,
+    propose_ties,
+    tensor_profile,
+)
+from mixle.models.transformer import build_causal_lm
+
+pytestmark = pytest.mark.fast
+
+
+def test_profile_of_permuted_tensor_is_identical():
+    """Sorting removes the arrangement: a permutation of a tensor has an IDENTICAL profile."""
+    torch.manual_seed(0)
+    base = torch.randn(64)
+    perm = base[torch.randperm(64)]
+    p_base = tensor_profile(base, n_quantiles=128)
+    p_perm = tensor_profile(perm, n_quantiles=128)
+    # Same multiset of values -> same sorted curve -> same profile, up to float roundoff.
+    assert profile_distance(p_base, p_perm) < 1e-6
+
+
+def test_profile_of_permuted_tensor_of_different_shape_is_still_identical():
+    """Profiles are shape-agnostic: reshaping (which is a permutation of a flat view) doesn't move the profile."""
+    torch.manual_seed(1)
+    base = torch.randn(8, 8)
+    reshaped = base.flatten()[torch.randperm(64)].reshape(4, 16)
+    p_base = tensor_profile(base, n_quantiles=64)
+    p_reshaped = tensor_profile(reshaped, n_quantiles=64)
+    assert profile_distance(p_base, p_reshaped) < 1e-6
+
+
+def test_profile_distance_is_large_for_clearly_different_distributions():
+    """N(0, 1) vs N(10, 5): very different scale/mean -> large profile distance."""
+    torch.manual_seed(2)
+    a = torch.randn(2000) * 1.0 + 0.0
+    b = torch.randn(2000) * 5.0 + 10.0
+    p_a = tensor_profile(a, n_quantiles=256)
+    p_b = tensor_profile(b, n_quantiles=256)
+    distance = profile_distance(p_a, p_b)
+    # These distributions barely overlap; the gap between quantile functions should be on the order of the
+    # mean shift (10) minus some slack for the differing spreads -- comfortably bigger than any noise-level
+    # distance we'd see between near-duplicate tensors (see the "close" case below, which is < 1).
+    assert distance > 5.0
+
+
+def test_profile_distance_is_small_for_near_duplicate_tensors():
+    """A tensor plus a small amount of noise should have a small, comfortably-separated profile distance."""
+    torch.manual_seed(3)
+    base = torch.randn(500)
+    noisy = base + torch.randn(500) * 0.01
+    p_base = tensor_profile(base, n_quantiles=256)
+    p_noisy = tensor_profile(noisy, n_quantiles=256)
+    distance = profile_distance(p_base, p_noisy)
+    assert distance < 0.1
+
+
+def _synthetic_batch(vocab=16, block=8, n=32, seed=0):
+    rng = np.random.RandomState(seed)
+    x = rng.randint(0, vocab, size=(n, block)).astype(float)
+    y = rng.randint(0, vocab, size=n).astype(int)
+    return torch.as_tensor(x), torch.as_tensor(y, dtype=torch.long)
+
+
+def _train_briefly(model, x, y, steps=20, lr=1e-2):
+    opt = torch.optim.Adam(model.parameters(), lr=lr)
+    model.train()
+    for _ in range(steps):
+        opt.zero_grad()
+        logits = model(x)
+        loss = torch.nn.functional.cross_entropy(logits, y)
+        loss.backward()
+        opt.step()
+    return float(loss.item())
+
+
+def _head_slice(module, layer, head, part, d_model, n_head):
+    """Return the (d_head, d_model) weight sub-block of a Block's fused qkv.weight for one head's Q/K/V.
+
+    ``CausalAttention.qkv`` is a single ``nn.Linear(d_model, 3 * d_model)``; its weight (shape
+    ``(3*d_model, d_model)``) reshapes as ``(3, n_head, d_head, d_model)`` in the same order the forward pass
+    uses (``reshape(b, t, 3, h, d//h)``). Used only for the discovery-side test (profile comparison of
+    per-head slices) -- applying a tie needs a whole standalone ``nn.Parameter``, see
+    ``_whole_tensor_candidates`` below for the tensors actually tied.
+    """
+    d_head = d_model // n_head
+    part_idx = {"q": 0, "k": 1, "v": 2}[part]
+    qkv_weight = module.blocks[layer].attn.qkv.weight  # (3*d_model, d_model)
+    reshaped = qkv_weight.reshape(3, n_head, d_head, d_model)
+    return reshaped[part_idx, head]  # (d_head, d_model) view into qkv.weight
+
+
+def _build_and_train():
+    torch.manual_seed(42)
+    vocab, d_model, n_layer, n_head, block = 16, 32, 2, 4, 8
+    model = build_causal_lm(vocab, d_model, n_layer, n_head, block)
+    x, y = _synthetic_batch(vocab=vocab, block=block)
+    loss = _train_briefly(model, x, y)
+    return model, x, y, loss, dict(vocab=vocab, d_model=d_model, n_layer=n_layer, n_head=n_head, block=block)
+
+
+def _plant_tying_opportunity(model, cfg, noise_std=1e-3):
+    """Deliberately copy layer0/head0's Q weight into layer1/head2's Q slot, with a bit of noise.
+
+    Small noise simulates the realistic "very similar but not identical" case tying discovery is meant to
+    catch (an exact copy would be a degenerate, uninterestingly-easy case).
+    """
+    d_model, n_head = cfg["d_model"], cfg["n_head"]
+    d_head = d_model // n_head
+    with torch.no_grad():
+        src = _head_slice(model, layer=0, head=0, part="q", d_model=d_model, n_head=n_head).clone()
+        qkv1 = model.blocks[1].attn.qkv.weight  # (3*d_model, d_model)
+        reshaped = qkv1.reshape(3, n_head, d_head, d_model)
+        reshaped[0, 2] = src + torch.randn(d_head, d_model) * noise_std
+        model.blocks[1].attn.qkv.weight.copy_(reshaped.reshape(3 * d_model, d_model))
+
+
+def _collect_head_profiles_input(model, cfg):
+    d_model, n_head, n_layer = cfg["d_model"], cfg["n_head"], cfg["n_layer"]
+    named = {}
+    for layer in range(n_layer):
+        for head in range(n_head):
+            for part in ("q", "k", "v"):
+                name = "layer%d.head%d.%s" % (layer, head, part)
+                named[name] = _head_slice(model, layer, head, part, d_model, n_head)
+    return named
+
+
+def test_tying_discovery_surfaces_the_planted_pair():
+    model, x, y, loss, cfg = _build_and_train()
+    assert np.isfinite(loss)
+
+    _plant_tying_opportunity(model, cfg)
+
+    named = _collect_head_profiles_input(model, cfg)
+    candidates = propose_ties(named, n_quantiles=128)
+    assert len(candidates) > 0
+
+    planted = {"layer0.head0.q", "layer1.head2.q"}
+    top = candidates[0]
+    top_pair = {top.name_a, top.name_b}
+    # The planted pair should be the single closest (or at worst clearly separated within the top few) --
+    # check it is #1, and that its distance is well below the next-closest UNRELATED pair's distance.
+    assert top_pair == planted, "expected planted pair on top, got %r (distance=%.4g)" % (top_pair, top.distance)
+
+    unrelated_distances = [c.distance for c in candidates if {c.name_a, c.name_b} != planted]
+    assert unrelated_distances, "need at least one unrelated pair to compare separation against"
+    assert top.distance < min(unrelated_distances) / 2.0, (
+        "planted pair (%.4g) should be clearly separated from the closest unrelated pair (%.4g)"
+        % (top.distance, min(unrelated_distances))
+    )
+
+
+def _plant_whole_tensor_tying_opportunity(model, noise_std=1e-3):
+    """Deliberately copy block0's whole MLP input-projection weight into block1's, plus small noise.
+
+    Unlike the fused ``qkv.weight`` (whose per-head Q/K/V slices are views, not standalone
+    ``nn.Parameter``s), ``mlp[0].weight`` is a real, independently addressable ``nn.Parameter`` per block --
+    so it is directly tie-able via :func:`apply_tie`, which needs an attribute path it can ``setattr`` a
+    shared ``nn.Parameter`` onto.
+    """
+    with torch.no_grad():
+        src = model.blocks[0].mlp[0].weight.detach().clone()
+        model.blocks[1].mlp[0].weight.copy_(src + torch.randn_like(src) * noise_std)
+
+
+def test_apply_tie_gives_bounded_parity_and_real_param_reduction():
+    model, x, y, loss, cfg = _build_and_train()
+    _plant_whole_tensor_tying_opportunity(model)
+
+    named = {"blocks.%d.mlp[0].weight" % layer: model.blocks[layer].mlp[0].weight for layer in range(cfg["n_layer"])}
+    candidates = propose_ties(named, n_quantiles=128)
+    assert len(candidates) > 0
+    top = candidates[0]
+    assert {top.name_a, top.name_b} == {"blocks.0.mlp[0].weight", "blocks.1.mlp[0].weight"}
+
+    receipt = apply_tie(
+        model,
+        "blocks.0.mlp.0.weight",
+        "blocks.1.mlp.0.weight",
+        inputs=x,
+        strategy="average",
+    )
+
+    print("H4 parity receipt: max_abs_diff=%.6g relative_l2=%.6g" % (receipt.max_abs_diff, receipt.relative_l2))
+    print(
+        "H4 param reduction: %d -> %d params (-%d, -%.2f%%)"
+        % (
+            receipt.params_before,
+            receipt.params_after,
+            receipt.params_reduced,
+            100.0 * receipt.params_reduced_fraction,
+        )
+    )
+
+    # Tolerance: block1's mlp[0].weight was planted as block0's mlp[0].weight plus noise_std=1e-3 Gaussian
+    # noise (see _plant_whole_tensor_tying_opportunity), so "average" replaces each of the two tensors with
+    # something within ~noise_std/2 of where it started -- a small, bounded perturbation, not zero (weight
+    # tying is NOT assumed output-preserving; this is the measured receipt). 0.25 relative-L2 is a generous
+    # multiple of what that small a weight perturbation, propagated through two un-normalized-after residual
+    # blocks plus an output head, is expected to produce -- loose enough to not be flaky over the model's
+    # random init/training seed, tight enough to demonstrate the tie was genuinely near-function-preserving
+    # (as the profile-similarity threshold that nominated it promised) rather than an arbitrary large edit.
+    assert np.isfinite(receipt.max_abs_diff)
+    assert np.isfinite(receipt.relative_l2)
+    assert receipt.relative_l2 < 0.25
+
+    # Real, strictly non-zero parameter reduction: two (d_model, 4*d_model) tensors collapse to one.
+    assert receipt.params_reduced > 0
+    assert receipt.params_after < receipt.params_before


### PR DESCRIPTION
## Summary

Implements roadmap item **H4** (tying discovery via arrangement similarity), the neural half of ConditionalJIT's adaptive-structure work, applying the R1 copula note (`v = P . s`, sorted profile x arrangement -- Sklar's theorem one level down) as a weight-tying discovery tool.

- `mixle/experimental/tying_discovery.py`:
  - `tensor_profile(tensor, n_quantiles)` -- extracts a fixed-length quantile-function profile (empirical quantile function, i.e. sorted values resampled onto `n_quantiles` fixed positions) from a weight tensor of any shape.
  - `profile_distance(a, b)` -- L2 distance between two profiles. Docstring calls out explicitly that sorted-vector-vs-sorted-vector L2 distance between empirical quantile functions **is** the 1-D Wasserstein-2 distance between the underlying empirical distributions.
  - `propose_ties(named_tensors, ...)` -- pairwise profile-distance ranking over a dict of named tensors (e.g. every attention head/layer's weights of a trained model), returning ranked `TyingCandidate`s (most similar first), with optional `max_distance`/`top_k` filters.
  - `apply_tie(module, name_a, name_b, inputs, strategy="average"|"keep_a")` -- actually replaces two named `nn.Parameter` attributes with one shared `nn.Parameter` (a real tie: a gradient step on either now updates both), and returns a `ParityReceipt` with the **measured** (not assumed) output delta (max-abs-diff, relative L2) plus before/after parameter counts. Tying is explicitly *not* assumed output-preserving -- the receipt is the honest measured cost.

This stays on the "discovery" side of R1: no differentiable OT/Sinkhorn machinery (explicitly out of scope per the task -- the codebase's existing `sinkhorn`/OT-adjacent code lives in `mixle/stats/rankings/low_rank_permutation.py` and wasn't a fit here since profile comparison for *discovery* needs no trained permutation). Lives in `mixle/experimental/` per F7; `mixle/experimental/graduation.py` doesn't exist yet on this branch, so no graduation-registry dependency was added -- registering this mechanism once E0's ledger lands is a trivial follow-up.

This mirrors, at the tensor level, this codebase's existing `keys=` mechanism (see `mixle/stats/combinator/`, e.g. `transform.py`, `hurdle.py`) for tying distribution *parameters* across combinator children via shared accumulator keys -- here the tie is a shared `nn.Parameter` instead of a shared accumulator slot.

## Judgment calls

- **Which tensors to profile**: the test plants and discovers a tying opportunity at Q-head-slice granularity (to match the acceptance note's "layers/heads" framing) for discovery, but *applies* the tie at whole-`nn.Parameter` granularity (`mlp[0].weight` per block) -- `CausalAttention.qkv` is one fused `nn.Linear(d_model, 3*d_model)`, so per-head Q/K/V slices are views into a shared tensor, not independently addressable `nn.Parameter`s, and can't be `setattr`-swapped without restructuring the attention module (out of scope here).
- **Apply strategy**: `"average"` (elementwise mean of the two tensors) is the default and what the tests use -- it splits the perturbation across both tensors rather than forcing one to fully absorb the other's values (`"keep_a"` is also provided for when one tensor is trusted more, e.g. trained longer).
- **Threshold**: `propose_ties` takes an optional `max_distance`/`top_k` but ships with no hardcoded default threshold -- left to the caller, since "similar enough to tie" is a judgment call that depends on the tolerance budget of the specific application.

## Test plan

New file `mixle/tests/tying_discovery_test.py` (`pytest.mark.fast`, matches `mixle/tests/streaming_transformer_weights_test.py` conventions):

- Profile-similarity correctness: identical-up-to-permutation tensors (including across differing shapes) give profile distance `< 1e-6`; N(0,1) vs N(10,5) gives distance `> 5.0`; near-duplicate tensors (noise std 0.01) give distance `< 0.1`.
- Tying-candidate discovery on a briefly-trained (20 Adam steps) small causal LM (`build_causal_lm(vocab=16, d_model=32, n_layer=2, n_head=4, block=8)`) with a planted near-duplicate Q-head pair (layer0/head0 copied into layer1/head2 plus Gaussian noise, std 1e-3): discovery ranks the planted pair #1, with distance `< half` of the closest unrelated pair's distance.
- Apply-with-receipts + param reduction, on a separately planted whole-tensor near-duplicate (`blocks.0.mlp[0].weight` copied into `blocks.1.mlp[0].weight` plus noise): discovery again ranks that pair #1, and `apply_tie(..., strategy="average")` gives, **actual measured numbers from the test run**:
  - **Parity delta**: `max_abs_diff = 0.0116341`, `relative_l2 = 0.00072333` -- asserted `< 0.25` (generous multiple of what a ~5e-4-scale weight perturbation is expected to produce through two residual blocks + head; loose enough not to be seed-flaky, tight enough to demonstrate the tie was genuinely near-function-preserving as the similarity threshold that nominated it promised).
  - **Param reduction**: `26240 -> 22144` params, **-4096 (-15.61%)** -- asserted strictly `> 0`.

All 6 new tests pass:
```
mixle/tests/tying_discovery_test.py::test_profile_of_permuted_tensor_is_identical PASSED
mixle/tests/tying_discovery_test.py::test_profile_of_permuted_tensor_of_different_shape_is_still_identical PASSED
mixle/tests/tying_discovery_test.py::test_profile_distance_is_large_for_clearly_different_distributions PASSED
mixle/tests/tying_discovery_test.py::test_profile_distance_is_small_for_near_duplicate_tensors PASSED
mixle/tests/tying_discovery_test.py::test_tying_discovery_surfaces_the_planted_pair PASSED
mixle/tests/tying_discovery_test.py::test_apply_tie_gives_bounded_parity_and_real_param_reduction PASSED
```

Also ran, no regressions:
- `mixle/tests/streaming_transformer_weights_test.py` (2 passed)
- `mixle/tests/hmm_keys_test.py`, `mixle/tests/base_dist_test.py` (existing `keys=` tying coverage; 9 passed)
- `mixle/tests/grad_control_test.py`, `mixle/tests/lm_serialization_test.py`, `mixle/tests/neural_ppl_test.py`, `mixle/tests/task_artifact_test.py`, `mixle/tests/torch_neural_test.py` (other `mixle/models/transformer.py` consumers; 30 passed, 1 skipped -- pre-existing gated torchrun smoke test)

`ruff check --fix` and `ruff format` are clean on both new files.