### PR TITLE
K2: numerics-error receipts through accumulators (opt-in Kahan + conditioning)

### DIFF
--- a/mixle/stats/compute/error_receipts.py
+++ b/mixle/stats/compute/error_receipts.py
@@ -1,0 +1,186 @@
+"""Optional compensated (Kahan) accumulation, carrying a running numerics-error bound.
+
+Precedent: :mod:`mixle.inference.precision_plan` already tracks a *validated* summed-LL error band
+("~1e-6 relative") for the reduced-precision fused kernel -- a static, offline-verified bound picked
+once per model/data pair. This module is the *dynamic, per-accumulator* counterpart: an OPT-IN
+compensated-summation mode that carries its own running error bound as the computation proceeds, so a
+partition's numerics receipt travels with its sufficient statistics through ``combine()`` exactly like
+the statistics themselves.
+
+Design: the receipt an accumulator carries is ``(abs_total, n)`` -- the running sum of absolute
+addend magnitudes and the running term count. Both are *exactly* additive under ``combine()`` (no
+approximation: ``abs_total_combined = abs_total_a + abs_total_b``, ``n_combined = n_a + n_b``, by
+definition), so they satisfy the roadmap's "bounds ADD through combine() like the stats" literally --
+they are themselves additive sufficient statistics. The error BOUND is then the pure function
+:func:`error_bound` of those two additive quantities. This is deliberately the SAFE direction: for the
+naive bound, recomputing from the merged ``(n, abs_total)`` is always >= summing the two children's
+bounds separately (since ``(n_a + n_b - 1) >= (n_a - 1) + (n_b - 1)`` whenever ``n_a, n_b >= 1``), so
+composing through the additive receipt never under-reports the merged error.
+
+Bound formulas (Higham, *Accuracy and Stability of Numerical Algorithms*, 2nd ed., secs 4.2 / 8.1):
+  - naive summation of n terms: ``|error| <= (n-1) * eps * sum(|x_i|)``           (eq. 8.13 style)
+  - Kahan compensated summation: ``|error| <= (2*eps + n*eps**2) * sum(|x_i|)``   (eq. 8.15 style)
+where ``eps`` is the float64 machine epsilon (``2**-52``). Both are asymptotic first/second-order
+bounds under the idealized no-overflow/no-underflow model; they are verified as non-violated upper
+bounds (against a high-precision ``math.fsum`` reference) in
+``mixle/tests/numerics_error_receipts_test.py``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+EPS = float(np.finfo(np.float64).eps)  # 2**-52 ~= 2.22e-16
+
+
+def error_bound(n: int, abs_total: float, compensated: bool) -> float:
+    """Return a valid upper bound on the float64 summation round-off error.
+
+    Args:
+        n (int): Number of terms summed.
+        abs_total (float): Running sum of the absolute value of each (weighted) addend.
+        compensated (bool): Whether the sum was accumulated with Kahan compensation.
+
+    Returns:
+        float: Non-negative upper bound on ``|computed_sum - true_sum|``.
+    """
+    if n <= 1 or abs_total <= 0.0:
+        return 0.0
+    if compensated:
+        return (2.0 * EPS + n * EPS * EPS) * abs_total
+    return (n - 1) * EPS * abs_total
+
+
+@dataclass
+class CompensatedAccumulator:
+    """A running (optionally Kahan-compensated) sum plus the additive receipt its bound derives from.
+
+    ``total`` is the running sum (Kahan-corrected when ``compensated=True``, plain float64
+    accumulation otherwise). ``abs_total`` and ``n`` are the additive receipt: they compose exactly
+    under :meth:`combine`, and :meth:`bound` derives the error bound from them via
+    :func:`error_bound`.
+    """
+
+    total: float = 0.0
+    compensation: float = 0.0
+    abs_total: float = 0.0
+    n: int = 0
+    compensated: bool = True
+
+    def add(self, x: float, weight: float = 1.0) -> CompensatedAccumulator:
+        """Fold one (weighted) addend into the running sum."""
+        term = float(x) * float(weight)
+        if self.compensated:
+            y = term - self.compensation
+            t = self.total + y
+            self.compensation = (t - self.total) - y
+            self.total = t
+        else:
+            self.total += term
+        self.abs_total += abs(term)
+        self.n += 1
+        return self
+
+    def combine(self, other: CompensatedAccumulator) -> CompensatedAccumulator:
+        """Merge another partition's running sum + receipt into this one, in place.
+
+        The other accumulator's compensation-corrected estimate (``other.total -
+        other.compensation``) is folded in as a single addend via the same (compensated or plain)
+        addition rule this accumulator uses; ``abs_total``/``n`` -- the receipt -- add exactly, the
+        same way the underlying sufficient statistics (``sum``, ``count``, ...) do.
+        """
+        value_to_add = other.total - other.compensation
+        if self.compensated:
+            y = value_to_add - self.compensation
+            t = self.total + y
+            self.compensation = (t - self.total) - y
+            self.total = t
+        else:
+            self.total += value_to_add
+        self.abs_total += other.abs_total
+        self.n += other.n
+        return self
+
+    def bound(self) -> float:
+        """Return the current error-bound receipt (see :func:`error_bound`)."""
+        return error_bound(self.n, self.abs_total, self.compensated)
+
+
+def kahan_reduce(values: Iterable[float], weights: Iterable[float] | None = None) -> CompensatedAccumulator:
+    """Reduce a sequence (optionally weighted) to a fresh :class:`CompensatedAccumulator`.
+
+    A convenience one-shot reducer, mainly used by tests and small ad hoc reductions; accumulators
+    that need this incrementally (across ``update``/``seq_update`` calls) should hold their own
+    :class:`CompensatedAccumulator` instance instead of re-reducing from scratch each time.
+    """
+    acc = CompensatedAccumulator(compensated=True)
+    if weights is None:
+        for v in values:
+            acc.add(v)
+    else:
+        for v, w in zip(values, weights):
+            acc.add(v, w)
+    return acc
+
+
+@dataclass
+class ConditioningReceipt:
+    """A real, computed numerical-conditioning diagnostic for a (multivariate) fit.
+
+    Captures the covariance eigenvalue spectrum an ``estimate()`` call saw, so a caller can tell a
+    healthy fit from one balanced on a near-degenerate direction without recomputing the eigenspectrum
+    itself.
+
+    Attributes:
+        eigenvalues (np.ndarray): Eigenvalues of the (raw, pre-regularization) covariance, ascending.
+        condition_number (float): ``max_eigenvalue / min_eigenvalue`` (``inf`` if the smallest
+            eigenvalue is <= 0, i.e. the raw covariance is singular / numerically indefinite).
+        near_degenerate (bool): True when the smallest-to-largest eigenvalue ratio falls below
+            ``degenerate_ratio_threshold`` (or the smallest eigenvalue is non-positive).
+        degenerate_ratio_threshold (float): The ratio threshold used to set ``near_degenerate``.
+    """
+
+    eigenvalues: np.ndarray
+    condition_number: float
+    near_degenerate: bool
+    degenerate_ratio_threshold: float
+
+    def to_dict(self) -> dict[str, Any]:
+        """JSON-friendly view of this receipt."""
+        return {
+            "eigenvalues": [float(v) for v in self.eigenvalues],
+            "condition_number": float(self.condition_number),
+            "near_degenerate": bool(self.near_degenerate),
+            "degenerate_ratio_threshold": float(self.degenerate_ratio_threshold),
+        }
+
+
+def conditioning_receipt(covar: np.ndarray, degenerate_ratio: float = 1.0e-6) -> ConditioningReceipt:
+    """Compute a :class:`ConditioningReceipt` from a (symmetric) covariance matrix.
+
+    ``degenerate_ratio`` is the smallest/largest eigenvalue ratio below which the covariance is
+    flagged near-degenerate (i.e. it has a direction of near-zero variance relative to the dominant
+    one) -- the "near-degenerate variance flag" the roadmap calls for, generalized from a single
+    variance to the eigenvalue spectrum for the multivariate case.
+    """
+    covar = np.asarray(covar, dtype=np.float64)
+    covar = 0.5 * (covar + covar.T)  # symmetrize away accumulation round-off before eigh
+    eigvals = np.linalg.eigvalsh(covar)
+    max_eig = float(np.max(eigvals))
+    min_eig = float(np.min(eigvals))
+    if min_eig <= 0.0:
+        condition_number = float("inf")
+        near_degenerate = True
+    else:
+        condition_number = max_eig / min_eig if max_eig > 0.0 else float("inf")
+        near_degenerate = (min_eig / max_eig) < degenerate_ratio if max_eig > 0.0 else True
+    return ConditioningReceipt(
+        eigenvalues=eigvals,
+        condition_number=condition_number,
+        near_degenerate=near_degenerate,
+        degenerate_ratio_threshold=degenerate_ratio,
+    )

--- a/mixle/stats/multivariate/multivariate_gaussian.py
+++ b/mixle/stats/multivariate/multivariate_gaussian.py
@@ -793,6 +793,8 @@ class MultivariateGaussianEstimator(ParameterEstimator):
         prior: SequenceEncodableProbabilityDistribution | None = None,
         min_covar: float | None = None,
         ridge: float | None = None,
+        track_conditioning: bool = False,
+        degenerate_ratio: float = 1.0e-6,
     ) -> None:
         """MultivariateGaussianEstimator object for estimating multivariate normal distribution from sufficient stats.
 
@@ -814,6 +816,16 @@ class MultivariateGaussianEstimator(ParameterEstimator):
                 ``eps = max(min_covar, ridge * trace(cov) / d)`` so a singular / non-finite
                 covariance (a component holding < d points) cannot break the Cholesky factor.
                 Bias is negligible at the defaults.
+            track_conditioning (bool): Opt-in numerics-conditioning receipt. When ``True``,
+                ``estimate`` computes the eigenspectrum of the RAW (pre-ridge) empirical covariance
+                and attaches it to the returned distribution as ``.conditioning_receipt`` -- a
+                :class:`~mixle.stats.compute.error_receipts.ConditioningReceipt` with the eigenvalues,
+                condition number, and a near-degenerate-variance flag. Computed on the raw scatter
+                (not the ridge-regularized one) so the receipt reports the DATA's true conditioning
+                rather than the numerical safety net masking it. ``False`` by default (no overhead).
+            degenerate_ratio (float): Smallest/largest covariance-eigenvalue ratio below which
+                ``track_conditioning`` flags the fit as near-degenerate. Only used when
+                ``track_conditioning=True``.
 
         Attributes:
             dim (int): Dimension of multivariate normal.
@@ -844,6 +856,8 @@ class MultivariateGaussianEstimator(ParameterEstimator):
         self.has_conj_prior = isinstance(prior, NormalWishartDistribution)
         self.min_covar = 1.0e-8 if min_covar is None else float(min_covar)
         self.ridge = 1.0e-6 if ridge is None else float(ridge)
+        self.track_conditioning = track_conditioning
+        self.degenerate_ratio = float(degenerate_ratio)
 
     def accumulator_factory(self) -> "MultivariateGaussianAccumulatorFactory":
         """Returns a MultivariateGaussianAccumulatorFactory built from the estimator's attributes."""
@@ -922,9 +936,11 @@ class MultivariateGaussianEstimator(ParameterEstimator):
             # rather than dividing by zero and emitting a NaN mean.
             d = self.dim if self.dim is not None else len(suff_stat[0])
             mu = np.asarray(self.prior_mu, dtype=float) if self.prior_mu is not None else vec.zeros(d)
-            covar = np.asarray(self.prior_covar, dtype=float) if self.prior_covar is not None else np.eye(d)
-            covar = self._regularize_covar(covar)
-            return MultivariateGaussianDistribution(mu, covar, name=self.name, keys=self.keys)
+            raw_covar = np.asarray(self.prior_covar, dtype=float) if self.prior_covar is not None else np.eye(d)
+            covar = self._regularize_covar(raw_covar)
+            dist = MultivariateGaussianDistribution(mu, covar, name=self.name, keys=self.keys)
+            self._attach_conditioning_receipt(dist, raw_covar)
+            return dist
 
         if pc1 is not None and self.prior_mu is not None:
             mu = (suff_stat[0] + pc1 * self.prior_mu) / (nobs + pc1)
@@ -932,13 +948,23 @@ class MultivariateGaussianEstimator(ParameterEstimator):
             mu = suff_stat[0] / nobs
 
         if pc2 is not None and self.prior_covar is not None:
-            covar = (suff_stat[1] + (pc2 * self.prior_covar) - vec.outer(mu, mu * nobs)) / (nobs + pc2)
+            raw_covar = (suff_stat[1] + (pc2 * self.prior_covar) - vec.outer(mu, mu * nobs)) / (nobs + pc2)
         else:
-            covar = (suff_stat[1] / nobs) - vec.outer(mu, mu)
+            raw_covar = (suff_stat[1] / nobs) - vec.outer(mu, mu)
 
-        covar = self._regularize_covar(covar)
+        covar = self._regularize_covar(raw_covar)
 
-        return MultivariateGaussianDistribution(mu, covar, name=self.name, keys=self.keys)
+        dist = MultivariateGaussianDistribution(mu, covar, name=self.name, keys=self.keys)
+        self._attach_conditioning_receipt(dist, raw_covar)
+        return dist
+
+    def _attach_conditioning_receipt(self, dist: "MultivariateGaussianDistribution", raw_covar: np.ndarray) -> None:
+        """Opt-in: compute and attach a numerics-conditioning receipt to ``dist`` (see ``__init__``)."""
+        if not self.track_conditioning:
+            return
+        from mixle.stats.compute.error_receipts import conditioning_receipt
+
+        dist.conditioning_receipt = conditioning_receipt(raw_covar, degenerate_ratio=self.degenerate_ratio)
 
     def _regularize_covar(self, covar: np.ndarray) -> np.ndarray:
         """P1 covariance ridge: cov <- cov + eps*I with eps = max(min_covar, ridge*trace/d).

--- a/mixle/stats/univariate/continuous/gaussian.py
+++ b/mixle/stats/univariate/continuous/gaussian.py
@@ -20,6 +20,7 @@ from numpy.random import RandomState
 from mixle.engines.arithmetic import *
 from mixle.inference.fisher import FixedFisherView
 from mixle.stats.bayes.normal_gamma import NormalGammaDistribution
+from mixle.stats.compute.error_receipts import CompensatedAccumulator
 from mixle.stats.compute.pdist import (
     DataSequenceEncoder,
     DistributionSampler,
@@ -426,13 +427,34 @@ class GaussianSampler(DistributionSampler):
         return self.rng.normal(loc=self.dist.mu, scale=sqrt(self.dist.sigma2), size=size)
 
 
+class GaussianSuffStat(tuple):
+    """A ``(sum, sum2, count, count2)`` sufficient statistic that also carries a numerics receipt.
+
+    Behaves exactly like the plain 4-tuple everywhere it is indexed, unpacked, or iterated (it *is*
+    one); ``receipt`` is extra payload that :meth:`GaussianAccumulator.combine` reads to fold the
+    Kahan error-bound bookkeeping (``abs_total``, ``n`` for ``sum`` and ``sum2``) into the receiving
+    accumulator when both sides are ``compensated``. Code that doesn't know about ``compensated``
+    accumulation (serialization, generic ``scale_suff_stat``, ...) sees an ordinary tuple.
+    """
+
+    def __new__(cls, sum_: float, sum2_: float, count_: float, count2_: float, receipt: dict | None = None):
+        obj = super().__new__(cls, (sum_, sum2_, count_, count2_))
+        obj.receipt = receipt
+        return obj
+
+
 class GaussianAccumulator(SequenceEncodableStatisticAccumulator):
-    def __init__(self, keys: str | None = None, name: str | None = None) -> None:
+    def __init__(self, keys: str | None = None, name: str | None = None, compensated: bool = False) -> None:
         """GaussianAccumulator object used to accumulate sufficient statistics from observed data.
 
         Args:
             keys (Optional[str]): Set key for GaussianAccumulator object.
             name (Optional[str]): Set name for GaussianAccumulator object.
+            compensated (bool): Opt-in Kahan-compensated accumulation of ``sum``/``sum2`` with a
+                running numerics-error bound (see :mod:`mixle.stats.compute.error_receipts`), read
+                back via :meth:`error_bound`. ``False`` (the default) is the plain float64
+                accumulation this class always used -- that code path is untouched, so it carries no
+                measurable overhead over the pre-existing behavior.
 
         Attributes:
             sum (float): Sum of weighted observations (sum_i w_i*X_i).
@@ -450,6 +472,9 @@ class GaussianAccumulator(SequenceEncodableStatisticAccumulator):
         self.count2 = 0.0
         self.keys = keys
         self.name = name
+        self.compensated = compensated
+        self._sum_acc = CompensatedAccumulator(compensated=True) if compensated else None
+        self._sum2_acc = CompensatedAccumulator(compensated=True) if compensated else None
 
     def update(self, x: float, weight: float, estimate: Optional["GaussianDistribution"]) -> None:
         """Update sufficient statistics for GaussianAccumulator with one weighted observation.
@@ -465,8 +490,14 @@ class GaussianAccumulator(SequenceEncodableStatisticAccumulator):
 
         """
         x_weight = x * weight
-        self.sum += x_weight
-        self.sum2 += x * x_weight
+        if self.compensated:
+            self._sum_acc.add(x_weight)
+            self._sum2_acc.add(x * x_weight)
+            self.sum = self._sum_acc.total
+            self.sum2 = self._sum2_acc.total
+        else:
+            self.sum += x_weight
+            self.sum2 += x * x_weight
         self.count += weight
         self.count2 += weight
 
@@ -515,9 +546,18 @@ class GaussianAccumulator(SequenceEncodableStatisticAccumulator):
             None.
 
         """
-        self.sum += np.dot(x, weights)
-        self.sum2 += np.dot(x * x, weights)
-        w_sum = weights.sum()
+        if self.compensated:
+            for xi, wi in zip(x, weights):
+                xw = float(xi) * float(wi)
+                self._sum_acc.add(xw)
+                self._sum2_acc.add(float(xi) * xw)
+            self.sum = self._sum_acc.total
+            self.sum2 = self._sum2_acc.total
+            w_sum = float(np.sum(weights))
+        else:
+            self.sum += np.dot(x, weights)
+            self.sum2 += np.dot(x * x, weights)
+            w_sum = weights.sum()
         self.count += w_sum
         self.count2 += w_sum
 
@@ -529,6 +569,11 @@ class GaussianAccumulator(SequenceEncodableStatisticAccumulator):
             suff_stat[1] (float): Sum of weighted observations (sum_i w_i*X_i^2),
             suff_stat[2] (float): Sum of weighted observations (sum_i w_i),
             suff_stat[3] (float): Sum of weighted observations (sum_i w_i).
+
+        When this accumulator is ``compensated`` and ``suff_stat`` carries a numerics-error
+        receipt (see :meth:`value` / :class:`GaussianSuffStat`), the receipt is folded in too --
+        its ``(abs_total, n)`` fields add exactly, just like ``sum``/``count`` above, so
+        :meth:`error_bound` composes correctly across combined partitions.
 
         Args:
             suff_stat (Tuple[float, float, float, float]): See above for details.
@@ -542,10 +587,44 @@ class GaussianAccumulator(SequenceEncodableStatisticAccumulator):
         self.count += suff_stat[2]
         self.count2 += suff_stat[3]
 
+        if self.compensated:
+            receipt = getattr(suff_stat, "receipt", None)
+            if receipt is not None:
+                abs_s, n_s = receipt["sum"]
+                abs_s2, n_s2 = receipt["sum2"]
+                self._sum_acc.abs_total += abs_s
+                self._sum_acc.n += n_s
+                self._sum2_acc.abs_total += abs_s2
+                self._sum2_acc.n += n_s2
+            # keep the running Kahan total (and its compensation) in sync with the merged sum
+            self._sum_acc.total = self.sum
+            self._sum2_acc.total = self.sum2
+
         return self
 
+    def error_bound(self) -> dict[str, float] | None:
+        """Return the running numerics-error bound receipt for ``sum``/``sum2``.
+
+        ``None`` when this accumulator was not constructed with ``compensated=True`` -- the
+        disabled default carries no receipt to report.
+        """
+        if not self.compensated:
+            return None
+        return {"sum": self._sum_acc.bound(), "sum2": self._sum2_acc.bound()}
+
     def value(self) -> tuple[float, float, float, float]:
-        """Returns sufficient statistics of GaussianAccumulator object (Tuple[float, float, float, float])."""
+        """Returns sufficient statistics of GaussianAccumulator object (Tuple[float, float, float, float]).
+
+        When ``compensated``, the returned value is a :class:`GaussianSuffStat` -- a drop-in 4-tuple
+        (indexing/unpacking/iteration all behave identically) that additionally carries the
+        numerics-error receipt in its ``.receipt`` attribute, so :meth:`combine` can fold it in.
+        """
+        if self.compensated:
+            receipt = {
+                "sum": (self._sum_acc.abs_total, self._sum_acc.n),
+                "sum2": (self._sum2_acc.abs_total, self._sum2_acc.n),
+            }
+            return GaussianSuffStat(self.sum, self.sum2, self.count, self.count2, receipt=receipt)
         return self.sum, self.sum2, self.count, self.count2
 
     def from_value(self, x: tuple[float, float, float, float]) -> "GaussianAccumulator":
@@ -568,6 +647,17 @@ class GaussianAccumulator(SequenceEncodableStatisticAccumulator):
         self.sum2 = x[1]
         self.count = x[2]
         self.count2 = x[3]
+
+        if self.compensated:
+            receipt = getattr(x, "receipt", None)
+            if receipt is not None:
+                abs_s, n_s = receipt["sum"]
+                abs_s2, n_s2 = receipt["sum2"]
+                self._sum_acc = CompensatedAccumulator(total=self.sum, abs_total=abs_s, n=n_s, compensated=True)
+                self._sum2_acc = CompensatedAccumulator(total=self.sum2, abs_total=abs_s2, n=n_s2, compensated=True)
+            else:
+                self._sum_acc = CompensatedAccumulator(total=self.sum, compensated=True)
+                self._sum2_acc = CompensatedAccumulator(total=self.sum2, compensated=True)
 
         return self
 
@@ -612,12 +702,13 @@ class GaussianAccumulator(SequenceEncodableStatisticAccumulator):
 
 
 class GaussianAccumulatorFactory(StatisticAccumulatorFactory):
-    def __init__(self, name: str | None = None, keys: str | None = None) -> None:
+    def __init__(self, name: str | None = None, keys: str | None = None, compensated: bool = False) -> None:
         """GaussianAccumulatorFactory object for creating GaussianAccumulator.
 
         Args:
             name (Optional[str]): Assign a name to GaussianAccumulatorFactory object.
             keys (Optional[str]): Assign keys member for GaussianAccumulators.
+            compensated (bool): Passed through to each made :class:`GaussianAccumulator`; see there.
 
         Attributes:
             name (Optional[str]): Name of the GaussianAccumulatorFactory obejct.
@@ -626,10 +717,11 @@ class GaussianAccumulatorFactory(StatisticAccumulatorFactory):
         """
         self.keys = keys
         self.name = name
+        self.compensated = compensated
 
     def make(self) -> "GaussianAccumulator":
         """Return a GaussianAccumulator object with name and keys passed."""
-        return GaussianAccumulator(name=self.name, keys=self.keys)
+        return GaussianAccumulator(name=self.name, keys=self.keys, compensated=self.compensated)
 
 
 class GaussianEstimator(ParameterEstimator):
@@ -641,6 +733,7 @@ class GaussianEstimator(ParameterEstimator):
         keys: str | None = None,
         prior: SequenceEncodableProbabilityDistribution | None = None,
         min_covar: float | None = None,
+        compensated: bool = False,
     ):
         """GaussianEstimator object used to estimate GaussianDistribution from aggregated sufficient statistics.
 
@@ -657,6 +750,9 @@ class GaussianEstimator(ParameterEstimator):
                 (default) uses a tiny ``1e-8`` floor; the estimated variance is also floored at a
                 relative ``1e-6 * sigma2`` to keep the safeguard data-scaled. Set explicitly to widen
                 the floor for hard / high-dimensional cases. Bias is negligible at the default.
+            compensated (bool): Opt-in Kahan-compensated accumulation with a running numerics-error
+                bound for the accumulators this estimator makes; see
+                :class:`GaussianAccumulator`. ``False`` by default (no overhead).
 
         Attributes:
             pseudo_count (Tuple[Optional[float], Optional[float]]): Weights for suff_stat.
@@ -672,10 +768,11 @@ class GaussianEstimator(ParameterEstimator):
         self.prior = prior
         self.has_conj_prior = isinstance(prior, NormalGammaDistribution)
         self.min_covar = 1.0e-8 if min_covar is None else float(min_covar)
+        self.compensated = compensated
 
     def accumulator_factory(self) -> "GaussianAccumulatorFactory":
         """Return GaussianAccumulatorFactory with name and keys passed."""
-        return GaussianAccumulatorFactory(self.name, self.keys)
+        return GaussianAccumulatorFactory(self.name, self.keys, compensated=self.compensated)
 
     def model_log_density(self, model: "GaussianDistribution") -> float:
         """Log-density of the model parameters under the NormalGamma prior (ELBO global term).

--- a/mixle/tests/numerics_error_receipts_test.py
+++ b/mixle/tests/numerics_error_receipts_test.py
@@ -1,0 +1,328 @@
+"""K2: numerics-error receipts through accumulators.
+
+Optional compensated (Kahan) accumulation carries a running numerics-error bound alongside the
+accumulated sufficient statistics; the bound composes through ``combine()`` the same way the
+statistics themselves do. ``MultivariateGaussianEstimator.estimate()`` grows an opt-in conditioning
+receipt (covariance eigenvalue ratio / near-degenerate-variance flag). Both are OFF by default with
+no measurable overhead over the pre-existing behavior.
+
+Acceptance criteria under test:
+  1. Planted ill-conditioning (and a well-conditioned control) is correctly flagged.
+  2. Planted catastrophic cancellation is flagged with correct bound ORDERING, verified against a
+     high-precision (``math.fsum``) reference -- not just naive-bound > kahan-bound in isolation.
+  3. The disabled/default path is unaffected: behaviorally identical to the pre-existing
+     implementation, and a large-workload timing check confirms no measurable regression.
+"""
+
+import math
+import time
+import unittest
+
+import numpy as np
+
+from mixle.stats.compute.error_receipts import CompensatedAccumulator, conditioning_receipt, error_bound
+from mixle.stats.multivariate.multivariate_gaussian import MultivariateGaussianEstimator
+from mixle.stats.univariate.continuous.gaussian import GaussianAccumulator, GaussianEstimator
+
+# Stated overhead threshold for the disabled/default path (acceptance criterion: "overhead < stated %
+# when disabled"). This repo's test suite runs under pytest-xdist -n auto by default (see
+# pyproject.toml), so wall-clock timing here is contended by sibling workers and cannot support a
+# tight percentage threshold without flaking. The primary overhead guarantee is therefore the
+# STRUCTURAL check (test_disabled_path_matches_naive_float64_reference /
+# test_disabled_accumulator_carries_no_receipt_state below): the disabled path is bit-for-bit
+# identical to the pre-existing np.dot-based implementation, so it cannot regress. The timing check
+# is corroborating evidence with a generous, non-flaky threshold (min-of-many-repeats, large
+# workload) -- generous enough to absorb worker contention while still catching a real regression
+# (e.g. an accidental O(n) Python loop on the disabled path, which would blow the ratio far past it).
+_DISABLED_OVERHEAD_THRESHOLD = 0.50  # 50%, deliberately generous under parallel test contention
+
+
+# --------------------------------------------------------------------------------------------------
+# 1. Planted ill-conditioning
+# --------------------------------------------------------------------------------------------------
+class ConditioningReceiptTest(unittest.TestCase):
+    def _fit(self, data, **kwargs):
+        est = MultivariateGaussianEstimator(dim=data.shape[1], track_conditioning=True, **kwargs)
+        acc = est.accumulator_factory().make()
+        acc.seq_update(data, np.ones(len(data)), None)
+        return est.estimate(None, acc.value())
+
+    def test_planted_near_degenerate_direction_is_flagged(self):
+        # 3 well-spread dims + 1 dim with variance ~1e8x smaller -> a genuinely near-degenerate
+        # covariance direction, not a numerical artifact.
+        rng = np.random.RandomState(0)
+        n = 5000
+        well = rng.normal(loc=0.0, scale=1.0, size=(n, 3))
+        degenerate = rng.normal(loc=0.0, scale=1.0e-4, size=(n, 1))  # variance ~1e-8 vs ~1
+        data = np.hstack([well, degenerate])
+
+        dist = self._fit(data)
+        receipt = dist.conditioning_receipt
+        self.assertIsNotNone(receipt)
+        self.assertTrue(receipt.near_degenerate)
+        self.assertGreater(receipt.condition_number, 1.0e4)
+        # the smallest eigenvalue should correspond to the planted near-zero-variance dimension
+        self.assertLess(float(np.min(receipt.eigenvalues)), 1.0e-4)
+
+    def test_well_conditioned_control_is_not_flagged(self):
+        rng = np.random.RandomState(1)
+        n = 5000
+        # isotropic-ish covariance: comparable variances on every axis -> healthy condition number
+        data = rng.multivariate_normal(mean=np.zeros(4), cov=np.diag([1.0, 1.2, 0.8, 1.1]), size=n)
+
+        dist = self._fit(data)
+        receipt = dist.conditioning_receipt
+        self.assertIsNotNone(receipt)
+        self.assertFalse(receipt.near_degenerate)
+        self.assertLess(receipt.condition_number, 100.0)
+
+    def test_disabled_by_default_no_receipt_attached(self):
+        rng = np.random.RandomState(2)
+        data = rng.normal(size=(200, 3))
+        est = MultivariateGaussianEstimator(dim=3)  # track_conditioning defaults to False
+        acc = est.accumulator_factory().make()
+        acc.seq_update(data, np.ones(len(data)), None)
+        dist = est.estimate(None, acc.value())
+        self.assertFalse(hasattr(dist, "conditioning_receipt"))
+
+    def test_conditioning_receipt_function_matches_known_eigenvalues(self):
+        # a diagonal covariance's eigenvalues are exactly its diagonal -- a direct correctness check
+        # of conditioning_receipt() independent of the estimator plumbing.
+        covar = np.diag([4.0, 1.0, 1.0e-9])
+        receipt = conditioning_receipt(covar, degenerate_ratio=1.0e-6)
+        self.assertTrue(np.allclose(sorted(receipt.eigenvalues), [1.0e-9, 1.0, 4.0]))
+        self.assertAlmostEqual(receipt.condition_number, 4.0 / 1.0e-9, delta=4.0 / 1.0e-9 * 1e-6)
+        self.assertTrue(receipt.near_degenerate)
+
+
+# --------------------------------------------------------------------------------------------------
+# 2. Planted catastrophic cancellation: bound ordering + validity against a high-precision reference
+# --------------------------------------------------------------------------------------------------
+class CatastrophicCancellationTest(unittest.TestCase):
+    @staticmethod
+    def _planted_values(n=200000, big=1.0e8, seed=0):
+        # A large offset followed by many small increments that mostly cancel: the classic
+        # catastrophic-cancellation setup for naive left-to-right float64 summation. Values:
+        # [+big, -big, +tiny_1, -tiny_1, +tiny_2, -tiny_2, ...] with a tiny residual net sum so the
+        # true answer is well-defined and far smaller than the naive rounding noise.
+        rng = np.random.RandomState(seed)
+        small = rng.uniform(1.0, 10.0, size=n // 2)
+        values = [big, -big]
+        for s in small:
+            values.append(s)
+            values.append(-s + 1e-3)  # tiny net residual per pair, not exact cancellation
+        return values
+
+    def test_naive_vs_kahan_bound_ordering_and_validity(self):
+        values = self._planted_values()
+
+        naive_acc = CompensatedAccumulator(compensated=False)
+        kahan_acc = CompensatedAccumulator(compensated=True)
+        for v in values:
+            naive_acc.add(v)
+            kahan_acc.add(v)
+
+        reference = math.fsum(values)  # near-exact (Shewchuk's algorithm): ground truth
+        naive_error = abs(naive_acc.total - reference)
+        kahan_error = abs(kahan_acc.total - reference)
+        naive_bound = naive_acc.bound()
+        kahan_bound = kahan_acc.bound()
+
+        # Sanity: the planted scenario actually exercises meaningfully different float64 results
+        # under naive vs compensated summation (otherwise the ordering claim would be vacuous).
+        self.assertNotEqual(naive_acc.total, kahan_acc.total)
+
+        # (a) the reported bound is a genuinely valid, non-violated upper bound on the real error,
+        #     for BOTH accumulation modes, verified against the high-precision reference.
+        self.assertLessEqual(naive_error, naive_bound, "naive bound must not be violated")
+        self.assertLessEqual(kahan_error, kahan_bound, "kahan bound must not be violated")
+
+        # (b) bound ORDERING: the naive path's reported bound is larger than the compensated path's.
+        self.assertGreater(naive_bound, kahan_bound)
+
+        # (c) the ordering matches reality, not just the formula: Kahan's actual error is also
+        #     smaller (or equal) than naive's actual error on this cancellation-heavy workload.
+        self.assertLessEqual(kahan_error, naive_error)
+
+        self._naive_bound, self._kahan_bound = naive_bound, kahan_bound
+        self._naive_error, self._kahan_error = naive_error, kahan_error
+
+    def test_error_bound_function_matches_accumulator_bound(self):
+        values = self._planted_values(n=2000, seed=3)
+        acc = CompensatedAccumulator(compensated=True)
+        for v in values:
+            acc.add(v)
+        self.assertAlmostEqual(acc.bound(), error_bound(acc.n, acc.abs_total, compensated=True))
+
+    def test_gaussian_accumulator_compensated_bound_ordering(self):
+        # The same catastrophic-cancellation scenario through the real GaussianAccumulator wiring
+        # (not just the standalone CompensatedAccumulator primitive), on the 'sum' sufficient
+        # statistic (large mu offset + many small-magnitude observations).
+        rng = np.random.RandomState(4)
+        n = 100000
+        offset = 1.0e7
+        x = np.concatenate([[offset], rng.uniform(-1.0, 1.0, size=n - 1)])
+        weights = np.ones(n)
+
+        naive = GaussianAccumulator(compensated=False)
+        kahan = GaussianAccumulator(compensated=True)
+        naive.seq_update(x, weights, None)
+        kahan.seq_update(x, weights, None)
+
+        reference = math.fsum(x.tolist())
+        naive_error = abs(naive.sum - reference)
+        kahan_error = abs(kahan.sum - reference)
+        naive_bound = error_bound(n, float(np.sum(np.abs(x))), compensated=False)
+        kahan_bound = kahan.error_bound()["sum"]
+
+        self.assertLessEqual(naive_error, naive_bound)
+        self.assertLessEqual(kahan_error, kahan_bound)
+        self.assertGreater(naive_bound, kahan_bound)
+
+    def test_bounds_compose_through_combine(self):
+        # split the planted workload into two partitions, accumulate each separately (as two
+        # workers would), then combine() -- the resulting bound must equal what a single
+        # accumulator over the whole stream would report (bounds compose exactly through the
+        # additive (abs_total, n) receipt, like the roadmap requires).
+        values = self._planted_values(n=20000, seed=5)
+        half = len(values) // 2
+
+        whole = CompensatedAccumulator(compensated=True)
+        for v in values:
+            whole.add(v)
+
+        part_a = CompensatedAccumulator(compensated=True)
+        for v in values[:half]:
+            part_a.add(v)
+        part_b = CompensatedAccumulator(compensated=True)
+        for v in values[half:]:
+            part_b.add(v)
+        part_a.combine(part_b)
+
+        self.assertEqual(whole.n, part_a.n)
+        self.assertAlmostEqual(whole.abs_total, part_a.abs_total, delta=1e-6 * whole.abs_total)
+        self.assertAlmostEqual(whole.bound(), part_a.bound(), delta=1e-9 * whole.bound())
+
+    def test_gaussian_accumulator_combine_preserves_bound_composition(self):
+        # Same composition property, but through the real GaussianAccumulator.combine() /
+        # .value() plumbing (GaussianSuffStat receipt round-trip), matching how partitions are
+        # actually merged in this codebase (acc.combine(other.value())).
+        rng = np.random.RandomState(6)
+        x = np.concatenate([[5.0e6], rng.uniform(-2.0, 2.0, size=4999)])
+
+        whole = GaussianAccumulator(compensated=True)
+        whole.seq_update(x, np.ones(len(x)), None)
+
+        a = GaussianAccumulator(compensated=True)
+        b = GaussianAccumulator(compensated=True)
+        a.seq_update(x[:2500], np.ones(2500), None)
+        b.seq_update(x[2500:], np.ones(len(x) - 2500), None)
+        a.combine(b.value())
+
+        self.assertAlmostEqual(whole.sum, a.sum, places=6)
+        self.assertAlmostEqual(whole.error_bound()["sum"], a.error_bound()["sum"], delta=1e-9)
+
+
+# --------------------------------------------------------------------------------------------------
+# 3. Disabled path: identical behavior + no measurable overhead
+# --------------------------------------------------------------------------------------------------
+class DisabledPathOverheadTest(unittest.TestCase):
+    def test_disabled_accumulator_carries_no_receipt_state(self):
+        acc = GaussianAccumulator()  # compensated defaults to False
+        self.assertIsNone(acc._sum_acc)
+        self.assertIsNone(acc._sum2_acc)
+        self.assertIsNone(acc.error_bound())
+
+    def test_disabled_path_matches_naive_float64_reference(self):
+        # behavioral identity: the disabled path's sum/sum2 must equal plain np.dot accumulation
+        # exactly (bit-for-bit) -- i.e. it takes the SAME code path as before this change.
+        rng = np.random.RandomState(7)
+        x = rng.normal(size=5000)
+        w = np.ones(5000)
+        acc = GaussianAccumulator(compensated=False)
+        acc.seq_update(x, w, None)
+        self.assertEqual(acc.sum, float(np.dot(x, w)))
+        self.assertEqual(acc.sum2, float(np.dot(x * x, w)))
+
+    def test_disabled_seq_update_overhead_under_threshold(self):
+        # Large workload + repeated trials so the timing comparison is not flaky: the disabled path
+        # (vectorized np.dot, untouched) must not run measurably slower than a plain baseline
+        # reimplementation of the pre-existing formula. Stated threshold: <50% overhead (see the
+        # module-level comment on _DISABLED_OVERHEAD_THRESHOLD for why this is generous rather than
+        # tight -- the tight guarantee is the structural/behavioral-identity test below).
+        rng = np.random.RandomState(8)
+        n = 2_000_000
+        x = rng.normal(size=n)
+        w = np.ones(n)
+        repeats = 15
+
+        def baseline():
+            s = 0.0
+            s2 = 0.0
+            s += np.dot(x, w)
+            s2 += np.dot(x * x, w)
+            return s, s2
+
+        def disabled_path():
+            acc = GaussianAccumulator(compensated=False)
+            acc.seq_update(x, w, None)
+            return acc.sum, acc.sum2
+
+        # warm-up (avoid first-call cache effects dominating the measurement)
+        baseline()
+        disabled_path()
+
+        # Take the MIN over independently-timed repeats (standard robust microbenchmark
+        # methodology -- the min is the least noise-contaminated estimate, since noise from other
+        # processes/GC/scheduling can only ever slow a single trial down, never speed it up) rather
+        # than a single summed loop, so this is not flaky under parallel test execution (pytest-xdist).
+        baseline_times = []
+        disabled_times = []
+        for _ in range(repeats):
+            t0 = time.perf_counter()
+            baseline()
+            baseline_times.append(time.perf_counter() - t0)
+            t0 = time.perf_counter()
+            disabled_path()
+            disabled_times.append(time.perf_counter() - t0)
+        t_baseline = min(baseline_times)
+        t_disabled = min(disabled_times)
+
+        overhead = (t_disabled - t_baseline) / t_baseline if t_baseline > 0 else 0.0
+        self.assertLess(
+            overhead,
+            _DISABLED_OVERHEAD_THRESHOLD,
+            "disabled GaussianAccumulator.seq_update overhead %.1f%% exceeds the %.0f%% threshold"
+            % (overhead * 100.0, _DISABLED_OVERHEAD_THRESHOLD * 100.0),
+        )
+
+    def test_compensated_path_is_much_slower_than_disabled(self):
+        # Corroborating evidence the disabled path is genuinely the fast/untouched one: the
+        # compensated path (Python-level per-element Kahan loop) should be dramatically slower on
+        # a large workload, confirming the two paths are not accidentally sharing the slow branch.
+        rng = np.random.RandomState(9)
+        n = 200000
+        x = rng.normal(size=n)
+        w = np.ones(n)
+
+        t0 = time.perf_counter()
+        acc = GaussianAccumulator(compensated=False)
+        acc.seq_update(x, w, None)
+        t_disabled = time.perf_counter() - t0
+
+        t0 = time.perf_counter()
+        acc2 = GaussianAccumulator(compensated=True)
+        acc2.seq_update(x, w, None)
+        t_compensated = time.perf_counter() - t0
+
+        self.assertGreater(t_compensated, t_disabled * 2.0)
+
+    def test_estimator_compensated_flag_defaults_false(self):
+        est = GaussianEstimator()
+        self.assertFalse(est.compensated)
+        acc = est.accumulator_factory().make()
+        self.assertFalse(acc.compensated)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements roadmap item **K2 (Numerics-error receipts through accumulators)**:

- New module `mixle/stats/compute/error_receipts.py`:
  - `CompensatedAccumulator`: an opt-in Kahan-compensated running sum. It tracks `(abs_total, n)` as
    an explicit additive receipt — these compose **exactly** through `combine()` the same way `sum`/
    `count` sufficient statistics do (no approximation) — and derives a valid error bound from them
    via `error_bound()` (Higham, *Accuracy and Stability of Numerical Algorithms*, eq. 8.13/8.15-style
    formulas for naive vs. Kahan summation).
  - `conditioning_receipt()` / `ConditioningReceipt`: covariance eigenvalue spectrum, condition
    number, and a near-degenerate-variance flag (eigenvalue-ratio threshold).
- `GaussianAccumulator` grows an opt-in `compensated=False` constructor flag (also threaded through
  `GaussianEstimator`/`GaussianAccumulatorFactory`). When `True`, `sum`/`sum2` accumulate via Kahan
  summation and `error_bound()` reports the running receipt; `value()` returns a `GaussianSuffStat`
  (a transparent 4-tuple subclass) carrying the receipt so `combine()` folds it in correctly across
  partitions. **Default is `False` and the code path is byte-for-byte the pre-existing
  `np.dot`/plain-accumulation implementation** — no new branching cost baked into the hot path beyond
  a single boolean check.
- `MultivariateGaussianEstimator` grows an opt-in `track_conditioning=False` (+ `degenerate_ratio`)
  flag. When `True`, `estimate()` computes the conditioning receipt from the **raw, pre-ridge**
  empirical covariance (so the ridge regularization safety net can't mask a genuinely ill-conditioned
  fit) and attaches it to the returned distribution as `.conditioning_receipt`.

Only `GaussianAccumulator`/`MultivariateGaussianEstimator` are wired up per the K2 acceptance
criteria ("at least the Gaussian/multivariate-Gaussian family"); the `CompensatedAccumulator`/
`error_bound()` primitives are generic and reusable by other accumulator `combine()` paths (e.g.
Categorical) as a natural follow-up.

### Deferred / explicitly out of scope
- **D1 NodeReport wiring**: D1 (node report protocol) is being built concurrently by another agent
  and isn't something this PR should guess the interface of. Once it lands, surfacing
  `GaussianAccumulator.error_bound()` / `.conditioning_receipt` through it is a small, natural
  follow-up — not done here.
- **`fit.report()`**: grepped for `def report` under `mixle/inference/` and `mixle/stats/` — it does
  not exist yet in this codebase. Not inventing a reporting framework here; noting it as deferred per
  the task instructions.

## Test plan

New file `mixle/tests/numerics_error_receipts_test.py` (14 tests, all passing):

- **Planted ill-conditioning** (`ConditioningReceiptTest`): a 4D fit with 3 well-spread dims + 1
  planted near-zero-variance dim (`~1e-8` vs `~1`) is flagged `near_degenerate=True` with condition
  number `> 1e4`; a well-conditioned isotropic-ish control (`condition_number < 100`) is correctly
  **not** flagged. Also a direct correctness check of `conditioning_receipt()` against known diagonal
  eigenvalues, and confirmation the receipt is absent by default (`track_conditioning=False`).

- **Planted catastrophic cancellation with bound ordering** (`CatastrophicCancellationTest`): a
  large-offset-plus-many-small-cancelling-terms workload (`[+1e8, -1e8, ...many small +/- pairs...]`),
  measured against a `math.fsum` high-precision reference. Actual measured numbers from this run:

  | | value | 
  |---|---|
  | reference (`math.fsum`) | `99.99999999999878` |
  | naive total | `100.00000000000152` |
  | naive actual error | `2.7427e-12` |
  | **naive reported bound** | `8.9306e-03` |
  | kahan total | `99.99999999999815` |
  | kahan actual error | `6.2528e-13` |
  | **kahan reported bound** | `8.9306e-08` |

  Both bounds are valid (never violated against the `fsum` reference), the naive bound is ~1e5x
  looser than the Kahan bound (correct ordering), and the *actual* error is also smaller under Kahan
  than naive on this workload (ordering matches reality, not just the formula). Also verified through
  the real `GaussianAccumulator(compensated=True/False)` wiring (not just the standalone primitive),
  and that bounds compose correctly through `combine()` — splitting a workload into two partitions,
  accumulating separately, then `combine()`-ing reproduces the same `(n, abs_total, bound)` as one
  accumulator over the whole stream, both for the raw `CompensatedAccumulator` and through
  `GaussianAccumulator.combine(other.value())`.

- **Disabled-path overhead** (`DisabledPathOverheadTest`): a *structural/behavioral* identity check is
  the primary guarantee — `compensated=False` leaves `_sum_acc`/`_sum2_acc` as `None` and produces
  bit-for-bit identical `sum`/`sum2` to the pre-existing `np.dot`-based formula. A timing check is
  included as corroborating evidence (min-of-15-repeats over a 2M-element workload, generous 50%
  threshold — this repo's test suite runs under `pytest -n auto` by default per `pyproject.toml`, so
  tight percentage timing thresholds flake under sibling-worker contention; a tight threshold flaked
  in local runs even though the actual overhead is a single boolean check). A separate test confirms
  the compensated path is measurably (>2x) slower than the disabled path, as expected for its
  Python-level per-element loop.

Also ran and confirmed passing with zero regressions:
- `mixle/tests/precision_plan_test.py`
- `mixle/tests/multivariate_gaussian_audit_test.py`, `mvn_robust_cholesky_test.py`,
  `audit_fixes_regression_test.py`, `stats_bayes_gaussian_test.py`,
  `stats_bayes_mvgaussian_group_test.py`, `consistency_fixes_regression_test.py`, `wave_mvn_test.py`,
  `mixture_stability_test.py`, `gaussian_process_matern_test.py`, `gaussian_process_monotone_test.py`,
  `gaussian_copula_test.py`, `generalized_gaussian_test.py`, `automatic_exgaussian_test.py`,
  `exgaussian_test.py`, `fused_codegen_test.py`, `fused_em_mixtures_test.py`
- Full `mixle/tests/` suite: `4508 passed, 16 skipped` (2 pre-existing failures —
  `compute_metadata_test.py::test_high_level_compute_utilities_do_not_import_concrete_distributions`
  and `sampler_seed_test.py::test_all_public_stats_samplers_are_seed_repeatable` — confirmed via
  `git stash` to already fail on the base branch commit before this PR's changes, from concurrent
  copula work (#136/#141) unrelated to K2)

`ruff check --fix` and `ruff format` clean on all touched files.
