### PR TITLE
F4: training-health + MFU receipts

### DIFF
--- a/mixle/tests/training_health_test.py
+++ b/mixle/tests/training_health_test.py
@@ -1,0 +1,283 @@
+"""Training-health receipts: MFU accounting, loss/grad-norm anomaly detection, restart continuity.
+
+Runs a real (tiny) mixle.models.transformer.CausalLM for a handful of steps on synthetic data -- no
+cluster needed. The absolute MFU numbers this produces on a laptop/CI runner are not meaningful versus a
+real cluster's; what is tested is that the FLOPs formula and the anomaly/continuity math are correct.
+"""
+
+from __future__ import annotations
+
+import time
+import unittest
+
+import torch
+
+from mixle.models.transformer import build_causal_lm
+from mixle.utils.parallel.training_health import (
+    RollingBaseline,
+    TrainingHealthMonitor,
+    flop_config_from_causal_lm,
+    theoretical_flops_per_iter,
+)
+
+
+def _tiny_model(vocab: int = 32, d_model: int = 16, n_layer: int = 2, n_head: int = 2, block: int = 8):
+    torch.manual_seed(0)
+    return build_causal_lm(vocab=vocab, d_model=d_model, n_layer=n_layer, n_head=n_head, block=block)
+
+
+def _synthetic_batch(vocab: int, block: int, batch: int = 4):
+    x = torch.randint(0, vocab, (batch, block))
+    y = torch.randint(0, vocab, (batch,))
+    return x, y
+
+
+def _train_step(model, opt, x, y):
+    opt.zero_grad()
+    logits = model(x)
+    loss = torch.nn.functional.cross_entropy(logits, y)
+    loss.backward()
+    grad_norm = torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1e9)  # measure, don't clip away signal
+    opt.step()
+    return float(loss.item()), float(grad_norm.item())
+
+
+class TheoreticalFlopsTest(unittest.TestCase):
+    def test_matches_hand_computed_reference(self):
+        # Hand-computed reference for a toy config: N=1000 params, L=2, H=2, d_model=16 -> head_dim=8, T=8, B=4.
+        n_params, n_layer, n_head, d_model, seq_len, batch = 1000, 2, 2, 16, 8, 4
+        head_dim = d_model / n_head
+        expected_flops_per_token = 6.0 * n_params + 12.0 * n_layer * n_head * head_dim * seq_len
+        expected_flops_per_fwdbwd = expected_flops_per_token * seq_len
+        expected = expected_flops_per_fwdbwd * batch
+
+        got = theoretical_flops_per_iter(
+            n_params=n_params, n_layer=n_layer, n_head=n_head, d_model=d_model, seq_len=seq_len, batch_size=batch
+        )
+        self.assertAlmostEqual(got, expected, places=6)
+        # Sanity: bigger batch/seq_len must strictly increase FLOPs.
+        bigger = theoretical_flops_per_iter(
+            n_params=n_params, n_layer=n_layer, n_head=n_head, d_model=d_model, seq_len=seq_len, batch_size=batch * 2
+        )
+        self.assertGreater(bigger, got)
+
+    def test_rejects_non_divisible_head_config(self):
+        from mixle.utils.parallel.training_health import ModelFlopConfig
+
+        with self.assertRaises(ValueError):
+            ModelFlopConfig(n_params=100, n_layer=1, n_head=3, d_model=10, seq_len=8)
+
+    def test_flop_config_from_real_model_excludes_position_embedding(self):
+        model = _tiny_model()
+        cfg = flop_config_from_causal_lm(model, seq_len=8)
+        total_params = sum(p.numel() for p in model.parameters())
+        self.assertLess(cfg.n_params, total_params)
+        self.assertEqual(cfg.n_params, total_params - model.pos.weight.numel())
+        self.assertEqual(cfg.n_layer, 2)
+        self.assertEqual(cfg.n_head, 2)
+        self.assertEqual(cfg.d_model, 16)
+
+
+class MFURatioTest(unittest.TestCase):
+    def test_mfu_ratio_is_achieved_over_peak(self):
+        from mixle.utils.parallel.training_health import MFUSample
+
+        # Synthetic (achieved, theoretical/peak) pair: step_flops chosen so achieved = step_flops/step_time.
+        step_flops = 1.0e9
+        step_time_s = 0.5  # achieved = 2e9 FLOPs/sec
+        peak = 4.0e9  # -> MFU should be exactly 0.5
+        s = MFUSample(step=0, step_flops=step_flops, step_time_s=step_time_s, peak_flops_per_sec=peak)
+        self.assertAlmostEqual(s.achieved_flops_per_sec, 2.0e9)
+        self.assertAlmostEqual(s.mfu, 0.5)
+
+    def test_monitor_tracks_mfu_from_real_wall_clock_timing_of_real_model(self):
+        model = _tiny_model()
+        opt = torch.optim.SGD(model.parameters(), lr=1e-3)
+        cfg = flop_config_from_causal_lm(model, seq_len=8)
+        # Peak is a made-up hardware number for ratio-correctness testing only -- not a real GPU spec.
+        monitor = TrainingHealthMonitor(flop_config=cfg, peak_flops_per_sec=1e12)
+        for step in range(5):
+            x, y = _synthetic_batch(vocab=32, block=8)
+            t0 = time.perf_counter()
+            loss, grad_norm = _train_step(model, opt, x, y)
+            dt = max(time.perf_counter() - t0, 1e-6)
+            monitor.observe_step(step, loss, grad_norm=grad_norm, step_time_s=dt, batch_size=4)
+
+        report = monitor.report()
+        self.assertEqual(report["mfu"]["n_samples"], 5)
+        self.assertIsNotNone(report["mfu"]["mean"])
+        # MFU is a ratio: real hardware would keep it in (0, 1]; our timing/flops are both real numbers so
+        # the ratio must at least be finite and non-negative, though the absolute value is meaningless here.
+        self.assertGreaterEqual(report["mfu"]["mean"], 0.0)
+
+
+class RollingBaselineTest(unittest.TestCase):
+    def test_warmup_returns_none(self):
+        rb = RollingBaseline(window=10, min_periods=5)
+        for v in [1.0, 1.0, 1.0]:
+            self.assertIsNone(rb.z_score(v))
+            rb.update(v)
+
+    def test_z_score_is_causal_not_leaking_current_point(self):
+        rb = RollingBaseline(window=20, min_periods=5)
+        for v in [1.0, 1.0, 1.0, 1.0, 1.0]:
+            rb.update(v)
+        # A huge outlier should score high against the stable prior window.
+        z = rb.z_score(1000.0)
+        self.assertIsNotNone(z)
+        self.assertGreater(z, 10.0)
+
+    def test_state_round_trip(self):
+        rb = RollingBaseline(window=5, min_periods=3)
+        for v in [1.0, 2.0, 3.0]:
+            rb.update(v)
+        restored = RollingBaseline.from_state(rb.state())
+        self.assertEqual(rb.baseline(), restored.baseline())
+
+
+class InjectedAnomalyDetectionTest(unittest.TestCase):
+    """Injected anomalies flagged within N steps -- real small transformer, deliberate injections at known steps."""
+
+    def test_loss_spike_detected_immediately(self):
+        monitor = TrainingHealthMonitor(loss_window=10, loss_min_periods=5, loss_z_thresh=6.0)
+        stable_losses = [3.0, 3.05, 2.95, 3.02, 2.98, 3.01]
+        injected_step = None
+        detected_step = None
+        for step, loss in enumerate(stable_losses):
+            monitor.observe_step(step, loss)
+        # Inject a clear spike at a known step.
+        injected_step = len(stable_losses)
+        anomalies = monitor.observe_step(injected_step, 50.0)
+        detected_step = anomalies[0].step if anomalies else None
+
+        self.assertIsNotNone(detected_step, "loss spike was not flagged")
+        latency = detected_step - injected_step
+        self.assertEqual(latency, 0, "loss spike should be flagged the same step it occurs (N=0)")
+        self.assertEqual(anomalies[0].kind, "loss_spike")
+
+    def test_grad_norm_spike_detected_immediately(self):
+        monitor = TrainingHealthMonitor(grad_window=10, grad_min_periods=5, grad_z_thresh=6.0)
+        for step in range(6):
+            monitor.observe_step(step, loss=1.0, grad_norm=0.5 + 0.01 * step)
+        injected_step = 6
+        anomalies = monitor.observe_step(injected_step, loss=1.0, grad_norm=500.0)
+        kinds = [a.kind for a in anomalies]
+        self.assertIn("grad_norm_spike", kinds)
+        detected = next(a for a in anomalies if a.kind == "grad_norm_spike")
+        self.assertEqual(detected.step - injected_step, 0)
+
+    def test_nan_loss_detected_immediately(self):
+        monitor = TrainingHealthMonitor()
+        for step in range(3):
+            monitor.observe_step(step, loss=1.0)
+        injected_step = 3
+        anomalies = monitor.observe_step(injected_step, loss=float("nan"))
+        kinds = [a.kind for a in anomalies]
+        self.assertIn("nan_inf_loss", kinds)
+        detected = next(a for a in anomalies if a.kind == "nan_inf_loss")
+        self.assertEqual(detected.step - injected_step, 0)
+
+    def test_inf_grad_norm_detected_immediately(self):
+        monitor = TrainingHealthMonitor()
+        for step in range(3):
+            monitor.observe_step(step, loss=1.0, grad_norm=0.5)
+        injected_step = 3
+        anomalies = monitor.observe_step(injected_step, loss=1.0, grad_norm=float("inf"))
+        kinds = [a.kind for a in anomalies]
+        self.assertIn("nan_inf_grad", kinds)
+
+    def test_real_tiny_transformer_loop_with_injected_grad_explosion(self):
+        """End-to-end: real model, real optimizer, a handful of steps, one deliberately broken step."""
+        model = _tiny_model()
+        opt = torch.optim.SGD(model.parameters(), lr=1e-2)
+        monitor = TrainingHealthMonitor(grad_window=10, grad_min_periods=4, grad_z_thresh=6.0)
+
+        injected_step = 6
+        detected_step = None
+        for step in range(10):
+            x, y = _synthetic_batch(vocab=32, block=8)
+            if step == injected_step:
+                # Deliberately inject a gradient-norm anomaly: scale one param's grad up enormously
+                # after a normal backward pass, simulating a precision/numerics blowup mid-run.
+                opt.zero_grad()
+                logits = model(x)
+                loss = torch.nn.functional.cross_entropy(logits, y)
+                loss.backward()
+                with torch.no_grad():
+                    first_param = next(model.parameters())
+                    first_param.grad.mul_(1e8)
+                grad_norm = torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1e12)
+                opt.step()
+                loss_val, grad_norm_val = float(loss.item()), float(grad_norm.item())
+            else:
+                loss_val, grad_norm_val = _train_step(model, opt, x, y)
+
+            anomalies = monitor.observe_step(step, loss_val, grad_norm=grad_norm_val)
+            for a in anomalies:
+                if a.kind in ("grad_norm_spike", "nan_inf_grad") and detected_step is None:
+                    detected_step = a.step
+
+        self.assertIsNotNone(detected_step, "injected gradient-norm anomaly was never flagged")
+        latency = detected_step - injected_step
+        self.assertLessEqual(latency, 1, f"expected detection within 1 step, got latency={latency}")
+
+
+class RestartContinuityTest(unittest.TestCase):
+    def test_well_behaved_restart_passes(self):
+        monitor = TrainingHealthMonitor(loss_window=10, loss_min_periods=5, loss_z_thresh=6.0)
+        losses = [3.0, 2.9, 2.85, 2.8, 2.75, 2.7]
+        for step, loss in enumerate(losses):
+            monitor.observe_step(step, loss)
+        # Checkpoint + resume: state is saved/reloaded correctly, so training continues the same trend.
+        restart_step = len(losses)
+        monitor.observe_step(restart_step, 2.68, restart=True)
+        # Next step continues the coherent downward trend -- no discontinuity.
+        anomalies = monitor.observe_step(restart_step + 1, 2.65)
+        self.assertTrue(monitor.continuity_ok())
+        self.assertFalse(any(a.kind == "restart_discontinuity" for a in anomalies))
+
+    def test_broken_restart_is_flagged(self):
+        monitor = TrainingHealthMonitor(loss_window=10, loss_min_periods=5, loss_z_thresh=6.0)
+        losses = [3.0, 2.9, 2.85, 2.8, 2.75, 2.7]
+        for step, loss in enumerate(losses):
+            monitor.observe_step(step, loss)
+        # Checkpoint + resume, but the reload silently drops optimizer/RNG state (e.g. a fresh optimizer
+        # with no momentum, or a re-shuffled data cursor) -- the loss jumps back up on resume.
+        restart_step = len(losses)
+        monitor.observe_step(restart_step, 2.68, restart=True)
+        anomalies = monitor.observe_step(restart_step + 1, 9.5)  # a real discontinuity, not explained by trend
+        self.assertFalse(monitor.continuity_ok())
+        self.assertTrue(any(a.kind == "restart_discontinuity" for a in anomalies))
+
+
+class ReportSmokeTest(unittest.TestCase):
+    def test_report_is_complete_and_sane(self):
+        model = _tiny_model()
+        opt = torch.optim.SGD(model.parameters(), lr=1e-3)
+        cfg = flop_config_from_causal_lm(model, seq_len=8)
+        monitor = TrainingHealthMonitor(
+            flop_config=cfg, peak_flops_per_sec=1e12, loss_min_periods=3, grad_min_periods=3
+        )
+
+        for step in range(8):
+            x, y = _synthetic_batch(vocab=32, block=8)
+            t0 = time.perf_counter()
+            loss, grad_norm = _train_step(model, opt, x, y)
+            dt = max(time.perf_counter() - t0, 1e-6)
+            restart = step == 5
+            monitor.observe_step(step, loss, grad_norm=grad_norm, step_time_s=dt, batch_size=4, restart=restart)
+
+        report = monitor.report()
+        self.assertEqual(report["n_steps"], 8)
+        self.assertIn("anomalies_by_kind", report)
+        self.assertIn("mfu", report)
+        self.assertEqual(report["mfu"]["n_samples"], 8)
+        self.assertIn("restarts", report)
+        self.assertEqual(report["restarts"]["steps"], [5])
+        self.assertIsInstance(report["restarts"]["continuity_ok"], bool)
+        self.assertIsInstance(report["n_anomalies"], int)
+        self.assertEqual(report["n_anomalies"], len(report["anomalies"]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mixle/utils/parallel/training_health.py
+++ b/mixle/utils/parallel/training_health.py
@@ -1,0 +1,394 @@
+"""Training-health receipts: MFU, loss/grad-norm anomaly detection, precision checks, restart continuity.
+
+The frontier-scale trainer (the vendored TorchTitan/Megatron loop atop :mod:`mixle.models.transformer`,
+sharded via :mod:`mixle.utils.parallel.torchrun` / :mod:`mixle.utils.parallel.dcp_checkpoint`) runs for
+weeks unattended -- the only way to know it is healthy is receipts computed *from the loop itself*, not a
+human staring at a loss curve. :class:`TrainingHealthMonitor` is that receipt machine: call
+``observe_step(...)`` once per optimizer step (mirroring :meth:`mixle.telemetry.core.Telemetry.record`) and
+call ``report()`` once at the end (mirroring :class:`mixle.evolve.ledger.EvolutionLedger` /
+:meth:`mixle.evolve.population.OperatorBandit.report`) for a structured, JSON-serializable summary.
+
+Four things are tracked:
+
+* **MFU** -- :class:`ModelFlopConfig` computes the theoretical FLOPs/step for a transformer config (the
+  standard ``6N + attention`` accounting, same formula nanoGPT's ``estimate_mfu`` uses); ``achieved
+  FLOPs/sec`` comes from a caller-supplied wall-clock step time (real timing, whatever hardware the loop
+  runs on); MFU is the ratio against a caller-supplied hardware peak.
+* **Loss-spike / changepoint detection** -- a robust (median/MAD) rolling z-score per step.
+* **Grad-norm / precision anomalies** -- the same rolling z-score on grad-norm, plus NaN/Inf checks on both
+  streams (these always fire, independent of the rolling window's warmup).
+* **Per-restart continuity** -- ``restart=True`` on the first step after a checkpoint resume marks the
+  rolling baseline boundary; the next step's z-score is evaluated against the *pre-restart* baseline (it
+  has not been updated with any post-restart value yet), so a resume that silently drops optimizer/RNG
+  state and produces a real loss jump is caught as ``restart_discontinuity`` -- a well-behaved resume is
+  not.
+
+No cluster is required to exercise any of this: the FLOPs accounting and anomaly math are exact regardless
+of scale, and the tests drive a real (tiny) :func:`mixle.models.transformer.build_causal_lm` for a handful
+of steps. The *absolute* MFU number a laptop/CI runner produces is not comparable to a real cluster's --
+that comparison is deferred until the real distributed trainer (roadmap F1) exists.
+"""
+
+from __future__ import annotations
+
+import math
+from collections import deque
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+__all__ = [
+    "Anomaly",
+    "ModelFlopConfig",
+    "MFUSample",
+    "RollingBaseline",
+    "StepRecord",
+    "TrainingHealthMonitor",
+    "theoretical_flops_per_iter",
+    "flop_config_from_causal_lm",
+]
+
+
+# ---------------------------------------------------------------------------
+# MFU: theoretical FLOPs accounting + achieved/peak ratio
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ModelFlopConfig:
+    """The shape a transformer's FLOPs/step depends on -- enough to compute theoretical FLOPs exactly.
+
+    ``n_params`` should exclude position-embedding params (they are a lookup, not a matmul); use
+    :func:`flop_config_from_causal_lm` to derive this correctly from a real
+    :class:`mixle.models.transformer.CausalLM`.
+    """
+
+    n_params: int
+    n_layer: int
+    n_head: int
+    d_model: int
+    seq_len: int
+
+    def __post_init__(self) -> None:
+        if self.d_model % self.n_head != 0:
+            raise ValueError(f"d_model={self.d_model} not divisible by n_head={self.n_head}")
+
+    def flops_per_iter(self, batch_size: int) -> float:
+        return theoretical_flops_per_iter(
+            n_params=self.n_params,
+            n_layer=self.n_layer,
+            n_head=self.n_head,
+            d_model=self.d_model,
+            seq_len=self.seq_len,
+            batch_size=batch_size,
+        )
+
+
+def theoretical_flops_per_iter(
+    *, n_params: int, n_layer: int, n_head: int, d_model: int, seq_len: int, batch_size: int
+) -> float:
+    """Theoretical forward+backward FLOPs for one training iteration of a decoder-only transformer.
+
+    The standard two-term accounting (see nanoGPT's ``estimate_mfu`` / the PaLM paper appendix): ``6*N``
+    per token for the dense matmuls (forward+backward is ~3x forward, and each matmul is a multiply-add =
+    2 FLOPs, giving the well-known ``6N`` per-token constant), plus ``12*L*H*Q*T`` per token for the
+    attention matmuls (QK^T and attn@V), which scale with context length ``T`` and are *not* captured by
+    the ``6N`` param-count term. Multiplying by ``T`` (all tokens in the sequence) and ``batch_size`` gives
+    the FLOPs for one full iteration.
+    """
+    if seq_len <= 0 or batch_size <= 0:
+        raise ValueError("seq_len and batch_size must be positive")
+    head_dim = d_model / n_head
+    flops_per_token = 6.0 * n_params + 12.0 * n_layer * n_head * head_dim * seq_len
+    flops_per_fwdbwd = flops_per_token * seq_len
+    return flops_per_fwdbwd * batch_size
+
+
+def flop_config_from_causal_lm(model: Any, seq_len: int) -> ModelFlopConfig:
+    """Derive a :class:`ModelFlopConfig` from a real :class:`mixle.models.transformer.CausalLM`.
+
+    Position-embedding params are excluded from the count (a lookup table, not a matmul) -- the same
+    convention nanoGPT's ``get_num_params(non_embedding=True)`` uses.
+    """
+    n_params = sum(p.numel() for p in model.parameters())
+    pos = getattr(model, "pos", None)
+    if pos is not None and hasattr(pos, "weight"):
+        n_params -= pos.weight.numel()
+    return ModelFlopConfig(
+        n_params=int(n_params),
+        n_layer=int(model.n_layer),
+        n_head=int(model.n_head),
+        d_model=int(model.d_model),
+        seq_len=int(seq_len),
+    )
+
+
+@dataclass
+class MFUSample:
+    """One step's MFU measurement: real wall-clock timing against the theoretical FLOPs for that step."""
+
+    step: int
+    step_flops: float
+    step_time_s: float
+    peak_flops_per_sec: float
+
+    @property
+    def achieved_flops_per_sec(self) -> float:
+        return self.step_flops / self.step_time_s if self.step_time_s > 0 else float("nan")
+
+    @property
+    def mfu(self) -> float:
+        if self.peak_flops_per_sec <= 0:
+            return float("nan")
+        return self.achieved_flops_per_sec / self.peak_flops_per_sec
+
+
+# ---------------------------------------------------------------------------
+# Loss-spike / grad-norm changepoint detection: robust (median/MAD) rolling z-score
+# ---------------------------------------------------------------------------
+
+
+class RollingBaseline:
+    """A robust rolling baseline (median + scaled MAD) over a trailing window of values.
+
+    Median/MAD rather than mean/std so a *previous* spike does not itself blow up the spread used to judge
+    the *next* one. ``z_score(value)`` is evaluated against the window as it stood before ``value`` was
+    seen, so calling ``update`` only after scoring makes the check causal (no leakage of the current point
+    into its own baseline) -- this is also what makes the restart-continuity check work: the window carries
+    only pre-restart history until the caller updates it.
+    """
+
+    def __init__(self, window: int = 20, min_periods: int = 5):
+        if min_periods < 2:
+            raise ValueError("min_periods must be >= 2")
+        self.window = int(window)
+        self.min_periods = int(min_periods)
+        self._values: deque[float] = deque(maxlen=self.window)
+
+    def baseline(self) -> tuple[float, float] | None:
+        """``(median, scaled_mad)`` of the current window, or ``None`` during warmup."""
+        if len(self._values) < self.min_periods:
+            return None
+        arr = np.asarray(self._values, dtype=float)
+        med = float(np.median(arr))
+        mad = float(np.median(np.abs(arr - med))) * 1.4826  # consistent estimator of std under normality
+        return med, mad
+
+    def z_score(self, value: float) -> float | None:
+        """Robust z-score of ``value`` against the window *before* ``value`` is added, or ``None`` in warmup."""
+        b = self.baseline()
+        if b is None:
+            return None
+        med, mad = b
+        spread = mad if mad > 1e-12 else 1e-12
+        return (value - med) / spread
+
+    def update(self, value: float) -> None:
+        self._values.append(float(value))
+
+    def state(self) -> dict[str, Any]:
+        """Serializable snapshot -- carry this across a checkpoint/restart to preserve continuity."""
+        return {"window": self.window, "min_periods": self.min_periods, "values": list(self._values)}
+
+    @classmethod
+    def from_state(cls, state: dict[str, Any]) -> RollingBaseline:
+        obj = cls(window=state["window"], min_periods=state["min_periods"])
+        obj._values.extend(state["values"])
+        return obj
+
+
+# ---------------------------------------------------------------------------
+# The run: one record per step, one report() at the end
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class StepRecord:
+    """One observed training step."""
+
+    step: int
+    loss: float
+    grad_norm: float | None = None
+    step_time_s: float | None = None
+    restart: bool = False
+
+
+@dataclass
+class Anomaly:
+    """One flagged anomaly: what kind, at which step, and the baseline it was judged against."""
+
+    step: int
+    kind: str  # "nan_inf_loss" | "nan_inf_grad" | "loss_spike" | "grad_norm_spike" | "restart_discontinuity"
+    value: float
+    baseline: float | None
+    z_score: float | None
+    detected_at_step: int  # step at which the monitor raised this (== step for spikes, == step for nan/inf)
+
+    def latency(self, injected_at_step: int) -> int:
+        """Steps between the true anomaly step and detection -- 0 means caught on the same step."""
+        return self.detected_at_step - injected_at_step
+
+
+class TrainingHealthMonitor:
+    """The ``run`` object: ``observe_step(...)`` per optimizer step, ``report()`` once at the end.
+
+    Follows the shape of :class:`mixle.telemetry.core.Telemetry` (``record``/buffer) and
+    :class:`mixle.evolve.ledger.EvolutionLedger` (``.report()``-style terminal summary): no I/O, pure
+    in-process accounting, JSON-serializable output.
+    """
+
+    def __init__(
+        self,
+        *,
+        flop_config: ModelFlopConfig | None = None,
+        peak_flops_per_sec: float | None = None,
+        loss_window: int = 20,
+        loss_min_periods: int = 5,
+        loss_z_thresh: float = 6.0,
+        grad_window: int = 20,
+        grad_min_periods: int = 5,
+        grad_z_thresh: float = 6.0,
+    ) -> None:
+        self.flop_config = flop_config
+        self.peak_flops_per_sec = peak_flops_per_sec
+        self.loss_z_thresh = float(loss_z_thresh)
+        self.grad_z_thresh = float(grad_z_thresh)
+
+        self._loss_baseline = RollingBaseline(window=loss_window, min_periods=loss_min_periods)
+        self._grad_baseline = RollingBaseline(window=grad_window, min_periods=grad_min_periods)
+
+        self.records: list[StepRecord] = []
+        self.anomalies: list[Anomaly] = []
+        self.mfu_samples: list[MFUSample] = []
+        self._pending_restart_step: int | None = None  # step index whose *next* observation is post-restart
+
+    def observe_step(
+        self,
+        step: int,
+        loss: float,
+        *,
+        grad_norm: float | None = None,
+        step_time_s: float | None = None,
+        batch_size: int | None = None,
+        restart: bool = False,
+    ) -> list[Anomaly]:
+        """Record one step; returns any anomalies raised at this step (also appended to ``self.anomalies``)."""
+        loss = float(loss)
+        rec = StepRecord(step=step, loss=loss, grad_norm=grad_norm, step_time_s=step_time_s, restart=restart)
+        self.records.append(rec)
+        found: list[Anomaly] = []
+
+        is_post_restart = self._pending_restart_step is not None and step == self._pending_restart_step + 1
+
+        # --- precision: NaN/Inf, unconditional, no warmup needed ---------------------------------------
+        if not math.isfinite(loss):
+            found.append(
+                Anomaly(step=step, kind="nan_inf_loss", value=loss, baseline=None, z_score=None, detected_at_step=step)
+            )
+        if grad_norm is not None and not math.isfinite(grad_norm):
+            found.append(
+                Anomaly(
+                    step=step,
+                    kind="nan_inf_grad",
+                    value=float(grad_norm),
+                    baseline=None,
+                    z_score=None,
+                    detected_at_step=step,
+                )
+            )
+
+        # --- loss spike / restart discontinuity (same statistic, different label) ----------------------
+        if math.isfinite(loss):
+            z = self._loss_baseline.z_score(loss)
+            if z is not None and z > self.loss_z_thresh:
+                base = self._loss_baseline.baseline()
+                kind = "restart_discontinuity" if is_post_restart else "loss_spike"
+                found.append(
+                    Anomaly(
+                        step=step,
+                        kind=kind,
+                        value=loss,
+                        baseline=base[0] if base else None,
+                        z_score=z,
+                        detected_at_step=step,
+                    )
+                )
+            self._loss_baseline.update(loss)
+
+        # --- grad-norm spike ------------------------------------------------------------------------
+        if grad_norm is not None and math.isfinite(grad_norm):
+            gz = self._grad_baseline.z_score(grad_norm)
+            if gz is not None and gz > self.grad_z_thresh:
+                gbase = self._grad_baseline.baseline()
+                found.append(
+                    Anomaly(
+                        step=step,
+                        kind="grad_norm_spike",
+                        value=float(grad_norm),
+                        baseline=gbase[0] if gbase else None,
+                        z_score=gz,
+                        detected_at_step=step,
+                    )
+                )
+            self._grad_baseline.update(grad_norm)
+
+        if restart:
+            self._pending_restart_step = step
+        elif is_post_restart:
+            self._pending_restart_step = None  # consumed; only the immediate next step is checked
+
+        # --- MFU -------------------------------------------------------------------------------------
+        if step_time_s is not None and self.flop_config is not None and self.peak_flops_per_sec:
+            bs = int(batch_size) if batch_size is not None else 1
+            step_flops = self.flop_config.flops_per_iter(bs)
+            self.mfu_samples.append(
+                MFUSample(
+                    step=step,
+                    step_flops=step_flops,
+                    step_time_s=float(step_time_s),
+                    peak_flops_per_sec=self.peak_flops_per_sec,
+                )
+            )
+
+        self.anomalies.extend(found)
+        return found
+
+    def continuity_ok(self) -> bool:
+        """``True`` unless any ``restart_discontinuity`` was ever flagged."""
+        return not any(a.kind == "restart_discontinuity" for a in self.anomalies)
+
+    def report(self) -> dict[str, Any]:
+        """A complete, JSON-serializable summary: step count, MFU, anomalies by kind, continuity verdict."""
+        by_kind: dict[str, int] = {}
+        for a in self.anomalies:
+            by_kind[a.kind] = by_kind.get(a.kind, 0) + 1
+
+        mfu_values = [s.mfu for s in self.mfu_samples if math.isfinite(s.mfu)]
+        restart_steps = [r.step for r in self.records if r.restart]
+
+        return {
+            "n_steps": len(self.records),
+            "n_anomalies": len(self.anomalies),
+            "anomalies_by_kind": by_kind,
+            "anomalies": [
+                {
+                    "step": a.step,
+                    "kind": a.kind,
+                    "value": a.value,
+                    "baseline": a.baseline,
+                    "z_score": a.z_score,
+                }
+                for a in self.anomalies
+            ],
+            "mfu": {
+                "n_samples": len(self.mfu_samples),
+                "mean": float(np.mean(mfu_values)) if mfu_values else None,
+                "min": float(np.min(mfu_values)) if mfu_values else None,
+                "max": float(np.max(mfu_values)) if mfu_values else None,
+            },
+            "restarts": {
+                "steps": restart_steps,
+                "continuity_ok": self.continuity_ok(),
+            },
+        }


### PR DESCRIPTION
## Summary

Implements roadmap item **F4 (Frontier training infrastructure): training-health + MFU receipts**.

- **MFU tracking** (`ModelFlopConfig`, `theoretical_flops_per_iter`, `MFUSample`): real theoretical FLOPs/step accounting for a decoder-only transformer using the standard `6N + 12*L*H*Q*T` formula (nanoGPT's `estimate_mfu` / PaLM-paper accounting — the `6N` term for dense matmuls plus the attention term that scales with context length). `flop_config_from_causal_lm` derives this from a real `mixle.models.transformer.CausalLM`, excluding position-embedding params (a lookup, not a matmul). `achieved FLOPs/sec` comes from real wall-clock step timing; MFU is the ratio against a caller-supplied hardware peak.
- **Loss-spike / changepoint detection**: `RollingBaseline` is a causal (median + scaled-MAD) rolling z-score. Robust statistics (not mean/std) so one spike doesn't inflate the baseline used to judge the next one; `z_score(value)` is scored against the window as it stood *before* `value`, then `update()` commits it — no leakage.
- **Grad-norm / precision anomalies**: the same rolling z-score applied to per-step grad-norm, plus unconditional NaN/Inf checks on both loss and grad-norm (these fire even during the rolling window's warmup).
- **Per-restart continuity**: `restart=True` marks the step boundary; the very next observation's z-score is judged against the *pre-restart* baseline (untouched by any post-restart value yet), so a checkpoint resume that silently drops optimizer/RNG state and produces a real loss jump is flagged as `restart_discontinuity`. A well-behaved resume that continues the same trend is not flagged.
- **`TrainingHealthMonitor`** is the `run` object: `observe_step(...)` per optimizer step (mirrors `mixle.telemetry.core.Telemetry.record`), `.report()` once at the end (mirrors `mixle.evolve.ledger.EvolutionLedger` / `OperatorBandit.report()`) — a plain JSON-serializable dict with step count, MFU stats, anomalies by kind, and restart continuity verdict.

New module: `mixle/utils/parallel/training_health.py` (alongside `torchrun.py`/`dcp_checkpoint.py`, the other pieces of the real distributed-training stack this monitors).

Searched the codebase for existing machinery to reuse first: `mixle/utils/hvis/topology.py`'s `model_fit_health` is model-vs-data topology fit (merged/shattered regimes), not a per-step training-loop changepoint detector, so it wasn't a fit for reuse here; `mixle/inference/precision_plan.py`'s `PrecisionPlan` is about picking compute dtype for a *fit*, not runtime NaN/Inf/grad-norm anomaly detection during a training loop. Followed `Telemetry`/`EvolutionLedger`'s shape for the `.report()` convention instead.

**Honest scoping note:** the acceptance criterion "MFU reproduces skeleton baselines" is deferred — there is no real distributed trainer skeleton to compare against yet (that's roadmap F1, not yet built). What's verified here is that the FLOPs formula and the achieved/theoretical ratio computation are correct; the absolute MFU number this produces on a laptop/CI runner is real but not comparable to a real cluster's.

## Test plan

New file `mixle/tests/training_health_test.py`, run against a real (tiny) `mixle.models.transformer.CausalLM` — 16 tests, all passing:

- **Injected anomalies flagged within N steps** (measured, not asserted-eventually):
  - Loss spike: detected at **N=0** steps (same step it occurs).
  - Grad-norm spike: detected at **N=0** steps.
  - NaN loss / Inf grad-norm: detected at **N=0** steps (unconditional check).
  - End-to-end real training loop (real tiny transformer + SGD, 10 steps) with a deliberately injected 1e8x gradient-norm blowup at step 6: detected at **N≤1** step latency.
- **MFU correctness**: theoretical-FLOPs formula checked against a hand-computed reference for a toy config (asserted exact to 6 decimal places); synthetic `(achieved, peak)` pair checked to produce the exact expected ratio (0.5); explicit test-level note that absolute MFU from this runner isn't meaningful vs. real hardware.
- **Restart continuity**: well-behaved restart (loss continues its trend) passes (`continuity_ok() == True`); a deliberately broken restart (loss jumps from a smooth ~2.7 trend to 9.5, simulating dropped optimizer/RNG state) is correctly flagged as `restart_discontinuity` (`continuity_ok() == False`).
- **`report()` smoke test**: confirms a complete, sane report (step count, MFU stats, anomalies-by-kind, restart steps/continuity verdict) from a real 8-step training run with a restart injected mid-loop.

Ran alongside existing adjacent suites to confirm no regressions: `telemetry_test.py`, `model_parallel_test.py`, `parallel_test.py`, `streaming_transformer_weights_test.py` — 30 passed, 3 skipped (missing optional `pyspark`/`mpi4py`, pre-existing).

Lint: `ruff check` and `ruff format` clean on both new files.
