### PR TITLE
L2: cross-modal reasoning as conditional inference in a shared-latent joint

### DIFF
--- a/mixle/reason/__init__.py
+++ b/mixle/reason/__init__.py
@@ -34,9 +34,11 @@ from mixle.reason.core import (
     block_selector,
     reason,
 )
+from mixle.reason.cross_modal import CrossModalJoint
 from mixle.reason.cycle_consistency import (
     cycle_inconsistency,
     fit_cycle_transport,
+    joint_cycle_consistency_receipt,
     posterior_mean_estimate,
     selective_error,
 )
@@ -117,6 +119,8 @@ __all__ = [
     "fit_cycle_transport",
     "posterior_mean_estimate",
     "selective_error",
+    "CrossModalJoint",
+    "joint_cycle_consistency_receipt",
     "HopTransport",
     "WalkResult",
     "belief_walk",

--- a/mixle/reason/cross_modal.py
+++ b/mixle/reason/cross_modal.py
@@ -1,0 +1,114 @@
+"""Cross-modal reasoning as conditional inference in a shared-latent joint (workstream L2).
+
+The loop this module runs -- discrepancy -> propose -> verify -> adopt -> remember -- is generic
+across altitudes; L2's edge is that "cross-modal" needs no bespoke machinery here. A composite over
+heterogeneous fields (one Gaussian field standing in for an "image embedding," one Categorical field
+standing in for a "text label," etc.) already ties every field to a single shared latent regime the
+moment those fields are wrapped as one :class:`~mixle.stats.combinator.composite.CompositeDistribution`
+and mixed over a component index via :class:`~mixle.stats.latent.mixture.MixtureDistribution` -- the
+component index *is* the shared latent regime spanning modalities, and per-component parameter
+``keys=`` ties (see :class:`~mixle.stats.latent.mixture.MixtureEstimator`) are the same mechanism used
+to pool statistics across otherwise-independent per-modality estimators when fitting such a joint.
+
+``MixtureDistribution.conditional`` already implements "condition on any subset, infer any other
+subset" for exactly this shape of joint: it returns the full posterior mixture over the unobserved
+coordinates, itself scoreable and sampleable. :class:`CrossModalJoint` is a thin, name-addressed
+wrapper around that machinery so callers condition on modality NAMES ("image", "text", ...) instead of
+bare composite field indices, and so a further subset of the remaining fields can be requested (not
+just "everything unobserved").
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+from mixle.stats.combinator.composite import CompositeDistribution
+from mixle.stats.compute.pdist import SequenceEncodableProbabilityDistribution
+from mixle.stats.latent.mixture import MixtureDistribution
+
+
+@dataclass(frozen=True)
+class CrossModalJoint:
+    """A joint over named modalities sharing one latent regime (a mixture component index).
+
+    ``names`` fixes the modality-name -> composite-field-index mapping; ``joint`` is a
+    :class:`~mixle.stats.latent.mixture.MixtureDistribution` whose components are
+    :class:`~mixle.stats.combinator.composite.CompositeDistribution` instances over ``len(names)``
+    heterogeneous fields, in ``names`` order. The mixture weights are the shared latent's prior
+    ``p(regime)``; each component is ``p(modality_0, modality_1, ... | regime=k)``.
+    """
+
+    names: tuple[str, ...]
+    joint: MixtureDistribution
+
+    @classmethod
+    def from_components(
+        cls,
+        names: Sequence[str],
+        component_fields: Sequence[Sequence[SequenceEncodableProbabilityDistribution]],
+        weights: Sequence[float],
+    ) -> CrossModalJoint:
+        """Build a shared-latent joint from per-regime per-modality distributions.
+
+        ``component_fields[k]`` is the sequence of ``len(names)`` per-modality distributions for
+        latent regime ``k`` (in ``names`` order); ``weights[k]`` is ``p(regime=k)``. Each regime is
+        wrapped as one :class:`CompositeDistribution` over the (heterogeneous) modality fields and the
+        regimes are mixed, so the resulting joint's own component index is exactly the shared latent
+        tying every modality together.
+        """
+        names = tuple(names)
+        if any(len(fields) != len(names) for fields in component_fields):
+            raise ValueError(
+                f"every regime must supply one distribution per modality ({len(names)} modalities), "
+                f"got field counts {[len(f) for f in component_fields]}"
+            )
+        components = [CompositeDistribution(list(fields)) for fields in component_fields]
+        joint = MixtureDistribution(components, w=np.asarray(weights, dtype=np.float64))
+        return cls(names=names, joint=joint)
+
+    def _index_of(self, name: str) -> int:
+        try:
+            return self.names.index(name)
+        except ValueError:
+            raise KeyError(f"unknown modality {name!r}; known modalities are {self.names!r}") from None
+
+    def infer(
+        self,
+        observed: Mapping[str, Any],
+        target: Sequence[str] | None = None,
+    ) -> MixtureDistribution:
+        """Posterior over ``target`` modalities given observed values for any OTHER subset.
+
+        ``observed`` maps modality name -> its observed value, for any subset (including the empty
+        set, which returns the marginal/prior). ``target`` names the modalities to infer the joint
+        posterior over; defaults to every modality not in ``observed``. Every ``target`` name must be
+        absent from ``observed`` (you cannot condition on and infer the same modality).
+
+        Returns a :class:`~mixle.stats.latent.mixture.MixtureDistribution` over a
+        ``len(target)``-tuple, in ``target`` order (a 1-modality target is a mixture over a
+        1-tuple, matching :class:`CompositeDistribution`'s own convention for a single field).
+        """
+        observed_idx = {self._index_of(name): value for name, value in observed.items()}
+        remaining = [name for name in self.names if name not in observed]
+        if target is None:
+            target = remaining
+        target = list(target)
+        missing = [name for name in target if name not in remaining]
+        if missing:
+            raise ValueError(
+                f"target modalities must not be observed and must be known: bad target(s) {missing!r}, "
+                f"observed={list(observed)!r}, known modalities={list(self.names)!r}"
+            )
+        posterior = self.joint.conditional(observed_idx)
+        rel_idx = [remaining.index(name) for name in target]
+        # Build the sub-composite directly off ``component.dists`` (rather than via
+        # ``CompositeDistribution.marginal``, which always returns fields in SORTED index order) so
+        # the returned tuple matches the caller's requested ``target`` order exactly.
+        marginal_components = [
+            CompositeDistribution([component.dists[i] for i in rel_idx]) for component in posterior.components
+        ]
+        return MixtureDistribution(marginal_components, w=posterior.w.copy())

--- a/mixle/reason/cycle_consistency.py
+++ b/mixle/reason/cycle_consistency.py
@@ -23,6 +23,8 @@ from typing import Any
 import numpy as np
 
 from mixle.inference import optimize
+from mixle.reason.cross_modal import CrossModalJoint
+from mixle.stats.latent.mixture import MixtureDistribution
 
 
 def _as_paired_batch(a: np.ndarray) -> np.ndarray:
@@ -108,6 +110,63 @@ def posterior_mean_estimate(sampler: Any, given_value: np.ndarray, *, n_draws: i
     x_batch = np.repeat(np.atleast_2d(np.asarray(given_value, dtype=np.float64)), n_draws, axis=0)
     draws = np.asarray(sampler.sample_given_batch(x_batch), dtype=np.float64)
     return draws.mean(axis=0)
+
+
+def joint_cycle_consistency_receipt(
+    joint: CrossModalJoint,
+    source: str,
+    target: str,
+    *,
+    backward_joint: CrossModalJoint | None = None,
+    n_round_trip: int = 300,
+    n_kl_samples: int = 500,
+    seed: int = 0,
+) -> float:
+    """Cross-modal generalization (workstream L2) of this module's round-trip closure signal.
+
+    ``cycle_inconsistency`` above measures round-trip closure (A -> B -> A) for a NEURAL transport,
+    where the true target is unknown at serving time and self-AGREEMENT among repeated draws is the
+    only available proxy. A :class:`~mixle.reason.cross_modal.CrossModalJoint` is a typed grammar
+    object, not an opaque transport: its true marginal ``p(source)`` is available in closed form
+    (:meth:`CrossModalJoint.infer` with no observations), so the round-trip receipt here compares the
+    round-trip estimate DIRECTLY against that true marginal, rather than against itself.
+
+    Two ways to arrive at a belief about ``source`` through the joint: (1) directly, its own marginal
+    ``p(source)``; (2) via a round trip, ``p(source) -> infer p(target | source) -> infer p(source |
+    target) back``, averaged over many draws into one aggregate "round-trip" belief. This receipt is a
+    Monte-Carlo KL-divergence estimate between (2) and (1); a well-specified joint recovers its own
+    marginal on a round trip (the receipt is ~0 up to Monte-Carlo noise), while a deliberately
+    mis-specified backward projection (``backward_joint`` -- e.g. a joint whose ``target``-given-regime
+    distributions have been shuffled relative to ``joint``'s, standing in for a broken/incompatible
+    A<-B projection) breaks that identity and the receipt becomes clearly, measurably elevated.
+    """
+    backward = joint if backward_joint is None else backward_joint
+    rng = np.random.RandomState(seed)
+
+    true_marginal = joint.infer({}, [source])
+    forward_sampler = true_marginal.sampler(seed=int(rng.randint(0, 2**31 - 1)))
+
+    round_trip_components = []
+    round_trip_weights = []
+    for _ in range(n_round_trip):
+        a_value = forward_sampler.sample()[0]
+        post_target = joint.infer({source: a_value}, [target])
+        b_sampler = post_target.sampler(seed=int(rng.randint(0, 2**31 - 1)))
+        b_value = b_sampler.sample()[0]
+        post_source = backward.infer({target: b_value}, [source])
+        for component, weight in zip(post_source.components, post_source.w):
+            round_trip_components.append(component)
+            round_trip_weights.append(weight / n_round_trip)
+
+    round_trip = MixtureDistribution(round_trip_components, w=np.asarray(round_trip_weights, dtype=np.float64))
+
+    kl_sampler = round_trip.sampler(seed=int(rng.randint(0, 2**31 - 1)))
+    kl_terms = [
+        round_trip.log_density(x) - true_marginal.log_density(x)
+        for x in (kl_sampler.sample() for _ in range(n_kl_samples))
+    ]
+    # KL divergence is non-negative in theory; clamp away small Monte-Carlo undershoot at (near-)zero.
+    return float(max(float(np.mean(kl_terms)), 0.0))
 
 
 def selective_error(errors: Sequence[float], abstain_scores: Sequence[float], keep_frac: float) -> float:

--- a/mixle/tests/cross_modal_conditional_test.py
+++ b/mixle/tests/cross_modal_conditional_test.py
@@ -1,0 +1,240 @@
+"""Cross-modal reasoning = conditional inference in a shared-latent joint (workstream L2).
+
+Generalizes ``mixle/reason/cycle_consistency.py``'s round-trip closure diagnostic (previously proven
+only for a single neural conditional-density transport, workstream F5) to a typed-grammar
+:class:`~mixle.reason.cross_modal.CrossModalJoint`: a :class:`~mixle.stats.latent.mixture.MixtureDistribution`
+over :class:`~mixle.stats.combinator.composite.CompositeDistribution` fields, where the shared mixture
+component index IS the latent regime tying heterogeneous modalities together. Because the joint is a
+typed grammar object (not an opaque transport), its true marginals are available in closed form, so this
+generalization compares the round-trip receipt directly against the true marginal rather than only
+against itself (see ``joint_cycle_consistency_receipt``'s docstring for the full comparison).
+"""
+
+import math
+import unittest
+
+import numpy as np
+
+from mixle.reason.cross_modal import CrossModalJoint
+from mixle.reason.cycle_consistency import joint_cycle_consistency_receipt
+from mixle.stats.univariate.continuous.gaussian import GaussianDistribution
+from mixle.stats.univariate.discrete.categorical import CategoricalDistribution
+
+
+def _gaussian_pdf(x: float, mu: float, sigma2: float) -> float:
+    return math.exp(-((x - mu) ** 2) / (2.0 * sigma2)) / math.sqrt(2.0 * math.pi * sigma2)
+
+
+def _two_modality_joint() -> CrossModalJoint:
+    """A 2-component, 2-modality (image=Gaussian, text=Categorical) joint with hand-derivable posteriors.
+
+    regime 0 (w=0.6): image ~ N(-3, 1), text ~ Categorical({"cat": 0.9, "dog": 0.1})
+    regime 1 (w=0.4): image ~ N(3, 1),  text ~ Categorical({"cat": 0.1, "dog": 0.9})
+    """
+    return CrossModalJoint.from_components(
+        names=("image", "text"),
+        component_fields=[
+            (
+                GaussianDistribution(mu=-3.0, sigma2=1.0),
+                CategoricalDistribution(pmap={"cat": 0.9, "dog": 0.1}),
+            ),
+            (
+                GaussianDistribution(mu=3.0, sigma2=1.0),
+                CategoricalDistribution(pmap={"cat": 0.1, "dog": 0.9}),
+            ),
+        ],
+        weights=[0.6, 0.4],
+    )
+
+
+class CrossModalAnalyticPosteriorTest(unittest.TestCase):
+    """Acceptance criterion 1: cross-modal posteriors on a synthetic joint match hand-derived analytic answers."""
+
+    def setUp(self):
+        self.joint = _two_modality_joint()
+
+    def test_condition_on_text_infer_image_matches_analytic_posterior(self):
+        posterior = self.joint.infer({"text": "cat"}, ["image"])
+
+        w0 = 0.6 * 0.9
+        w1 = 0.4 * 0.1
+        expected_w = np.asarray([w0, w1]) / (w0 + w1)
+
+        np.testing.assert_allclose(posterior.w, expected_w, atol=1e-10)
+        # component means are untouched by conditioning on the OTHER modality
+        self.assertAlmostEqual(posterior.components[0].dists[0].mu, -3.0)
+        self.assertAlmostEqual(posterior.components[1].dists[0].mu, 3.0)
+
+        # spot-check the actual posterior density against the hand-derived mixture density
+        for x in (-3.0, 0.0, 3.0, 5.0):
+            expected_density = expected_w[0] * _gaussian_pdf(x, -3.0, 1.0) + expected_w[1] * _gaussian_pdf(x, 3.0, 1.0)
+            self.assertAlmostEqual(posterior.density((x,)), expected_density, places=8)
+
+    def test_condition_on_image_infer_text_matches_analytic_posterior(self):
+        x = -3.0
+        posterior = self.joint.infer({"image": x}, ["text"])
+
+        p0 = 0.6 * _gaussian_pdf(x, -3.0, 1.0)
+        p1 = 0.4 * _gaussian_pdf(x, 3.0, 1.0)
+        expected_w = np.asarray([p0, p1]) / (p0 + p1)
+
+        expected_p_cat = expected_w[0] * 0.9 + expected_w[1] * 0.1
+        expected_p_dog = expected_w[0] * 0.1 + expected_w[1] * 0.9
+
+        self.assertAlmostEqual(posterior.density(("cat",)), expected_p_cat, places=8)
+        self.assertAlmostEqual(posterior.density(("dog",)), expected_p_dog, places=8)
+        self.assertAlmostEqual(posterior.density(("cat",)) + posterior.density(("dog",)), 1.0, places=8)
+
+    def test_empty_observation_recovers_the_prior_marginal(self):
+        posterior = self.joint.infer({}, ["image"])
+        np.testing.assert_allclose(posterior.w, [0.6, 0.4])
+        for x in (-3.0, 0.0, 3.0):
+            expected_density = 0.6 * _gaussian_pdf(x, -3.0, 1.0) + 0.4 * _gaussian_pdf(x, 3.0, 1.0)
+            self.assertAlmostEqual(posterior.density((x,)), expected_density, places=8)
+
+
+class CrossModalThreeModalitySubsetTest(unittest.TestCase):
+    """Acceptance criterion 3: condition on ANY subset, infer ANY other subset, for >= 3 modalities."""
+
+    def setUp(self):
+        # regime 0 (w=0.5): image ~ N(-4, 0.5), text -> mostly "cat", audio ~ N(-1, 0.2)
+        # regime 1 (w=0.5): image ~ N(4, 0.5),  text -> mostly "dog", audio ~ N(1, 0.2)
+        self.joint = CrossModalJoint.from_components(
+            names=("image", "text", "audio"),
+            component_fields=[
+                (
+                    GaussianDistribution(mu=-4.0, sigma2=0.5),
+                    CategoricalDistribution(pmap={"cat": 0.95, "dog": 0.05}),
+                    GaussianDistribution(mu=-1.0, sigma2=0.2),
+                ),
+                (
+                    GaussianDistribution(mu=4.0, sigma2=0.5),
+                    CategoricalDistribution(pmap={"cat": 0.05, "dog": 0.95}),
+                    GaussianDistribution(mu=1.0, sigma2=0.2),
+                ),
+            ],
+            weights=[0.5, 0.5],
+        )
+
+    def _regime_posterior(self, observed):
+        """Hand-computed regime posterior for a given ``{modality: value}`` observation, used as the
+        ground truth every ``infer`` result below is checked against."""
+        log_w = np.log([0.5, 0.5])
+        dists = {
+            "image": [-4.0, 4.0],  # means, sigma2=0.5 for both regimes
+            "audio": [-1.0, 1.0],  # means, sigma2=0.2 for both regimes
+        }
+        for name, value in observed.items():
+            if name == "text":
+                p = [0.95 if value == "cat" else 0.05, 0.05 if value == "cat" else 0.95]
+                log_w = log_w + np.log(p)
+            elif name in dists:
+                sigma2 = 0.5 if name == "image" else 0.2
+                mus = dists[name]
+                log_w = log_w + np.log([_gaussian_pdf(value, mu, sigma2) for mu in mus])
+        w = np.exp(log_w - np.max(log_w))
+        return w / w.sum()
+
+    def test_condition_on_one_infer_other_two_jointly(self):
+        post = self.joint.infer({"audio": -1.0}, ["image", "text"])
+        expected_w = self._regime_posterior({"audio": -1.0})
+        np.testing.assert_allclose(post.w, expected_w, atol=1e-10)
+        self.assertAlmostEqual(post.components[0].dists[0].mu, -4.0)
+        self.assertEqual(post.components[0].dists[1].pmap, {"cat": 0.95, "dog": 0.05})
+
+    def test_condition_on_two_infer_the_remaining_one(self):
+        post = self.joint.infer({"image": -4.0, "text": "cat"}, ["audio"])
+        expected_w = self._regime_posterior({"image": -4.0, "text": "cat"})
+        np.testing.assert_allclose(post.w, expected_w, atol=1e-6)
+        for x in (-1.0, 0.0, 1.0):
+            expected_density = expected_w[0] * _gaussian_pdf(x, -1.0, 0.2) + expected_w[1] * _gaussian_pdf(x, 1.0, 0.2)
+            self.assertAlmostEqual(post.density((x,)), expected_density, places=6)
+
+    def test_condition_on_none_infer_all_three_jointly(self):
+        post = self.joint.infer({})
+        np.testing.assert_allclose(post.w, [0.5, 0.5])
+        self.assertEqual(post.components[0].count, 3)
+
+    def test_target_order_matches_requested_order_not_composite_order(self):
+        forward = self.joint.infer({"audio": -1.0}, ["text", "image"])
+        backward = self.joint.infer({"audio": -1.0}, ["image", "text"])
+        # same underlying posterior, tuple fields swapped
+        self.assertAlmostEqual(forward.density(("cat", -4.0)), backward.density((-4.0, "cat")), places=8)
+
+    def test_target_must_not_overlap_observed(self):
+        with self.assertRaises(ValueError):
+            self.joint.infer({"image": -4.0}, ["image"])
+
+    def test_unknown_modality_name_raises_key_error(self):
+        with self.assertRaises(KeyError):
+            self.joint.infer({"smell": 1.0})
+
+
+class CycleConsistencyReceiptFlagsBrokenProjectionTest(unittest.TestCase):
+    """Acceptance criterion 2: the generalized cycle-consistency receipt flags a broken projection."""
+
+    def setUp(self):
+        # Regimes are well-separated (10 std apart in image, near-deterministic text) so both the
+        # well-behaved round trip and the broken one are essentially noise-free -- the receipt gap
+        # between them should be large and not a Monte-Carlo coin flip.
+        # Regime weights are deliberately skewed (0.9/0.1): a broken backward projection that swaps
+        # regime<->text assignments then also swaps which image mode each text label routes back to,
+        # which (combined with the skew) produces a large, unambiguous round-trip weight inversion
+        # rather than a small perturbation.
+        self.well_behaved = CrossModalJoint.from_components(
+            names=("image", "text"),
+            component_fields=[
+                (
+                    GaussianDistribution(mu=-5.0, sigma2=0.25),
+                    CategoricalDistribution(pmap={"cat": 0.99, "dog": 0.01}),
+                ),
+                (
+                    GaussianDistribution(mu=5.0, sigma2=0.25),
+                    CategoricalDistribution(pmap={"cat": 0.01, "dog": 0.99}),
+                ),
+            ],
+            weights=[0.9, 0.1],
+        )
+        # Same image/weight structure, but the regime -> text mapping is SWAPPED relative to
+        # ``well_behaved``: regime 0 (image near -5) is now the "mostly dog" regime and vice versa.
+        # Using this as the BACKWARD leg of the round trip means inferring image-from-text routes to
+        # the wrong Gaussian mode almost every time -- a deliberately broken A<-B projection.
+        self.broken = CrossModalJoint.from_components(
+            names=("image", "text"),
+            component_fields=[
+                (
+                    GaussianDistribution(mu=-5.0, sigma2=0.25),
+                    CategoricalDistribution(pmap={"cat": 0.01, "dog": 0.99}),
+                ),
+                (
+                    GaussianDistribution(mu=5.0, sigma2=0.25),
+                    CategoricalDistribution(pmap={"cat": 0.99, "dog": 0.01}),
+                ),
+            ],
+            weights=[0.9, 0.1],
+        )
+
+    def test_well_behaved_receipt_is_near_zero(self):
+        receipt = joint_cycle_consistency_receipt(
+            self.well_behaved, "image", "text", n_round_trip=200, n_kl_samples=400, seed=0
+        )
+        self.assertLess(receipt, 0.1)
+
+    def test_broken_backward_projection_is_clearly_elevated(self):
+        well_receipt = joint_cycle_consistency_receipt(
+            self.well_behaved, "image", "text", n_round_trip=200, n_kl_samples=400, seed=0
+        )
+        broken_receipt = joint_cycle_consistency_receipt(
+            self.well_behaved,
+            "image",
+            "text",
+            backward_joint=self.broken,
+            n_round_trip=200,
+            n_kl_samples=400,
+            seed=0,
+        )
+        self.assertGreater(broken_receipt, max(well_receipt * 10.0, 1.0))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements roadmap item **L2 — cross-modal reasoning = conditional inference in a shared-latent joint**.

- **`mixle/reason/cross_modal.py`** (new): `CrossModalJoint`, a thin name-addressed wrapper around the existing `CompositeDistribution` / `MixtureDistribution` machinery. A joint is built as a `MixtureDistribution` over `CompositeDistribution`s of heterogeneous per-modality fields (e.g. a Gaussian "image embedding" field + a Categorical "text label" field) — the shared mixture *component index* is the latent regime tying every modality together. `CrossModalJoint.infer(observed, target)` gives condition-on-any-subset / infer-any-other-subset by name, entirely via the pre-existing `MixtureDistribution.conditional` + `CompositeDistribution.marginal`/`condition` protocol (`Conditionable`/`Marginalizable` in `mixle/capability.py`) — no new inference machinery.
- **`mixle/reason/cycle_consistency.py`** (extended): adds `joint_cycle_consistency_receipt`, which **generalizes** this module's existing round-trip closure diagnostic (`cycle_inconsistency`, previously proven only for a single neural conditional-density transport, workstream F5). Because a `CrossModalJoint` is a typed grammar object rather than an opaque transport, its true marginals are available in closed form, so the new receipt compares the round-trip estimate (`p(A) -> infer B -> infer A back`, aggregated over many draws) directly against the *true marginal* `p(A)` via a Monte-Carlo KL-divergence estimate, rather than only against itself.
- **`mixle/reason/__init__.py`**: exports `CrossModalJoint` and `joint_cycle_consistency_receipt`.

## Test plan

New file `mixle/tests/cross_modal_conditional_test.py` (11 tests):
- Cross-modal posteriors on a synthetic 2-regime Gaussian/Categorical joint match hand-derived analytic posteriors exactly (both `text -> image` and `image -> text` directions, plus the empty-observation prior).
- Arbitrary-subset conditioning across **3 modalities** (image/text/audio): condition on 1 infer 2 jointly, condition on 2 infer the remaining 1, condition on none infer all 3, target-order fidelity, and error paths (target overlaps observed / unknown modality name).
- Cycle-consistency receipt: near-zero (`≈0.0008`) for a well-behaved joint vs. clearly elevated (`≈1.29`, ~1600x) for a deliberately broken backward projection (regime↔text-label mapping swapped between the forward and backward joints).

Confirmed no regressions:
```
pytest mixle/tests/cross_modal_conditional_test.py mixle/tests/cycle_consistency_test.py -m "" -q   # 19 passed
pytest mixle/tests/mixture_conditional_test.py mixle/tests/mixture_heterogeneous_test.py mixle/tests/ppl_composite_sampling_test.py -m "" -q   # 24 passed
pytest mixle/tests/belief_walk_test.py mixle/tests/anchor_harness_test.py -m "" -q   # part of the reason package's existing suite, unaffected
ruff check / ruff format on all touched files -> clean
```
