### PR TITLE
models: muP width-parametrization for lr/init hyperparameter transfer (F9)

### DIFF
--- a/mixle/models/__init__.py
+++ b/mixle/models/__init__.py
@@ -72,6 +72,16 @@ from mixle.models.mixture_density import (
     build_conditional_flow,
     build_mdn,
 )
+from mixle.models.mup import (
+    apply_mup_init,
+    classify_causal_lm_params,
+    init_std_multiplier,
+    lr_multiplier,
+    mup_param_groups,
+    output_forward_multiplier,
+    transfer_init_std,
+    transfer_lr,
+)
 from mixle.models.neural import (
     CategoricalClassificationNeuralNetwork,
     GaussianRegressionNeuralNetwork,
@@ -174,6 +184,14 @@ __all__ = [
     "lm_train_fn",
     "snapshot",
     "tune_training",
+    "apply_mup_init",
+    "classify_causal_lm_params",
+    "init_std_multiplier",
+    "lr_multiplier",
+    "mup_param_groups",
+    "output_forward_multiplier",
+    "transfer_init_std",
+    "transfer_lr",
     "stream_fit",
     "GrammarLearningResult",
     "HamiltonianNet",

--- a/mixle/models/mup.py
+++ b/mixle/models/mup.py
@@ -1,0 +1,247 @@
+"""muP (Maximal Update Parametrization) -- width-independent lr/init transfer for :mod:`mixle.models.transformer`.
+
+**The idea.** In the standard parametrization, the learning rate and init scale that work best for a
+transformer depend on its width (``d_model``): as a model gets wider, activations/gradients grow (or
+shrink) with width unless the parametrization compensates, so a wider model needs a *different* tuned
+lr than a narrower one -- hyperparameter search has to be repeated at every scale. muP (Yang et al.,
+"Tensor Programs V: Tuning Large Neural Networks via Zero-Shot Hyperparameter Transfer", 2022) chooses
+init-variance and lr scaling rules per layer *role* (input/embedding, hidden, output/readout) such
+that, in the infinite-width limit, the optimal lr stops moving with width. In practice this means: tune
+lr (and init scale) once, cheaply, on a small model, then *transfer* those hyperparameters to a much
+larger model at (almost) zero extra tuning cost -- the mechanism a capacity ladder needs so its tuning
+bill doesn't scale with every rung.
+
+**Why implemented from scratch instead of depending on the `mup` package.** Microsoft's reference
+``mup`` library is not installed in this environment (checked: ``import mup`` fails) and adding it as a
+dependency is unnecessary weight for what it buys here: the abc-parametrization rules for a transformer
+are a short, precisely published table (a handful of closed-form multipliers), not a large or fiddly
+algorithm, and mixle already treats torch as an optional soft dependency (see the ``_HAS_TORCH`` guard
+pattern used across ``mixle.models``) -- pulling in a required third-party package for ~10 lines of
+well-specified math would work against that. This module implements the rules directly against
+:class:`mixle.models.transformer.CausalLM`'s actual module structure.
+
+**The rules (muP for Adam; Tensor Programs V, Table 8 / the ``mup`` library's Adam column).** Let
+``width_mult = target_width / base_width`` (the ratio of the layer's fan-in-scaling width to the base
+width it was tuned at). Every parameter is classified into one of three roles:
+
+* **input** -- embeddings (token, position) and LayerNorm affine params. Fan-in does not scale with
+  ``d_model`` (it's the fixed vocab size, or LayerNorm has no fan-in at all), so muP leaves both init
+  variance and lr **unscaled** (``Theta(1)`` in ``width_mult``).
+* **hidden** -- every ``Linear`` inside a transformer block (attention qkv/proj, MLP in/out). Fan-in
+  scales linearly with width. Init variance stays at the standard ``1/fan_in`` (std multiplier
+  ``width_mult**-0.5``); the lr is scaled down as ``width_mult**-1`` -- *this* is the headline muP
+  rule and the reason a wide model doesn't blow up (or stall) with the narrow model's lr.
+* **output** -- the unembedding/readout. Fan-in scales with width, fan-out (vocab) is fixed. Init
+  variance gets an *extra* ``1/width_mult`` beyond the hidden rule (std multiplier ``width_mult**-1``),
+  lr scales as ``width_mult**-1`` like hidden, and the forward pass gets an explicit
+  ``width_mult**-1`` multiplier on the logits (the "c" of the abc-parametrization) so the *output scale*
+  is also width-independent at init.
+
+**Weight tying.** ``CausalLM`` ties ``head.weight = tok.weight`` (see ``mixle/models/transformer.py``)
+-- the same ``nn.Parameter`` object plays both the embedding-lookup and the unembedding-projection role.
+Since a single tensor can't have two different init/lr rules at once, this module follows the standard
+treatment for muP with tied embeddings (the same one the ``mup`` library's ``MuReadout`` implements):
+the shared parameter is classified under the **input** rule (fixed variance/lr -- it *is* the embedding
+table), and the muP **output** role is instead realized as a multiplicative rescale applied to the
+*logits* at readout time (:func:`output_forward_multiplier`), independent of the (shared) weight's own
+init/lr. This reproduces the correct output-scale behavior without touching weight tying.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+try:
+    import torch.nn as nn
+
+    _HAS_TORCH = True
+except ImportError:  # pragma: no cover - torch is optional
+    _HAS_TORCH = False
+
+Role = Literal["input", "hidden", "output"]
+_ROLES: tuple[Role, ...] = ("input", "hidden", "output")
+
+
+def _check_width_mult(width_mult: float) -> float:
+    width_mult = float(width_mult)
+    if width_mult <= 0:
+        raise ValueError(f"width_mult must be positive, got {width_mult}.")
+    return width_mult
+
+
+def init_std_multiplier(role: Role, width_mult: float) -> float:
+    """Return the muP multiplier on init std for a parameter of ``role`` at the given ``width_mult``.
+
+    ``width_mult = target_width / base_width``. Multiply the BASE width's tuned/measured init std by
+    this factor to get the init std to use at the target width:
+
+    * ``"input"``  -> ``1``                  (fan-in fixed, e.g. vocab size -- no rescale)
+    * ``"hidden"`` -> ``width_mult ** -0.5``  (variance ``1/fan_in``, standard, unchanged form)
+    * ``"output"`` -> ``width_mult ** -1``    (variance ``1/fan_in**2`` -- an extra ``1/width_mult``)
+    """
+    width_mult = _check_width_mult(width_mult)
+    if role == "input":
+        return 1.0
+    if role == "hidden":
+        return width_mult**-0.5
+    if role == "output":
+        return width_mult**-1.0
+    raise ValueError(f"unknown muP role {role!r}; expected one of {_ROLES}.")
+
+
+def lr_multiplier(role: Role, width_mult: float) -> float:
+    """Return the muP multiplier on learning rate for a parameter of ``role`` at the given ``width_mult``.
+
+    ``width_mult = target_width / base_width``. Multiply the BASE width's tuned lr by this factor to
+    get the transferred lr to use at the target width:
+
+    * ``"input"``  -> ``1``                (constant lr -- the muP "don't touch it" role)
+    * ``"hidden"`` -> ``width_mult ** -1``  (the headline muP rule: lr shrinks as the model widens)
+    * ``"output"`` -> ``width_mult ** -1``  (same shrink as hidden, for Adam)
+    """
+    width_mult = _check_width_mult(width_mult)
+    if role == "input":
+        return 1.0
+    if role in ("hidden", "output"):
+        return width_mult**-1.0
+    raise ValueError(f"unknown muP role {role!r}; expected one of {_ROLES}.")
+
+
+def output_forward_multiplier(width_mult: float) -> float:
+    """Return the muP readout multiplier (the "c" of abc-parametrization) applied to output-role logits.
+
+    Multiply the raw ``head`` output by this factor so the readout's output scale stays width-independent
+    at init, even though (due to weight tying, see the module docstring) ``head.weight`` itself is
+    parametrized under the ``"input"`` rule rather than a separate ``"output"`` init/lr rule.
+    """
+    return _check_width_mult(width_mult) ** -1.0
+
+
+def transfer_lr(base_lr: float, base_width: int, target_width: int, *, role: Role = "hidden") -> float:
+    """Rescale ``base_lr`` (tuned at ``base_width``) to the muP-predicted optimum at ``target_width``.
+
+    This is the deliverable that "collapses the ladder's tuning bill": tune ``role="hidden"`` lr once,
+    cheaply, at a small ``base_width``, then call this to predict the optimal lr at any larger
+    ``target_width`` with (ideally) no further search. Defaults to ``role="hidden"`` -- the dominant
+    parameter group (attention + MLP) and the one muP's headline lr-transfer guarantee is about.
+    """
+    if base_width <= 0 or target_width <= 0:
+        raise ValueError("base_width and target_width must be positive.")
+    width_mult = target_width / base_width
+    return float(base_lr) * lr_multiplier(role, width_mult)
+
+
+def transfer_init_std(base_std: float, base_width: int, target_width: int, *, role: Role = "hidden") -> float:
+    """Rescale ``base_std`` (tuned/measured at ``base_width``) to the muP init std at ``target_width``."""
+    if base_width <= 0 or target_width <= 0:
+        raise ValueError("base_width and target_width must be positive.")
+    width_mult = target_width / base_width
+    return float(base_std) * init_std_multiplier(role, width_mult)
+
+
+def _is_layernorm_param(name: str) -> bool:
+    parts = name.split(".")
+    return "ln1" in parts or "ln2" in parts or (len(parts) >= 2 and parts[-2] == "ln")
+
+
+def classify_causal_lm_params(model) -> dict[str, Role]:
+    """Map every named parameter of a :class:`mixle.models.transformer.CausalLM` to its muP role.
+
+    * ``tok.weight`` / ``pos.weight`` (embeddings) -> ``"input"`` -- fan-in is the fixed vocab / block
+      length, not ``d_model``.
+    * LayerNorm affine params (``blocks.*.ln1``/``ln2``, top-level ``ln``) -> ``"input"`` -- no
+      fan-in at all, muP leaves them at their standard ``Theta(1)`` scale/shift regardless of width.
+    * ``head.weight`` -> not a separate entry: it is the *same* ``nn.Parameter`` as ``tok.weight``
+      (weight tying), so ``model.named_parameters()`` already reports it once, under ``"tok.weight"``.
+      See the module docstring for how the muP output role is instead applied at readout time.
+    * everything else (the attention qkv/proj and MLP ``Linear`` weights/biases inside each block) ->
+      ``"hidden"`` -- fan-in scales linearly with ``d_model``.
+    """
+    roles: dict[str, Role] = {}
+    for name, _ in model.named_parameters():
+        top = name.split(".")[0]
+        if top in ("tok", "pos"):
+            roles[name] = "input"
+        elif top == "ln" or _is_layernorm_param(name):
+            roles[name] = "input"
+        else:
+            roles[name] = "hidden"
+    return roles
+
+
+def apply_mup_init(model, *, base_width: int, base_std: float = 0.02) -> None:
+    """Re-initialize ``model`` in place per the muP init rules, relative to ``base_width``.
+
+    ``base_std`` is the hidden-role init std tuned/measured at ``base_width`` (the mixle default,
+    ``0.02``, matches common transformer practice and is a reasonable base-width value on its own).
+    ``model.d_model`` is read as the target width, so ``width_mult = model.d_model / base_width``.
+    LayerNorm weight/bias keep their identity init (``1`` / ``0``, unaffected by width, matching the
+    ``"input"`` role's no-rescale treatment); every other bias is zero-initialized (muP does not
+    rescale bias init); every other weight matrix is drawn ``Normal(0, base_std * init_std_multiplier(role, width_mult))``.
+    """
+    if not _HAS_TORCH:  # pragma: no cover - torch is optional
+        raise ImportError("apply_mup_init requires torch.")
+    width_mult = float(model.d_model) / float(base_width)
+    roles = classify_causal_lm_params(model)
+    named = dict(model.named_parameters())
+    for name, role in roles.items():
+        p = named[name]
+        if _is_layernorm_param(name) or (name == "ln.weight" or name == "ln.bias"):
+            if name.endswith(".weight"):
+                nn.init.ones_(p)
+            else:
+                nn.init.zeros_(p)
+            continue
+        if p.dim() < 2:
+            nn.init.zeros_(p)
+            continue
+        std = base_std * init_std_multiplier(role, width_mult)
+        nn.init.normal_(p, mean=0.0, std=std)
+
+
+@dataclass(frozen=True)
+class MuPParamGroup:
+    """One torch-optimizer param group under muP, tagged with the role it was scaled for."""
+
+    role: Role
+    lr: float
+    n_params: int
+
+
+def mup_param_groups(model, *, base_width: int, lr: float) -> list[dict]:
+    """Build torch optimizer param groups implementing muP's per-role lr scaling for ``model``.
+
+    ``lr`` is the BASE (hidden-role) learning rate -- the one hyperparameter tuned once, cheaply, at
+    ``base_width``. ``model.d_model`` is read as the target width. Returns a list of
+    ``{"params": [...], "lr": ..., "mup_role": ...}`` dicts suitable for ``torch.optim.Adam(groups)``;
+    the ``"input"`` group's lr is unscaled, the ``"hidden"``/``"output"`` groups get
+    ``lr * lr_multiplier(role, width_mult)`` -- i.e. passing the same tuned ``lr`` at any target width
+    reproduces exactly what :func:`transfer_lr` predicts for that role. ``transfer_lr`` is the formula;
+    this is the mechanism that applies it to a live model + optimizer.
+    """
+    width_mult = float(model.d_model) / float(base_width)
+    roles = classify_causal_lm_params(model)
+    named = dict(model.named_parameters())
+    by_role: dict[Role, list] = {"input": [], "hidden": [], "output": []}
+    for name, role in roles.items():
+        by_role[role].append(named[name])
+    return [
+        {"params": params, "lr": float(lr) * lr_multiplier(role, width_mult), "mup_role": role}
+        for role, params in by_role.items()
+        if params
+    ]
+
+
+__all__ = [
+    "MuPParamGroup",
+    "Role",
+    "apply_mup_init",
+    "classify_causal_lm_params",
+    "init_std_multiplier",
+    "lr_multiplier",
+    "mup_param_groups",
+    "output_forward_multiplier",
+    "transfer_init_std",
+    "transfer_lr",
+]

--- a/mixle/tests/mup_test.py
+++ b/mixle/tests/mup_test.py
@@ -1,0 +1,311 @@
+"""Acceptance tests for F9 (muP / hyperparameter transfer) -- see ``mixle/models/mup.py``.
+
+The headline claim under test: tune a learning rate once, cheaply, on a small "base width" transformer,
+then use :func:`mixle.models.mup.transfer_lr` to *predict* (no search) the optimal lr at a larger
+"target width" -- and that prediction should land close to what an INDEPENDENT small hyperparameter
+search at the target width finds on its own. A contrast test shows the standard (non-muP) parametrization
+does *not* have this property: naively reusing the base width's tuned lr at a much wider target performs
+measurably worse than the muP-transferred lr.
+
+The "tuned optimum" searches use :class:`mixle.doe.optimizer.BayesianOptimizer` (mixle's own ask/tell
+Bayesian-optimization machinery, ``mixle.doe``) over ``log10(lr)`` -- a real, if small, hyperparameter
+search, not a hand-rolled loop, per the F5-adjacent guidance that this codebase's own DOE tools are the
+right way to do "find the tuned optimum at width X".
+
+All training here is on tiny synthetic data with tiny models (``d_model`` in 32..256, a couple hundred
+parameters to a few thousand) specifically so the search loops (many training runs) are cheap -- this is
+squarely muP's designed use case: verify hyperparameter transfer AT SMALL SCALE, because muP's entire
+premise is that what's tuned small transfers to big.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+import torch.nn.functional as F  # noqa: E402
+
+from mixle.doe.optimizer import BayesianOptimizer  # noqa: E402
+from mixle.models.mup import (  # noqa: E402
+    apply_mup_init,
+    classify_causal_lm_params,
+    init_std_multiplier,
+    lr_multiplier,
+    mup_param_groups,
+    output_forward_multiplier,
+    transfer_lr,
+)
+from mixle.models.transformer import build_causal_lm  # noqa: E402
+
+# The formula/classification/param-group unit tests below are individually marked `fast` (they run in
+# the default `pytest` gate); the two full training-loop acceptance tests are marked `slow` only (they
+# run many small training loops via BayesianOptimizer search and are excluded from the default fast
+# gate, matching this repo's `-m fast` default -- see pyproject.toml's addopts comment).
+
+VOCAB = 8
+BLOCK = 8
+BATCH = 64
+N_LAYER = 2
+N_HEAD = 2
+BASE_WIDTH = 32
+
+# Fixed ground-truth rule for the synthetic task -- shared by every training AND eval batch so the
+# model is always being trained and scored against the SAME target function (see next-token bigram
+# task below); only the input tokens are resampled per seed/step.
+_TASK_PERM = np.random.RandomState(0xBEEF).permutation(VOCAB)
+
+
+def _batches(seed: int, n_batches: int):
+    """A trivial "bigram" next-token task: y = fixed_permutation(x[:, -1]). Easy to learn quickly,
+    but from-scratch (random init), so a bad lr (too small: undertrained; too large: unstable) is
+    visibly worse than a well-tuned one -- exactly the sensitivity muP's lr-transfer rule needs to
+    be tested against.
+    """
+    rng = np.random.RandomState(seed)
+    out = []
+    for _ in range(n_batches):
+        x = rng.randint(0, VOCAB, size=(BATCH, BLOCK))
+        y = _TASK_PERM[x[:, -1]]
+        out.append((x.astype(np.float32), y.astype(np.int64)))
+    return out
+
+
+def _train_eval(d_model: int, lr: float, seed: int, *, use_mup: bool, n_steps: int) -> float:
+    """Train a tiny CausalLM at ``d_model`` with a single flat Adam lr, return held-out CE loss.
+
+    ``use_mup=True`` applies muP init (:func:`apply_mup_init`, relative to ``BASE_WIDTH``) and the muP
+    output-readout multiplier at the logits; ``use_mup=False`` uses the model's standard (untouched)
+    init and no readout multiplier -- the "naive" comparison. Both use the SAME flat ``lr`` for every
+    parameter (this is deliberately the simple, single-hyperparameter regime a capacity ladder actually
+    tunes -- not per-role optimizer groups, which is what :func:`mup_param_groups` is for and is tested
+    separately in ``test_mup_param_groups_scale_lr_by_role``).
+    """
+    torch.manual_seed(seed)
+    model = build_causal_lm(VOCAB, d_model, N_LAYER, N_HEAD, BLOCK)
+    width_mult = d_model / BASE_WIDTH
+    if use_mup:
+        apply_mup_init(model, base_width=BASE_WIDTH, base_std=0.02)
+        out_mult = output_forward_multiplier(width_mult)
+    else:
+        out_mult = 1.0
+    opt = torch.optim.Adam(model.parameters(), lr=lr)
+    for x, y in _batches(seed=100 + seed, n_batches=n_steps):
+        xt, yt = torch.from_numpy(x), torch.from_numpy(y)
+        loss = F.cross_entropy(model(xt) * out_mult, yt)
+        opt.zero_grad()
+        loss.backward()
+        torch.nn.utils.clip_grad_norm_(model.parameters(), 1.0)  # bound single-seed lr-instability blowups
+        opt.step()
+    model.eval()
+    with torch.no_grad():
+        losses = [
+            F.cross_entropy(model(torch.from_numpy(x)) * out_mult, torch.from_numpy(y)).item()
+            for x, y in _batches(seed=999, n_batches=8)  # fixed held-out batches, same task rule
+        ]
+    return float(np.mean(losses))
+
+
+def _avg_loss(d_model: int, log10_lr: float, *, use_mup: bool, seeds: tuple[int, ...], n_steps: int) -> float:
+    lr = 10.0**log10_lr
+    return float(np.mean([_train_eval(d_model, lr, s, use_mup=use_mup, n_steps=n_steps) for s in seeds]))
+
+
+def _bo_tune_log_lr(
+    d_model: int, bounds, *, use_mup: bool, seeds: tuple[int, ...], n_steps: int, n_iter: int, seed: int
+) -> tuple[float, float]:
+    """Search for the best flat lr at ``d_model`` over ``bounds`` (log10-lr) using mixle's own
+    ask/tell Bayesian optimizer (:class:`mixle.doe.optimizer.BayesianOptimizer`) -- a real, if small,
+    hyperparameter search, standing in for "the per-rung tuned optimum" in the acceptance criterion.
+    """
+    opt = BayesianOptimizer(bounds, acq="ei", n_init=6, seed=seed)
+    for _ in range(n_iter):
+        x = opt.ask()
+        y = _avg_loss(d_model, float(x[0]), use_mup=use_mup, seeds=seeds, n_steps=n_steps)
+        opt.tell(x, y)
+    best = opt.best
+    return float(10.0 ** best.best_x[0]), float(best.best_y)
+
+
+# --- 3. hand-checkable unit tests of the abc-parametrization formulas themselves -----------------
+
+
+@pytest.mark.fast
+def test_init_std_multiplier_matches_published_mup_formula():
+    # input role: Theta(1), never rescaled.
+    assert init_std_multiplier("input", width_mult=1.0) == pytest.approx(1.0)
+    assert init_std_multiplier("input", width_mult=4.0) == pytest.approx(1.0)
+    assert init_std_multiplier("input", width_mult=0.25) == pytest.approx(1.0)
+    # hidden role: variance ~ 1/width_mult -> std ~ width_mult**-0.5.
+    assert init_std_multiplier("hidden", width_mult=4.0) == pytest.approx(0.5)
+    assert init_std_multiplier("hidden", width_mult=16.0) == pytest.approx(0.25)
+    assert init_std_multiplier("hidden", width_mult=1.0) == pytest.approx(1.0)
+    # output role: variance ~ 1/width_mult**2 -> std ~ width_mult**-1 (an extra 1/width_mult vs hidden).
+    assert init_std_multiplier("output", width_mult=4.0) == pytest.approx(0.25)
+    assert init_std_multiplier("output", width_mult=16.0) == pytest.approx(1.0 / 16.0)
+
+
+@pytest.mark.fast
+def test_lr_multiplier_matches_published_mup_formula():
+    # input role: constant lr, never rescaled.
+    assert lr_multiplier("input", width_mult=8.0) == pytest.approx(1.0)
+    # hidden and output roles: lr ~ 1/width_mult (the headline Adam-muP lr-transfer rule).
+    assert lr_multiplier("hidden", width_mult=4.0) == pytest.approx(0.25)
+    assert lr_multiplier("hidden", width_mult=1.0) == pytest.approx(1.0)
+    assert lr_multiplier("output", width_mult=8.0) == pytest.approx(0.125)
+
+
+@pytest.mark.fast
+def test_output_forward_multiplier_matches_hidden_and_output_lr_scaling():
+    assert output_forward_multiplier(width_mult=1.0) == pytest.approx(1.0)
+    assert output_forward_multiplier(width_mult=4.0) == pytest.approx(0.25)
+
+
+@pytest.mark.fast
+def test_transfer_lr_and_transfer_init_std_apply_the_role_multiplier():
+    # width doubles -> hidden lr predicted to halve; base_width==target_width -> identity.
+    assert transfer_lr(1e-3, base_width=32, target_width=64) == pytest.approx(5e-4)
+    assert transfer_lr(1e-3, base_width=32, target_width=32) == pytest.approx(1e-3)
+    assert transfer_lr(1e-3, base_width=32, target_width=32, role="input") == pytest.approx(1e-3)
+
+
+@pytest.mark.fast
+def test_unknown_role_raises():
+    with pytest.raises(ValueError):
+        init_std_multiplier("bogus", width_mult=2.0)  # type: ignore[arg-type]
+    with pytest.raises(ValueError):
+        lr_multiplier("bogus", width_mult=2.0)  # type: ignore[arg-type]
+
+
+# --- classification / param-group unit tests (fast, no training) ---------------------------------
+
+
+@pytest.mark.fast
+def test_classify_causal_lm_params_assigns_expected_roles():
+    model = build_causal_lm(vocab=VOCAB, d_model=16, n_layer=2, n_head=2, block=BLOCK)
+    roles = classify_causal_lm_params(model)
+    assert roles["tok.weight"] == "input"
+    assert roles["pos.weight"] == "input"
+    assert roles["ln.weight"] == "input"
+    assert roles["ln.bias"] == "input"
+    assert roles["blocks.0.ln1.weight"] == "input"
+    assert roles["blocks.0.attn.qkv.weight"] == "hidden"
+    assert roles["blocks.0.attn.proj.weight"] == "hidden"
+    assert roles["blocks.0.mlp.0.weight"] == "hidden"
+    assert roles["blocks.0.mlp.2.weight"] == "hidden"
+    # head.weight is tied to tok.weight (mixle/models/transformer.py: `self.head.weight = self.tok.weight`)
+    # so it is the SAME nn.Parameter and torch's named_parameters() de-dupes it -- it must not appear
+    # as a second, separately-classified entry.
+    assert "head.weight" not in roles
+    assert model.head.weight is model.tok.weight
+
+
+@pytest.mark.fast
+def test_mup_param_groups_scale_lr_by_role():
+    model = build_causal_lm(vocab=VOCAB, d_model=64, n_layer=2, n_head=2, block=BLOCK)
+    groups = mup_param_groups(model, base_width=32, lr=1e-2)  # width_mult = 64/32 = 2
+    by_role = {g["mup_role"]: g for g in groups}
+    assert set(by_role) == {"input", "hidden"}  # no untied "output" group in this tied-embedding model
+    assert by_role["input"]["lr"] == pytest.approx(1e-2)  # unscaled
+    assert by_role["hidden"]["lr"] == pytest.approx(5e-3)  # 1e-2 * 2**-1
+    # every model parameter is accounted for exactly once across the groups.
+    grouped = sum((g["params"] for g in groups), [])
+    assert len(grouped) == len(list(model.parameters()))
+
+
+@pytest.mark.fast
+def test_apply_mup_init_rescales_hidden_weight_std_with_width():
+    torch.manual_seed(0)
+    small = build_causal_lm(vocab=VOCAB, d_model=32, n_layer=2, n_head=2, block=BLOCK)
+    apply_mup_init(small, base_width=32, base_std=0.02)
+    torch.manual_seed(0)
+    big = build_causal_lm(vocab=VOCAB, d_model=128, n_layer=2, n_head=2, block=BLOCK)
+    apply_mup_init(big, base_width=32, base_std=0.02)
+
+    small_std = small.blocks[0].attn.proj.weight.detach().std().item()
+    big_std = big.blocks[0].attn.proj.weight.detach().std().item()
+    # width_mult = 128/32 = 4 -> hidden std multiplier = 4**-0.5 = 0.5, so big's std should be
+    # ~half of small's (measured on a few thousand samples, generous tolerance for sampling noise).
+    assert big_std == pytest.approx(0.5 * small_std, rel=0.25)
+
+    # LayerNorm affine params keep their identity init (Theta(1), width-independent) at every width.
+    assert torch.allclose(big.blocks[0].ln1.weight, torch.ones_like(big.blocks[0].ln1.weight))
+    assert torch.allclose(big.blocks[0].ln1.bias, torch.zeros_like(big.blocks[0].ln1.bias))
+
+
+# --- 1. the core acceptance criterion: transferred lr vs. independently-tuned optimum ------------
+
+
+@pytest.mark.slow
+def test_mup_lr_transfer_matches_independently_tuned_optimum():
+    """Tune once at BASE_WIDTH=32, transfer to widths 64 and 128 (mixle's rungs i-ii capacity-ladder
+    proxy), and check the muP-predicted lr lands close to what an independent search finds at each
+    target width -- reporting the actual measured ratio, not just asserting "close enough".
+    """
+    seeds = (1, 2, 3)
+    n_steps = 60
+
+    base_lr, base_loss = _bo_tune_log_lr(
+        BASE_WIDTH, [(-4.0, -1.0)], use_mup=True, seeds=seeds, n_steps=n_steps, n_iter=12, seed=1
+    )
+    assert base_loss < 1.0  # sanity: the base-width search actually found something that learns the task
+
+    ratios = []
+    for target_width, bo_seed in ((64, 2), (128, 3)):
+        predicted = transfer_lr(base_lr, BASE_WIDTH, target_width)
+        # search a window around the prediction so the independent search isn't handed the answer,
+        # but also isn't forced to rediscover the whole [1e-4, 1e-1] range from scratch every time.
+        window = [(np.log10(predicted) - 1.5, np.log10(predicted) + 1.5)]
+        tuned_lr, _tuned_loss = _bo_tune_log_lr(
+            target_width, window, use_mup=True, seeds=seeds, n_steps=n_steps, n_iter=12, seed=bo_seed
+        )
+        ratio = predicted / tuned_lr
+        ratios.append(ratio)
+        print(
+            f"[muP transfer] base_width={BASE_WIDTH} base_lr={base_lr:.4g} -> "
+            f"target_width={target_width} predicted_lr={predicted:.4g} tuned_lr={tuned_lr:.4g} "
+            f"ratio={ratio:.3f} ({abs(1 - ratio) * 100:.1f}% off)"
+        )
+        # muP is an asymptotic (large-width) guarantee; at these deliberately tiny, fast-to-train
+        # widths (32 -> 64/128) the transferred lr is expected to land within a factor of ~3x of an
+        # independent search's optimum -- loose relative to production-scale muP papers (which report
+        # single-digit-percent transfer at 100x+ width) precisely because we're validating the
+        # mechanism cheaply, not because the rule is expected to be looser at scale.
+        assert 1.0 / 3.0 <= ratio <= 3.0, (
+            f"transferred/tuned lr ratio {ratio:.3f} outside [1/3, 3] at width {target_width}"
+        )
+
+    print(f"[muP transfer] mean |ratio - 1| = {np.mean([abs(1 - r) for r in ratios]) * 100:.1f}%")
+
+
+# --- 2. sanity contrast: WITHOUT muP, naively reusing the base lr does not transfer --------------
+
+
+@pytest.mark.slow
+def test_without_mup_naive_lr_reuse_is_worse_than_mup_transfer():
+    """At a much wider target (16x the base width), reusing the base width's tuned lr verbatim with
+    STANDARD (non-muP) parametrization should measurably underperform using the muP-transferred lr --
+    this is the actual point of muP, demonstrated as an explicit contrast rather than tested in isolation.
+    """
+    seeds = (1, 2, 3)
+    n_steps = 60
+    target_width = 8 * BASE_WIDTH  # 256 -- large enough for standard parametrization to visibly break
+
+    base_lr, _ = _bo_tune_log_lr(
+        BASE_WIDTH, [(-4.0, -1.0)], use_mup=True, seeds=seeds, n_steps=n_steps, n_iter=12, seed=1
+    )
+    predicted = transfer_lr(base_lr, BASE_WIDTH, target_width)
+
+    loss_transferred = _avg_loss(target_width, np.log10(predicted), use_mup=True, seeds=seeds, n_steps=n_steps)
+    loss_naive = _avg_loss(target_width, np.log10(base_lr), use_mup=False, seeds=seeds, n_steps=n_steps)
+
+    print(
+        f"[muP contrast] target_width={target_width} base_lr={base_lr:.4g} predicted_lr={predicted:.4g}\n"
+        f"  loss @ muP-transferred lr           = {loss_transferred:.4f}\n"
+        f"  loss @ naive reuse (no muP, no rescale) = {loss_naive:.4f}"
+    )
+    # entropy floor for VOCAB=8 uniform predictions is ln(8) ~= 2.079; the naive run should be at or
+    # above it (i.e. it has learned nothing, or worse, destabilized), while the transferred run should
+    # have made real progress below it.
+    assert loss_transferred < np.log(VOCAB) * 0.75
+    assert loss_naive > loss_transferred * 2.0


### PR DESCRIPTION
## Summary

Roadmap item F9 ("muP / hyperparameter transfer"): width-parametrization so lr/init transfer across capacity-ladder rungs, collapsing the tuning bill.

- **`mixle/models/mup.py`** (new): the muP (Maximal Update Parametrization) abc-parametrization rules applied to `mixle.models.transformer.CausalLM`'s actual module structure -- `input` (embeddings, LayerNorm), `hidden` (attention/MLP linears), and `output` (readout) roles each get their own published init-variance and lr scaling rule (Yang et al., "Tensor Programs V" / the muP-for-Adam table). `CausalLM` ties `head.weight = tok.weight`, so per the standard treatment for weight-tied muP transformers, the shared parameter is classified under the `input` rule and the muP output role is instead realized as a `output_forward_multiplier` applied to the logits at readout time.
  - `transfer_lr` / `transfer_init_std` -- the actual "collapse the tuning bill" deliverable: rescale a hyperparameter tuned at a small base width to the muP-predicted value at a larger target width, no search required.
  - `mup_param_groups` -- builds torch optimizer param groups with muP's per-role lr scaling baked in.
  - `apply_mup_init` -- re-initializes a model in place per the muP init rules.
- Implemented from scratch rather than depending on Microsoft's `mup` package: it isn't installed in this environment, and the rules are a compact, precisely published table (not a large or fiddly algorithm), so adding a required third-party dependency for ~10 lines of well-specified math would work against `mixle.models`' existing "torch is optional" story.
- Exported from `mixle.models` alongside `build_causal_lm`.

## Verification (the acceptance criteria)

All in `mixle/tests/mup_test.py`. Unit tests (`fast`, no training) check the formulas against hand-checkable values and the param classification/grouping. Two `slow` tests do real small hyperparameter searches (via `mixle.doe.optimizer.BayesianOptimizer`, mixle's own ask/tell Bayes-opt machinery) on tiny synthetic transformers (`d_model` 32-256):

1. **Core acceptance criterion** -- tune lr once at base width 32, transfer to widths 64 and 128 (a proxy for the roadmap's rungs i-ii, 1B/8k/8-GPU -> 8B/128k/256-GPU). Measured:
   - width 64: predicted lr 0.00574 vs. independently-tuned optimum 0.00604 -- **5.0% off**
   - width 128: predicted lr 0.00287 vs. independently-tuned optimum 0.00517 -- **44.5% off**
   - (mean |ratio - 1| = 24.7%; asserted within a factor of 3x at each width -- loose relative to production-scale muP papers because this is validating the mechanism cheaply at tiny, non-asymptotic widths, not because the rule is expected to be looser at scale)

2. **Without-muP contrast** -- at width 256 (16x base), naively reusing the base-width tuned lr under *standard* (non-muP) parametrization: held-out loss 2.24 (near the task's entropy floor of ln(8)=2.08, i.e. it learned essentially nothing) vs. 0.30 for the muP-transferred lr -- **~7.6x worse**.

3. Unit tests pin the exact published formulas (e.g. hidden-role init std multiplier = `width_mult**-0.5`, lr multiplier = `width_mult**-1`; input role unscaled) and the param-role classification / optimizer-group construction on `CausalLM`.

## Test plan

- [x] `ruff check --fix` + `ruff format` on all changed files -- clean
- [x] `pytest mixle/tests/mup_test.py -m ""` -- 10/10 pass (~30s)
- [x] `pytest mixle/tests/torch_neural_test.py mixle/tests/streaming_transformer_weights_test.py mixle/tests/lm_serialization_test.py mixle/tests/task_artifact_test.py mixle/tests/grad_control_test.py mixle/tests/neural_ppl_test.py mixle/tests/shared_embedding_test.py mixle/tests/mup_test.py -m ""` (transformer-adjacent regressions) -- 48 passed, 1 pre-existing unrelated skip
- [x] `python -c "from mixle.models import apply_mup_init, transfer_lr, build_causal_lm"` -- package-level import works
