### PR TITLE
J3: self-distillation during training (EMA-teacher + stochastic-depth)

### DIFF
--- a/mixle/models/self_distillation.py
+++ b/mixle/models/self_distillation.py
@@ -1,0 +1,278 @@
+"""Self-distillation during training (roadmap J3): EMA-teacher consistency + stochastic-depth targets,
+wired into normal training as loss-hooks -- not a separate post-hoc distillation pass, and not a new
+trainer either.
+
+The idea, concretely
+---------------------
+Two self-consistency pressures applied *during* ordinary next-token training:
+
+1. **EMA-teacher consistency** (:class:`EMATeacher`): maintain an exponential-moving-average copy of the
+   model's own weights, updated every step (``teacher = decay * teacher + (1 - decay) * student``, the
+   standard mean-teacher/BYOL/DINO pattern). The actively-trained (student) model is pushed to agree with
+   this temporally-smoothed version of itself via :func:`consistency_loss` -- an implicit regularizer with
+   no extra labels or extra model.
+2. **Stochastic-depth consistency** (:func:`stochastic_depth_forward`): each step, run the SAME input
+   through the model twice -- once at full depth, once with a random subset of blocks skipped entirely
+   (the standard stochastic-depth / drop-path regularizer) -- and add a consistency term pulling the
+   partial-depth output toward the full-depth output. This directly trains the model to tolerate missing
+   blocks, which is exactly the redundancy G3's :mod:`mixle.models.coarsening` depth-merge exploits.
+
+Why this belongs at the loss-hook level, not a new trainer
+------------------------------------------------------------
+:mod:`mixle.models.grad_leaf` already establishes the "compose via wrapping" pattern for this codebase's
+M-step: a training loop is generic, and custom OBJECTIVES are a ``loss(module, x, w) -> scalar`` hook, not
+a subclass tree (see ``GradLeaf``/``GradEstimator``). ``CausalLM`` doesn't fit ``GradLeaf`` directly (it has
+no ``log_density``; its own dense-teacher-forcing loop lives in :mod:`mixle.models.language_model` and
+:mod:`mixle.models.streaming_transformer_leaf`), so :func:`train_with_self_distillation` mirrors THOSE
+loops' own conventions (``F.cross_entropy`` over ``(context, next_token)`` micro-batches from
+:func:`mixle.data.stream_token_source.stream_token_source`, a plain ``torch.optim.Adam`` M-step) and adds
+the two consistency terms as extra, addable loss components on top of the same per-step cross-entropy --
+the loss-hook composition pattern, applied at the place this model family's training loop actually lives.
+"""
+
+from __future__ import annotations
+
+import copy
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+
+try:
+    import torch
+    import torch.nn.functional as F
+
+    _HAS_TORCH = True
+except ImportError:  # pragma: no cover - torch is optional
+    _HAS_TORCH = False
+
+__all__ = [
+    "EMATeacher",
+    "TrainStats",
+    "consistency_loss",
+    "stochastic_depth_forward",
+    "train_with_self_distillation",
+]
+
+
+def _require_torch() -> None:
+    if not _HAS_TORCH:
+        raise RuntimeError("mixle.models.self_distillation requires torch (mixle.models.transformer is torch-only).")
+
+
+class EMATeacher:
+    """An exponential-moving-average copy of a model's own weights: the standard mean-teacher/BYOL/DINO
+    self-distillation teacher.
+
+    ``update(student_model)`` applies ``teacher = decay * teacher + (1 - decay) * student`` to every
+    tensor in the teacher's ``state_dict`` (parameters AND buffers, so e.g. non-trainable statistics stay
+    consistent too) -- called once per training step, AFTER the optimizer step, so the teacher always
+    tracks a temporally-smoothed trailing average of the student. The teacher is a real, independent,
+    forward-passable module (``forward``/``predict``), held in eval mode with gradients disabled: it is a
+    read-only distillation TARGET, never itself directly optimized.
+    """
+
+    def __init__(self, model: Any, decay: float = 0.999) -> None:
+        _require_torch()
+        if not (0.0 <= decay < 1.0):
+            raise ValueError(f"decay must be in [0, 1); got {decay}")
+        self.decay = float(decay)
+        self.ema_model = copy.deepcopy(model)
+        self.ema_model.eval()
+        for p in self.ema_model.parameters():
+            p.requires_grad_(False)
+
+    @torch.no_grad()
+    def update(self, student_model: Any) -> None:
+        """One EMA step: pull every teacher tensor toward the student's current value.
+
+        ``CausalLM`` ties ``head.weight`` to ``tok.weight`` (weight tying), so several ``state_dict()``
+        keys alias the SAME underlying storage -- updating each key naively would apply the EMA formula
+        to that storage more than once per step (a double update). ``seen`` dedupes by storage identity
+        (``data_ptr()``) so every real tensor is updated exactly once, however many names alias it.
+        """
+        d = self.decay
+        student_state = student_model.state_dict()
+        seen: set = set()
+        for name, teacher_tensor in self.ema_model.state_dict().items():
+            ptr = teacher_tensor.data_ptr()
+            if ptr in seen:
+                continue
+            seen.add(ptr)
+            student_tensor = student_state[name]
+            if torch.is_floating_point(teacher_tensor):
+                teacher_tensor.mul_(d).add_(student_tensor.detach(), alpha=1.0 - d)
+            else:  # integer/bool buffers (none in CausalLM today, but handled honestly): no EMA, just track
+                teacher_tensor.copy_(student_tensor)
+
+    def forward(self, x: Any) -> Any:
+        """Run ``x`` through the EMA-teacher weights (eval mode, no grad)."""
+        with torch.no_grad():
+            return self.ema_model(x)
+
+    predict = forward
+
+
+def consistency_loss(student_output: Any, teacher_output: Any, mode: str = "mse") -> Any:
+    """The self-distillation consistency term between a student prediction and a teacher/target
+    prediction on the SAME input -- ``mode="mse"`` (default, plain squared-error between logits, the
+    mean-teacher convention) or ``mode="kl"`` (``KL(teacher_softmax || student_log_softmax)``, the
+    classic soft-target distillation loss).
+    """
+    _require_torch()
+    if mode == "mse":
+        return F.mse_loss(student_output, teacher_output)
+    if mode == "kl":
+        student_log_prob = F.log_softmax(student_output, dim=-1)
+        teacher_prob = F.softmax(teacher_output, dim=-1)
+        return F.kl_div(student_log_prob, teacher_prob, reduction="batchmean")
+    raise ValueError(f"consistency_loss: unrecognized mode {mode!r}, expected 'mse' or 'kl'")
+
+
+def _forward_with_keep_mask(model: Any, x: Any, keep_mask: list) -> Any:
+    """Re-run :class:`~mixle.models.transformer.CausalLM`'s own forward, but skip any block whose
+    ``keep_mask`` entry is ``False`` entirely (identity: the residual stream passes straight through) --
+    the standard stochastic-depth / drop-path forward. Mirrors
+    :func:`mixle.models.language_model._forward_all_positions`'s block-walking convention, restricted to
+    the last position (``CausalLM.forward``'s own output shape) since that is what the acceptance-relevant
+    cross-entropy and consistency losses score here.
+    """
+    xt = x.long()
+    t = xt.shape[1]
+    pos = torch.arange(t, device=xt.device)
+    h = model.tok(xt) + model.pos(pos)[None, :, :]
+    for keep, blk in zip(keep_mask, model.blocks):
+        if keep:
+            h = blk(h)
+        # else: drop this block -- identity, the defining move of stochastic depth
+    return model.head(model.ln(h))[:, -1]
+
+
+def stochastic_depth_forward(model: Any, x: Any, drop_prob: float, generator: Any = None) -> tuple:
+    """Run ``model`` on ``x`` twice: once at full depth, once with each block independently dropped with
+    probability ``drop_prob`` (at least one block is always kept, so the partial pass never degenerates to
+    the bare embedding/head). Returns ``(full_output, partial_output)`` -- the pair
+    :func:`train_with_self_distillation` feeds to :func:`consistency_loss`.
+
+    At ``drop_prob == 0`` both passes keep every block, so the two outputs are IDENTICAL (no dropout
+    elsewhere in :class:`~mixle.models.transformer.Block`) -- the degenerate-case sanity check pinned in
+    ``mixle/tests/self_distillation_test.py``.
+    """
+    _require_torch()
+    n = len(model.blocks)
+    full_output = _forward_with_keep_mask(model, x, [True] * n)
+    if drop_prob <= 0.0:
+        partial_output = _forward_with_keep_mask(model, x, [True] * n)
+        return full_output, partial_output
+
+    if generator is not None:
+        r = torch.rand(n, generator=generator)
+        keep_idx_if_empty = int(torch.randint(0, n, (1,), generator=generator).item())
+    else:
+        r = torch.rand(n)
+        keep_idx_if_empty = int(torch.randint(0, n, (1,)).item())
+    keep_mask = (r >= float(drop_prob)).tolist()
+    if not any(keep_mask):
+        keep_mask[keep_idx_if_empty] = True
+    partial_output = _forward_with_keep_mask(model, x, keep_mask)
+    return full_output, partial_output
+
+
+@dataclass
+class TrainStats:
+    """Per-step telemetry from :func:`train_with_self_distillation` -- cross-entropy, stochastic-depth
+    consistency, and EMA-teacher consistency losses, kept separately so a caller can see which pressure is
+    doing what (and the combined total actually optimized)."""
+
+    ce_loss: list = field(default_factory=list)
+    stochastic_depth_loss: list = field(default_factory=list)
+    ema_consistency_loss: list = field(default_factory=list)
+    total_loss: list = field(default_factory=list)
+
+
+def train_with_self_distillation(
+    model: Any,
+    data: Any,
+    steps: int,
+    *,
+    ema_decay: float = 0.999,
+    drop_prob: float = 0.1,
+    consistency_weight: float = 1.0,
+    ema_weight: float | None = None,
+    stochastic_depth_weight: float | None = None,
+    consistency_mode: str = "mse",
+    lr: float = 3e-3,
+    device: str = "cpu",
+    optimizer: Any = None,
+    seed: int = 0,
+    log: Any = None,
+) -> Any:
+    """Train ``model`` (a :class:`~mixle.models.transformer.CausalLM`, trained in place and also
+    returned) for ``steps`` next-token cross-entropy steps, with EMA-teacher consistency and
+    stochastic-depth consistency added as extra loss terms on top of the SAME per-step batch -- both
+    self-distillation pressures happen DURING training, not as a separate post-hoc pass.
+
+    ``data`` yields ``(context, next_token)`` micro-batches shaped exactly like
+    :func:`mixle.data.stream_token_source.stream_token_source` (``context: (batch, block)`` float ids,
+    ``next_token: (batch,)`` int ids). ``data`` may be:
+
+    * a zero-arg CALLABLE returning a fresh iterator each time (e.g.
+      ``lambda: stream_token_source(ids, block=64, batch_size=32)``) -- restarted automatically whenever
+      it runs dry before ``steps`` is reached, so training can outlast one epoch; or
+    * a plain iterable/iterator (e.g. a list of batches, or a single generator object) -- consumed once,
+      sized to yield at least ``steps`` batches (a bare generator can't be rewound).
+
+    Per step: ``loss = cross_entropy(full_depth_logits, target) + stochastic_depth_weight *
+    consistency(partial_depth_logits, full_depth_logits.detach()) + ema_weight *
+    consistency(full_depth_logits, ema_teacher(context))``, then one optimizer step, then one EMA-teacher
+    update. ``ema_weight``/``stochastic_depth_weight`` each default to ``consistency_weight`` when unset.
+    """
+    _require_torch()
+    torch.manual_seed(int(seed))
+    model.to(device).train()
+    ema_teacher = EMATeacher(model, decay=ema_decay)
+
+    params = [p for p in model.parameters() if p.requires_grad]
+    opt = optimizer(params) if optimizer is not None else torch.optim.Adam(params, lr=lr)
+
+    sd_weight = float(consistency_weight if stochastic_depth_weight is None else stochastic_depth_weight)
+    ema_w = float(consistency_weight if ema_weight is None else ema_weight)
+
+    def _fresh_iter() -> Any:
+        return iter(data()) if callable(data) else iter(data)
+
+    data_iter = _fresh_iter()
+    stats = TrainStats()
+
+    for step in range(int(steps)):
+        try:
+            ctx, nxt = next(data_iter)
+        except StopIteration:
+            data_iter = _fresh_iter()
+            ctx, nxt = next(data_iter)
+
+        x = torch.as_tensor(np.asarray(ctx), dtype=torch.float32, device=device)
+        y = torch.as_tensor(np.asarray(nxt), dtype=torch.long, device=device)
+
+        full_out, partial_out = stochastic_depth_forward(model, x, drop_prob)
+        ce_loss = F.cross_entropy(full_out, y)
+        sd_loss = consistency_loss(partial_out, full_out.detach(), mode=consistency_mode)
+        with torch.no_grad():
+            teacher_out = ema_teacher.forward(x)
+        ema_loss = consistency_loss(full_out, teacher_out, mode=consistency_mode)
+
+        loss = ce_loss + sd_weight * sd_loss + ema_w * ema_loss
+        opt.zero_grad()
+        loss.backward()
+        opt.step()
+        ema_teacher.update(model)
+
+        stats.ce_loss.append(float(ce_loss.detach()))
+        stats.stochastic_depth_loss.append(float(sd_loss.detach()))
+        stats.ema_consistency_loss.append(float(ema_loss.detach()))
+        stats.total_loss.append(float(loss.detach()))
+        if log is not None:
+            log(step, stats)
+
+    model.eval()
+    return model

--- a/mixle/tests/self_distillation_test.py
+++ b/mixle/tests/self_distillation_test.py
@@ -1,0 +1,231 @@
+"""Acceptance tests for mixle.models.self_distillation (roadmap J3: self-distillation during training).
+
+Each test below is an acceptance criterion from the roadmap item, not just a smoke test:
+    1. EMA-teacher weight-averaging math is exactly correct against a hand-computed EMA.
+    2. stochastic_depth_forward produces a DIFFERENT partial-depth output when blocks are dropped, and an
+       IDENTICAL one at drop_prob=0 (the degenerate-case sanity check).
+    3. THE core acceptance criterion: J2's not-yet-built "ladder" is substituted, per the roadmap note,
+       with G3's already-built `coarsen()` (PR #151) as the compressibility proxy. Train a small CausalLM
+       two ways for the SAME number of steps -- plain vs. train_with_self_distillation -- then run
+       `coarsen()` on BOTH at the SAME divergence budget and trust region, and confirm the J3-trained
+       checkpoint compresses measurably better (lower total KL for the same accepted depth cut).
+"""
+
+import unittest
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from mixle.data.stream_token_source import stream_token_source
+from mixle.models.coarsening import coarsen
+from mixle.models.moment_propagation import GaussianLaw
+from mixle.models.self_distillation import (
+    EMATeacher,
+    consistency_loss,
+    stochastic_depth_forward,
+    train_with_self_distillation,
+)
+from mixle.models.transformer import build_causal_lm
+
+pytestmark = pytest.mark.fast
+
+
+# --------------------------------------------------------------------------------------------------------
+# shared synthetic-data helper: a small Markov-ish token stream, so there is real structure to learn
+# --------------------------------------------------------------------------------------------------------
+
+
+def _synthetic_token_stream(n: int, vocab: int, seed: int) -> np.ndarray:
+    """A simple order-1 Markov chain over `vocab` tokens -- learnable structure (next-token distribution
+    depends on the current token), so cross-entropy training has a real target to fit."""
+    rng = np.random.RandomState(seed)
+    trans = rng.dirichlet(np.full(vocab, 0.3), size=vocab)  # (vocab, vocab) row-stochastic transition matrix
+    ids = np.zeros(n, dtype=np.int64)
+    ids[0] = rng.randint(vocab)
+    for i in range(1, n):
+        ids[i] = rng.choice(vocab, p=trans[ids[i - 1]])
+    return ids
+
+
+def _empirical_input_law(model, token_ids: np.ndarray, block: int, rng: np.random.Generator) -> GaussianLaw:
+    """The residual-stream distribution ENTERING model.blocks (i.e. after tok+pos embedding), estimated
+    empirically from real synthetic contexts run through `model`'s OWN (trained) embedding -- exactly what
+    `coarsen`'s `input_law` argument documents it should represent, computed the same way for both models
+    under comparison so the divergence budget means the same thing for each.
+    """
+    n = len(token_ids) - block
+    idx = rng.choice(n, size=min(256, n), replace=False)
+    ctx = np.stack([token_ids[i : i + block] for i in idx])
+    x = torch.as_tensor(ctx, dtype=torch.float32)
+    with torch.no_grad():
+        t = x.shape[1]
+        pos = torch.arange(t)
+        h = model.tok(x.long()) + model.pos(pos)[None, :, :]
+    flat = h.reshape(-1, h.shape[-1]).numpy().astype(np.float64)
+    mu = flat.mean(axis=0)
+    covar = np.cov(flat, rowvar=False) + 1e-6 * np.eye(flat.shape[-1])
+    return GaussianLaw(mu=mu, covar=covar)
+
+
+class EMATeacherCorrectnessTest(unittest.TestCase):
+    """Acceptance criterion: "EMA teacher's weight-averaging math is exactly correct -- a direct numerical
+    check across a couple of update steps against a hand-computed EMA"."""
+
+    def test_ema_update_matches_hand_computed_average(self):
+        torch.manual_seed(0)
+        model = build_causal_lm(vocab=11, d_model=8, n_layer=2, n_head=2, block=8)
+        decay = 0.9
+        teacher = EMATeacher(model, decay=decay)
+
+        # hand-computed EMA of every tensor, tracked independently in plain torch/numpy
+        expected = {k: v.detach().clone() for k, v in model.state_dict().items()}
+
+        for step in range(3):
+            with torch.no_grad():
+                for p in model.parameters():
+                    p.add_(torch.randn_like(p) * 0.05)  # simulate one optimizer step
+            teacher.update(model)
+            student_state = model.state_dict()
+            for k in expected:
+                expected[k] = decay * expected[k] + (1.0 - decay) * student_state[k].detach()
+
+        teacher_state = teacher.ema_model.state_dict()
+        for k, exp_v in expected.items():
+            torch.testing.assert_close(teacher_state[k], exp_v, atol=1e-6, rtol=1e-5)
+
+    def test_ema_teacher_is_frozen_and_forward_works(self):
+        torch.manual_seed(1)
+        model = build_causal_lm(vocab=11, d_model=8, n_layer=2, n_head=2, block=8)
+        teacher = EMATeacher(model, decay=0.99)
+        for p in teacher.ema_model.parameters():
+            self.assertFalse(p.requires_grad)
+
+        x = torch.randint(0, 11, (4, 8)).float()
+        out = teacher.forward(x)
+        self.assertEqual(tuple(out.shape), (4, 11))
+        # predict is an alias for forward
+        out2 = teacher.predict(x)
+        torch.testing.assert_close(out, out2)
+
+
+class StochasticDepthCorrectnessTest(unittest.TestCase):
+    """Acceptance criterion: "verify stochastic_depth_forward actually produces a DIFFERENT (partial)
+    output when blocks are dropped vs. the full-depth output, and that at drop_prob=0 the two outputs are
+    IDENTICAL"."""
+
+    def test_drop_prob_zero_gives_identical_outputs(self):
+        torch.manual_seed(0)
+        model = build_causal_lm(vocab=13, d_model=16, n_layer=4, n_head=2, block=8)
+        model.eval()
+        x = torch.randint(0, 13, (3, 8)).float()
+        full, partial = stochastic_depth_forward(model, x, drop_prob=0.0)
+        torch.testing.assert_close(full, partial, atol=0.0, rtol=0.0)
+
+    def test_dropping_blocks_changes_the_output(self):
+        torch.manual_seed(2)
+        model = build_causal_lm(vocab=13, d_model=16, n_layer=6, n_head=2, block=8)
+        model.eval()
+        x = torch.randint(0, 13, (5, 8)).float()
+        gen = torch.Generator().manual_seed(0)
+        full, partial = stochastic_depth_forward(model, x, drop_prob=0.9, generator=gen)
+        self.assertFalse(torch.allclose(full, partial))
+        # sanity: full-depth output itself matches a bare model(x) call
+        with torch.no_grad():
+            direct = model(x)
+        torch.testing.assert_close(full, direct)
+
+    def test_consistency_loss_is_zero_for_identical_inputs_and_positive_otherwise(self):
+        torch.manual_seed(3)
+        a = torch.randn(4, 5)
+        b = a.clone()
+        self.assertAlmostEqual(float(consistency_loss(a, b, mode="mse")), 0.0, delta=1e-8)
+        c = torch.randn(4, 5)
+        self.assertGreater(float(consistency_loss(a, c, mode="mse")), 0.0)
+        self.assertGreaterEqual(float(consistency_loss(a, c, mode="kl")), 0.0)
+
+
+class J3CompressibilityAcceptanceTest(unittest.TestCase):
+    """THE acceptance criterion (substituting G3's coarsen() for the not-yet-built J2 ladder, per the
+    roadmap note): a J3-trained checkpoint must compress better under coarsen() at an EQUAL divergence
+    budget/trust region than a plainly-trained checkpoint of the identical architecture, trained for the
+    SAME number of steps on the SAME data.
+    """
+
+    def test_j3_trained_checkpoint_compresses_better_than_plain_under_g3_coarsen(self):
+        vocab, d_model, n_head, n_layer, block = 17, 24, 3, 6, 16
+        steps = 250
+        batch_size = 16
+        seed = 0
+
+        token_ids = _synthetic_token_stream(n=20_000, vocab=vocab, seed=seed)
+
+        def fresh_model():
+            torch.manual_seed(seed)
+            return build_causal_lm(vocab=vocab, d_model=d_model, n_layer=n_layer, n_head=n_head, block=block)
+
+        # (a) plain training: identical architecture, identical data, identical step count -- ordinary
+        # cross-entropy only, no self-distillation.
+        plain_model = fresh_model()
+        opt = torch.optim.Adam(plain_model.parameters(), lr=3e-3)
+        plain_model.train()
+        src = stream_token_source(token_ids, block=block, batch_size=batch_size, epochs=1, shuffle=True, seed=seed)
+        for step, (ctx, nxt) in enumerate(src):
+            if step >= steps:
+                break
+            x = torch.as_tensor(ctx, dtype=torch.float32)
+            y = torch.as_tensor(nxt, dtype=torch.long)
+            logits = plain_model(x)
+            loss = torch.nn.functional.cross_entropy(logits, y)
+            opt.zero_grad()
+            loss.backward()
+            opt.step()
+        plain_model.eval()
+
+        # (b) J3 training: same architecture/data/step count, with EMA-teacher + stochastic-depth
+        # self-distillation added on top of the same per-step cross-entropy.
+        j3_model = fresh_model()
+        j3_model = train_with_self_distillation(
+            j3_model,
+            data=lambda: stream_token_source(
+                token_ids, block=block, batch_size=batch_size, epochs=1, shuffle=True, seed=seed
+            ),
+            steps=steps,
+            ema_decay=0.99,
+            drop_prob=0.3,
+            consistency_weight=0.5,
+            lr=3e-3,
+            seed=seed,
+        )
+        j3_model.eval()
+
+        # G3's coarsen(), called directly as the compressibility proxy for the not-yet-built J2 ladder --
+        # SAME budget, trust region, and (per-model, but identically-constructed) input_law for both.
+        rng = np.random.default_rng(seed)
+        budget = 8.0
+        trust_region = 8.0
+
+        law_plain = _empirical_input_law(plain_model, token_ids, block, rng)
+        law_j3 = _empirical_input_law(j3_model, token_ids, block, rng)
+
+        result_plain = coarsen(plain_model, budget=budget, trust_region=trust_region, input_law=law_plain, seed=seed)
+        result_j3 = coarsen(j3_model, budget=budget, trust_region=trust_region, input_law=law_j3, seed=seed)
+
+        print(
+            f"\n[J3 acceptance] plain: accepted_pairs={len(result_plain.accepted_pairs)} "
+            f"total_kl={result_plain.total_kl:.6f} depth={result_plain.model.n_layer}\n"
+            f"[J3 acceptance] j3:    accepted_pairs={len(result_j3.accepted_pairs)} "
+            f"total_kl={result_j3.total_kl:.6f} depth={result_j3.model.n_layer}"
+        )
+
+        # Same architecture, same budget/trust region -> compare directly. The concrete metric: for the
+        # SAME number of accepted merges (or more), the J3-trained model's accumulated divergence is
+        # LOWER -- i.e. it needs less of the divergence budget to achieve the same (or a larger) depth cut.
+        self.assertGreaterEqual(len(result_j3.accepted_pairs), len(result_plain.accepted_pairs))
+        if len(result_j3.accepted_pairs) == len(result_plain.accepted_pairs):
+            self.assertLess(result_j3.total_kl, result_plain.total_kl)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Stacking

Stacked on top of `coarsening-operator` (G3, PR #151) -- this branch is based on that branch's tip because the acceptance test below calls G3's `coarsen()` directly. Please merge #151 first (or review this diff as G3 + this commit).

## What

Roadmap J3: EMA-teacher consistency and stochastic-depth targets applied *during* normal training, inside `mixle/models/self_distillation.py`:

- `EMATeacher(model, decay)` -- maintains a mean-teacher EMA copy of a model's own weights (`teacher = decay*teacher + (1-decay)*student`), updated via `.update(student_model)`; `.forward`/`.predict` run the frozen teacher. Handles `CausalLM`'s weight-tied `tok`/`head` embedding correctly (dedupes by storage identity so a tied tensor isn't EMA-updated twice per step).
- `consistency_loss(student_output, teacher_output, mode="mse"|"kl")` -- the self-distillation loss term.
- `stochastic_depth_forward(model, x, drop_prob)` -- runs the same input at full depth and with a random subset of blocks skipped (standard stochastic depth / drop-path), returning `(full_output, partial_output)` for consistency.
- `train_with_self_distillation(model, data, steps, ema_decay, drop_prob, consistency_weight, ...)` -- wires both pressures into ordinary next-token cross-entropy training as extra additive loss terms, mirroring `GradLeaf`'s loss-hook composition pattern and `language_model.py`'s own training loop conventions (no new trainer abstraction). `data` is shaped exactly like `mixle.data.stream_token_source.stream_token_source`'s `(context, next_token)` batches.

Searched first for existing EMA / stochastic-depth machinery (`grep -rln "exponential.moving.average\|ema_decay\|class EMA"` and `"stochastic.depth\|drop.path\|droppath"` across `mixle/`) -- neither exists yet, so both are implemented fresh here.

## Acceptance criterion -- substituting G3's `coarsen()` for J2's not-yet-built "ladder"

J2 (checkpoint-compression ladder) and F1 (distributed trainer) don't exist yet. Per the roadmap note, the acceptance test (`mixle/tests/self_distillation_test.py::J3CompressibilityAcceptanceTest`) substitutes G3's already-built `coarsen()` (PR #151) as the compressibility proxy: a small `CausalLM` is trained two ways for the *same* number of steps on the *same* synthetic data -- (a) plain cross-entropy, (b) `train_with_self_distillation` -- then both checkpoints are run through `coarsen()` at the *same* divergence budget and trust region.

Measured result (printed by the test, `-n0 -m ""`):

```
[J3 acceptance] plain: accepted_pairs=3 total_kl=2.063826 depth=3
[J3 acceptance] j3:    accepted_pairs=3 total_kl=1.001612 depth=3
```

Same architecture (6 -> 3 layers, full 2x depth cut accepted for both), same budget/trust region: the J3-trained checkpoint's accumulated divergence is ~2x lower for the identical depth cut -- the causal claim ("self-consistency pressure -> flatter, more redundant, more coarsen-friendly solutions") holds in this measured run.

## Tests

`mixle/tests/self_distillation_test.py` (6 tests, all pass):
1. `EMATeacherCorrectnessTest` -- EMA math checked numerically against a hand-computed average across 3 update steps (plus a frozen/forward sanity check).
2. `StochasticDepthCorrectnessTest` -- `drop_prob=0` gives byte-identical full/partial outputs; `drop_prob=0.9` gives a measurably different partial output; `consistency_loss` sanity (zero for identical inputs, positive otherwise).
3. `J3CompressibilityAcceptanceTest` -- the core acceptance criterion above.

No regressions: `mixle/tests/coarsening_test.py` (10 tests) still passes unchanged.

## Workflow

- `ruff check --fix` / `ruff format` clean on both new files.
- `pytest mixle/tests/self_distillation_test.py mixle/tests/coarsening_test.py -n0 -m ""` -- 16/16 pass.
