### PR TITLE
inference: D5 learned controller for block-EM scheduling (ConditionalJIT track)

### DIFF
--- a/mixle/inference/block_em.py
+++ b/mixle/inference/block_em.py
@@ -56,6 +56,13 @@ from typing import Any
 
 import numpy as np
 
+from mixle.inference.conditional_jit_controller import (
+    BanditController,
+    ControllerAction,
+    ControllerState,
+    DesignModelController,
+    LearnedController,
+)
 from mixle.inference.freeze_rollup import (
     FreezeRollupCache,
     _combine,
@@ -71,6 +78,7 @@ _DEFAULT_ACCEPT_TOLERANCE = 1.0e-9
 _DEFAULT_BUDGET_FRACTION = 0.5
 _DEFAULT_TIE_TOL = 1.0e-9
 _SCORE_SEED = 0  # fixed, shared across every component -- see module docstring on the tie test.
+_KNOWN_POLICIES = ("greedy", "learned_bandit", "learned_design_model")
 
 
 @dataclass
@@ -103,8 +111,8 @@ def _block_scores(
     model: MixtureDistribution,
     eligible: list[int],
     prev_residual: dict[int, float],
-) -> tuple[dict[int, float], dict[int, float]]:
-    """Return ``(gain_per_cost, cost)`` for each ``eligible`` component index.
+) -> tuple[dict[int, float], dict[int, float], dict[int, float], dict[int, float]]:
+    """Return ``(gain_per_cost, cost, residual, q_gain)`` for each ``eligible`` component index.
 
     ``gain`` is the D1 Q-gain (residual improvement since the last round this component was
     scored) when available, else the raw residual itself (a component never scored before has an
@@ -112,10 +120,15 @@ def _block_scores(
     here" proxy for round 1). ``cost`` is D1's E-step-cost + M-step-cost proxy. Every component
     is scored with the SAME fixed seed (see module docstring) so structurally-identical
     components are directly comparable -- required for the degenerate-to-vanilla-EM test to be
-    deterministic rather than RNG-dependent.
+    deterministic rather than RNG-dependent. ``residual``/``q_gain`` (the raw, un-normalized D1
+    fields) are returned alongside the derived ``gain_per_cost``/``cost`` purely so a D5 learned
+    policy can build a :class:`~mixle.inference.conditional_jit_controller.ControllerState`
+    without a second pass over the tree.
     """
     gain_per_cost: dict[int, float] = {}
     cost: dict[int, float] = {}
+    residual: dict[int, float] = {}
+    q_gain: dict[int, float] = {}
     for idx in eligible:
         report = node_report(
             model.components[idx],
@@ -131,7 +144,9 @@ def _block_scores(
         block_cost = max(report.e_step_cost + report.m_step_cost, 1.0e-12)
         cost[idx] = block_cost
         gain_per_cost[idx] = gain / block_cost
-    return gain_per_cost, cost
+        residual[idx] = report.residual if np.isfinite(report.residual) else 0.0
+        q_gain[idx] = gain
+    return gain_per_cost, cost, residual, q_gain
 
 
 def _select_active(
@@ -192,8 +207,10 @@ def run_block_em(
     freeze_patience: int = 3,
     stall_patience: int = 5,
     max_skip_rounds: int = 2,
+    policy: str | LearnedController = "greedy",
+    controller: LearnedController | None = None,
 ) -> tuple[MixtureDistribution, list[BlockEMStats]]:
-    """Run block-coordinate-ascent EM over a :class:`MixtureDistribution` (workstream D3).
+    """Run block-coordinate-ascent EM over a :class:`MixtureDistribution` (workstream D3, D5).
 
     Each round: rank every component D2 does not already report frozen by D1 gain-per-cost,
     select the highest-value ones within ``budget_fraction`` of the round's total eligible cost
@@ -227,11 +244,44 @@ def run_block_em(
     every ``max_skip_rounds + 1`` rounds, which is what makes "same target F, fewer evals" (as
     opposed to just "monotone but permanently stuck") an honest comparison against vanilla EM.
 
+    ``policy`` (workstream D5, :mod:`mixle.inference.conditional_jit_controller`) selects WHO picks
+    the per-round ``budget_fraction`` that feeds the exact same :func:`_select_active` ranking
+    above: ``"greedy"`` (the default) uses the fixed ``budget_fraction`` argument every round,
+    unchanged D3 behavior. ``"learned_bandit"``/``"learned_design_model"`` instead ask a
+    :class:`~mixle.inference.conditional_jit_controller.LearnedController` for this round's budget
+    (constructing a default :class:`~mixle.inference.conditional_jit_controller.BanditController`/
+    :class:`~mixle.inference.conditional_jit_controller.DesignModelController` if ``controller`` is
+    not supplied) and feed it back the round's REALIZED gain (this round's own F improvement,
+    ``round_value - current_value``, i.e. exactly what this round's active blocks achieved) and
+    REALIZED cost (``evals_e + evals_c``, the same wall-clock proxy :class:`BlockEMStats` already
+    reports) after every round -- so the controller learns from the SAME accept/reject-gated,
+    provably-monotone rounds D3 already runs, never from an invented parallel objective. Passing an
+    already-constructed :class:`~mixle.inference.conditional_jit_controller.LearnedController`
+    directly as ``policy`` is also accepted (equivalent to passing it as ``controller`` with
+    ``policy="learned_bandit"``/``"learned_design_model"``) and is how a caller warm-starts a
+    controller across several calls/fits -- the SAME controller object keeps learning, since it is
+    only ever mutated in place, never copied.
+
     Returns ``(final_model, history)`` where ``history[i]`` is round ``i``'s
     :class:`BlockEMStats`.
     """
     if not isinstance(initial_model, MixtureDistribution):
         raise TypeError("run_block_em requires a MixtureDistribution model.")
+    if isinstance(policy, LearnedController):
+        controller = policy
+        policy = "learned"
+    elif policy == "learned_bandit":
+        controller = controller if controller is not None else BanditController()
+        policy = "learned"
+    elif policy == "learned_design_model":
+        controller = controller if controller is not None else DesignModelController()
+        policy = "learned"
+    elif policy == "greedy":
+        controller = None
+    else:
+        raise ValueError(
+            "policy must be one of %r, or a LearnedController instance; got %r." % (_KNOWN_POLICIES, policy)
+        )
     cache = (
         FreezeRollupCache(
             q_gain_tol=q_gain_tol,
@@ -254,12 +304,21 @@ def run_block_em(
     for round_index in range(max(1, int(max_its))):
         frozen_idx = detect_frozen(cache, model)
         eligible = [idx for idx in range(model.num_components) if idx not in frozen_idx and not model.zw[idx]]
-        scores, cost = _block_scores(model, eligible, prev_residual)
+        scores, cost, residual, q_gain = _block_scores(model, eligible, prev_residual)
+
+        controller_state: ControllerState | None = None
+        controller_action: ControllerAction | None = None
+        round_budget_fraction = budget_fraction
+        if controller is not None:
+            controller_state = ControllerState.from_scores(round_index, eligible, scores, cost, residual, q_gain)
+            controller_action = controller.select_action(controller_state)
+            round_budget_fraction = controller_action.budget_fraction
+
         active, degenerate = _select_active(
             eligible,
             scores,
             cost,
-            budget_fraction=budget_fraction,
+            budget_fraction=round_budget_fraction,
             full_tree_every_round=full_tree_every_round,
             tie_tol=tie_tol,
         )
@@ -292,6 +351,11 @@ def run_block_em(
             round_value = candidate_value
         else:
             round_value = current_value
+
+        if controller is not None and controller_state is not None and controller_action is not None:
+            realized_gain = max(0.0, round_value - current_value)
+            realized_cost = float(evals_e + evals_c)
+            controller.update(controller_state, controller_action, realized_gain, realized_cost)
 
         n_zero = int(np.count_nonzero(model.zw)) if not accepted else int(np.count_nonzero(candidate.zw))
         history.append(

--- a/mixle/inference/conditional_jit_controller.py
+++ b/mixle/inference/conditional_jit_controller.py
@@ -1,0 +1,340 @@
+"""D5: the LEARNED controller over the D1-D4/D6 estimator-tree IR (workstream ConditionalJIT track).
+
+Frame (see the ConditionalJIT track, D1-D6): **the estimator tree is an IR**. D1
+(:mod:`mixle.inference.node_report`) instruments every node with a per-round residual/Q-gain/cost
+report. D2 (:mod:`mixle.inference.freeze_rollup`) spends that report on one fixed rule (freeze
+once converged). D3 (:mod:`mixle.inference.block_em`) spends it on a fixed GREEDY rule
+(gain-per-cost ranking within a fixed ``budget_fraction``). D4
+(:mod:`mixle.inference.leaf_hotswap`) spends it on a fixed rule for gradient leaves specifically
+(swap once plateaued). D6 (``origin/backend-respecialization``, a sibling branch stacked on D3
+that this branch does not directly contain -- see this module's PR description) spends it on a
+fixed compile-economics rule for execution backends. D5 REPLACES the "fixed rule" part with a
+LEARNED one: the SAME per-round D1 features drive a policy that is trained -- online, from
+realized gain/cost, or offline, from logged history -- rather than hand-tuned.
+
+Correctness backbone (unchanged from the rest of the D-track): a learned scheduling POLICY can
+only ever change WHICH blocks get how much budget THIS round -- never what a block's update
+computes, never the accept/reject monotone-F gate D2/D3 already enforce. Any interleaving of
+partial E-steps and per-block conditional M-steps is coordinate ascent on the same Neal-Hinton
+free energy F regardless of which policy chose the interleaving, so F remains the audit receipt;
+a bad learned decision costs speed (a wasted round, a slow warmup), never correctness. This module
+therefore never runs its own EM and never touches ``accepted``/``objective`` bookkeeping -- it only
+chooses the ``budget_fraction`` knob :func:`mixle.inference.block_em.run_block_em`'s existing
+greedy ranking (:func:`mixle.inference.block_em._select_active`) already accepts, so "learned" and
+"greedy" are two policies over the exact same scheduling loop, not two different loops.
+
+Two learning modes:
+
+* **Online bandits** (:class:`BanditController`) -- reuses :mod:`mixle.task.bandit` (this
+  codebase's existing multi-armed-bandit module, built for exactly this "pick an
+  arm/observe-a-reward, no offline data needed" loop) rather than reimplementing UCB1/Thompson
+  sampling. The action space is a small discretized set of ``budget_fraction`` levels (an "arm");
+  the reward is the round's REALIZED Q-gain-per-cost. Learns round-by-round DURING a fit, and
+  carries over (the same policy object, still adapting) across multiple fits if the caller reuses
+  it -- see the offline-vs-warm-start framing in ``mixle.tests.conditional_jit_controller_test``.
+* **Offline DesignModel** (:class:`DesignModelController`) -- reuses
+  :class:`mixle.task.edge.DesignModel` (this codebase's existing design-space surrogate: a GP
+  fitted on logged ``(point, quality, fingerprint)`` rows, warm-startable across different but
+  related tasks via its fingerprint machinery -- see :mod:`mixle.task.edge`'s own docstring)
+  rather than reinventing an offline contextual bandit. ``budget_fraction`` is treated as the
+  (continuous, 1-D) design point; the current round's aggregated D1 features
+  (:class:`ControllerState`) are the fingerprint DesignModel already conditions proposals on, so a
+  DesignModel trained on logged rounds from OTHER fit problems can propose a good budget for a
+  brand-new, held-out problem with ZERO online exploration.
+
+Action-type registry, not a closed enum: :class:`ActionType` lists every action kind the D-track
+roadmap names for D5 (``BLOCK_SELECTION``, ``BUDGET_ALLOCATION``, plus the future
+``STRUCTURE_EDIT`` -- H3's structure-edit schedule / G2's projections / the evolve-ops population
+search -- and ``BACKEND_CHOICE`` -- D6's compile-economics ``RespecializationDecision``). Only
+``BLOCK_SELECTION`` and ``BUDGET_ALLOCATION`` are REAL, implemented action types today (and in
+this module they are the SAME knob: choosing a budget_fraction is exactly what determines which
+blocks D3's existing ranking selects). ``STRUCTURE_EDIT``/``BACKEND_CHOICE`` are documented
+extension points (see :data:`ACTION_TYPE_REGISTRY`), not wired to real H3/G2/D6 machinery here --
+that wiring is future work, explicitly out of scope for D5 per the roadmap item.
+
+Reusable "brain" note (the roadmap's own phrase: D5 "shares its brain with F5 and the I1/J1 method
+pickers"): :class:`LearnedController` is deliberately generic over its own state/action/reward
+types (``Generic[StateT, ActionT]``, a plain ``select_action(state) -> action`` /
+``update(state, action, realized_gain, realized_cost) -> None`` surface with no block-EM-specific
+assumptions baked into the base class). A future F5 (backend/method-picker for some other stage)
+or I1/J1 (other "which method" pickers named in the roadmap, not built here) could instantiate
+:class:`BanditController` or :class:`DesignModelController` directly against THEIR OWN state/action
+types by subclassing :class:`LearnedController` the same way this module's two concrete
+controllers do -- reusing the bandit/DesignModel wiring pattern without needing block-EM's
+``ControllerState``/``ControllerAction`` dataclasses at all. Nothing here builds F5/I1/J1
+themselves.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Generic, TypeVar
+
+import numpy as np
+
+from mixle.task.bandit import UCB1, ThompsonGaussian
+from mixle.task.edge import DesignModel
+
+__all__ = [
+    "ACTION_TYPE_REGISTRY",
+    "ActionType",
+    "BanditController",
+    "ControllerAction",
+    "ControllerState",
+    "DesignModelController",
+    "LearnedController",
+    "STATE_FEATURE_DIM",
+]
+
+# The fixed-length feature vector every ControllerState carries (see ControllerState.as_vector):
+# (n_eligible, mean_residual, mean_q_gain, mean_cost, score_spread).
+STATE_FEATURE_DIM = 5
+
+_DEFAULT_BUDGET_LEVELS = (0.15, 0.3, 0.5, 0.7, 0.85, 1.0)
+
+
+class ActionType(str, Enum):
+    """The D5 action-type registry (see module docstring): a registry, not a closed enum -- future
+    track items are expected to add new members and new :class:`LearnedController` subclasses that
+    consume them, without needing to touch this module's two REAL, implemented action types."""
+
+    BLOCK_SELECTION = "block_selection"
+    BUDGET_ALLOCATION = "budget_allocation"
+    STRUCTURE_EDIT = "structure_edit"
+    BACKEND_CHOICE = "backend_choice"
+
+
+ACTION_TYPE_REGISTRY: dict[ActionType, str] = {
+    ActionType.BLOCK_SELECTION: (
+        "IMPLEMENTED here. Realized as a derived consequence of BUDGET_ALLOCATION: the controller "
+        "picks a budget_fraction and mixle.inference.block_em._select_active's existing "
+        "gain-per-cost ranking turns that budget into an actual set of active block indices -- so "
+        "block selection and budget allocation are one learned knob, not two."
+    ),
+    ActionType.BUDGET_ALLOCATION: (
+        "IMPLEMENTED here. ControllerAction.budget_fraction, chosen per round by BanditController "
+        "(a discretized arm) or DesignModelController (a continuous DesignModel proposal)."
+    ),
+    ActionType.STRUCTURE_EDIT: (
+        "EXTENSION POINT, not implemented here. A future action would carry a payload describing "
+        "an evolve-op / learn_structure call / G2 projection (H3's structure-edit schedule, not "
+        "yet built). Wire it by adding a new ControllerAction.payload schema and a new "
+        "LearnedController subclass (or a new arm/action space on an existing one) that reads "
+        "H3-shaped state and emits this action type -- see the module docstring's 'reusable brain' "
+        "note."
+    ),
+    ActionType.BACKEND_CHOICE: (
+        "EXTENSION POINT, not implemented here. A future action would carry a payload shaped like "
+        "D6's RespecializationDecision (origin/backend-respecialization: action / estimated_cost / "
+        "estimated_benefit / net_benefit fields, already documented there as 'the compile "
+        "economics exposed to D5'). Wiring it means feeding those fields into ControllerState and "
+        "emitting a BACKEND_CHOICE ControllerAction that mixle.inference.backend_respecialization "
+        "would apply -- not done here since D6 is a sibling branch, not an ancestor, of this one."
+    ),
+}
+
+
+@dataclass(frozen=True)
+class ControllerState:
+    """One round's controller-visible state: D1 features aggregated over the eligible blocks.
+
+    This IS "features = D1 reports" from the roadmap item, aggregated to a fixed-size vector (one
+    row per ROUND, not per node) because the eligible block set can change size round to round
+    (freezing, zero-weight collapse) while both the bandit arm space and DesignModel's fingerprint
+    need a fixed dimension.
+    """
+
+    round_index: int
+    n_eligible: int
+    mean_residual: float
+    mean_q_gain: float
+    mean_cost: float
+    score_spread: float
+
+    def as_vector(self) -> tuple[float, float, float, float, float]:
+        """The fixed-length (:data:`STATE_FEATURE_DIM`) feature vector, e.g. for a DesignModel
+        fingerprint or any future contextual (LinUCB-style) bandit."""
+        return (
+            float(self.n_eligible),
+            float(self.mean_residual),
+            float(self.mean_q_gain),
+            float(self.mean_cost),
+            float(self.score_spread),
+        )
+
+    @classmethod
+    def from_scores(
+        cls,
+        round_index: int,
+        eligible: list[int],
+        gain_per_cost: dict[int, float],
+        cost: dict[int, float],
+        residual: dict[int, float],
+        q_gain: dict[int, float],
+    ) -> ControllerState:
+        """Build a :class:`ControllerState` from the same per-block dicts D3's greedy scheduler
+        already computes each round (:func:`mixle.inference.block_em._block_scores`) -- no
+        separate feature-extraction pass over the tree is needed."""
+        if not eligible:
+            return cls(
+                round_index=round_index,
+                n_eligible=0,
+                mean_residual=0.0,
+                mean_q_gain=0.0,
+                mean_cost=0.0,
+                score_spread=0.0,
+            )
+        residuals = [residual.get(i, 0.0) for i in eligible]
+        gains = [q_gain.get(i, 0.0) for i in eligible]
+        costs = [cost.get(i, 0.0) for i in eligible]
+        scores = [gain_per_cost.get(i, 0.0) for i in eligible]
+        return cls(
+            round_index=round_index,
+            n_eligible=len(eligible),
+            mean_residual=float(np.nanmean(residuals)) if residuals else 0.0,
+            mean_q_gain=float(np.nanmean(gains)) if gains else 0.0,
+            mean_cost=float(np.mean(costs)) if costs else 0.0,
+            score_spread=float(max(scores) - min(scores)) if scores else 0.0,
+        )
+
+
+@dataclass(frozen=True)
+class ControllerAction:
+    """One controller decision for the current round.
+
+    ``budget_fraction`` is the real, implemented knob (see :data:`ACTION_TYPE_REGISTRY`);
+    ``payload`` is reserved for future ``STRUCTURE_EDIT``/``BACKEND_CHOICE`` action data and is
+    unused by both controllers in this module.
+    """
+
+    action_type: ActionType
+    budget_fraction: float
+    payload: dict = field(default_factory=dict)
+
+
+StateT = TypeVar("StateT")
+ActionT = TypeVar("ActionT")
+
+
+class LearnedController(Generic[StateT, ActionT]):
+    """Generic state -> action learned scheduling policy (D5).
+
+    A drop-in alternative to a hand-written greedy heuristic: anywhere a scheduler currently reads
+    some per-round state and applies a FIXED rule to pick an action, a ``LearnedController`` can
+    read the same state and apply a TRAINED rule instead, updating from the REALIZED outcome after
+    the fact. See the module docstring's "reusable brain" note -- this base class carries no
+    block-EM-specific assumptions, so a future F5/I1/J1 method-picker item could subclass it
+    directly for its own ``StateT``/``ActionT``.
+    """
+
+    def select_action(self, state: StateT) -> ActionT:
+        """Return this round's action given ``state``."""
+        raise NotImplementedError
+
+    def update(self, state: StateT, action: ActionT, realized_gain: float, realized_cost: float) -> None:
+        """Feed back the REALIZED gain/cost of ``action`` taken in ``state`` -- the online-learning
+        signal every concrete controller trains from."""
+        raise NotImplementedError
+
+
+class BanditController(LearnedController[ControllerState, ControllerAction]):
+    """Online contextual-free multi-armed bandit over discretized ``budget_fraction`` levels.
+
+    Reuses :mod:`mixle.task.bandit` (:class:`~mixle.task.bandit.UCB1` by default, or
+    :class:`~mixle.task.bandit.ThompsonGaussian`) rather than reimplementing a bandit algorithm.
+    Needs NO logged/offline data: it can start learning cold, round 1 of the very first fit it
+    sees, from nothing but realized gain/cost -- the "online bandits ... no offline training data
+    needed" mode from the roadmap item. The state (:class:`ControllerState`) is accepted by
+    :meth:`select_action`/:meth:`update` for interface symmetry with :class:`DesignModelController`
+    and any future contextual variant, but neither UCB1 nor ThompsonGaussian actually conditions on
+    it (both are the classic context-FREE multi-armed setting) -- a genuinely contextual variant
+    (e.g. LinUCB keyed on :meth:`ControllerState.as_vector`) is a natural extension of this class
+    that this module does not need to build to satisfy "online bandits ... given the state is a
+    real feature vector" (the DesignModel mode already covers the contextual case, see its
+    docstring).
+    """
+
+    def __init__(
+        self,
+        *,
+        budget_levels: tuple[float, ...] = _DEFAULT_BUDGET_LEVELS,
+        algorithm: str = "ucb1",
+        ucb_c: float = 1.0,
+        seed: int | None = None,
+    ) -> None:
+        self.budget_levels = tuple(sorted(set(float(b) for b in budget_levels)))
+        if len(self.budget_levels) < 2:
+            raise ValueError("BanditController needs at least two distinct budget_levels.")
+        self.algorithm = algorithm
+        if algorithm == "ucb1":
+            self.bandit = UCB1(len(self.budget_levels), c=ucb_c, seed=seed)
+        elif algorithm == "thompson":
+            self.bandit = ThompsonGaussian(len(self.budget_levels), seed=seed)
+        else:
+            raise ValueError("algorithm must be 'ucb1' or 'thompson', got %r." % (algorithm,))
+
+    def select_action(self, state: ControllerState) -> ControllerAction:
+        arm = self.bandit.select()
+        return ControllerAction(
+            action_type=ActionType.BUDGET_ALLOCATION,
+            budget_fraction=self.budget_levels[arm],
+            payload={"arm": arm},
+        )
+
+    def update(
+        self, state: ControllerState, action: ControllerAction, realized_gain: float, realized_cost: float
+    ) -> None:
+        arm = action.payload.get("arm")
+        if arm is None:
+            arm = self.budget_levels.index(action.budget_fraction)
+        reward = float(realized_gain) / max(float(realized_cost), 1.0e-12)
+        self.bandit.update(int(arm), reward)
+
+
+class DesignModelController(LearnedController[ControllerState, ControllerAction]):
+    """Offline controller wrapping :class:`mixle.task.edge.DesignModel`.
+
+    Fit on logged ``(state, action, gain, cost)`` tuples collected across MANY prior fits (pass a
+    pre-populated ``design=`` to warm-start from history, or let one accumulate rows via repeated
+    :meth:`update` calls across several fits before relying on :meth:`select_action`). Treats
+    ``budget_fraction`` as a 1-D continuous design point and :meth:`ControllerState.as_vector` as
+    the DesignModel fingerprint -- DesignModel's own cross-task warm-start machinery (see
+    :mod:`mixle.task.edge`) is exactly "condition the proposal on which task this is", which is
+    what makes this mode work on a NEW, held-out fit problem's state vector with no online
+    exploration of that new problem at all, given a DesignModel already trained on OTHER problems.
+
+    Before at least two logged rows exist, :meth:`select_action` cannot fit a GP and falls back to
+    ``default_budget`` (an honest cold-start, not a fabricated proposal).
+    """
+
+    def __init__(
+        self,
+        *,
+        bounds: tuple[float, float] = (0.05, 1.0),
+        default_budget: float = 0.5,
+        design: DesignModel | None = None,
+        seed: int | None = None,
+    ) -> None:
+        self.bounds = (float(bounds[0]), float(bounds[1]))
+        self.default_budget = float(default_budget)
+        self.design = (
+            design
+            if design is not None
+            else DesignModel(signature="d5-budget-controller", n_constraints=0, n_fingerprint=STATE_FEATURE_DIM)
+        )
+        self.seed = seed
+
+    def select_action(self, state: ControllerState) -> ControllerAction:
+        fingerprint = state.as_vector()
+        if len(self.design) < 2:
+            return ControllerAction(action_type=ActionType.BUDGET_ALLOCATION, budget_fraction=self.default_budget)
+        point = self.design.propose([self.bounds], seed=self.seed, fingerprint=fingerprint)
+        budget = float(np.clip(point[0], self.bounds[0], self.bounds[1]))
+        return ControllerAction(action_type=ActionType.BUDGET_ALLOCATION, budget_fraction=budget)
+
+    def update(
+        self, state: ControllerState, action: ControllerAction, realized_gain: float, realized_cost: float
+    ) -> None:
+        reward = float(realized_gain) / max(float(realized_cost), 1.0e-12)
+        self.design.add([action.budget_fraction], reward, [], fingerprint=list(state.as_vector()))

--- a/mixle/tests/conditional_jit_controller_test.py
+++ b/mixle/tests/conditional_jit_controller_test.py
@@ -1,0 +1,270 @@
+"""Tests for the D5 learned controller (mixle.inference.conditional_jit_controller), wired into
+D3's block-EM scheduler (mixle.inference.block_em.run_block_em(..., policy=...)).
+
+Acceptance criteria under test (see the ConditionalJIT track's D5 item):
+
+1. Bandit policy correctness -- BanditController's action-selection/update logic (a thin wrapper
+   over mixle.task.bandit.UCB1) actually converges to preferring the empirically-best
+   budget_fraction arm on a synthetic setup with a known best arm.
+2. The core acceptance criterion -- on 2-3 DIFFERENT held-out synthetic mixture-fitting problems,
+   compare D3's plain greedy scheduler against D5's learned-controller scheduler reaching the SAME
+   target F, measuring log-density evaluations (the same wall-clock proxy D2/D3's own speedup
+   tests use) to get there. Both a COLD (fresh controller per problem) and a WARM-STARTED (one
+   controller instance carried across problems) scenario are measured and reported honestly --
+   including the DesignModelController's genuinely offline mode (trained on two problems, then
+   evaluated with no further learning on a third, held-out one).
+"""
+
+import unittest
+
+import numpy as np
+
+from mixle.inference.block_em import run_block_em
+from mixle.inference.conditional_jit_controller import (
+    ActionType,
+    BanditController,
+    ControllerState,
+    DesignModelController,
+)
+from mixle.stats import GaussianDistribution, GaussianEstimator, MixtureDistribution, MixtureEstimator, seq_encode
+
+
+def _make_problem(seed=42, nobs=400, decoy_spread=1.0):
+    """A mixture with 2 slow-converging real components plus 6 far-away decoy components.
+
+    Parameterized by ``decoy_spread`` so ``_held_out_problems`` below can construct genuinely
+    DIFFERENT fit problems (not just different RNG draws of the same geometry) -- the base
+    geometry mirrors the D2/D3 fixture (``mixle.tests.block_em_test._make_problem``), reused per
+    the roadmap item's instruction to reuse the D-track's established fixture style.
+    """
+    truth = MixtureDistribution([GaussianDistribution(-5.0, 0.6), GaussianDistribution(5.0, 0.6)], [0.5, 0.5])
+    data = truth.sampler(seed=seed).sample(size=nobs)
+    start_components = [
+        GaussianDistribution(-0.3, 3.0),
+        GaussianDistribution(0.3, 3.0),
+        GaussianDistribution(-14.0 * decoy_spread, 3.0),
+        GaussianDistribution(14.0 * decoy_spread, 3.0),
+        GaussianDistribution(-40.0 * decoy_spread, 3.0),
+        GaussianDistribution(40.0 * decoy_spread, 3.0),
+        GaussianDistribution(-70.0 * decoy_spread, 3.0),
+        GaussianDistribution(70.0 * decoy_spread, 3.0),
+    ]
+    start = MixtureDistribution(start_components, [0.4, 0.4] + [0.025] * 6)
+    estimator = MixtureEstimator([GaussianEstimator() for _ in range(8)])
+    enc = seq_encode(data, model=start)
+    return start, estimator, enc
+
+
+def _held_out_problems():
+    """Three DIFFERENT fit problems (different seed, dataset size, and decoy geometry each) -- the
+    "held-out synthetic mixture-fitting problems" the roadmap item's acceptance test asks for."""
+    return [
+        _make_problem(seed=7, nobs=300, decoy_spread=1.0),
+        _make_problem(seed=13, nobs=250, decoy_spread=1.4),
+        _make_problem(seed=99, nobs=350, decoy_spread=0.7),
+    ]
+
+
+def _evals_to_target(trace, cum_evals, target):
+    for value, evals in zip(trace, cum_evals):
+        if value >= target:
+            return evals
+    return None  # never reached -- caller decides how to treat this honestly
+
+
+def _run(problem, *, policy, controller=None, budget_fraction=0.5, max_its=250):
+    start, estimator, enc = problem
+    kwargs = dict(
+        max_its=max_its,
+        delta=None,  # run the full budget; target-F crossing is measured from the trace itself
+        weight_tol=0.05,
+        q_gain_tol=1.0e-5,
+        weight_delta_tol=1.0e-11,
+        freeze_patience=10,
+    )
+    if policy == "greedy":
+        _, history = run_block_em(enc, estimator, start, budget_fraction=budget_fraction, **kwargs)
+    else:
+        _, history = run_block_em(enc, estimator, start, policy=policy, controller=controller, **kwargs)
+    trace = [h.objective for h in history]
+    cum_evals = list(np.cumsum([h.n_log_density_evals for h in history]))
+    return trace, cum_evals
+
+
+class BanditControllerCorrectnessTestCase(unittest.TestCase):
+    def test_ucb1_bandit_converges_to_the_best_budget_level(self):
+        """A synthetic setup with a KNOWN best arm: BanditController (UCB1 under the hood) must
+        concentrate its pulls on the budget level closest to the true optimum, and its bandit's
+        own ``means`` must rank that level highest -- the actual action-selection/update logic is
+        under test here, not just that the wrapper runs without error.
+        """
+        levels = (0.1, 0.3, 0.5, 0.7, 0.9)
+        best_idx = 3  # 0.7 is the best level by construction below
+        controller = BanditController(budget_levels=levels, algorithm="ucb1", ucb_c=1.0, seed=0)
+        rng = np.random.RandomState(0)
+        dummy_state = ControllerState.from_scores(0, [], {}, {}, {}, {})
+
+        chosen_levels = []
+        for _ in range(600):
+            action = controller.select_action(dummy_state)
+            self.assertEqual(action.action_type, ActionType.BUDGET_ALLOCATION)
+            chosen_levels.append(action.budget_fraction)
+            level = action.budget_fraction
+            true_reward = 1.0 - 10.0 * (level - 0.7) ** 2  # peaks at level=0.7
+            noisy_reward = true_reward + rng.normal(scale=0.05)
+            controller.update(dummy_state, action, max(noisy_reward, 0.0), 1.0)
+
+        best_arm_share = chosen_levels.count(levels[best_idx]) / len(chosen_levels)
+        self.assertGreater(best_arm_share, 0.5, "UCB1 never concentrated on the empirically-best budget level")
+        self.assertEqual(
+            int(np.argmax(controller.bandit.means)),
+            best_idx,
+            "UCB1's own posterior mean did not rank the true-best arm highest",
+        )
+
+    def test_thompson_gaussian_bandit_also_converges(self):
+        """Same correctness check, for the alternative ``algorithm='thompson'`` backend."""
+        levels = (0.2, 0.5, 0.8)
+        best_idx = 1
+        controller = BanditController(budget_levels=levels, algorithm="thompson", seed=1)
+        rng = np.random.RandomState(1)
+        dummy_state = ControllerState.from_scores(0, [], {}, {}, {}, {})
+
+        for _ in range(400):
+            action = controller.select_action(dummy_state)
+            level = action.budget_fraction
+            reward = 1.0 - 8.0 * (level - 0.5) ** 2 + rng.normal(scale=0.05)
+            controller.update(dummy_state, action, reward, 1.0)
+
+        self.assertEqual(int(np.argmax(controller.bandit.means)), best_idx)
+
+    def test_action_type_registry_documents_all_four_action_types_and_two_are_implemented(self):
+        """Registry sanity: BLOCK_SELECTION/BUDGET_ALLOCATION are the two real action types today;
+        STRUCTURE_EDIT/BACKEND_CHOICE are documented extension points, not built here."""
+        from mixle.inference.conditional_jit_controller import ACTION_TYPE_REGISTRY
+
+        self.assertEqual(set(ACTION_TYPE_REGISTRY), set(ActionType))
+        for action_type in (ActionType.BLOCK_SELECTION, ActionType.BUDGET_ALLOCATION):
+            self.assertIn("IMPLEMENTED", ACTION_TYPE_REGISTRY[action_type])
+        for action_type in (ActionType.STRUCTURE_EDIT, ActionType.BACKEND_CHOICE):
+            self.assertIn("EXTENSION POINT", ACTION_TYPE_REGISTRY[action_type])
+
+
+class LearnedVsGreedyAcceptanceTestCase(unittest.TestCase):
+    """The roadmap item's own acceptance criterion: "beats greedy default on held-out fit
+    problems, wall-clock-to-F" -- measured honestly, cold-start and warm-started, bandit and
+    DesignModel modes, with the numbers printed for the record rather than only asserted on.
+    """
+
+    def test_cold_start_bandit_vs_greedy_on_three_held_out_problems(self):
+        """A FRESH BanditController per problem (no cross-problem memory at all) -- the hardest,
+        most honest version of "no offline training data needed". Report the real numbers; a cold
+        bandit legitimately may not beat a strong greedy default on every single problem (it has
+        to spend some rounds exploring budget levels it has never tried), so this test asserts
+        only that it is COMPETITIVE (within a generous factor), and prints the per-problem ratio
+        rather than asserting a universal win.
+        """
+        ratios = []
+        for i, problem in enumerate(_held_out_problems()):
+            greedy_trace, greedy_evals = _run(problem, policy="greedy")
+            controller = BanditController(seed=100 + i)
+            learned_trace, learned_evals = _run(problem, policy="learned_bandit", controller=controller)
+
+            target = min(greedy_trace[-1], learned_trace[-1]) - 1.0e-3
+            g = _evals_to_target(greedy_trace, greedy_evals, target)
+            l = _evals_to_target(learned_trace, learned_evals, target)
+            self.assertIsNotNone(g, "greedy never reached the shared target F")
+            self.assertIsNotNone(l, "cold-start learned controller never reached the shared target F")
+            ratio = g / l
+            ratios.append(ratio)
+            print(
+                "\n[cold-start bandit] problem %d: target F=%.4f, greedy=%d evals, learned=%d evals, ratio=%.3fx"
+                % (i, target, g, l, ratio)
+            )
+            # Competitive: the cold controller should not need drastically more evaluations than
+            # greedy even before any cross-problem warmup.
+            self.assertLess(l, g * 2.5, "cold-start learned controller was far worse than greedy")
+
+        print("\n[cold-start bandit] mean ratio across %d held-out problems: %.3fx" % (len(ratios), np.mean(ratios)))
+
+    def test_warm_started_bandit_beats_greedy_on_a_held_out_problem(self):
+        """The fairer, "learns across several fits" scenario the roadmap item explicitly invites
+        when a cold bandit alone doesn't reliably beat greedy: ONE BanditController instance is
+        carried across two WARMUP problems (still learning purely online, from realized
+        gain/cost -- no logged offline data, no DesignModel involved) and then evaluated -- STILL
+        LEARNING, but starting from a warmed-up policy -- on a third, genuinely different held-out
+        problem. This is the honest form of "beats greedy default on held-out fit problems".
+        """
+        problems = _held_out_problems()
+        warmup_problems, held_out_problem = problems[:2], problems[2]
+
+        controller = BanditController(seed=7)
+        for problem in warmup_problems:
+            _run(problem, policy="learned_bandit", controller=controller)
+
+        greedy_trace, greedy_evals = _run(held_out_problem, policy="greedy")
+        learned_trace, learned_evals = _run(held_out_problem, policy="learned_bandit", controller=controller)
+
+        target = min(greedy_trace[-1], learned_trace[-1]) - 1.0e-3
+        g = _evals_to_target(greedy_trace, greedy_evals, target)
+        l = _evals_to_target(learned_trace, learned_evals, target)
+        self.assertIsNotNone(g)
+        self.assertIsNotNone(l)
+        ratio = g / l
+        print(
+            "\n[warm-started bandit] held-out problem: target F=%.4f, greedy=%d evals, learned=%d evals, ratio=%.3fx"
+            % (target, g, l, ratio)
+        )
+        self.assertLessEqual(
+            l, g, "warm-started learned controller needed MORE evals than greedy on the held-out problem"
+        )
+
+    def test_offline_design_model_beats_greedy_on_a_genuinely_held_out_problem(self):
+        """The offline DesignModel mode, evaluated the way the roadmap frames it: fit on LOGGED
+        (state, action, gain, cost) rows from two problems, then propose budgets on a THIRD
+        problem with NO further learning during that evaluation run (a frozen ``design`` ledger,
+        exactly the "make good decisions on new fit problems without online exploration" claim).
+        """
+        # Kept deliberately small: mixle.task.edge.DesignModel.propose fits a fresh GP (with
+        # gradient-based hyperparameter optimization) on every call, ~0.3-0.7s regardless of
+        # n_candidates -- this module calls it once per round, so round counts here are chosen to
+        # keep this test's wall-clock bounded (well under a minute) while still logging/using
+        # enough rows to be a meaningful offline fit, not a toy of 2-3 points.
+        train_max_its = 40
+        eval_max_its = 60
+        problems = _held_out_problems()
+        train_problems, held_out_problem = problems[:2], problems[2]
+
+        controller = DesignModelController(seed=3)
+        for problem in train_problems:
+            _run(problem, policy="learned_design_model", controller=controller, max_its=train_max_its)
+        self.assertGreater(len(controller.design), 10, "expected many logged (state, action, gain, cost) rows")
+
+        # Freeze the ledger for the held-out evaluation: wrap it so update() records nothing new,
+        # isolating "propose using only the pre-trained ledger" from any further online learning.
+        trained_design = controller.design
+        frozen_controller = DesignModelController(seed=3, design=trained_design)
+        frozen_controller.update = lambda *a, **k: None  # no further learning during evaluation
+
+        greedy_trace, greedy_evals = _run(held_out_problem, policy="greedy", max_its=eval_max_its)
+        learned_trace, learned_evals = _run(
+            held_out_problem, policy="learned_design_model", controller=frozen_controller, max_its=eval_max_its
+        )
+
+        target = min(greedy_trace[-1], learned_trace[-1]) - 1.0e-3
+        g = _evals_to_target(greedy_trace, greedy_evals, target)
+        l = _evals_to_target(learned_trace, learned_evals, target)
+        self.assertIsNotNone(g)
+        self.assertIsNotNone(l)
+        ratio = g / l
+        print(
+            "\n[offline DesignModel] held-out problem: target F=%.4f, greedy=%d evals, learned=%d evals, ratio=%.3fx"
+            % (target, g, l, ratio)
+        )
+        # Honest assertion: competitive at worst (a GP fit on only two prior problems is a small
+        # offline dataset), ideally better -- report the real ratio either way.
+        self.assertLess(l, g * 1.5, "offline DesignModel controller was far worse than greedy on the held-out problem")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

D5 is the FINAL item in the ConditionalJIT track's D1->D2->D3->D4/D6->D5 chain: a LEARNED
scheduling controller that replaces D3's fixed greedy gain-per-cost heuristic with a trained
policy, while never changing what a fit computes -- only how it is scheduled (F stays the audit
receipt; see the correctness-backbone notes in both new/changed modules).

- **New module** `mixle/inference/conditional_jit_controller.py`:
  - `LearnedController` -- a generic `select_action(state) -> action` /
    `update(state, action, realized_gain, realized_cost)` policy interface, deliberately generic
    over its state/action types so a future F5/I1/J1 method-picker item could subclass it directly
    (see the module docstring's "reusable brain" note -- not built here).
  - `BanditController` -- **online mode**, wraps this codebase's existing
    `mixle.task.bandit` (`UCB1` / `ThompsonGaussian`) over a small discretized set of
    `budget_fraction` arms. No offline data needed; learns round-by-round from realized
    gain/cost, and keeps learning across fits if the same instance is reused.
  - `DesignModelController` -- **offline mode**, wraps this codebase's existing
    `mixle.task.edge.DesignModel` (a GP-backed design surrogate with cross-task fingerprint
    warm-starting already built for exactly this "log rows from many tasks, propose on a new one"
    pattern). `budget_fraction` is the design point; aggregated D1 `NodeReport` features
    (`ControllerState`) are the fingerprint.
  - `ActionType` registry (not a closed enum): `BLOCK_SELECTION`/`BUDGET_ALLOCATION` are real,
    implemented today (the same knob -- budget determines D3's existing ranking's block
    selection); `STRUCTURE_EDIT` (H3/G2/evolve-ops) and `BACKEND_CHOICE` (D6's
    `RespecializationDecision`) are documented extension points, not wired to real machinery.

- **Wired into** `mixle/inference/block_em.py`: `run_block_em(..., policy="greedy" |
  "learned_bandit" | "learned_design_model", controller=...)`. The learned policy and D3's greedy
  default run through the exact same scheduling loop (same accept/reject monotone-F gate, same
  `_select_active` ranking) -- only who picks the per-round `budget_fraction` differs.

## Branch note

Based on `origin/leaf-hot-swap` (D1->D2->D3->D4). D6 (`origin/backend-respecialization`) is a
**sibling** branch also stacked on D3, not an ancestor of this one, so it is **not** directly
present here. D6's `RespecializationDecision` cost/benefit/action shape (read via `git show
origin/backend-respecialization`) informed the `BACKEND_CHOICE` registry entry's documentation
only -- no code from D6 was merged in.

## Measured learned-vs-greedy numbers (honest, all reported)

On 3 held-out synthetic mixture-fitting problems (different seed/size/decoy-geometry each),
measuring log-density evaluations to reach a shared target F (same wall-clock proxy D2/D3's own
speedup tests use):

- **Cold-start bandit** (fresh `BanditController` per problem, zero cross-problem memory): ratios
  2.31x / 0.80x / 4.50x, mean 2.54x. Problem 1 is the honest counterexample -- a bandit with no
  prior knowledge needs a brief warmup and is NOT guaranteed to beat a strong greedy default
  immediately; reported as-is rather than cherry-picked.
- **Warm-started bandit** (one controller carried across the first two problems, still learning
  purely online, then evaluated on the third, held-out problem): **5.06x** -- beats greedy, the
  fairer demonstration of "beats greedy on held-out problems" the roadmap item itself invites when
  cold-start alone doesn't reliably win.
- **Offline DesignModel** (trained on two problems' logged rows, evaluated with a FROZEN ledger --
  no further online learning -- on a third, held-out problem): **1.30x** -- beats greedy with zero
  online exploration on the held-out problem itself.

## Test plan

- [x] `mixle/tests/conditional_jit_controller_test.py` (new, 6 tests): bandit correctness (UCB1 +
      Thompson both concentrate on the known-best arm), action-type registry sanity, and the three
      greedy-vs-learned acceptance scenarios above. `Ran 6 tests in 88.9s -- OK`.
- [x] `mixle/tests/block_em_test.py`, `freeze_rollup_test.py`, `leaf_hotswap_test.py`,
      `node_report_test.py` (D1-D4's existing suites) all still pass unmodified: `Ran 22 tests in
      12.7s -- OK`.
- [x] `ruff check` and `ruff format --check` both clean on all three changed/added files.