### PR TITLE
parallel/sdc_audit: continuous SDC audit + combine() NaN/Inf watchdog (K5)

### DIFF
--- a/mixle/tests/sdc_audit_test.py
+++ b/mixle/tests/sdc_audit_test.py
@@ -1,0 +1,316 @@
+"""Tests for the SDC (silent-data-corruption) audit layer (K5): injected-bit-flip catch rate,
+audit overhead, false-positive rate on clean runs, the NaN/Inf combine()-boundary watchdog, and
+end-to-end quarantine + receipt behavior built on top of K4's retry/blacklist machinery."""
+
+import pickle
+import time
+import unittest
+
+import numpy as np
+
+from mixle.tests.parallel_test import make_data, make_estimator, make_start_model
+from mixle.utils.parallel.sdc_audit import AuditedMPEncodedData, finite_guarded_fold, inject_bit_flip
+
+
+class _CountingAccumulator:
+    """Minimal StatisticAccumulator-protocol stand-in with a combine() call counter, used to
+    prove the finite watchdog fires at the FIRST offending combine() and does not keep going."""
+
+    def __init__(self):
+        self.total = 0.0
+        self.combine_calls = 0
+
+    def combine(self, x):
+        self.combine_calls += 1
+        self.total += x
+        return self
+
+    def value(self):
+        return self.total
+
+    def from_value(self, x):
+        self.total = x
+        return self
+
+    def key_merge(self, stats_dict):
+        pass
+
+    def key_replace(self, stats_dict):
+        pass
+
+
+class _CountingFactory:
+    def __init__(self):
+        self.made = []
+
+    def make(self):
+        acc = _CountingAccumulator()
+        self.made.append(acc)
+        return acc
+
+
+class _FakeEstimator:
+    def __init__(self):
+        self._factory = _CountingFactory()
+
+    def accumulator_factory(self):
+        return self._factory
+
+
+class FiniteWatchdogTestCase(unittest.TestCase):
+    """K5 acceptance criterion 4: the NaN/Inf watchdog fires at the FIRST combine() boundary
+    where a non-finite value appears, not at the end of the fold and not on some later shard."""
+
+    def _payloads(self, values):
+        return [pickle.dumps((1.0, v), protocol=pickle.HIGHEST_PROTOCOL) for v in values]
+
+    def test_watchdog_fires_at_first_offending_combine_not_later(self):
+        est = _FakeEstimator()
+        # payload index 2 (0-based) introduces the NaN; two more clean payloads follow it.
+        payloads = self._payloads([1.0, 2.0, float("nan"), 4.0, 5.0])
+
+        with self.assertRaises(ValueError) as ctx:
+            finite_guarded_fold(est, payloads)
+
+        self.assertIn("payload index 2", str(ctx.exception))
+        # exactly 3 combine() calls happened (indices 0, 1, 2) -- the watchdog stopped the fold
+        # immediately after the corrupting combine(), it did not process indices 3 and 4.
+        acc = est._factory.made[0]
+        self.assertEqual(acc.combine_calls, 3)
+
+    def test_watchdog_fires_on_inf_too(self):
+        est = _FakeEstimator()
+        payloads = self._payloads([1.0, float("inf"), 3.0])
+        with self.assertRaises(ValueError):
+            finite_guarded_fold(est, payloads)
+        self.assertEqual(est._factory.made[0].combine_calls, 2)
+
+    def test_clean_fold_is_unaffected_and_matches_plain_sum(self):
+        est = _FakeEstimator()
+        payloads = self._payloads([1.0, 2.0, 3.0, 4.0])
+        nobs, value = finite_guarded_fold(est, payloads)
+        self.assertEqual(nobs, 4.0)
+        self.assertEqual(value, 10.0)
+
+
+class BitFlipInjectionTestCase(unittest.TestCase):
+    def test_inject_bit_flip_changes_exactly_one_bit(self):
+        payload = bytes([0b00000000, 0b11110000, 0b10101010])
+        corrupted = inject_bit_flip(payload, bit_offset=4)  # 5th bit of byte 0
+        self.assertNotEqual(payload, corrupted)
+        diff_bits = sum(bin(a ^ b).count("1") for a, b in zip(payload, corrupted))
+        self.assertEqual(diff_bits, 1)
+
+
+class SDCAuditTestCase(unittest.TestCase):
+    """Real end-to-end tests against a live multiprocessing worker pool. A single pool is
+    reused across many independent audit rounds/trials within each test (spawning worker
+    processes dominates wall-clock time; each individual `_audit_shards` round call itself
+    takes ~1ms once the pool is up), which is what makes a statistically meaningful number of
+    trials affordable."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.data = make_data()
+        cls.est = make_estimator()
+        cls.m_start = make_start_model()
+        cls.num_workers = 10
+
+    def test_end_to_end_quarantine_and_receipt_on_a_real_bit_flip(self):
+        """A single injected bit-flip on one shard's primary rank, discovered during a real
+        pysp_seq_estimate round, produces a receipt and quarantines both suspect ranks via K4's
+        blacklist mechanism -- without derailing the round (K4 recovers the lost shards)."""
+        with AuditedMPEncodedData(
+            self.data, estimator=self.est, num_workers=6, audit_rate=1.0, rng=np.random.RandomState(42)
+        ) as enc:
+            target_shard = 2
+            hit = {"n": 0}
+
+            def hook(worker_id, shard_id, role, payload):
+                if shard_id == target_shard and role == "primary":
+                    hit["n"] += 1
+                    return inject_bit_flip(payload)
+                return payload
+
+            enc.arm_corruption(hook)
+            enc.pysp_seq_estimate(self.est, self.m_start)
+
+            self.assertGreaterEqual(hit["n"], 1)
+            self.assertEqual(len(enc.last_round_audit_mismatches), 1)
+            receipt = enc.last_round_audit_mismatches[0]
+            self.assertEqual(receipt.shard_id, target_shard)
+            self.assertIsNotNone(receipt.first_diff_byte_offset)
+            self.assertNotEqual(receipt.primary_sha256, receipt.audit_sha256)
+            # both suspect ranks were quarantined via K4's existing blacklist mechanism
+            self.assertTrue({receipt.primary_worker, receipt.audit_worker}.issubset(enc._blacklist))
+            self.assertEqual(enc.audit_receipts, [receipt])
+
+    def test_catch_rate_matches_audit_rate_per_single_round(self):
+        """Injected bit-flips are caught with empirical probability ~= audit_rate per round."""
+        num_workers = self.num_workers
+        audit_rate = 0.3
+        n_audit = round(audit_rate * num_workers)
+        expected_p = n_audit / num_workers  # exact per-round probability (sampling w/o replacement)
+        n_trials = 400
+
+        rng = np.random.RandomState(7)
+        with AuditedMPEncodedData(
+            self.data, estimator=self.est, num_workers=num_workers, audit_rate=audit_rate, rng=rng
+        ) as enc:
+            catches = 0
+            for _ in range(n_trials):
+                target = int(rng.randint(num_workers))
+
+                def hook(worker_id, shard_id, role, payload, _target=target):
+                    if shard_id == _target and role == "primary":
+                        return inject_bit_flip(payload)
+                    return payload
+
+                enc.arm_corruption(hook)
+                enc._audit_shards(self.est, self.m_start, set(range(num_workers)), quarantine_on_mismatch=False)
+                caught = any(r.shard_id == target for r in enc.last_round_audit_mismatches)
+                catches += int(caught)
+                enc.arm_corruption(None)
+
+            empirical_rate = catches / n_trials
+            print(
+                "\n[K5 receipt] single-round catch rate: audit_rate=%.3f expected_p=%.3f "
+                "empirical=%.3f (n=%d trials, %d catches)" % (audit_rate, expected_p, empirical_rate, n_trials, catches)
+            )
+            # binomial std at p=0.3, n=400 is ~0.023; allow a generous 5-sigma band
+            self.assertAlmostEqual(empirical_rate, expected_p, delta=0.12)
+
+    def test_cumulative_catch_rate_approaches_one_as_rounds_accumulate(self):
+        """If the SAME corrupted shard persists across multiple audit rounds, the CUMULATIVE
+        catch probability over N rounds approaches 100%, tracking 1 - (1 - p) ** N."""
+        num_workers = self.num_workers
+        audit_rate = 0.3
+        n_audit = round(audit_rate * num_workers)
+        p = n_audit / num_workers
+        max_rounds = 8
+        n_sequences = 250
+
+        rng = np.random.RandomState(11)
+        with AuditedMPEncodedData(
+            self.data, estimator=self.est, num_workers=num_workers, audit_rate=audit_rate, rng=rng
+        ) as enc:
+            catch_round = []  # round index (1-based) the corruption was first caught, or None
+            for _ in range(n_sequences):
+                target = int(rng.randint(num_workers))
+
+                def hook(worker_id, shard_id, role, payload, _target=target):
+                    if shard_id == _target and role == "primary":
+                        return inject_bit_flip(payload)
+                    return payload
+
+                enc.arm_corruption(hook)
+                caught_at = None
+                for r in range(1, max_rounds + 1):
+                    enc._audit_shards(self.est, self.m_start, set(range(num_workers)), quarantine_on_mismatch=False)
+                    if any(rec.shard_id == target for rec in enc.last_round_audit_mismatches):
+                        caught_at = r
+                        break
+                catch_round.append(caught_at)
+                enc.arm_corruption(None)
+
+            cumulative = []
+            for k in range(1, max_rounds + 1):
+                empirical = sum(1 for c in catch_round if c is not None and c <= k) / n_sequences
+                theoretical = 1.0 - (1.0 - p) ** k
+                cumulative.append((k, empirical, theoretical))
+
+            print("\n[K5 receipt] cumulative catch rate (p=%.3f per round, %d sequences):" % (p, n_sequences))
+            for k, empirical, theoretical in cumulative:
+                print("  round %d: empirical=%.3f theoretical=%.3f" % (k, empirical, theoretical))
+
+            # loose per-point tolerance (binomial noise), but the trend must clearly approach 1
+            for k, empirical, theoretical in cumulative:
+                self.assertAlmostEqual(empirical, theoretical, delta=0.15)
+            self.assertGreater(cumulative[-1][1], 0.9)
+
+    def test_overhead_scales_linearly_with_audit_rate(self):
+        """The extra redundant shard computations the audit performs scale linearly with
+        audit_rate -- not some hidden larger/quadratic cost -- measured both by the exact
+        evaluation count and by real wall-clock time."""
+        num_workers = self.num_workers
+        rates = [0.1, 0.3, 0.6]
+        reps = 60
+
+        rng = np.random.RandomState(3)
+        with AuditedMPEncodedData(
+            self.data, estimator=self.est, num_workers=num_workers, audit_rate=rates[0], rng=rng
+        ) as enc:
+            results = []
+            for r in rates:
+                enc.audit_rate = r
+                # warm-up rep (excluded from timing) to avoid first-call jitter
+                enc._audit_shards(self.est, self.m_start, set(range(num_workers)), quarantine_on_mismatch=False)
+                t0 = time.perf_counter()
+                total_eval = 0
+                for _ in range(reps):
+                    enc._audit_shards(self.est, self.m_start, set(range(num_workers)), quarantine_on_mismatch=False)
+                    total_eval += enc.last_round_audit_eval_count
+                elapsed = time.perf_counter() - t0
+                expected_eval_per_round = 2 * round(r * num_workers)
+                results.append((r, elapsed, total_eval, expected_eval_per_round))
+
+            print("\n[K5 receipt] audit overhead vs. audit_rate (%d reps/rate, num_workers=%d):" % (reps, num_workers))
+            for r, elapsed, total_eval, expected_eval_per_round in results:
+                print(
+                    "  audit_rate=%.2f: wall_clock=%.4fs (%.5fs/round) eval_count=%d (expected/round=%d)"
+                    % (r, elapsed, elapsed / reps, total_eval, expected_eval_per_round)
+                )
+
+            # eval_count is EXACTLY linear in audit_rate by construction (2 recomputes per
+            # audited shard); confirm that directly.
+            for r, _elapsed, total_eval, expected_eval_per_round in results:
+                self.assertEqual(total_eval, expected_eval_per_round * reps)
+
+            # and confirm real wall-clock time is not some hidden larger-than-linear cost:
+            # time-per-eval should be roughly constant across audit rates (a doubling of the
+            # audit rate should roughly double the wall-clock overhead, not 4x or 10x it).
+            per_eval_times = [elapsed / total_eval for _r, elapsed, total_eval, _e in results if total_eval > 0]
+            self.assertGreater(len(per_eval_times), 1)
+            self.assertLess(max(per_eval_times) / min(per_eval_times), 4.0)
+
+    def test_zero_false_positives_on_clean_runs(self):
+        """On genuinely uncorrupted runs the bitwise comparison must NEVER flag a mismatch.
+
+        This holds BY CONSTRUCTION, not merely empirically: the primary and audit recompute of
+        a shard both start from the identical raw shard bytes (self._shard_raw[shard_id]),
+        both go through the SAME "update_shard" code path with the SAME sub_chunks (so
+        floating-point summation order -- not associative in general -- is identical on both
+        ranks), and seq_update/seq_initialize are pure deterministic functions of (encoded
+        data, weights, model) with no per-rank randomness. Two evaluations of the same pure,
+        deterministic computation on identical inputs must produce identical IEEE-754 bit
+        patterns regardless of which physical rank executes them -- there is no tolerance band
+        here, no "close enough": a clean run has literally nothing that could make the two
+        payloads differ. This test verifies that argument empirically across enough trials to
+        be a meaningful receipt, not just an assertion.
+        """
+        num_workers = self.num_workers
+        n_rounds = 300
+
+        rng = np.random.RandomState(23)
+        with AuditedMPEncodedData(
+            self.data, estimator=self.est, num_workers=num_workers, audit_rate=0.5, rng=rng
+        ) as enc:
+            model = self.m_start
+            total_audited = 0
+            total_mismatches = 0
+            for _ in range(n_rounds):
+                enc._audit_shards(self.est, model, set(range(num_workers)), quarantine_on_mismatch=False)
+                total_audited += len(enc.last_round_audited_shards)
+                total_mismatches += len(enc.last_round_audit_mismatches)
+
+            print(
+                "\n[K5 receipt] clean-run false-positive check: %d rounds, %d total shard audits, "
+                "%d mismatches" % (n_rounds, total_audited, total_mismatches)
+            )
+            self.assertGreater(total_audited, 0)
+            self.assertEqual(total_mismatches, 0)
+            self.assertEqual(enc.audit_receipts, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mixle/utils/parallel/resilient_em.py
+++ b/mixle/utils/parallel/resilient_em.py
@@ -264,6 +264,13 @@ class ResilientMPEncodedData(EncodedDataHandle):
         self._ctx = mp.get_context("spawn")
         self._encoder_b = pickle.dumps(encoder, protocol=_PROTO)
 
+        # The final driver-side fold of per-shard payloads (see _resilient_update_round below)
+        # is always exactly checkpointed_fold -- UNLESS a subclass swaps this hook out. K5's
+        # AuditedMPEncodedData replaces it with a fold that wraps every combine() call with a
+        # NaN/Inf watchdog; this class's own retry/blacklist/elastic-repartition logic (the
+        # thing K5 reuses rather than reimplements) is otherwise untouched.
+        self._fold_fn: Callable[[Any, Sequence[bytes]], tuple[float, Any]] = checkpointed_fold
+
         self._shard_raw: dict[int, bytes] = {}
         self._worker_shards: dict[int, set[int]] = {}
         self._conns: dict[int, Any] = {}
@@ -462,7 +469,7 @@ class ResilientMPEncodedData(EncodedDataHandle):
         self.last_round_failed_workers = set(failed)
         self.last_round_blacklisted_workers = blacklisted_now
 
-        return checkpointed_fold(estimator, payloads)
+        return self._fold_fn(estimator, payloads)
 
     # -- protocol recognized by mixle.stats dispatch -------------------------
 

--- a/mixle/utils/parallel/sdc_audit.py
+++ b/mixle/utils/parallel/sdc_audit.py
@@ -1,0 +1,372 @@
+"""Silent-data-corruption (SDC) audit for the resilient mp EM backend (K5).
+
+Status audit this module leans on (see K4's docstring in ``resilient_em.py``, which this
+module builds directly on top of): fits are deterministic given seed (#115) and sufficient
+statistics are ADDITIVE. K4 already turns those two facts into exact, cheap *failure*
+recovery (a crashed worker's shard is just redone). K5's contribution is different: it turns
+the SAME two facts into a cheap *corruption* detector.
+
+**The idea.** Silent data corruption (SDC) is a bit-flip in memory or compute that produces a
+WRONG result with no exception and no crash -- the fit just silently converges to a corrupted
+answer. For gradient-based training this is expensive to catch (you'd have to redo an entire
+gradient step, or use redundant hardware). mixle's additive-stat EM makes it cheap: recompute
+the SAME shard's accumulator TWICE, from the SAME raw shard bytes / same estimator / same
+model / same ``sub_chunks`` split, once on the shard's normal ("primary") rank and once on a
+DIFFERENT ("audit") rank. Determinism-given-seed + additive stats + fixed chunking means the
+two ``(count, value())`` payloads MUST be bitwise identical if nothing is corrupted -- so any
+byte-level difference is proof of a real hardware/software fault, not numerical noise (there
+is no tolerance band to tune, unlike a gradient re-check).
+
+**Why zero false positives holds "by construction", not just empirically:**
+    1. Both the primary and audit recompute start from ``self._shard_raw[shard_id]`` -- the
+       IDENTICAL pickled raw observations the driver has held since construction. Neither rank
+       is given a different view of the data.
+    2. Both recomputes run the SAME code path: ``_worker_main``'s ``"update_shard"`` handler,
+       which pickles the shard with the SAME ``sub_chunks`` value (see ``_encode_shard``), so
+       floating-point summation order -- which is NOT associative -- is identical on both
+       ranks. This is exactly the "fixed chunking" half of the guarantee: without pinning
+       ``sub_chunks``, two honest ranks could legitimately disagree in the last bit.
+    3. ``seq_update`` (the E-step) and ``seq_initialize`` are pure, deterministic functions of
+       (encoded data, weights, model[, seed]) -- no per-rank RNG state, no nondeterministic
+       parallel reduction inside a single call. IEEE-754 arithmetic is deterministic given a
+       fixed sequence of operations, so replaying the identical operation sequence on
+       different physical hardware still produces the identical bit pattern.
+    4. Therefore an uncorrupted primary and an uncorrupted audit recompute of the same shard
+       are the same pure computation evaluated twice, and must agree bit-for-bit. A mismatch
+       can only arise if at least one of the two computations was NOT the pure computation --
+       i.e. something (memory fault, cosmic ray, buggy kernel) perturbed it. This is verified
+       empirically too, at scale, in ``mixle/tests/sdc_audit_test.py``.
+
+**NaN/Inf watchdog.** ``mixle.models._neural_serial.check_finite`` already guards individual
+density evaluations. K5 extends that same "fail loud, immediately, with the offending
+location named" philosophy to the accumulator-fold boundary: :func:`finite_guarded_fold` is a
+drop-in replacement for :func:`~mixle.utils.parallel.resilient_em.checkpointed_fold` that
+checks finiteness of the running accumulator's ``value()`` immediately after EVERY
+``combine()`` call, not just once at the end -- so a NaN/Inf introduced while folding payload
+``i`` is caught at payload ``i``'s ``combine()`` boundary, before it silently propagates into
+payload ``i+1..n``. Scope note: this wraps ``combine()`` calls made by THIS module's own fold
+loop only (mirroring ``checkpointed_fold``'s loop) -- it deliberately does NOT touch
+``SequenceEncodableStatisticAccumulator.combine()``'s contract itself, which every other
+caller in the codebase still uses unguarded, exactly as before.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import pickle
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+
+from mixle.models._neural_serial import check_finite
+from mixle.utils.parallel.resilient_em import ResilientMPEncodedData
+
+__all__ = [
+    "AuditedMPEncodedData",
+    "SDCAuditReceipt",
+    "finite_guarded_fold",
+    "inject_bit_flip",
+]
+
+_PROTO = pickle.HIGHEST_PROTOCOL
+
+
+def inject_bit_flip(payload: bytes, bit_offset: int | None = None) -> bytes:
+    """Flip exactly one bit of ``payload``, deterministically, and return the corrupted bytes.
+
+    A real, reproducible stand-in for a hardware/software bit-flip: this is the corruption
+    primitive the acceptance tests inject via :meth:`AuditedMPEncodedData.arm_corruption`.
+    ``bit_offset`` defaults to the middle bit of the payload (an arbitrary but fixed choice --
+    determinism of the test does not depend on which bit, only that the two payloads it is
+    applied to differ afterward).
+    """
+    if not payload:
+        raise ValueError("cannot flip a bit in an empty payload.")
+    n_bits = len(payload) * 8
+    if bit_offset is None:
+        bit_offset = n_bits // 2
+    bit_offset = int(bit_offset) % n_bits
+    byte_i, bit_i = divmod(bit_offset, 8)
+    corrupted = bytearray(payload)
+    corrupted[byte_i] ^= 1 << bit_i
+    return bytes(corrupted)
+
+
+def _assert_finite_value(value: Any, where: str) -> None:
+    """Recursively walk a (possibly nested list/tuple/dict) accumulator ``value()`` payload and
+    raise via :func:`check_finite` at the first non-finite numeric leaf found."""
+    if isinstance(value, np.ndarray):
+        check_finite(value, where)
+    elif isinstance(value, (int, float, np.floating, np.integer)) and not isinstance(value, bool):
+        check_finite(np.asarray([float(value)]), where)
+    elif isinstance(value, (list, tuple)):
+        for v in value:
+            _assert_finite_value(v, where)
+    elif isinstance(value, dict):
+        for v in value.values():
+            _assert_finite_value(v, where)
+    # else: non-numeric leaf (str, bool, None, categorical support metadata, ...) -- nothing to check.
+
+
+def finite_guarded_fold(
+    estimator: Any, payloads: Sequence[bytes], where: str = "AuditedMPEncodedData.combine"
+) -> tuple[float, Any]:
+    """``checkpointed_fold``, but check finiteness of the running accumulator immediately after
+    EVERY ``combine()`` call (see module docstring for why this is a wrapper around this
+    module's own fold loop rather than a change to ``combine()``'s contract)."""
+    accumulator = estimator.accumulator_factory().make()
+    nobs = 0.0
+    for i, raw in enumerate(payloads):
+        count, stats = pickle.loads(raw)
+        nobs += count
+        accumulator.combine(stats)
+        _assert_finite_value(
+            accumulator.value(), "%s (payload index %d, %d combine() calls so far)" % (where, i, i + 1)
+        )
+    stats_dict: dict[str, Any] = {}
+    accumulator.key_merge(stats_dict)
+    accumulator.key_replace(stats_dict)
+    return nobs, accumulator.value()
+
+
+@dataclass
+class SDCAuditReceipt:
+    """A structured record of one detected primary-vs-audit mismatch: which shard, which two
+    ranks, and a summary of what actually differed (never just a bare "mismatch" boolean)."""
+
+    round: int
+    shard_id: int
+    primary_worker: int
+    audit_worker: int
+    primary_nbytes: int
+    audit_nbytes: int
+    first_diff_byte_offset: int | None
+    primary_sha256: str
+    audit_sha256: str
+    primary_value_repr: str = field(default="", repr=False)
+    audit_value_repr: str = field(default="", repr=False)
+
+    def summary(self) -> str:
+        return (
+            "SDC audit mismatch: shard=%d primary_rank=%d audit_rank=%d "
+            "primary=%dB (sha256 %s) audit=%dB (sha256 %s) first_diff_byte=%s"
+            % (
+                self.shard_id,
+                self.primary_worker,
+                self.audit_worker,
+                self.primary_nbytes,
+                self.primary_sha256[:12],
+                self.audit_nbytes,
+                self.audit_sha256[:12],
+                self.first_diff_byte_offset,
+            )
+        )
+
+
+def _receipt(
+    round_no: int, shard_id: int, primary_worker: int, audit_worker: int, primary: bytes, audit: bytes
+) -> SDCAuditReceipt:
+    n = min(len(primary), len(audit))
+    first_diff = next((i for i in range(n) if primary[i] != audit[i]), None)
+    if first_diff is None and len(primary) != len(audit):
+        first_diff = n
+
+    def _safe_repr(payload: bytes) -> str:
+        try:
+            return repr(pickle.loads(payload))[:2000]
+        except Exception as e:  # a corrupted payload may not even unpickle -- that's fine, still a receipt
+            return "<unpicklable: %s>" % e
+
+    return SDCAuditReceipt(
+        round=round_no,
+        shard_id=shard_id,
+        primary_worker=primary_worker,
+        audit_worker=audit_worker,
+        primary_nbytes=len(primary),
+        audit_nbytes=len(audit),
+        first_diff_byte_offset=first_diff,
+        primary_sha256=hashlib.sha256(primary).hexdigest(),
+        audit_sha256=hashlib.sha256(audit).hexdigest(),
+        primary_value_repr=_safe_repr(primary),
+        audit_value_repr=_safe_repr(audit),
+    )
+
+
+class AuditedMPEncodedData(ResilientMPEncodedData):
+    """:class:`ResilientMPEncodedData` (K4) plus a continuous SDC audit (K5).
+
+    Every round (``pysp_seq_estimate`` / ``pysp_stream_accumulate``), a random ``audit_rate``
+    fraction of shards are ALSO recomputed on a second, different rank via the same ad hoc
+    ``"update_shard"`` wire command K4 already uses for shard recovery (see
+    ``ResilientMPEncodedData._recover_shard``) -- no new worker-side machinery. The primary and
+    audit ``(count, value())`` payloads are compared BYTE-FOR-BYTE. A mismatch:
+
+        1. is recorded as a structured :class:`SDCAuditReceipt` (``self.audit_receipts``,
+           ``self.last_round_audit_mismatches``);
+        2. quarantines BOTH ranks that produced the disagreeing payloads via K4's existing
+           ``_blacklist`` / ``_retire_worker`` / ``_migrate_shard_permanently`` machinery --
+           this is a deliberately conservative policy: a single 2-way mismatch cannot, by
+           itself, prove which of the two ranks is the corrupted one (that needs a third
+           witness / majority vote), so both are treated as suspect and the shard is migrated
+           to a clean survivor rather than risk silently trusting either.
+
+    The main EM round itself (retry, blacklisting on repeated *failure*, checkpointed fold) is
+    entirely K4's, untouched, reused via inheritance -- K5 only adds the audit phase (run
+    BEFORE the main round each call, so a quarantine decided by the audit is already reflected
+    in that same round's live-worker set) and swaps K4's plain ``checkpointed_fold`` for
+    :func:`finite_guarded_fold` via the ``_fold_fn`` hook K4 exposes for exactly this purpose.
+
+    Args:
+        audit_rate (float): fraction of shards (``0..1``) redundantly recomputed each round.
+        rng (np.random.RandomState | None): drives which shards are audited each round and
+            which live rank is picked as the second ("audit") rank. Not used for anything that
+            needs to be reproducible bit-for-bit across ranks -- only for *which* shards get
+            the (always bit-exact) double-check.
+
+    Testing hook:
+        :meth:`arm_corruption` registers a one-shot-per-round hook that can mutate a payload
+        right after it comes off the wire from an ad hoc ``"update_shard"`` recompute, letting
+        a test inject a deterministic, reproducible corruption (see :func:`inject_bit_flip`)
+        into a chosen (rank, shard, role) combination without touching worker internals -- the
+        same "observe the wire, mutate deterministically" pattern K4's ``arm_kill`` uses.
+    """
+
+    def __init__(
+        self,
+        data: Sequence[Any],
+        estimator: Any | None = None,
+        encoder: Any | None = None,
+        num_workers: int | None = None,
+        sub_chunks: int = 1,
+        max_retries: int = 2,
+        audit_rate: float = 0.1,
+        rng: np.random.RandomState | None = None,
+    ) -> None:
+        super().__init__(
+            data,
+            estimator=estimator,
+            encoder=encoder,
+            num_workers=num_workers,
+            sub_chunks=sub_chunks,
+            max_retries=max_retries,
+        )
+        if not (0.0 <= float(audit_rate) <= 1.0):
+            raise ValueError("audit_rate must be within [0, 1].")
+        self.audit_rate = float(audit_rate)
+        self._audit_rng = rng if rng is not None else np.random.RandomState()
+        self._fold_fn = finite_guarded_fold
+        self._corrupt_hook: Any = None
+        self._round = 0
+
+        # instrumentation, mirroring K4's last_round_* fields, exposed for tests/operators.
+        self.last_round_audited_shards: set[int] = set()
+        self.last_round_audit_mismatches: list[SDCAuditReceipt] = []
+        self.last_round_audit_eval_count = 0
+        self.audit_receipts: list[SDCAuditReceipt] = []
+
+    # -- testing hook ------------------------------------------------------
+
+    def arm_corruption(self, hook: Any) -> None:
+        """Register ``hook(worker_id, shard_id, role, payload_bytes) -> payload_bytes``
+        (``role`` is ``"primary"`` or ``"audit"``), applied to every ad hoc ``"update_shard"``
+        payload this instance receives until cleared. Unlike ``arm_kill`` this is NOT one-shot
+        by default (an SDC fault is typically persistent, e.g. a stuck bit in one DIMM) --
+        clear it explicitly with ``arm_corruption(None)`` to simulate a transient fault.
+        """
+        self._corrupt_hook = hook
+
+    # -- audit phase ---------------------------------------------------------
+
+    def _update_shard_on(self, worker_id: int, estimator_b: bytes, model_b: bytes, shard_id: int, role: str) -> bytes:
+        """Ad hoc, single-shard recompute on ``worker_id`` -- the exact same wire command K4's
+        ``_recover_shard`` uses, just with an explicit (not "lowest live") target rank."""
+        self._send_raw(
+            worker_id, ("update_shard", estimator_b, model_b, shard_id, self._shard_raw[shard_id], self.sub_chunks)
+        )
+        self._recv_raw(worker_id)  # "started" ack
+        self._send_raw(worker_id, ("go",))
+        _, payload = self._recv_raw(worker_id)
+        if self._corrupt_hook is not None:
+            payload = self._corrupt_hook(worker_id, shard_id, role, payload)
+        return payload
+
+    def _quarantine(self, worker_a: int, worker_b: int, shard_id: int) -> None:
+        """Blacklist both suspect ranks and permanently migrate whatever they held (see class
+        docstring for why both, not just one, are quarantined on a single mismatch)."""
+        for w in (worker_a, worker_b):
+            if w not in self._conns or w in self._blacklist:
+                continue
+            self._failures[w] = self.max_retries  # SDC evidence skips the normal retry grace period
+            self._blacklist.add(w)
+            shard_ids = self._worker_shards.pop(w, set())
+            self._retire_worker(w)
+            for sid in shard_ids:
+                self._migrate_shard_permanently(sid)
+
+    def _audit_shards(
+        self, estimator: Any, model: Any, shard_ids: set[int], quarantine_on_mismatch: bool = True
+    ) -> None:
+        """Redundantly recompute a random ``audit_rate`` fraction of ``shard_ids`` on a second
+        rank and bitwise-compare. ``quarantine_on_mismatch=False`` is a testing knob (used by
+        the catch-rate measurement in the test suite) to observe many independent corruption
+        trials against one live worker pool without each detection permanently shrinking it.
+        """
+        self._round += 1
+        shard_list = sorted(shard_ids)
+        n_audit = int(round(self.audit_rate * len(shard_list)))
+        n_audit = max(0, min(n_audit, len(shard_list)))
+
+        self.last_round_audited_shards = set()
+        self.last_round_audit_mismatches = []
+        self.last_round_audit_eval_count = 0
+
+        if n_audit == 0:
+            return
+        live = sorted(w for w in self._conns if w not in self._blacklist)
+        if len(live) < 2:
+            return
+
+        estimator_b = pickle.dumps(estimator, protocol=_PROTO)
+        model_b = pickle.dumps(model, protocol=_PROTO)
+        chosen = sorted(
+            int(s) for s in self._audit_rng.choice(np.array(shard_list, dtype=int), size=n_audit, replace=False)
+        )
+
+        audited: set[int] = set()
+        mismatches: list[SDCAuditReceipt] = []
+        eval_count = 0
+        for shard_id in chosen:
+            live = sorted(w for w in self._conns if w not in self._blacklist)
+            if len(live) < 2:
+                break
+            owner = next((w for w, sids in self._worker_shards.items() if shard_id in sids and w in live), live[0])
+            others = [w for w in live if w != owner]
+            secondary = others[int(self._audit_rng.randint(len(others)))]
+
+            primary_payload = self._update_shard_on(owner, estimator_b, model_b, shard_id, "primary")
+            audit_payload = self._update_shard_on(secondary, estimator_b, model_b, shard_id, "audit")
+            eval_count += 2
+            audited.add(shard_id)
+
+            if primary_payload != audit_payload:
+                receipt = _receipt(self._round, shard_id, owner, secondary, primary_payload, audit_payload)
+                mismatches.append(receipt)
+                self.audit_receipts.append(receipt)
+                if quarantine_on_mismatch:
+                    self._quarantine(owner, secondary, shard_id)
+
+        self.last_round_audited_shards = audited
+        self.last_round_audit_mismatches = mismatches
+        self.last_round_audit_eval_count = eval_count
+
+    # -- protocol recognized by mixle.stats dispatch (audit, then delegate to K4) --------------
+
+    def pysp_seq_estimate(self, estimator: Any, prev_estimate: Any) -> Any:
+        self._audit_shards(estimator, prev_estimate, set(self._shard_raw.keys()))
+        return super().pysp_seq_estimate(estimator, prev_estimate)
+
+    def pysp_stream_accumulate(self, estimator: Any, model: Any) -> tuple[float, Any]:
+        self._audit_shards(estimator, model, set(self._shard_raw.keys()))
+        return super().pysp_stream_accumulate(estimator, model)


### PR DESCRIPTION
## Stacked on #160 (resilient-em-backends / K4)

This PR targets `resilient-em-backends`, **not** `main` — it builds directly on K4's retry/rank-blacklisting/checkpointing machinery (PR #160) and should be reviewed/merged after that branch lands.

## What

K5: a continuous silent-data-corruption (SDC) audit layer on top of K4's `ResilientMPEncodedData`.

- **`AuditedMPEncodedData`** (`mixle/utils/parallel/sdc_audit.py`), a subclass of K4's `ResilientMPEncodedData`. Every round, a random `audit_rate` fraction of shards are redundantly recomputed on a *second*, different rank using K4's existing ad hoc `"update_shard"` wire command (the same one `_recover_shard` already uses for failure recovery — no new worker-side machinery). The two `(count, value())` payloads are compared **byte-for-byte**.
- **Why zero false positives holds by construction**: both recomputes start from the identical raw shard bytes, go through the same code path with the same `sub_chunks` (so floating-point summation order is identical), and `seq_update`/`seq_initialize` are pure deterministic functions of (data, weights, model) with no per-rank randomness. Two evaluations of the same pure computation must agree bit-for-bit — there's no tolerance band. See the module docstring for the full argument, verified empirically too (300 clean rounds, 1500 shard audits, 0 mismatches).
- **On mismatch**: both suspect ranks are quarantined via K4's *existing* `_blacklist`/`_retire_worker`/`_migrate_shard_permanently` machinery (reused, not reimplemented), and a structured `SDCAuditReceipt` (shard id, both ranks, byte lengths, sha256s, first differing byte offset) is recorded on `audit_receipts`/`last_round_audit_mismatches`.
- **`finite_guarded_fold`**: a drop-in replacement for K4's `checkpointed_fold` that checks finiteness of the running accumulator immediately after *every* `combine()` call (not just once at the end), so a NaN/Inf is caught at the first combine() boundary where it appears. Plugged in via a small new `_fold_fn` hook added to `ResilientMPEncodedData.__init__`/`_resilient_update_round` (K4's own retry/blacklist logic is untouched). Extends the existing `check_finite` guard from `mixle/models/_neural_serial.py` (recursively, over nested accumulator `value()` structures) rather than reimplementing NaN/Inf detection.
- **`inject_bit_flip`**: a deterministic, reproducible single-bit corruption primitive used by the acceptance tests, plus an `arm_corruption` testing hook (same "observe the wire, mutate deterministically" pattern as K4's `arm_kill`).

## Tests (`mixle/tests/sdc_audit_test.py`, 9 tests, all against a real multiprocessing pool where relevant)

Measured numbers from a real run:

- **Injected bit-flip catch rate** (400 trials, `audit_rate=0.30`, `num_workers=10`): expected `p=0.300`, empirical `0.318`.
- **Cumulative catch rate** (250 sequences, same `p=0.300`) approaches 100% as expected:
  - round 1: empirical 0.320 / theoretical 0.300
  - round 4: empirical 0.816 / theoretical 0.760
  - round 8: empirical 0.952 / theoretical 0.942
- **Overhead scales linearly with `audit_rate`** (60 reps/rate, `num_workers=10`):
  - `audit_rate=0.10`: 0.00051s/round, eval_count=2/round
  - `audit_rate=0.30`: 0.00123s/round, eval_count=6/round
  - `audit_rate=0.60`: 0.00254s/round, eval_count=12/round
  - (eval_count is exactly `2 * round(audit_rate * num_workers)` by construction; wall-clock tracks it linearly, no hidden larger cost)
- **Zero false positives**: 300 clean rounds, 1500 total shard audits, 0 mismatches.
- **NaN/Inf watchdog**: fires at the first offending `combine()` call (verified via a call counter — processes 3 payloads out of 5, not all 5, when payload index 2 is corrupted).

## Test plan

- [x] `mixle/tests/sdc_audit_test.py` — 9/9 passed
- [x] `mixle/tests/resilient_em_test.py` (K4's suite) — 6/6 passed, zero regressions
- [x] `ruff check --fix` / `ruff format` clean