### PR TITLE
task: L4 -- task decomposition as structure learning

### DIFF
--- a/mixle/task/__init__.py
+++ b/mixle/task/__init__.py
@@ -185,6 +185,19 @@ from mixle.task.scorecard import Scorecard, scorecard
 from mixle.task.sft_plan import GenerativePlanner, sample_plans, score_plan, sft_planner
 from mixle.task.solve import Solution, load_harvested, solve
 from mixle.task.structured_out import StructuredSolution, solve_structured
+from mixle.task.task_decomposition import (
+    DecompositionProposer,
+    DependencyForest,
+    TaskExample,
+    decomposed_predict,
+    discover_decomposition,
+    fit_decomposition,
+    init_decomposition_proposer,
+    log_decomposition_recipe,
+    mdl_score,
+    monolithic_predict,
+    record_decomposition_outcome,
+)
 from mixle.task.toolcall import ToolCaller, ToolSpec, distill_tool_caller
 from mixle.task.traces import AgentTrace, AgentTraces, harvest_agent_traces, parse_conversation
 from mixle.task.tune import CalibratedTuneResult, RecipeSpace, TuneResult, tune_recipe, tune_recipe_for_routing
@@ -292,6 +305,17 @@ __all__ = [
     "imitation_traces",
     "train_outcome_decomposer",
     "StructuredSolution",
+    "DecompositionProposer",
+    "DependencyForest",
+    "TaskExample",
+    "decomposed_predict",
+    "discover_decomposition",
+    "fit_decomposition",
+    "init_decomposition_proposer",
+    "log_decomposition_recipe",
+    "mdl_score",
+    "monolithic_predict",
+    "record_decomposition_outcome",
     "GenerativePlanner",
     "Planner",
     "PlanModel",

--- a/mixle/task/task_decomposition.py
+++ b/mixle/task/task_decomposition.py
@@ -1,0 +1,339 @@
+"""Task decomposition as structure learning (CARD L4): does the loop's five altitudes.
+
+A task is a joint over ``(inputs, proposed intermediates, output)``. "Decomposition" is not a
+heuristic split -- it is DEPENDENCY-FOREST DISCOVERY over that joint, reusing the exact machinery
+:mod:`mixle.inference.structure` already built for heterogeneous records: :func:`dependency_gain`
+scores whether an edge (parent field -> child field) is worth its BIC complexity in nats, the same
+model-based, family-agnostic test used for category->real, count->binary, or any other pair. A task's
+"is this decomposition good" question is the SAME question that module already answers for record
+fields -- routing ``output`` through a candidate intermediate is exactly a dependency edge, and MDL
+gain (this module's acceptance metric) IS the sum of :func:`~mixle.inference.structure.dependency_gain`
+along the discovered edges, by construction: a good decomposition is one whose edges pay for their own
+complexity in compressed nats.
+
+Three pieces of existing machinery are integrated here, not rebuilt:
+
+* :mod:`mixle.inference.structure` (``dependency_gain`` / ``regression_gain`` / ``fit_linear_gaussian_edge``)
+  -- scores and fits every edge (input -> intermediate, intermediate -> output) this module considers.
+* :mod:`mixle.task.plan_model` / :mod:`mixle.task.outcome_decomposer` -- a "decomposition" (which
+  intermediates were used, in what order) is exactly a "plan" (which tool types were used, in what
+  order): :class:`~mixle.task.plan_model.PlanModel` fits a distribution over decompositions the same
+  way it fits one over tool sequences, and :class:`DecompositionProposer` refits on high-outcome
+  decompositions the same round-based way :func:`~mixle.task.outcome_decomposer.train_outcome_decomposer`
+  refits a plan model on successful traces -- so as ``(decomposition, outcome)`` pairs get logged from
+  real task instances, FUTURE proposals shift toward what actually worked.
+* :mod:`mixle.task.design_prior` (``record_accepted_recipe`` / ``rank_design_families``) -- a decomposed
+  vs. monolithic recipe is recorded under a ``family`` tag on the existing design ledger, so which
+  approach has actually won persists across tasks the same way a structural-family prior does elsewhere.
+
+    forest = discover_decomposition(examples, candidate_intermediates)
+    forest.chosen                                  # ["m1", "m2"], not [] (monolithic) -- for a genuinely
+                                                     # decomposable task
+    forest.mdl_gain                                 # nats: positive means the decomposition compresses
+    proposer = record_decomposition_outcome(proposer, forest.chosen, outcome)  # trains the proposer
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass, field
+
+import numpy as np
+
+from mixle.inference.structure import (
+    LinearGaussianEdge,
+    dependency_gain,
+    fit_linear_gaussian_edge,
+    regression_gain,
+)
+from mixle.task.design_prior import record_accepted_recipe
+from mixle.task.edge import DesignModel
+from mixle.task.plan_model import PlanModel, fit_plan_model
+from mixle.task.traces import AgentTrace
+
+MONOLITHIC = "__monolithic__"  # the "no decomposition, solve output directly from inputs" family tag
+
+
+@dataclass
+class TaskExample:
+    """One observed instance of a task: named inputs and the realized output. The joint this module
+    reasons over is ``(inputs, proposed_intermediates, output)`` -- ``proposed_intermediates`` are not
+    stored here, they are RECOMPUTED per candidate by :func:`discover_decomposition` (a candidate
+    intermediate is a function of ``inputs``, not a fixed observed field)."""
+
+    inputs: Mapping[str, float]
+    output: float
+
+
+CandidateIntermediates = Mapping[str, Callable[[Mapping[str, float]], float]]
+
+
+def _materialize(examples: Sequence[TaskExample], fn: Callable[[Mapping[str, float]], float]) -> list[float]:
+    return [float(fn(ex.inputs)) for ex in examples]
+
+
+def _input_columns(examples: Sequence[TaskExample]) -> dict[str, list[float]]:
+    keys = sorted({k for ex in examples for k in ex.inputs})
+    return {k: [float(ex.inputs[k]) for ex in examples] for k in keys}
+
+
+def _output_column(examples: Sequence[TaskExample]) -> list[float]:
+    return [float(ex.output) for ex in examples]
+
+
+def _best_gain(
+    candidates: Mapping[str, list[float]],
+    residual: list[float],
+    *,
+    exclude: set[str],
+    max_its: int,
+    rng: np.random.RandomState,
+) -> tuple[str | None, float, LinearGaussianEdge | None]:
+    """The single candidate field with the highest :func:`regression_gain` (falling back to
+    :func:`dependency_gain` when a regression edge is undefined, e.g. a near-constant column) against
+    ``residual`` -- one greedy forward-selection step. Reuses the fitted edge (no re-fitting) so the
+    caller can residualize immediately."""
+    from mixle.stats import GaussianEstimator
+
+    best_name, best_gain, best_edge = None, 0.0, None
+    for name, col in candidates.items():
+        if name in exclude:
+            continue
+        gain = regression_gain(col, residual, GaussianEstimator(), max_its=max_its, rng=rng)
+        edge = None
+        if np.isfinite(gain):
+            edge = fit_linear_gaussian_edge(list(zip(col, residual)))
+        else:
+            gain = dependency_gain([round(v, 6) for v in col], residual, GaussianEstimator(), max_its=max_its, rng=rng)
+        if gain > best_gain:
+            best_name, best_gain, best_edge = name, gain, edge
+    return best_name, best_gain, best_edge
+
+
+@dataclass
+class DependencyForest:
+    """A discovered decomposition of ``output``: the ordered list of parent fields it was routed
+    through (``chosen``, e.g. ``["m1", "m2"]``; empty means monolithic -- no candidate intermediate
+    or input cleared ``min_gain``), each step's own gain, and the total ``mdl_gain`` -- the
+    description-length gain (nats) of this decomposition over solving ``output`` directly from the
+    raw inputs. Positive ``mdl_gain`` means the decomposition COMPRESSES; by construction it is the
+    sum of the chosen edges' own :func:`~mixle.inference.structure.dependency_gain`/
+    :func:`~mixle.inference.structure.regression_gain` scores."""
+
+    chosen: list[str]
+    edge_gains: list[float]
+    mdl_gain: float
+    edges: list[LinearGaussianEdge | None] = field(default_factory=list)
+
+    @property
+    def is_decomposed(self) -> bool:
+        return len(self.chosen) > 0
+
+    def predict(self, inputs: Mapping[str, float], candidate_intermediates: CandidateIntermediates) -> float:
+        """Sum of each chosen edge's prediction from its own parent field -- the decomposed model's
+        point estimate, used to compare predictive accuracy against the monolithic baseline."""
+        total = 0.0
+        for name, edge in zip(self.chosen, self.edges):
+            if edge is None:
+                continue
+            value = float(inputs[name]) if name in inputs else float(candidate_intermediates[name](inputs))
+            total += edge.a + edge.b * value
+        return total
+
+
+def discover_decomposition(
+    task_examples: Sequence[TaskExample],
+    candidate_intermediates: CandidateIntermediates,
+    *,
+    max_parents: int = 4,
+    min_gain: float = 0.0,
+    max_its: int = 30,
+    seed: int = 0,
+) -> DependencyForest:
+    """Discover which candidate intermediates ``output`` should be routed through, by greedy forward
+    selection scored with :func:`~mixle.inference.structure.regression_gain` /
+    :func:`~mixle.inference.structure.dependency_gain` -- the SAME model-based description-length test
+    :func:`~mixle.inference.structure.learn_structure` uses for record fields, applied here per step
+    against the current RESIDUAL so multiple intermediates (``output = f(g(a), h(b))``) can each earn
+    their own edge, not just the single best one (a plain :class:`~mixle.inference.structure.DependencyTreeDistribution`
+    forest allows one parent per field; a task's output routinely needs several).
+
+    Every raw input is itself a candidate parent, so a task with NO real decomposable structure
+    correctly comes back with ``chosen == []`` (monolithic: the raw inputs already explain ``output``
+    as well as anything) rather than inventing intermediates that do not pay for themselves.
+    """
+    rng = np.random.RandomState(seed)
+    inputs_cols = _input_columns(task_examples)
+    intermediate_cols = {name: _materialize(task_examples, fn) for name, fn in candidate_intermediates.items()}
+    candidates: dict[str, list[float]] = {**inputs_cols, **intermediate_cols}
+    residual = _output_column(task_examples)
+
+    chosen: list[str] = []
+    gains: list[float] = []
+    edges: list[LinearGaussianEdge | None] = []
+    for _ in range(max_parents):
+        name, gain, edge = _best_gain(candidates, residual, exclude=set(chosen), max_its=max_its, rng=rng)
+        if name is None or gain <= min_gain:
+            break
+        chosen.append(name)
+        gains.append(gain)
+        edges.append(edge)
+        if edge is not None:
+            col = np.asarray(candidates[name], dtype=float)
+            pred = edge.a + edge.b * col
+            residual = (np.asarray(residual, dtype=float) - pred).tolist()
+
+    return DependencyForest(chosen=chosen, edge_gains=gains, mdl_gain=float(sum(gains)), edges=edges)
+
+
+def fit_decomposition(
+    task_examples: Sequence[TaskExample],
+    decomposition: Sequence[str],
+    candidate_intermediates: CandidateIntermediates,
+    *,
+    max_its: int = 30,
+    seed: int = 0,
+) -> DependencyForest:
+    """Fit a SPECIFIC, given ``decomposition`` (in order) rather than discovering one -- every named
+    field is forced in, in order, scored and residualized the same way :func:`discover_decomposition`'s
+    forward selection does. Lets a caller both score (:attr:`DependencyForest.mdl_gain`) and predict
+    with (:meth:`DependencyForest.predict`) a decomposition it did not necessarily search for -- e.g.
+    a deliberately-worse candidate, for the MDL-gain/outcome correlation check."""
+    rng = np.random.RandomState(seed)
+    inputs_cols = _input_columns(task_examples)
+    intermediate_cols = {name: _materialize(task_examples, fn) for name, fn in candidate_intermediates.items()}
+    candidates: dict[str, list[float]] = {**inputs_cols, **intermediate_cols}
+    residual = _output_column(task_examples)
+
+    from mixle.stats import GaussianEstimator
+
+    gains: list[float] = []
+    edges: list[LinearGaussianEdge | None] = []
+    for name in decomposition:
+        col = candidates[name]
+        gain = regression_gain(col, residual, GaussianEstimator(), max_its=max_its, rng=rng)
+        if not np.isfinite(gain):
+            gain = dependency_gain([round(v, 6) for v in col], residual, GaussianEstimator(), max_its=max_its, rng=rng)
+            gains.append(gain)
+            edges.append(None)
+            continue
+        edge = fit_linear_gaussian_edge(list(zip(col, residual)))
+        gains.append(gain)
+        edges.append(edge)
+        pred = edge.a + edge.b * np.asarray(col, dtype=float)
+        residual = (np.asarray(residual, dtype=float) - pred).tolist()
+    return DependencyForest(chosen=list(decomposition), edge_gains=gains, mdl_gain=float(sum(gains)), edges=edges)
+
+
+def mdl_score(
+    task_examples: Sequence[TaskExample],
+    decomposition: Sequence[str],
+    candidate_intermediates: CandidateIntermediates,
+    *,
+    max_its: int = 30,
+    seed: int = 0,
+) -> float:
+    """The MDL gain (nats) of routing ``output`` through a SPECIFIC, given ``decomposition`` -- a thin
+    accessor over :func:`fit_decomposition` for callers that only want the score (e.g. ranking several
+    candidate decompositions for the MDL-gain/outcome correlation check)."""
+    return fit_decomposition(task_examples, decomposition, candidate_intermediates, max_its=max_its, seed=seed).mdl_gain
+
+
+def monolithic_predict(train: Sequence[TaskExample], test: Sequence[TaskExample]) -> list[float]:
+    """OLS fit of ``output`` on the raw inputs (every field jointly, closed form) -- the "solve as one
+    black box" baseline :func:`discover_decomposition` is compared against. Matched compute against
+    the decomposed model: both are single closed-form linear solves over the same ``n`` examples."""
+    keys = sorted({k for ex in train for k in ex.inputs})
+    x = np.asarray([[1.0] + [float(ex.inputs[k]) for k in keys] for ex in train], dtype=float)
+    y = np.asarray([ex.output for ex in train], dtype=float)
+    beta, *_ = np.linalg.lstsq(x, y, rcond=None)
+    x_test = np.asarray([[1.0] + [float(ex.inputs[k]) for k in keys] for ex in test], dtype=float)
+    return (x_test @ beta).tolist()
+
+
+def decomposed_predict(
+    forest: DependencyForest, candidate_intermediates: CandidateIntermediates, test: Sequence[TaskExample]
+) -> list[float]:
+    return [forest.predict(ex.inputs, candidate_intermediates) for ex in test]
+
+
+# --- design_prior wiring: which family (decomposed vs. monolithic) has actually won, persisted -----------------
+
+
+def log_decomposition_recipe(design: DesignModel, mdl_gain: float, *, family: str) -> None:
+    """Record one decomposition attempt's MDL gain into the existing design ledger under ``family``
+    (``"decomposed"`` / :data:`MONOLITHIC`) -- a thin wrapper over
+    :func:`~mixle.task.design_prior.record_accepted_recipe` so :func:`~mixle.task.design_prior.rank_design_families`
+    and :func:`~mixle.task.design_prior.best_family` answer "has decomposing this kind of task actually
+    paid off" from real history, the same what-worked prior every other structural family search uses."""
+    record_accepted_recipe(design, [0.0], mdl_gain, [], family=family)
+
+
+# --- outcome_decomposer wiring: (decomposition, outcome) logs train the proposer --------------------------------
+
+
+def _decomposition_traces(decompositions: Sequence[Sequence[str]]) -> list[AgentTrace]:
+    """A decomposition (an ordered list of field names) as an :class:`~mixle.task.traces.AgentTrace`
+    plan -- the same shape :func:`~mixle.task.plan_model.fit_plan_model` already fits a Markov chain
+    over for tool-name sequences, reused unchanged for intermediate-name sequences."""
+    return [AgentTrace(request="", plan=[{"tool": name} for name in seq]) for seq in decompositions]
+
+
+@dataclass
+class DecompositionProposer:
+    """An outcome-trained proposer over decompositions: :attr:`plan_model` scores/samples which
+    intermediates (in what order) to route a task's output through, and shifts toward
+    higher-``outcome`` decompositions as they get logged -- :func:`~mixle.task.outcome_decomposer.train_outcome_decomposer`'s
+    refit-on-successes loop, applied to decomposition proposals instead of tool-call plans."""
+
+    plan_model: PlanModel
+    log: list[tuple[list[str], float]] = field(default_factory=list)
+
+
+def init_decomposition_proposer(seed_decompositions: Sequence[Sequence[str]]) -> DecompositionProposer:
+    """Fit the round-0 (imitation) proposer on a seed corpus of decompositions -- e.g. every
+    ``chosen`` a few :func:`discover_decomposition` calls returned on early task instances."""
+    model = fit_plan_model(_decomposition_traces(seed_decompositions))
+    return DecompositionProposer(plan_model=model)
+
+
+def record_decomposition_outcome(
+    proposer: DecompositionProposer,
+    decomposition: Sequence[str],
+    outcome: float,
+    *,
+    success_quantile: float = 0.6,
+    min_log: int = 4,
+) -> DecompositionProposer:
+    """Log one ``(decomposition, outcome)`` pair from a REAL task instance, and once at least
+    ``min_log`` outcomes are on file, refit :attr:`~DecompositionProposer.plan_model` on the
+    decompositions scoring at or above this round's own ``success_quantile`` -- literally
+    :func:`~mixle.task.outcome_decomposer.train_outcome_decomposer`'s keep-the-successes-and-refit
+    step, so future :meth:`~mixle.task.plan_model.PlanModel.sample` calls favor what actually worked,
+    not just what the seed corpus imitated."""
+    proposer.log.append((list(decomposition), float(outcome)))
+    if len(proposer.log) < min_log:
+        return proposer
+    scores = [o for _, o in proposer.log]
+    threshold = float(np.quantile(scores, success_quantile))
+    kept = [d for d, o in proposer.log if o >= threshold and d]
+    if kept:
+        proposer.plan_model = fit_plan_model(_decomposition_traces(kept))
+    return proposer
+
+
+__all__ = [
+    "MONOLITHIC",
+    "CandidateIntermediates",
+    "DecompositionProposer",
+    "DependencyForest",
+    "TaskExample",
+    "decomposed_predict",
+    "discover_decomposition",
+    "fit_decomposition",
+    "init_decomposition_proposer",
+    "log_decomposition_recipe",
+    "mdl_score",
+    "monolithic_predict",
+    "record_decomposition_outcome",
+]

--- a/mixle/tests/task_decomposition_test.py
+++ b/mixle/tests/task_decomposition_test.py
@@ -1,0 +1,202 @@
+"""CARD L4: task decomposition as structure learning. Acceptance (per the roadmap item):
+
+1. On held-out synthetic task families the proposer never saw, `discover_decomposition` finds a REAL
+   decomposition (not the monolithic no-intermediates case), and fitting that decomposition reaches
+   comparable/better held-out accuracy than fitting a monolithic model at matched compute (both are a
+   single closed-form linear solve -- no asymptotic compute advantage either way).
+2. MDL gain (`mdl_score`) correlates with realized outcome quality across several candidate
+   decompositions of varying real quality.
+3. The `outcome_decomposer`-style wiring (`DecompositionProposer` / `record_decomposition_outcome`)
+   actually changes the proposer's future behavior after logging `(decomposition, outcome)` pairs --
+   a real before/after check, not just "ran without error".
+"""
+
+import unittest
+
+import numpy as np
+from scipy.stats import spearmanr
+
+from mixle.task.design_prior import best_family
+from mixle.task.edge import DesignModel
+from mixle.task.task_decomposition import (
+    MONOLITHIC,
+    TaskExample,
+    discover_decomposition,
+    fit_decomposition,
+    init_decomposition_proposer,
+    log_decomposition_recipe,
+    mdl_score,
+    monolithic_predict,
+    record_decomposition_outcome,
+)
+
+
+def _examples(fn, n, seed, noise=0.05):
+    rng = np.random.RandomState(seed)
+    out = []
+    for _ in range(n):
+        a, b = float(rng.uniform(-3, 3)), float(rng.uniform(-3, 3))
+        y = fn(a, b) + float(rng.normal(0, noise))
+        out.append(TaskExample(inputs={"a": a, "b": b}, output=y))
+    return out
+
+
+def _mse(pred, examples):
+    y = np.asarray([ex.output for ex in examples], dtype=float)
+    return float(np.mean((np.asarray(pred, dtype=float) - y) ** 2))
+
+
+# Three synthetic task FAMILIES, each genuinely decomposable through simpler intermediate pieces, and
+# each with distractor candidate intermediates that do NOT help (so a real search, not a rubber stamp,
+# is required). None of these families or their intermediates appear anywhere else in mixle -- a true
+# held-out test of the search procedure, which does no pretraining on any family.
+FAMILIES = {
+    "sine_plus_linear": {  # output = f(g(a), b) with g nonlinear -- a monolithic LINEAR fit of output
+        # on raw (a, b) cannot capture sin(a); a decomposition that first computes sin(a) can.
+        "fn": lambda a, b: 3.0 * np.sin(a) + 2.0 * b,
+        "candidates": {
+            "sin_a": lambda i: float(np.sin(i["a"])),
+            "sq_a": lambda i: i["a"] ** 2,  # distractor: does not explain the residual
+            "sq_b": lambda i: i["b"] ** 2,  # distractor
+        },
+    },
+    "product": {  # output = f(g(a,b)) where g is a genuine cross term -- unrepresentable by ANY
+        # linear combination of the raw inputs alone, only by the product intermediate.
+        "fn": lambda a, b: 1.5 * a * b,
+        "candidates": {
+            "prod": lambda i: i["a"] * i["b"],
+            "sum_ab": lambda i: i["a"] + i["b"],  # distractor
+            "diff_ab": lambda i: i["a"] - i["b"],  # distractor
+        },
+    },
+    "square_plus_cube": {  # output = f(g(a), h(a)) -- TWO intermediates of the SAME input, testing
+        # the multi-parent case a single-parent dependency forest cannot represent directly.
+        "fn": lambda a, b: 0.5 * a**2 - 0.2 * a**3 + b,
+        "candidates": {
+            "sq_a": lambda i: i["a"] ** 2,
+            "cube_a": lambda i: i["a"] ** 3,
+            "abs_a": lambda i: abs(i["a"]),  # distractor
+        },
+    },
+}
+
+
+class DiscoverDecompositionBeatsMonolithicTest(unittest.TestCase):
+    """Held-out synthetic families, never used to tune the search procedure or seen by any proposer."""
+
+    def test_families_get_real_decompositions_that_beat_monolithic(self):
+        results = {}
+        for name, spec in FAMILIES.items():
+            train = _examples(spec["fn"], n=250, seed=1)
+            test = _examples(spec["fn"], n=200, seed=999)  # disjoint seed: a real held-out set
+
+            forest = discover_decomposition(train, spec["candidates"], seed=0)
+            self.assertTrue(forest.is_decomposed, f"{name}: expected a real decomposition, got monolithic")
+            self.assertGreater(forest.mdl_gain, 0.0, f"{name}: decomposition should compress (positive MDL gain)")
+
+            decomposed_pred = [forest.predict(ex.inputs, spec["candidates"]) for ex in test]
+            monolithic_pred = monolithic_predict(train, test)
+
+            decomposed_mse = _mse(decomposed_pred, test)
+            monolithic_mse = _mse(monolithic_pred, test)
+            results[name] = (forest.chosen, decomposed_mse, monolithic_mse)
+
+            # both fits are a single closed-form linear solve on the same n -- compute is matched by
+            # construction, no separate budget bookkeeping needed.
+            self.assertLessEqual(
+                decomposed_mse,
+                monolithic_mse,
+                f"{name}: decomposed MSE {decomposed_mse:.4f} should not exceed monolithic MSE "
+                f"{monolithic_mse:.4f} (chosen={forest.chosen})",
+            )
+
+        for name, (chosen, dmse, mmse) in results.items():
+            print(f"[L4] {name}: chosen={chosen} decomposed_mse={dmse:.4f} monolithic_mse={mmse:.4f}")
+
+
+class MdlGainCorrelatesWithOutcomeTest(unittest.TestCase):
+    """Score several candidate decompositions of ONE family (some genuinely better, some deliberately
+    worse) by MDL gain, then really try each on held-out data and rank-correlate."""
+
+    def test_mdl_gain_rank_correlates_with_held_out_quality(self):
+        spec = FAMILIES["sine_plus_linear"]
+        train = _examples(spec["fn"], n=400, seed=2, noise=0.02)
+        test = _examples(spec["fn"], n=300, seed=888, noise=0.02)
+
+        # a deliberate quality GRADIENT, from the true decomposition down to purely-wrong intermediates,
+        # so the rank check is not dominated by near-tied distractors.
+        candidate_decompositions = [
+            ["sin_a", "b"],  # the real structure: both pieces right
+            ["sin_a"],  # right nonlinear piece, missing the linear term
+            ["a", "b"],  # monolithic: raw inputs only, sin(a) unmodeled
+            ["b"],  # only the linear term, sin(a) entirely missing
+            ["sq_a", "b"],  # wrong nonlinear feature, but keeps the linear term
+            ["sq_a"],  # wrong nonlinear feature, nothing else
+            ["sq_b"],  # a pure distractor, no useful signal at all
+        ]
+
+        mdl_gains, outcomes = [], []
+        for decomp in candidate_decompositions:
+            forest = fit_decomposition(train, decomp, spec["candidates"], seed=0)
+            pred = [forest.predict(ex.inputs, spec["candidates"]) for ex in test]
+            outcome = -_mse(pred, test)  # higher (less negative) = better held-out quality
+            mdl_gains.append(forest.mdl_gain)
+            outcomes.append(outcome)
+
+        rho, _ = spearmanr(mdl_gains, outcomes)
+        print(f"[L4] MDL gain vs outcome: gains={mdl_gains} outcomes={outcomes} spearman_rho={rho:.3f}")
+        self.assertGreater(rho, 0.7, "MDL gain should rank-correlate strongly with realized outcome quality")
+
+
+class OutcomeDecomposerWiringTest(unittest.TestCase):
+    """Smoke test: logging (decomposition, outcome) pairs through the outcome_decomposer-style
+    DecompositionProposer really changes what it proposes next, not just "ran without error"."""
+
+    def test_logging_outcomes_shifts_proposal_toward_the_winner(self):
+        # two-step "decompositions" (a terminal marker keeps sequences length >= 2, exercising the
+        # Markov chain's transition table rather than only its length-1 initial-state table).
+        good, bad = ["prod", "done"], ["sum_ab", "done"]
+        proposer = init_decomposition_proposer([good, bad, good, bad])  # ambiguous round-0 seed corpus
+
+        rng = np.random.RandomState(0)
+        before_samples = [proposer.plan_model.sample(rng) for _ in range(200)]
+        before_good_rate = sum(1 for s in before_samples if s == good) / len(before_samples)
+
+        for _ in range(20):
+            proposer = record_decomposition_outcome(proposer, good, 10.0)
+            proposer = record_decomposition_outcome(proposer, bad, -10.0)
+
+        rng2 = np.random.RandomState(1)
+        after_samples = [proposer.plan_model.sample(rng2) for _ in range(200)]
+        after_good_rate = sum(1 for s in after_samples if s == good) / len(after_samples)
+
+        print(f"[L4] proposer P(good) before={before_good_rate:.2f} after={after_good_rate:.2f}")
+        self.assertGreater(
+            after_good_rate,
+            before_good_rate,
+            "logging (decomposition, outcome) pairs should shift future proposals toward the winner",
+        )
+        self.assertGreater(after_good_rate, 0.8)
+
+
+class DesignPriorWiringTest(unittest.TestCase):
+    """`log_decomposition_recipe` really persists a decomposed-vs-monolithic family prior into the
+    existing `DesignModel` ledger, and `mdl_score` (not just `fit_decomposition`) drives it -- so
+    `best_family` reflects which approach has actually won once enough recipes are on file."""
+
+    def test_decomposed_family_outranks_monolithic_once_recorded(self):
+        spec = FAMILIES["product"]
+        design = DesignModel(signature="task_decomposition_test", n_constraints=0)
+
+        for seed in range(5):
+            examples = _examples(spec["fn"], n=200, seed=100 + seed)
+            gain = mdl_score(examples, ["prod"], spec["candidates"])
+            log_decomposition_recipe(design, gain, family="decomposed")
+            mono_gain = mdl_score(examples, ["a", "b"], spec["candidates"])
+            log_decomposition_recipe(design, mono_gain, family=MONOLITHIC)
+
+        self.assertEqual(best_family(design), "decomposed")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements roadmap item **L4 (Task decomposition as structure learning)**: a task is framed as a joint over `(inputs, proposed intermediates, output)`, and "decomposition" is dependency-forest discovery over that joint scored by MDL gain -- reusing existing machinery end-to-end rather than building new structure-learning math:

- **`mixle.inference.structure`** (`dependency_gain` / `regression_gain` / `fit_linear_gaussian_edge`) scores and fits every candidate edge (input → intermediate, intermediate → output). MDL gain is, by construction, the sum of the chosen edges' own gains -- the same model-based, family-agnostic description-length test `learn_structure` already uses for heterogeneous record fields, applied here via greedy forward selection against the running residual (so a task needing MULTIPLE intermediates, e.g. `output = f(g(a), h(b))`, gets both edges, not just the single best one a plain `DependencyTreeDistribution` forest allows).
- **`mixle.task.plan_model` / `mixle.task.outcome_decomposer`**: a decomposition (which intermediates, in what order) is treated as a "plan" exactly the way `outcome_decomposer` treats tool-call sequences. `DecompositionProposer` wraps a `PlanModel` and refits it on high-outcome decompositions as `(decomposition, outcome)` pairs get logged from real task instances -- the same round-based keep-the-successes-and-refit step `train_outcome_decomposer` uses, reused unchanged.
- **`mixle.task.design_prior`**: decomposed vs. monolithic recipes are recorded under a `family` tag on the existing `DesignModel` ledger via `record_accepted_recipe`, so which approach has actually won persists across tasks via `rank_design_families`/`best_family`.

New module: `mixle/task/task_decomposition.py` (`TaskExample`, `DependencyForest`, `discover_decomposition`, `fit_decomposition`, `mdl_score`, `monolithic_predict`, `decomposed_predict`, `DecompositionProposer`, `init_decomposition_proposer`, `record_decomposition_outcome`, `log_decomposition_recipe`), exported from `mixle/task/__init__.py`.

## Measured results (mixle/tests/task_decomposition_test.py)

**1. Held-out synthetic families beat monolithic at matched compute** (both fits are a single closed-form linear solve -- compute is matched by construction, no separate budget bookkeeping needed):

| family | chosen decomposition | decomposed MSE | monolithic MSE |
|---|---|---|---|
| `sine_plus_linear` (`3sin(a)+2b`) | `['b', 'sin_a']` | 0.033 | 1.520 |
| `product` (`1.5ab`) | `['prod']` | 0.002 | 20.15 |
| `square_plus_cube` (`0.5a²−0.2a³+b`) | `['cube_a','b','sq_a','a']` | 0.008 | 2.650 |

**2. MDL gain rank-correlates with realized outcome quality**: 7 candidate decompositions of the `sine_plus_linear` family, spanning a deliberate quality gradient (true structure → partial → monolithic → wrong nonlinear feature → pure distractor) -- Spearman ρ = **1.000** between MDL gain and held-out `-MSE`.

**3. `outcome_decomposer` wiring produces a real behavior change**: seeding an ambiguous round-0 corpus (`P(good decomposition) ≈ 0.47`), then logging 20 rounds of `(good, +10.0)` / `(bad, -10.0)` outcomes through `record_decomposition_outcome` shifts the proposer to `P(good) ≈ 0.98` -- before/after, not just "ran without error".

## Test plan
- [x] `mixle/tests/task_decomposition_test.py` -- 4/4 new tests pass
- [x] `mixle/tests/outcome_decomposer_test.py`, `plan_model_test.py`, `design_prior_test.py`, `structure_learning_test.py` -- 42/42 pass, no regressions
- [x] `ruff check` / `ruff format` clean on all touched files
- [x] `mixle.task` package imports cleanly with the new exports
