### PR TITLE
L3: Zero-shot modality bootstrap (resonance embedding + fit-health gate)

### DIFF
--- a/mixle/reason/zero_shot_bootstrap.py
+++ b/mixle/reason/zero_shot_bootstrap.py
@@ -1,0 +1,518 @@
+"""Zero-shot modality bootstrap (workstream L3): a brand-new data type joins a cross-modal joint
+with NO retraining of anything already fitted.
+
+Three pieces, in dependency order:
+
+1. :func:`induce_leaf_for_unseen_type` extends the automatic profiler (``mixle.utils.automatic``,
+   see B-series work) with a real fallback chain for a genuinely unrecognized data type: try the
+   profiler's own classical-family induction first (it already covers numeric/categorical/
+   embedding/image/sequence shapes); if that abstains (``IgnoredDistribution``), fall back to
+   classical (Gaussian/MVN) for simple numeric payloads, a generic GradLeaf-wrapped neural density
+   for complex/high-dimensional numeric payloads, or a graph model / sequence model when the data
+   carries that structure.
+
+2. :func:`resonance_embedding` scores a brand-new-modality sample against an existing, already-
+   fitted model zoo -- one generic "typicality" coordinate per zoo model, read off each model's own
+   capability surface (:mod:`mixle.capability`'s ``HasCDF``/``HasMoments``): where does a generic
+   scalar reduction of the new sample fall relative to THIS model's own typical range? Evaluation
+   only -- no gradient steps, no fitting -- hence "zero training."
+
+3. :func:`resonance_adequacy_gate` reuses the separation statistic behind
+   :func:`mixle.utils.hvis.topology.model_fit_health`'s merged-regime detector (a deterministic
+   2-means-style projected separation ratio, thresholded at the same measured finite-sample
+   correction ``2.65 + 6/sqrt(n)``) to decide: is the resonance embedding's class separation good
+   enough to use as a lightweight, training-free proxy representation, or should the modality
+   GRADUATE to a real native leaf (piece 1)?
+
+:func:`add_modality_to_joint` plugs a new per-regime leaf (a native induced leaf, or a lightweight
+fit over resonance coordinates) into an existing :class:`~mixle.reason.cross_modal.CrossModalJoint`
+by rebuilding each regime's :class:`~mixle.stats.combinator.composite.CompositeDistribution` with
+the OLD per-modality distributions reused BY REFERENCE (never refit, never copied) plus the one new
+field -- so every other modality's fitted parameters are bitwise identical before and after.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+from typing import Any
+
+import numpy as np
+
+from mixle.capability import HasCDF, HasMoments, supports
+from mixle.reason.cross_modal import CrossModalJoint
+from mixle.stats.combinator.composite import CompositeDistribution
+from mixle.stats.compute.pdist import SequenceEncodableProbabilityDistribution
+from mixle.stats.latent.mixture import MixtureDistribution
+
+__all__ = [
+    "induce_leaf_for_unseen_type",
+    "resonance_embedding",
+    "resonance_adequacy_gate",
+    "add_modality_to_joint",
+    "fit_resonance_leaves",
+]
+
+
+# ---------------------------------------------------------------------------------------------
+# 1. Automatic-profiler extension: classical -> neural -> sequence/graph fallback chain.
+# ---------------------------------------------------------------------------------------------
+
+_EMBEDDING_MIN_DIM = 16
+
+
+def induce_leaf_for_unseen_type(
+    samples: Sequence[Any],
+    *,
+    rng: np.random.RandomState | None = None,
+    max_its: int = 30,
+) -> SequenceEncodableProbabilityDistribution:
+    """Induce and FIT a reasonable leaf distribution for ``samples`` of a data type the caller has
+    never modeled before.
+
+    Tries, in order: (a) the existing automatic profiler's own structural induction (numeric,
+    categorical, embedding, image, sequence -- whatever it already recognizes); (b) for data the
+    profiler abstains on (``IgnoredDistribution``: e.g. arbitrary Python objects with no scalar or
+    container structure it parses), a classical family (Gaussian / multivariate Gaussian) when a
+    numeric feature vector can be extracted and is low/moderate-dimensional; (c) a generic
+    GradLeaf-wrapped neural density when the extracted numeric payload is high-dimensional; (d) a
+    graph model when samples carry adjacency/graph structure; (e) a sequence model when samples are
+    variable-length collections of otherwise-inducible elements.
+    """
+    rows = list(samples)
+    if len(rows) == 0:
+        raise ValueError("induce_leaf_for_unseen_type requires at least one sample")
+
+    leaf = _try_automatic_profiler(rows, rng=rng, max_its=max_its)
+    if leaf is not None:
+        return leaf
+
+    numeric = _coerce_numeric_matrix(rows)
+    if numeric is not None:
+        return _fit_numeric_fallback(numeric, rng=rng, max_its=max_its)
+
+    graph_rows = _coerce_graph_rows(rows)
+    if graph_rows is not None:
+        return _fit_graph_fallback(graph_rows, max_its=max_its)
+
+    sequence_elems = _coerce_sequence_elements(rows)
+    if sequence_elems is not None:
+        return _fit_sequence_fallback(rows, sequence_elems, rng=rng, max_its=max_its)
+
+    raise TypeError(
+        "induce_leaf_for_unseen_type: samples are neither profiler-recognized, numeric-coercible, "
+        "graph-structured, nor sequence-structured -- no fallback family applies"
+    )
+
+
+def _try_automatic_profiler(rows, *, rng, max_its):
+    from mixle.inference.estimation import optimize
+    from mixle.stats.combinator.ignored import IgnoredDistribution
+    from mixle.utils.automatic.profiling import get_prototype
+
+    try:
+        prototype = get_prototype(rows, seed=0)
+        fitted = optimize(rows, prototype, max_its=max_its, rng=rng)
+    except Exception:
+        return None
+    if isinstance(fitted, IgnoredDistribution):
+        return None
+    return fitted
+
+
+def _extract_numeric_vector(sample: Any) -> np.ndarray | None:
+    if isinstance(sample, (bool, np.bool_)):
+        return None
+    if isinstance(sample, (int, float, np.integer, np.floating)):
+        return np.asarray([float(sample)])
+    if isinstance(sample, np.ndarray):
+        try:
+            return sample.astype(float).ravel()
+        except (TypeError, ValueError):
+            return None
+    if isinstance(sample, (list, tuple)):
+        try:
+            return np.asarray(sample, dtype=float).ravel()
+        except (TypeError, ValueError):
+            return None
+    # A generic object carrying its numeric payload under a common attribute name.
+    for attr in ("vector", "vec", "embedding", "features", "values", "array", "x"):
+        val = getattr(sample, attr, None)
+        if val is None:
+            continue
+        try:
+            return np.asarray(val, dtype=float).ravel()
+        except (TypeError, ValueError):
+            continue
+    return None
+
+
+def _coerce_numeric_matrix(rows: Sequence[Any]) -> np.ndarray | None:
+    vectors = []
+    for row in rows:
+        vec = _extract_numeric_vector(row)
+        if vec is None or vec.size == 0 or not np.all(np.isfinite(vec)):
+            return None
+        vectors.append(vec)
+    dims = {v.size for v in vectors}
+    if len(dims) != 1:
+        return None
+    return np.stack(vectors, axis=0)
+
+
+def _fit_numeric_fallback(arr: np.ndarray, *, rng, max_its):
+    from mixle.inference.estimation import optimize
+    from mixle.utils.automatic.factories import _has_torch
+
+    n, dim = arr.shape
+    if dim == 1:
+        from mixle.stats.univariate.continuous.gaussian import GaussianEstimator
+
+        data = [float(v) for v in arr[:, 0]]
+        return optimize(data, GaussianEstimator(), max_its=max_its, rng=rng)
+
+    if dim < _EMBEDDING_MIN_DIM or not _has_torch():
+        from mixle.stats.multivariate.multivariate_gaussian import MultivariateGaussianEstimator
+
+        data = [tuple(float(v) for v in row) for row in arr]
+        return optimize(data, MultivariateGaussianEstimator(dim=dim), max_its=max_its, rng=rng)
+
+    # complex / high-dimensional numeric payload with no closed-form fingerprint the profiler
+    # already knows: fall back to a generic GradLeaf-wrapped neural density (evaluation-only
+    # scoring, fit by gradient ascent -- see mixle.models.grad_leaf).
+    return _fit_generic_grad_density(arr, max_its=max_its)
+
+
+class _GenericDensityModule:
+    """A small learnable diagonal-Gaussian-mixture density -- the generic neural-density fallback
+    for a numeric modality with no other recognized fingerprint. Built lazily so this module never
+    imports torch at import time (GradLeaf/torch is an optional dependency)."""
+
+    def __new__(cls, dim: int, n_components: int = 2):
+        import torch
+        from torch import nn
+
+        class _Module(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.dim = dim
+                self.means = nn.Parameter(torch.randn(n_components, dim) * 0.1)
+                self.log_vars = nn.Parameter(torch.zeros(n_components, dim))
+                self.logits = nn.Parameter(torch.zeros(n_components))
+
+            def log_density(self, x: Any) -> Any:
+                var = torch.exp(self.log_vars)
+                diff = x.unsqueeze(1) - self.means.unsqueeze(0)
+                comp_ll = -0.5 * (
+                    diff**2 / var.unsqueeze(0) + self.log_vars.unsqueeze(0) + math.log(2.0 * math.pi)
+                ).sum(-1)
+                log_w = torch.log_softmax(self.logits, dim=0)
+                return torch.logsumexp(comp_ll + log_w.unsqueeze(0), dim=1)
+
+            def sample(self, n: int) -> Any:
+                w = torch.softmax(self.logits, dim=0)
+                idx = torch.multinomial(w, n, replacement=True)
+                std = torch.exp(0.5 * self.log_vars[idx])
+                eps = torch.randn(n, self.dim)
+                return self.means[idx] + eps * std
+
+        return _Module()
+
+
+def _fit_generic_grad_density(arr: np.ndarray, *, max_its: int, n_components: int = 2):
+    from mixle.inference.estimation import optimize
+    from mixle.models.grad_leaf import GradEstimator
+
+    dim = arr.shape[1]
+    module = _GenericDensityModule(dim, n_components=n_components)
+    estimator = GradEstimator(module, m_steps=max(60, int(max_its) * 10))
+    data = [tuple(float(v) for v in row) for row in arr]
+    return optimize(data, estimator, max_its=1)
+
+
+def _extract_adjacency(sample: Any) -> Any | None:
+    if hasattr(sample, "nodes") and hasattr(sample, "edges") and not isinstance(sample, np.ndarray):
+        return sample  # networkx-like; the graph encoder handles this shape directly.
+    arr = None
+    for attr in ("adjacency", "adjacency_matrix", "matrix", "graph"):
+        val = getattr(sample, attr, None)
+        if val is not None:
+            try:
+                arr = np.asarray(val, dtype=float)
+            except (TypeError, ValueError):
+                arr = None
+            break
+    if arr is None and isinstance(sample, np.ndarray):
+        arr = sample
+    if arr is None and isinstance(sample, (list, tuple)):
+        try:
+            arr = np.asarray(sample, dtype=float)
+        except (TypeError, ValueError):
+            arr = None
+    if arr is not None and arr.ndim == 2 and arr.shape[0] == arr.shape[1] and arr.shape[0] >= 2:
+        return arr
+    return None
+
+
+def _coerce_graph_rows(rows: Sequence[Any]) -> list[Any] | None:
+    out = []
+    for row in rows:
+        adj = _extract_adjacency(row)
+        if adj is None:
+            return None
+        out.append(adj)
+    return out
+
+
+def _fit_graph_fallback(graph_rows: list[Any], *, max_its: int):
+    from mixle.inference.estimation import optimize
+    from mixle.stats.graphs.erdos_renyi_graph import ErdosRenyiGraphEstimator
+
+    return optimize(graph_rows, ErdosRenyiGraphEstimator(), max_its=max_its)
+
+
+def _coerce_sequence_elements(rows: Sequence[Any]) -> list[Any] | None:
+    """A variable-length (or genuinely heterogeneous) collection of elements the profiler could not
+    place; flatten to the pooled element stream so the caller can induce a leaf for the element type
+    and wrap it as a sequence."""
+    elems: list[Any] = []
+    saw_iterable = False
+    for row in rows:
+        if isinstance(row, (str, bytes, dict, set, frozenset, np.ndarray)) or not hasattr(row, "__iter__"):
+            return None
+        items = list(row)
+        if len(items) == 0:
+            continue
+        saw_iterable = True
+        elems.extend(items)
+    if not saw_iterable or not elems:
+        return None
+    return elems
+
+
+def _fit_sequence_fallback(rows, elems, *, rng, max_its):
+    from mixle.inference.estimation import optimize
+    from mixle.utils.automatic.factories import get_sequence_estimator
+
+    child_leaf = induce_leaf_for_unseen_type(elems, rng=rng, max_its=max_its)
+    len_dict: dict[int, int] = {}
+    for row in rows:
+        length = len(list(row))
+        len_dict[length] = len_dict.get(length, 0) + 1
+    seq_est = get_sequence_estimator(child_leaf.estimator(), len_dict=len_dict)
+    return optimize(list(rows), seq_est, max_its=max_its, rng=rng)
+
+
+# ---------------------------------------------------------------------------------------------
+# 2. RESONANCE embedding: evaluation-only typicality coordinates against an existing model zoo.
+# ---------------------------------------------------------------------------------------------
+
+
+def _generic_scalar_reduction(sample: Any) -> float:
+    """A model-agnostic scalar summary of an arbitrary (possibly brand-new-modality) sample: the
+    mean of its extracted numeric payload, or its own hash-derived pseudo-magnitude when no numeric
+    payload can be extracted at all (still deterministic, still comparable across samples)."""
+    vec = _extract_numeric_vector(sample)
+    if vec is not None and vec.size:
+        return float(np.mean(vec))
+    return float(abs(hash(repr(sample))) % 1000) / 1000.0
+
+
+def _model_typicality(model: Any, value: float) -> float:
+    """One generic "how typical does ``value`` look under ``model``'s own typical range" feature,
+    read off ``model`` purely by evaluation (its closed-form CDF/moments) -- no fitting, no
+    gradients. Returns 0.0 for a value squarely at the model's center and approaches 1.0 the more
+    atypical/extreme the value looks under that model's reference scale."""
+    if supports(model, HasCDF):
+        try:
+            u = float(model.cdf(value))
+            if math.isfinite(u):
+                return float(2.0 * abs(min(max(u, 0.0), 1.0) - 0.5))
+        except Exception:
+            pass
+    if supports(model, HasMoments):
+        try:
+            mean = float(model.mean())
+            std = float(model.variance()) ** 0.5
+            z = abs(value - mean) / max(std, 1.0e-9)
+            return float(z / (1.0 + z))
+        except Exception:
+            pass
+    return 0.5
+
+
+def resonance_embedding(
+    new_modality_samples: Sequence[Any],
+    model_zoo: Sequence[SequenceEncodableProbabilityDistribution],
+) -> np.ndarray:
+    """K-dim (K = ``len(model_zoo)``) embedding of each brand-new-modality sample, obtained by
+    EVALUATION ONLY against every existing, already-fitted zoo model (regardless of the modality it
+    was originally fitted to): coordinate ``k`` is how atypical a generic scalar reduction of the
+    sample looks under zoo model ``k``'s own closed-form typical range (its CDF/quantile position, or
+    a moment-normalized z-score when no CDF is exposed). No gradient steps, no fitting -- "zero
+    training."
+    """
+    if len(model_zoo) == 0:
+        raise ValueError("resonance_embedding requires a non-empty model_zoo")
+    rows = []
+    for sample in new_modality_samples:
+        value = _generic_scalar_reduction(sample)
+        rows.append([_model_typicality(model, value) for model in model_zoo])
+    return np.asarray(rows, dtype=float)
+
+
+# ---------------------------------------------------------------------------------------------
+# 3. Fit-health-style adequacy gate: is the resonance embedding good enough, or graduate?
+# ---------------------------------------------------------------------------------------------
+
+
+def _deterministic_two_means_split(proj: np.ndarray) -> np.ndarray:
+    """The same deterministic 2-means procedure (top-PC sign init, Lloyd iterations) used by
+    :func:`mixle.utils.hvis.topology.model_fit_health`'s merged-regime detector."""
+    assign = proj > float(proj.mean())
+    for _ in range(15):
+        if assign.all() or (~assign).all():
+            break
+        c1, c0 = float(proj[assign].mean()), float(proj[~assign].mean())
+        new_assign = np.abs(proj - c1) < np.abs(proj - c0)
+        if bool(np.all(new_assign == assign)):
+            break
+        assign = new_assign
+    return assign
+
+
+def _top_pc_projection(z: np.ndarray) -> np.ndarray:
+    mu = z.mean(axis=0)
+    centered = z - mu
+    if z.shape[1] == 1:
+        return centered[:, 0]
+    cov = centered.T @ centered / max(z.shape[0] - 1, 1) + 1.0e-9 * np.eye(z.shape[1])
+    vals, vecs = np.linalg.eigh(cov)
+    axis = vecs[:, np.argmax(vals)]
+    return centered @ axis
+
+
+def _separation_ratio(proj: np.ndarray, group_a: np.ndarray, group_b: np.ndarray) -> float | None:
+    pa, pb = proj[group_a], proj[group_b]
+    if pa.size < 2 or pb.size < 2:
+        return None
+    within = np.average([pa.var(), pb.var()], weights=[pa.size, pb.size])
+    return float(abs(pa.mean() - pb.mean())) / max(float(np.sqrt(within)), 1.0e-12)
+
+
+def resonance_adequacy_gate(
+    embedding_samples: np.ndarray,
+    labels_or_structure: Sequence[Any] | None = None,
+    *,
+    threshold: float | None = None,
+) -> bool:
+    """Reuse the fit-health merged-regime separation statistic (see
+    :func:`mixle.utils.hvis.topology.model_fit_health`) to decide whether the resonance embedding's
+    class separation is adequate to use as a lightweight, training-free proxy representation
+    indefinitely (``True``), or whether the modality should GRADUATE to a real native leaf
+    (``False``).
+
+    ``labels_or_structure``, when given, is the known class/cluster label per embedding row; the
+    worst (minimum) pairwise separation across classes is compared against the SAME finite-sample
+    threshold ``model_fit_health`` uses for its own merged/unmerged call:
+    ``2.65 + 6/sqrt(n)`` (population value ~2.65 for a unimodal normal, inflated at small n).
+    Without labels, the same deterministic 2-means split ``model_fit_health`` runs internally is used
+    to discover a candidate 2-way structure and test whether IT is well separated.
+    """
+    z = np.atleast_2d(np.asarray(embedding_samples, dtype=float))
+    n = z.shape[0]
+    if n < 4:
+        return False  # too little evidence to trust the proxy -- graduate.
+
+    proj = _top_pc_projection(z)
+    thr = threshold if threshold is not None else 2.65 + 6.0 / math.sqrt(float(n))
+
+    if labels_or_structure is not None:
+        labels = np.asarray(list(labels_or_structure))
+        if labels.shape[0] != n:
+            raise ValueError("labels_or_structure must have one entry per embedding row")
+        uniq = np.unique(labels)
+        if uniq.size < 2:
+            return False
+        seps = []
+        for i, a in enumerate(uniq):
+            for b in uniq[i + 1 :]:
+                sep = _separation_ratio(proj, labels == a, labels == b)
+                if sep is not None:
+                    seps.append(sep)
+        if not seps:
+            return False
+        return min(seps) > thr
+
+    assign = _deterministic_two_means_split(proj)
+    if assign.all() or (~assign).all():
+        return False  # no structure at all was found -- nothing to be confident about.
+    sep = _separation_ratio(proj, assign, ~assign)
+    return sep is not None and sep > thr
+
+
+# ---------------------------------------------------------------------------------------------
+# 4. Integration: add the new modality to a CrossModalJoint without retraining anything else.
+# ---------------------------------------------------------------------------------------------
+
+
+def add_modality_to_joint(
+    joint: CrossModalJoint,
+    name: str,
+    per_regime_leaves: Sequence[SequenceEncodableProbabilityDistribution],
+) -> CrossModalJoint:
+    """Return a NEW :class:`CrossModalJoint` with modality ``name`` added, one leaf per existing
+    regime, WITHOUT touching any other modality's fitted parameters.
+
+    Every existing per-regime :class:`~mixle.stats.combinator.composite.CompositeDistribution` is
+    rebuilt with its OLD field distributions reused by reference (never copied, never refit) plus the
+    one new field appended; the mixture weights are reused unchanged. ``per_regime_leaves`` can be
+    the modality's induced native leaf (see :func:`induce_leaf_for_unseen_type`) replicated across
+    regimes, or per-regime leaves fit only over resonance-embedding coordinates (see
+    :func:`fit_resonance_leaves`) -- either way, this function itself performs no fitting at all.
+    """
+    components = joint.joint.components
+    if len(per_regime_leaves) != len(components):
+        raise ValueError(
+            f"per_regime_leaves must supply one distribution per existing regime "
+            f"({len(components)} regimes), got {len(per_regime_leaves)}"
+        )
+    new_components = [
+        CompositeDistribution(list(component.dists) + [leaf]) for component, leaf in zip(components, per_regime_leaves)
+    ]
+    new_joint = MixtureDistribution(new_components, w=joint.joint.w.copy())
+    return CrossModalJoint(names=joint.names + (name,), joint=new_joint)
+
+
+def fit_resonance_leaves(
+    resonance_embeddings: np.ndarray,
+    regime_labels: Sequence[int],
+    num_regimes: int,
+) -> list[SequenceEncodableProbabilityDistribution]:
+    """Fit one lightweight per-regime leaf directly over the K-dim resonance-embedding coordinates
+    (a closed-form multivariate Gaussian, or a univariate Gaussian when K == 1), using known/assigned
+    regime labels for the new-modality samples.
+
+    This fit touches ONLY the new modality's own (yet-to-exist) leaf -- it never reads or writes any
+    other modality's parameters, so combining its output with :func:`add_modality_to_joint` cannot
+    retrain the rest of the joint.
+    """
+    from mixle.inference.estimation import optimize
+    from mixle.stats.univariate.continuous.gaussian import GaussianEstimator
+
+    z = np.atleast_2d(np.asarray(resonance_embeddings, dtype=float))
+    labels = np.asarray(list(regime_labels))
+    dim = z.shape[1]
+    leaves: list[SequenceEncodableProbabilityDistribution] = []
+    for k in range(num_regimes):
+        rows = z[labels == k]
+        if rows.shape[0] == 0:
+            rows = z  # no assigned samples for this regime -- fall back to the pooled fit.
+        if dim == 1:
+            leaves.append(optimize([float(v) for v in rows[:, 0]], GaussianEstimator(), max_its=10))
+        else:
+            from mixle.stats.multivariate.multivariate_gaussian import MultivariateGaussianEstimator
+
+            data = [tuple(float(v) for v in row) for row in rows]
+            leaves.append(optimize(data, MultivariateGaussianEstimator(dim=dim), max_its=10))
+    return leaves

--- a/mixle/tests/zero_shot_bootstrap_test.py
+++ b/mixle/tests/zero_shot_bootstrap_test.py
@@ -1,0 +1,251 @@
+"""Zero-shot modality bootstrap (workstream L3): a brand-new data type joins a cross-modal joint
+with NO retraining of anything already fitted; the RESONANCE embedding separates classes on a
+held-out modality never modeled natively; the fit-health-style gate correctly decides adequate vs
+graduate in both directions.
+"""
+
+import unittest
+
+import numpy as np
+
+from mixle.reason.cross_modal import CrossModalJoint
+from mixle.reason.zero_shot_bootstrap import (
+    add_modality_to_joint,
+    fit_resonance_leaves,
+    induce_leaf_for_unseen_type,
+    resonance_adequacy_gate,
+    resonance_embedding,
+)
+from mixle.stats.univariate.continuous.gaussian import GaussianDistribution
+from mixle.stats.univariate.discrete.categorical import CategoricalDistribution
+
+
+def _two_modality_joint() -> CrossModalJoint:
+    """Same shape as L2's fixture: 2 regimes, image=Gaussian, text=Categorical, already fitted."""
+    return CrossModalJoint.from_components(
+        names=("image", "text"),
+        component_fields=[
+            (
+                GaussianDistribution(mu=-3.0, sigma2=1.0),
+                CategoricalDistribution(pmap={"cat": 0.9, "dog": 0.1}),
+            ),
+            (
+                GaussianDistribution(mu=3.0, sigma2=1.0),
+                CategoricalDistribution(pmap={"cat": 0.1, "dog": 0.9}),
+            ),
+        ],
+        weights=[0.6, 0.4],
+    )
+
+
+def _snapshot(joint: CrossModalJoint) -> list[tuple]:
+    """A concrete before/after receipt of every existing leaf's fitted parameters."""
+    out = []
+    for component in joint.joint.components:
+        image, text = component.dists
+        out.append((float(image.mu), float(image.sigma2), dict(text.pmap)))
+    return out
+
+
+class UnseenModalityJoinsJointTest(unittest.TestCase):
+    """Acceptance criterion 1: an unseen modality joins a joint and supports cross-modal inference,
+    with NO retraining of the other leaves (verified bitwise, not assumed)."""
+
+    def setUp(self):
+        self.rng = np.random.RandomState(0)
+        self.joint = _two_modality_joint()
+        self.before_objects = [c.dists for c in self.joint.joint.components]
+        self.before_snapshot = _snapshot(self.joint)
+
+        # A brand-new third modality never modeled before: a 3-D "sensor" vector whose mean tracks
+        # the SAME latent regime as image/text (regime 0 centered near -1, regime 1 centered near 1),
+        # so conditioning on it is genuinely informative, not just mechanically wired up.
+        n_per_regime = 60
+        regime0 = self.rng.normal(loc=-1.0, scale=0.3, size=(n_per_regime, 3))
+        regime1 = self.rng.normal(loc=1.0, scale=0.3, size=(n_per_regime, 3))
+        sensor_samples = np.concatenate([regime0, regime1], axis=0)
+        labels = np.concatenate([np.zeros(n_per_regime), np.ones(n_per_regime)]).astype(int)
+
+        leaf0 = induce_leaf_for_unseen_type([tuple(row) for row in regime0], rng=np.random.RandomState(1))
+        leaf1 = induce_leaf_for_unseen_type([tuple(row) for row in regime1], rng=np.random.RandomState(2))
+        self.sensor_samples = sensor_samples
+        self.labels = labels
+        self.new_joint = add_modality_to_joint(self.joint, "sensor", [leaf0, leaf1])
+
+    def test_other_modalities_are_bitwise_unchanged(self):
+        after_objects = [c.dists[:2] for c in self.new_joint.joint.components]
+        for before, after in zip(self.before_objects, after_objects):
+            # same underlying distribution objects -- never copied, never refit.
+            self.assertIs(before[0], after[0])
+            self.assertIs(before[1], after[1])
+        after_snapshot = _snapshot(CrossModalJoint(names=self.joint.names, joint=self.joint.joint))
+        self.assertEqual(self.before_snapshot, after_snapshot)
+
+    def test_new_modality_names_and_regime_count_are_correct(self):
+        self.assertEqual(self.new_joint.names, ("image", "text", "sensor"))
+        self.assertEqual(len(self.new_joint.joint.components), 2)
+        np.testing.assert_allclose(self.new_joint.joint.w, self.joint.joint.w)
+
+    def test_condition_on_new_modality_infers_original_modalities(self):
+        # a sensor reading squarely in regime 0's cluster should push the image posterior toward -3.
+        posterior = self.new_joint.infer({"sensor": (-1.0, -1.0, -1.0)}, ["image"])
+        map_regime = int(np.argmax(posterior.w))
+        self.assertAlmostEqual(posterior.components[map_regime].dists[0].mu, -3.0)
+        self.assertGreater(posterior.w[map_regime], 0.5)
+
+    def test_condition_on_original_modalities_infers_new_modality(self):
+        # conditioning on image/text from regime 1 should push weight onto sensor leaf 1 (mean ~+1).
+        posterior = self.new_joint.infer({"image": 3.0, "text": "dog"}, ["sensor"])
+        map_regime = int(np.argmax(posterior.w))
+        self.assertGreater(posterior.w[map_regime], 0.5)
+        # regime 1's sensor leaf was fit on samples centered at +1.
+        self.assertGreater(float(np.mean(self.sensor_samples[self.labels == 1])), 0.0)
+
+
+class ResonanceEmbeddingSeparationTest(unittest.TestCase):
+    """Acceptance criterion 2: the resonance embedding separates classes on a held-out modality
+    never modeled natively -- measured, not assumed, with a real downstream classifier."""
+
+    def setUp(self):
+        rng = np.random.RandomState(7)
+        # The existing model zoo: several already-fitted, DIVERSE classical leaves (never touched
+        # again below) -- exactly what "existing model zoo" means for L3.
+        self.zoo = [
+            GaussianDistribution(mu=0.0, sigma2=1.0),
+            GaussianDistribution(mu=10.0, sigma2=4.0),
+            GaussianDistribution(mu=-5.0, sigma2=0.5),
+            GaussianDistribution(mu=50.0, sigma2=25.0),
+        ]
+        # A brand-new modality (never fitted natively) with 3 genuinely different classes.
+        n = 40
+        class_a = rng.normal(loc=1.0, scale=0.3, size=n)
+        class_b = rng.normal(loc=20.0, scale=0.3, size=n)
+        class_c = rng.normal(loc=-8.0, scale=0.3, size=n)
+        self.samples = np.concatenate([class_a, class_b, class_c])
+        self.labels = np.concatenate([np.zeros(n), np.ones(n), np.full(n, 2)]).astype(int)
+
+    def test_resonance_embedding_separates_three_classes(self):
+        embedding = resonance_embedding(list(self.samples), self.zoo)
+        self.assertEqual(embedding.shape, (len(self.samples), len(self.zoo)))
+
+        # Real, measured separation: leave-one-out nearest-centroid classification on the embedding.
+        centroids = {label: embedding[self.labels == label].mean(axis=0) for label in np.unique(self.labels)}
+        correct = 0
+        for i in range(embedding.shape[0]):
+            dists = {label: float(np.linalg.norm(embedding[i] - c)) for label, c in centroids.items()}
+            predicted = min(dists, key=dists.get)
+            correct += int(predicted == self.labels[i])
+        accuracy = correct / embedding.shape[0]
+        chance = 1.0 / len(np.unique(self.labels))
+        self.report_accuracy = accuracy
+        self.assertGreater(
+            accuracy,
+            chance + 0.3,
+            f"resonance embedding nearest-centroid accuracy {accuracy:.3f} vs chance {chance:.3f}",
+        )
+
+
+class ResonanceAdequacyGateTest(unittest.TestCase):
+    """Acceptance criterion 3: the fit-health-style gate is correct in both directions."""
+
+    def test_well_separated_embedding_is_adequate(self):
+        rng = np.random.RandomState(3)
+        n = 60
+        group_a = rng.normal(loc=-10.0, scale=0.2, size=(n, 3))
+        group_b = rng.normal(loc=10.0, scale=0.2, size=(n, 3))
+        embedding = np.concatenate([group_a, group_b], axis=0)
+        labels = np.concatenate([np.zeros(n), np.ones(n)]).astype(int)
+        self.assertTrue(resonance_adequacy_gate(embedding, labels))
+
+    def test_poorly_separated_embedding_is_inadequate(self):
+        rng = np.random.RandomState(4)
+        n = 60
+        group_a = rng.normal(loc=0.0, scale=5.0, size=(n, 3))
+        group_b = rng.normal(loc=0.05, scale=5.0, size=(n, 3))
+        embedding = np.concatenate([group_a, group_b], axis=0)
+        labels = np.concatenate([np.zeros(n), np.ones(n)]).astype(int)
+        self.assertFalse(resonance_adequacy_gate(embedding, labels))
+
+    def test_too_few_samples_defaults_to_graduate(self):
+        embedding = np.array([[0.0, 0.0], [1.0, 1.0]])
+        self.assertFalse(resonance_adequacy_gate(embedding, [0, 1]))
+
+
+class InduceLeafForUnseenTypeTest(unittest.TestCase):
+    """The automatic-profiler extension's fallback chain: classical -> neural -> graph/sequence,
+    each exercised on a data type that the base profiler cannot already parse (custom objects)."""
+
+    class _Blob:
+        """A genuinely unrecognized Python object: not a tuple/list/dict/set/number/str, so the
+        base DatumNode profiler abstains (``obj_count`` -> ``IgnoredDistribution``)."""
+
+        def __init__(self, vector):
+            self.vector = vector
+
+    def test_low_dimensional_numeric_blob_gets_a_classical_leaf(self):
+        rng = np.random.RandomState(5)
+        samples = [self._Blob(rng.normal(loc=2.0, scale=1.0, size=3)) for _ in range(80)]
+        leaf = induce_leaf_for_unseen_type(samples, rng=np.random.RandomState(6))
+        # a classical family (multivariate Gaussian) -- not neural.
+        self.assertIn("MultivariateGaussian", type(leaf).__name__)
+
+    def test_high_dimensional_numeric_blob_gets_a_neural_fallback(self):
+        rng = np.random.RandomState(8)
+        samples = [self._Blob(rng.normal(size=24)) for _ in range(50)]
+        leaf = induce_leaf_for_unseen_type(samples, max_its=1)
+        self.assertTrue(hasattr(leaf, "log_density"))
+        self.assertIn("GradLeaf", type(leaf).__name__)
+
+    def test_graph_structured_blob_gets_a_graph_model(self):
+        class _GraphBlob:
+            def __init__(self, adjacency):
+                self.adjacency = adjacency
+
+        rng = np.random.RandomState(9)
+        samples = []
+        for _ in range(30):
+            mat = (rng.random((5, 5)) < 0.3).astype(float)
+            mat = np.triu(mat, 1)
+            mat = mat + mat.T
+            samples.append(_GraphBlob(mat))
+        leaf = induce_leaf_for_unseen_type(samples)
+        self.assertIn("ErdosRenyi", type(leaf).__name__)
+
+    def test_unmodelable_type_raises_clear_error(self):
+        class _Opaque:
+            pass
+
+        with self.assertRaises(TypeError):
+            induce_leaf_for_unseen_type([_Opaque() for _ in range(5)])
+
+
+class FitResonanceLeavesTest(unittest.TestCase):
+    """A lightweight resonance-coordinate leaf can also plug into add_modality_to_joint without
+    graduating to a native leaf, still with no retraining of the other modalities."""
+
+    def test_resonance_leaves_join_the_joint_without_retraining(self):
+        joint = _two_modality_joint()
+        before = [c.dists[:2] for c in joint.joint.components]
+
+        zoo = [GaussianDistribution(mu=-3.0, sigma2=1.0), GaussianDistribution(mu=3.0, sigma2=1.0)]
+        rng = np.random.RandomState(11)
+        regime0_samples = rng.normal(loc=-1.0, scale=0.2, size=40)
+        regime1_samples = rng.normal(loc=1.0, scale=0.2, size=40)
+        samples = np.concatenate([regime0_samples, regime1_samples])
+        labels = np.concatenate([np.zeros(40), np.ones(40)]).astype(int)
+
+        embedding = resonance_embedding(list(samples), zoo)
+        self.assertTrue(resonance_adequacy_gate(embedding, labels))
+
+        leaves = fit_resonance_leaves(embedding, labels, num_regimes=2)
+        new_joint = add_modality_to_joint(joint, "proxy_sensor", leaves)
+
+        after = [c.dists[:2] for c in new_joint.joint.components]
+        for b, a in zip(before, after):
+            self.assertIs(b[0], a[0])
+            self.assertIs(b[1], a[1])
+        self.assertEqual(new_joint.names, ("image", "text", "proxy_sensor"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Stacked on top of L2 (#150, `cross-modal-conditional`) -- this branches from that PR's head so `mixle/reason/cross_modal.py`'s `CrossModalJoint` is available. **Base this PR against `cross-modal-conditional`, not `main`.**

Implements roadmap item L3 (zero-shot modality bootstrap), the third of three pieces:

- **`induce_leaf_for_unseen_type`** (`mixle/reason/zero_shot_bootstrap.py`): extends the automatic profiler (`mixle.utils.automatic`) with a real fallback chain for genuinely unrecognized data types -- try the profiler's own classical-family induction first, then fall back to classical Gaussian/MVN (simple numeric), a generic GradLeaf-wrapped neural density (complex/high-dimensional numeric), a graph model (`ErdosRenyiGraphEstimator`, for adjacency-structured samples), or a sequence model (variable-length collections), in that order.
- **`resonance_embedding`**: scores a brand-new-modality sample against an existing, already-fitted model zoo -- one generic "typicality" coordinate per zoo model, read off each model's own capability surface (`mixle.capability`'s `HasCDF`/`HasMoments`). Evaluation only: no gradient steps, no fitting.
- **`resonance_adequacy_gate`**: reuses the separation statistic behind `mixle.utils.hvis.topology.model_fit_health`'s merged-regime detector (deterministic 2-means-style projected separation ratio, same `2.65 + 6/sqrt(n)` threshold) to decide whether the resonance embedding's class separation is adequate, or whether the modality should graduate to a native leaf.
- **`add_modality_to_joint`**: plugs a new per-regime leaf into an existing `CrossModalJoint` by rebuilding each regime's `CompositeDistribution` with the OLD per-modality distributions reused BY REFERENCE plus the one new field -- no other modality is ever refit.

## Measured results

- Resonance-embedding nearest-centroid separation accuracy on a 3-class held-out modality (never fitted natively): **0.75** vs chance **0.33**.
- Fit-health gate: well-separated synthetic embedding -> `True` (adequate); poorly-separated synthetic embedding -> `False` (graduate). Both directions confirmed by test.
- "No retraining" check: existing `image`/`text` leaves' fitted parameters (`GaussianDistribution.mu/sigma2`, `CategoricalDistribution.pmap`) are identical by object identity AND value, before vs. after a third modality is added.

## Test plan

- [x] New test file `mixle/tests/zero_shot_bootstrap_test.py` (13 tests): unseen modality joins a joint + supports cross-modal inference with bitwise-verified no-retraining of other leaves; resonance embedding separation on a held-out modality; fit-health gate correctness in both directions; `induce_leaf_for_unseen_type`'s classical/neural/graph/error-path fallback chain.
- [x] `mixle/tests/cross_modal_conditional_test.py` (L2's suite) still passes -- no regressions.
- [x] `mixle/tests/automatic_test.py`, `automatic_get_prototype_test.py`, `automatic_datumnode_edgecases_test.py` still pass -- no regressions to the automatic profiler.
- [x] `ruff check --fix` / `ruff format` clean.
