### PR TITLE
L5: the discrepancy->invention loop

### DIFF
--- a/mixle/task/discrepancy_invention_loop.py
+++ b/mixle/task/discrepancy_invention_loop.py
@@ -1,0 +1,375 @@
+"""L5: the discrepancy -> invention loop -- wiring epistemic discrepancy into structural invention.
+
+The full chain named by the roadmap item, end to end:
+
+    discrepancy_report(champion, held_out)      -- 1. is the fitted champion's predictive off?
+    capacity ladder + ceiling_report(...)        -- 2. "tune it" (same family, needs more capacity/data)
+                                                        vs. "the structure CLASS is exhausted" (invention
+                                                        trigger): a capacity ladder of same-family refits is
+                                                        fit and, unlike a bare ``ceiling_report`` call, its
+                                                        *trend* is read -- meaningful gain from more capacity
+                                                        means "tune it", a plateau below target means
+                                                        ceiling-bound.
+    propose_structure(candidates, ...)           -- 3. search the composition grammar for a genuinely richer
+                                                        structure (only reached when ceiling-bound).
+    mixle.epistemic.loop.step(..., action_space=...) -- 4. EIG picks the cheapest probe that would
+                                                        distinguish the champion from the surviving proposals.
+    challenger_beats_champion(...)               -- 5. the same anti-regression gate L1/L4/L6 reuse.
+    EpistemicJournal                             -- 6. every step above is appended as a DecisionRecord with
+                                                        a human-readable rationale; the ordered rationale
+                                                        list *is* the replayable reasoning chain.
+    design_prior.rank_design_families(...)       -- 7. novelty of an accepted proposal, scored as surprise
+                                                        relative to the design prior's expectation for that
+                                                        structural family (``achieved - expected``, or
+                                                        ``+inf`` when the family has never been tried).
+
+Every piece above is an EXISTING module (:mod:`mixle.epistemic.discrepancy`/``loop``/``journal``,
+:mod:`mixle.task.imagine`, :mod:`mixle.task.design_prior`, :mod:`mixle.evolve.verify`); this module adds
+no new core math, only the orchestration that chains them into one auditable loop.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+
+from mixle.epistemic.discrepancy import DiscrepancyResult, discrepancy_report
+from mixle.epistemic.journal import DecisionRecord, EpistemicJournal
+from mixle.epistemic.loop import EpistemicStep, step
+from mixle.epistemic.portfolio import Hypothesis, HypothesisPortfolio
+from mixle.evolve.objective import Objective
+from mixle.evolve.verify import Verdict, challenger_beats_champion
+from mixle.task.design_prior import rank_design_families, record_accepted_recipe
+from mixle.task.edge import DesignModel
+from mixle.task.imagine import CeilingReport, ImagineResult, StructuralCandidate, ceiling_report, propose_structure
+
+
+def _mean_log_density(model: Any, data: Sequence[Any]) -> float:
+    return float(np.mean([model.log_density(x) for x in data]))
+
+
+def _sample_one(dist: Any, rng: np.random.RandomState) -> float:
+    """Draw a single scalar from ``dist`` via its ``.sampler(seed).sample(n)`` (or ``.sample(n)``) surface."""
+    sampler_fn = getattr(dist, "sampler", None)
+    if callable(sampler_fn):
+        seed = int(rng.randint(0, 2**31 - 1))
+        return float(np.asarray(sampler_fn(seed).sample(1)).reshape(-1)[0])
+    return float(np.asarray(dist.sample(1)).reshape(-1)[0])
+
+
+def _record_stage(
+    journal: EpistemicJournal,
+    portfolio: HypothesisPortfolio,
+    *,
+    observation: Any,
+    rationale: str,
+    surprise: float = 0.0,
+) -> DecisionRecord:
+    """Append a non-probe stage to ``journal`` -- a real snapshot of ``portfolio`` plus a rationale.
+
+    Unlike the EIG-probe stage, these stages (discrepancy / ceiling / proposal / gate) don't advance
+    the belief trajectory -- they *reason about* it -- so :class:`~mixle.epistemic.loop.EpistemicStep`
+    is constructed directly here rather than via :func:`~mixle.epistemic.loop.step`, whose UPDATE/ACT
+    arrows would otherwise be invoked redundantly against an unchanging portfolio just to get a shell.
+    """
+    return journal.append(
+        EpistemicStep(
+            observation=observation,
+            portfolio_before=portfolio,
+            portfolio_after=portfolio,
+            surprise=surprise,
+            next_action=None,
+            next_action_eig=None,
+        ),
+        rationale=rationale,
+    )
+
+
+def default_probe_action_space(data: Sequence[Any], *, n_probes: int = 5) -> list[float]:
+    """A default set of candidate probe locations: quantiles of ``data``'s own range.
+
+    Querying near a quantile of the already-observed data is the natural default "where would the
+    next observation land" grid when the caller has no domain-specific probe design of their own.
+    """
+    arr = np.asarray(list(data), dtype=np.float64)
+    qs = np.linspace(0.15, 0.85, n_probes)
+    return [float(np.quantile(arr, q)) for q in qs]
+
+
+def default_probe_simulate_fn(
+    hypothesis: Hypothesis, action: float, rng: np.random.RandomState, *, window: float
+) -> float:
+    """Simulate "if we probed near ``action``, what would ``hypothesis`` predict we'd observe?"
+
+    Rejection-samples from ``hypothesis.payload`` (a fitted distribution) until a draw lands within
+    ``window`` of ``action``; falls back to ``action`` itself (an honest degraded value, not a crash)
+    if the budget is exhausted -- e.g. a hypothesis that assigns near-zero mass to that region, which is
+    itself exactly the kind of information a distinguishing probe should surface.
+    """
+    for _ in range(200):
+        y = _sample_one(hypothesis.payload, rng)
+        if abs(y - action) <= window:
+            return y
+    return float(action)
+
+
+@dataclass
+class InventionResult:
+    """The full outcome of one discrepancy -> invention loop run, with its replayable journal."""
+
+    verdict: str  # 'target_met' | 'tune' | 'ceiling_bound'
+    discrepancy: DiscrepancyResult
+    ceiling: CeilingReport
+    ceiling_bound: bool
+    capacity_ladder_scores: dict[str, float]
+    imagine: ImagineResult | None
+    novelty_scores: dict[str, float] = field(default_factory=dict)
+    probe_action: Any | None = None
+    probe_eig: float | None = None
+    gate_verdict: Verdict | None = None
+    adopted_structure: str | None = None
+    journal: EpistemicJournal = field(default_factory=EpistemicJournal)
+
+
+def score_design_prior_surprise(name: str, achieved_score: float, design: DesignModel) -> float:
+    """Novelty of an accepted structural family, as design-prior surprise: ``achieved - expected``.
+
+    ``expected`` is :func:`mixle.task.design_prior.rank_design_families`'s recorded mean quality for
+    ``name``'s family, or ``-inf`` (via ``rank_design_families``'s own ``default_score`` convention) if
+    the family has never been tried before -- which makes it maximally surprising by construction:
+    ``+inf`` rather than an arbitrary finite number, so "genuinely never-seen-before" is never confused
+    with "merely better than a middling prior."
+    """
+    prior_score = dict(rank_design_families(design, candidates=[name]))[name]
+    if not math.isfinite(prior_score):
+        return float("inf")
+    return float(achieved_score) - prior_score
+
+
+def _capacity_ladder_verdict(
+    champion_score: float, target: float, tuning_scores: dict[str, float], *, plateau_tol: float
+) -> tuple[bool, float]:
+    """Read the *trend* across a same-family capacity ladder: does more capacity meaningfully help?
+
+    ``tune`` if the best-tuned variant reaches ``target`` outright, or closes at least
+    ``plateau_tol`` of the champion's gap to target -- "more capacity/data within this family is still
+    buying real ground." Otherwise the ladder has plateaued short of target: no amount of same-family
+    tuning closes the gap, which is the actual "structure CLASS is exhausted" invention trigger (as
+    opposed to a bare single-point ``ceiling_report`` check, which cannot tell a plateau from a family
+    that just hasn't been tuned yet).
+    """
+    best_tuned_score = max([champion_score, *tuning_scores.values()]) if tuning_scores else champion_score
+    gap = target - champion_score
+    if best_tuned_score >= target:
+        return True, best_tuned_score
+    if gap <= 0:
+        return True, best_tuned_score
+    gain = best_tuned_score - champion_score
+    return (gain >= plateau_tol * gap), best_tuned_score
+
+
+def run_discrepancy_invention_loop(
+    champion_fit: Callable[[Sequence[Any]], Any],
+    train: Sequence[Any],
+    held_out: Sequence[Any],
+    target: float,
+    candidates: Sequence[StructuralCandidate],
+    *,
+    objective: Objective,
+    tuning_variants: Sequence[Callable[[Sequence[Any]], Any]] = (),
+    plateau_tol: float = 0.15,
+    design: DesignModel | None = None,
+    probe_action_space: Sequence[float] | None = None,
+    probe_window: float | None = None,
+    probe_reweight_n: int = 20,
+    seed: int = 0,
+) -> InventionResult:
+    """The end-to-end L5 loop: discrepancy receipt -> ceiling verdict -> proposal -> EIG probe -> gate -> journal.
+
+    ``champion_fit`` fits an instance of the CURRENT structural family; ``tuning_variants`` are other
+    fits within that SAME family (more capacity, different regularization, more data, ...) used to read
+    the capacity ladder's trend. ``candidates`` is the composition-grammar search space handed to
+    :func:`~mixle.task.imagine.propose_structure`, only consulted when the ladder is ceiling-bound.
+    ``design`` is the persistent design prior (:mod:`mixle.task.design_prior`) an adopted structure's
+    family gets recorded into; a fresh, empty one is used if omitted. Every stage is appended to the
+    returned journal with a plain-English ``rationale`` -- ``journal.records`` (or
+    :func:`reconstruct_reasoning_chain`) is the full, ordered, replayable audit trail.
+    """
+    rng = np.random.RandomState(seed)
+    journal = EpistemicJournal()
+    design = design if design is not None else DesignModel(signature="discrepancy-invention-loop", n_constraints=0)
+
+    champion_model = champion_fit(train)
+    champion_score = _mean_log_density(champion_model, held_out)
+
+    # 1. discrepancy receipt: does the champion's predictive diverge from the real held-out data?
+    discrepancy = discrepancy_report(champion_model, held_out, metric="auto")
+    root_portfolio = HypothesisPortfolio([Hypothesis("champion", champion_model)], np.array([1.0]), w_open=0.0)
+    root_surprise = root_portfolio.surprise_score(held_out[0], lambda h, y: float(np.exp(h.payload.log_density(y))))
+    _record_stage(
+        journal,
+        root_portfolio,
+        observation=held_out[0],
+        surprise=root_surprise,
+        rationale=(
+            f"discrepancy detected: metric={discrepancy.metric} value={discrepancy.value:.6g} "
+            f"degraded={discrepancy.degraded}"
+        ),
+    )
+
+    # 2. ceiling verdict: 'tune it' (capacity ladder still gaining) vs. 'ceiling-bound' (plateaued).
+    ceiling = ceiling_report(champion_score, target)
+    tuning_scores = {
+        f"tune_variant_{i}": _mean_log_density(variant_fit(train), held_out)
+        for i, variant_fit in enumerate(tuning_variants)
+    }
+    tune_helps, best_tuned_score = _capacity_ladder_verdict(
+        champion_score, target, tuning_scores, plateau_tol=plateau_tol
+    )
+
+    if ceiling.met:
+        verdict_label = "target_met"
+    elif tune_helps:
+        verdict_label = "tune"
+    else:
+        verdict_label = "ceiling_bound"
+    ceiling_bound = verdict_label == "ceiling_bound"
+
+    _record_stage(
+        journal,
+        root_portfolio,
+        observation=champion_score,
+        rationale=(
+            f"ceiling verdict: {verdict_label} (champion_held_out={champion_score:.6g} "
+            f"best_tuned={best_tuned_score:.6g} target={target:.6g}) -- "
+            + (
+                "the capacity ladder plateaus below target: no amount of same-family tuning closes the "
+                "gap, this is the structural-invention trigger."
+                if ceiling_bound
+                else "same-family tuning still meaningfully closes the gap (or already meets target); "
+                "no invention needed."
+            )
+        ),
+    )
+
+    result = InventionResult(
+        verdict=verdict_label,
+        discrepancy=discrepancy,
+        ceiling=ceiling,
+        ceiling_bound=ceiling_bound,
+        capacity_ladder_scores=tuning_scores,
+        imagine=None,
+        journal=journal,
+    )
+    if not ceiling_bound:
+        return result
+
+    # 3. propose_structure: search the composition grammar for a genuinely richer structure.
+    imagine = propose_structure(list(candidates), train, held_out, ceiling)
+    result.imagine = imagine
+    _record_stage(
+        journal,
+        root_portfolio,
+        observation=imagine.breaks_ceiling,
+        rationale=(
+            "structure proposal: "
+            + (
+                f"breaks the ceiling with {imagine.breaks_ceiling!r}"
+                if imagine.breaks_ceiling
+                else "no candidate broke the ceiling"
+            )
+            + "; verdicts="
+            + ", ".join(
+                f"{v.name}={'accepted' if v.accepted else 'rejected(' + v.reason + ')'}" for v in imagine.verdicts
+            )
+        ),
+    )
+
+    accepted = [v for v in imagine.verdicts if v.accepted]
+    if not accepted:
+        return result
+
+    result.novelty_scores = {v.name: score_design_prior_surprise(v.name, v.held_out_score, design) for v in accepted}
+
+    winning_name = imagine.breaks_ceiling or max(accepted, key=lambda v: v.held_out_score).name
+    winning_candidate = next(c for c in candidates if c.name == winning_name)
+    winning_model = winning_candidate.fit(train)
+
+    # 4. EIG probe: which experiment would most efficiently distinguish champion from the surviving
+    #    proposals? Reweight on the real held-out evidence, then let ACT pick the highest-EIG probe.
+    accepted_models = {v.name: next(c for c in candidates if c.name == v.name).fit(train) for v in accepted}
+    hyps = [Hypothesis("champion", champion_model)] + [Hypothesis(name, m) for name, m in accepted_models.items()]
+    portfolio = HypothesisPortfolio(hyps, np.full(len(hyps), 1.0 / len(hyps)), w_open=0.0)
+
+    def likelihood_fn(h: Hypothesis, y: Any) -> float:
+        return float(np.exp(h.payload.log_density(y)))
+
+    action_space = list(probe_action_space) if probe_action_space is not None else default_probe_action_space(held_out)
+    window = probe_window if probe_window is not None else float(np.std(np.asarray(held_out, dtype=np.float64))) * 0.5
+
+    def simulate_fn(h: Hypothesis, action: Any, r: np.random.RandomState) -> Any:
+        return default_probe_simulate_fn(h, action, r, window=window)
+
+    subsample = list(held_out)[: max(1, probe_reweight_n)]
+    probe_outcome = None
+    for i, y in enumerate(subsample):
+        is_last = i == len(subsample) - 1
+        probe_outcome = step(
+            portfolio,
+            y,
+            likelihood_fn,
+            action_space=action_space if is_last else None,
+            simulate_fn=simulate_fn if is_last else None,
+            rng=rng,
+        )
+        portfolio = probe_outcome.portfolio_after
+
+    result.probe_action = probe_outcome.next_action
+    result.probe_eig = probe_outcome.next_action_eig
+    journal.append(
+        probe_outcome,
+        action_considered=action_space,
+        rationale=(
+            f"EIG probe: cheapest distinguishing experiment is action={probe_outcome.next_action!r} "
+            f"(EIG={probe_outcome.next_action_eig!r}), among candidates {list(accepted_models)}"
+        ),
+    )
+
+    # 5. gate: does the winning proposal actually beat the champion (same anti-regression gate as L1/L4/L6)?
+    gate_verdict = challenger_beats_champion(champion_model, winning_model, held_out, objective=objective)
+    result.gate_verdict = gate_verdict
+    _record_stage(
+        journal,
+        portfolio,
+        observation=winning_name,
+        rationale=(
+            f"gate verdict: favored={gate_verdict.favored} promote={gate_verdict.promote} "
+            f"delta={gate_verdict.delta:.6g} winning_structure={winning_name!r}"
+        ),
+    )
+
+    if gate_verdict.promote:
+        result.adopted_structure = winning_name
+        winning_verdict = next(v for v in imagine.verdicts if v.name == winning_name)
+        record_accepted_recipe(design, [0.0], winning_verdict.held_out_score, [], family=winning_name)
+
+    return result
+
+
+def reconstruct_reasoning_chain(journal: EpistemicJournal) -> list[str]:
+    """The ordered list of every stage's rationale -- the human-readable replay of the full chain."""
+    return [r.rationale for r in journal if r.rationale is not None]
+
+
+__all__ = [
+    "InventionResult",
+    "default_probe_action_space",
+    "default_probe_simulate_fn",
+    "reconstruct_reasoning_chain",
+    "run_discrepancy_invention_loop",
+    "score_design_prior_surprise",
+]

--- a/mixle/tests/discrepancy_invention_loop_test.py
+++ b/mixle/tests/discrepancy_invention_loop_test.py
@@ -1,0 +1,216 @@
+"""L5: the discrepancy -> invention loop (mixle.task.discrepancy_invention_loop).
+
+Two scenarios, the crux of the whole item:
+
+* a genuine ceiling case -- data drawn from a two-component Gaussian mixture, a single Gaussian
+  champion that CANNOT represent it no matter how it's tuned -- must be detected as ceiling-bound (not
+  "needs more tuning"), and the loop must find the correct richer structure, gate-adopt it, and leave a
+  replayable reasoning chain in the journal.
+* a contrast case -- a single Gaussian champion that is merely undertrained (fit on too little data)
+  -- must be correctly diagnosed as "tune it", NOT ceiling-bound, with no invention attempted.
+"""
+
+import unittest
+
+import numpy as np
+
+from mixle.evolve import nll_objective
+from mixle.inference import optimize
+from mixle.stats import GaussianEstimator, MixtureEstimator
+from mixle.task.design_prior import record_accepted_recipe
+from mixle.task.discrepancy_invention_loop import (
+    reconstruct_reasoning_chain,
+    run_discrepancy_invention_loop,
+    score_design_prior_surprise,
+)
+from mixle.task.edge import DesignModel
+from mixle.task.imagine import StructuralCandidate
+
+
+def _bimodal_data(n, rng, sep=3.0, sigma=0.4):
+    labels = rng.randint(0, 2, size=n)
+    means = np.where(labels == 0, -sep, sep)
+    return (means + rng.normal(scale=sigma, size=n)).tolist()
+
+
+def _fit_single_gaussian(data):
+    return optimize(list(data), GaussianEstimator(), out=None)
+
+
+def _fit_wider_single_gaussian(data):
+    """Decoy tuning variant: still a single Gaussian, different regularization -- same structural
+    family, cannot represent bimodality no matter how it's tuned."""
+    return optimize(list(data), GaussianEstimator(pseudo_count=(0.1, 0.1)), out=None)
+
+
+def _fit_two_component_mixture(data):
+    # seeded: EM mixture init is random, and this fit is called more than once (this test's own probe,
+    # then again inside the loop's propose_structure/probe/gate stages) -- must land in the same, truly
+    # bimodal optimum every time (some seeds collapse to a degenerate near-unimodal local optimum).
+    est = MixtureEstimator([GaussianEstimator(), GaussianEstimator()])
+    return optimize(list(data), est, out=None, max_its=100, rng=np.random.RandomState(2))
+
+
+class CeilingBoundInventionTest(unittest.TestCase):
+    """The core acceptance criterion: a genuinely out-of-class phenomenon."""
+
+    def setUp(self):
+        rng = np.random.RandomState(0)
+        self.train = _bimodal_data(300, rng)
+        self.held_out = _bimodal_data(150, np.random.RandomState(1))
+        single_probe = _fit_single_gaussian(self.train)
+        mixture_probe = _fit_two_component_mixture(self.train)
+        single_score = float(np.mean([single_probe.log_density(x) for x in self.held_out]))
+        mixture_score = float(np.mean([mixture_probe.log_density(x) for x in self.held_out]))
+        self.assertGreater(mixture_score, single_score)  # sanity: benchmark is honest
+        self.target = (single_score + mixture_score) / 2.0
+        self.candidates = [
+            StructuralCandidate(
+                "two_component_mixture",
+                _fit_two_component_mixture,
+                new_information="2-component mixture: represents a bimodal posterior a single Gaussian cannot",
+            )
+        ]
+
+    def _run(self, design=None):
+        return run_discrepancy_invention_loop(
+            _fit_single_gaussian,
+            self.train,
+            self.held_out,
+            self.target,
+            self.candidates,
+            objective=nll_objective(),
+            tuning_variants=[_fit_wider_single_gaussian],
+            design=design,
+            seed=0,
+        )
+
+    def test_a_ceiling_bound_phenomenon_is_detected_as_ceiling_bound_not_tune_it(self):
+        result = self._run()
+        self.assertEqual(result.verdict, "ceiling_bound")
+        self.assertTrue(result.ceiling_bound)
+        self.assertFalse(result.ceiling.met)
+
+    def test_the_search_finds_the_correct_novel_composition_and_it_is_gate_adopted(self):
+        result = self._run()
+        self.assertIsNotNone(result.imagine)
+        self.assertEqual(result.imagine.breaks_ceiling, "two_component_mixture")
+        accepted = {v.name: v for v in result.imagine.verdicts}
+        self.assertTrue(accepted["two_component_mixture"].accepted)
+        self.assertGreater(accepted["two_component_mixture"].held_out_score, result.ceiling.held_out_score)
+        # gate: a genuinely better structure should be promoted over the champion.
+        self.assertIsNotNone(result.gate_verdict)
+        self.assertEqual(result.gate_verdict.favored, "challenger")
+        self.assertTrue(result.gate_verdict.promote)
+        self.assertEqual(result.adopted_structure, "two_component_mixture")
+
+    def test_eig_probe_selects_a_real_distinguishing_action(self):
+        result = self._run()
+        self.assertIsNotNone(result.probe_action)
+        self.assertIsNotNone(result.probe_eig)
+
+    def test_journal_reconstructs_the_full_reasoning_chain_in_order(self):
+        result = self._run()
+        chain = reconstruct_reasoning_chain(result.journal)
+        self.assertEqual(len(chain), 5)
+        self.assertIn("discrepancy detected", chain[0])
+        self.assertIn("ceiling verdict: ceiling_bound", chain[1])
+        self.assertIn("structure proposal", chain[2])
+        self.assertIn("two_component_mixture", chain[2])
+        self.assertIn("EIG probe", chain[3])
+        self.assertIn("gate verdict", chain[4])
+        self.assertIn("two_component_mixture", chain[4])
+        self.assertTrue(result.journal.verify())
+        trajectory = result.journal.replay()
+        self.assertEqual(len(trajectory), 5)
+        # the belief trajectory grows real new hypotheses once proposals are folded in.
+        self.assertEqual(len(trajectory[0]), 1)  # champion-only, before any proposal
+        self.assertGreaterEqual(len(trajectory[3]), 2)  # champion + accepted candidate(s), at the probe stage
+
+    def test_novelty_scored_as_design_prior_surprise_unprecedented_family_is_maximally_surprising(self):
+        result = self._run(design=DesignModel(signature="fresh", n_constraints=0))
+        self.assertIn("two_component_mixture", result.novelty_scores)
+        self.assertEqual(result.novelty_scores["two_component_mixture"], float("inf"))
+
+    def test_novelty_is_finite_surprise_relative_to_a_seeded_design_prior(self):
+        design = DesignModel(signature="seeded", n_constraints=0)
+        record_accepted_recipe(design, [0.0], -1.0, [], family="two_component_mixture")
+        result = self._run(design=design)
+        surprise = result.novelty_scores["two_component_mixture"]
+        self.assertTrue(np.isfinite(surprise))
+        winning_verdict = next(v for v in result.imagine.verdicts if v.name == "two_component_mixture")
+        expected = winning_verdict.held_out_score - (-1.0)
+        self.assertAlmostEqual(surprise, expected, places=6)
+
+    def test_score_design_prior_surprise_helper_matches_loop_output(self):
+        design = DesignModel(signature="direct", n_constraints=0)
+        record_accepted_recipe(design, [0.0], 0.5, [], family="fam")
+        self.assertAlmostEqual(score_design_prior_surprise("fam", 0.8, design), 0.3, places=6)
+        self.assertEqual(score_design_prior_surprise("never_tried", 0.8, design), float("inf"))
+
+
+class TuneItContrastTest(unittest.TestCase):
+    """The contrast case: same structural family, just needs tuning/more data -- NOT ceiling-bound."""
+
+    def setUp(self):
+        rng = np.random.RandomState(7)
+        self.true_mu, self.true_sigma2 = 3.0, 1.5
+        self.small_train = list(rng.normal(self.true_mu, np.sqrt(self.true_sigma2), 15))
+        self.large_train = list(rng.normal(self.true_mu, np.sqrt(self.true_sigma2), 3000))
+        self.held_out = list(np.random.RandomState(8).normal(self.true_mu, np.sqrt(self.true_sigma2), 500))
+
+        undertrained = _fit_single_gaussian(self.small_train)
+        well_trained = _fit_single_gaussian(self.large_train)
+        undertrained_score = float(np.mean([undertrained.log_density(x) for x in self.held_out]))
+        well_trained_score = float(np.mean([well_trained.log_density(x) for x in self.held_out]))
+        self.assertGreater(well_trained_score, undertrained_score)  # sanity
+        # target: close to (but not exactly at) the well-tuned score, so the champion alone falls
+        # short but tuning within the SAME family closes almost all of the gap.
+        self.target = well_trained_score - 0.01
+
+    def _champion_fit(self, data):
+        # ignore ``data`` (the loop always passes ``train``): the "champion" is deliberately the
+        # undertrained fit, and the tuning variant below is the same family with more data.
+        return _fit_single_gaussian(self.small_train)
+
+    def _tuned_fit(self, data):
+        return _fit_single_gaussian(self.large_train)
+
+    def test_a_merely_undertrained_model_is_diagnosed_as_tune_it_not_ceiling_bound(self):
+        result = run_discrepancy_invention_loop(
+            self._champion_fit,
+            self.small_train,
+            self.held_out,
+            self.target,
+            candidates=[],
+            objective=nll_objective(),
+            tuning_variants=[self._tuned_fit],
+            seed=0,
+        )
+        self.assertEqual(result.verdict, "tune")
+        self.assertFalse(result.ceiling_bound)
+        self.assertIsNone(result.imagine)
+        self.assertIsNone(result.adopted_structure)
+        self.assertIsNone(result.gate_verdict)
+
+    def test_no_invention_machinery_is_invoked_when_tuning_suffices(self):
+        result = run_discrepancy_invention_loop(
+            self._champion_fit,
+            self.small_train,
+            self.held_out,
+            self.target,
+            candidates=[],
+            objective=nll_objective(),
+            tuning_variants=[self._tuned_fit],
+            seed=0,
+        )
+        chain = reconstruct_reasoning_chain(result.journal)
+        self.assertEqual(len(chain), 2)
+        self.assertIn("discrepancy detected", chain[0])
+        self.assertIn("ceiling verdict: tune", chain[1])
+        self.assertIn("no invention needed", chain[1])
+        self.assertNotIn("ceiling_bound", chain[1].split("--")[0])  # the verdict itself isn't ceiling_bound
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements roadmap item L5 ("the discrepancy -> invention loop"): wires together five already-existing subsystems into one coherent, auditable loop in a new module `mixle/task/discrepancy_invention_loop.py`. No new core math is added -- this is integration/orchestration only, per the item's own framing.

Subsystems integrated (all pre-existing, read in full before writing any code):

- `mixle.epistemic.discrepancy` (`discrepancy_report`/`kl_divergence`/`mmd`) -- step 1, the discrepancy trigger: does the champion's predictive diverge from real held-out data?
- `mixle.task.imagine` (`ceiling_report`/`propose_structure`) -- steps 2-3. A same-family **capacity ladder** (multiple `tuning_variants` fits) is read for *trend*, not just a single-point check: meaningful gain from more capacity/data means "tune it"; a plateau below target is the actual "structure CLASS is exhausted" invention trigger. Only when ceiling-bound does `propose_structure` search the composition grammar.
- `mixle.epistemic.loop` (`step`, `HypothesisPortfolio`) -- step 4: after reweighting a champion-vs-proposals portfolio on real held-out evidence, `step`'s EIG machinery (`_portfolio_eig_nmc`) picks the cheapest probe location that would most distinguish the surviving hypotheses.
- `mixle.evolve.verify.challenger_beats_champion` -- step 5, the same anti-regression gate reused by L1/L4/L6, deciding whether the winning proposal is actually adopted.
- `mixle.epistemic.journal.EpistemicJournal` -- step 6: every stage (discrepancy / ceiling / proposal / probe / gate) is appended as a `DecisionRecord` with a plain-English `rationale`; `reconstruct_reasoning_chain()` returns the ordered rationale list as the replayable audit trail, and `journal.replay()`/`.verify()` reconstruct the belief trajectory and content-address integrity.
- `mixle.task.design_prior.rank_design_families` -- step 7: `score_design_prior_surprise` scores an adopted proposal's novelty as `achieved - expected` against the design prior's recorded mean quality for that family, or `+inf` when the family has never been tried (an honest "maximally surprising" rather than an arbitrary finite number).

Entry point: `run_discrepancy_invention_loop(champion_fit, train, held_out, target, candidates, *, objective, tuning_variants=(), design=None, ...) -> InventionResult`.

## Test plan

New `mixle/tests/discrepancy_invention_loop_test.py` (9 tests):

- **Ceiling-bound acceptance case**: data drawn from a genuine two-component Gaussian mixture; a single-Gaussian champion cannot represent it no matter how it's tuned (tested against a same-family decoy tuning variant). Confirms:
  - `ceiling_bound` is correctly `True` (not "needs tuning").
  - `propose_structure`'s search finds the correct two-component-mixture proposal, which genuinely improves held-out score and is gate-adopted (`gate_verdict.promote is True`).
  - `journal`'s reconstructed reasoning chain has the full 5-stage order (discrepancy -> ceiling -> proposal -> probe -> gate) with the right content, `journal.verify()` passes, and `journal.replay()` shows the belief trajectory growing real new hypotheses.
  - Novelty is `+inf` for a never-before-seen family, and a finite `achieved - expected` surprise once the design prior has been seeded with a prior recording for that family.
- **Tune-it contrast case**: a merely undertrained single-Gaussian champion (fit on 15 points) vs. the same family fit on 3000 points, which closes almost all of the gap to target. Confirms `ceiling_bound` is correctly `False`, no invention machinery (`propose_structure`/probe/gate) is invoked, and the journal has exactly the 2 discrepancy+ceiling stages.

Ran:
```
mixle/.venv/bin/python -m pytest mixle/tests/discrepancy_invention_loop_test.py mixle/tests/epistemic_*.py mixle/tests/imagine_test.py mixle/tests/design_prior_test.py mixle/tests/evolve_verify_test.py -q
```
72 passed, no regressions.

Lint: `ruff check --fix` and `ruff format` clean on both new files.
