### PR TITLE
task/data_mixture: DoReMi-style domain-weight optimization (roadmap F8)

### DIFF
--- a/mixle/task/__init__.py
+++ b/mixle/task/__init__.py
@@ -55,6 +55,7 @@ from mixle.task.collapse import (
     entropy_diversity,
 )
 from mixle.task.compose import ComposedAnswer, ComposedModel, compose
+from mixle.task.data_mixture import SyntheticDomain, estimate_near_duplicate_rate, optimize_mixture, proxy_run_score
 from mixle.task.density import DensityGate
 from mixle.task.design import DesignedModel, design_model, spec_to_estimator
 from mixle.task.design_prior import best_family, rank_design_families, record_accepted_recipe
@@ -208,6 +209,10 @@ __all__ = [
     "CascadeStats",
     "ComposedAnswer",
     "ComposedModel",
+    "SyntheticDomain",
+    "estimate_near_duplicate_rate",
+    "optimize_mixture",
+    "proxy_run_score",
     "EstimatorBandit",
     "ThompsonBernoulli",
     "ThompsonGaussian",

--- a/mixle/task/data_mixture.py
+++ b/mixle/task/data_mixture.py
@@ -1,0 +1,322 @@
+"""DoReMi-style data-mixture optimization: domain weights as a bandit/DOE problem (roadmap F8).
+
+A pretraining corpus is normally split into named domains (web text, code, books, ...) mixed by a
+hand-picked weight vector. DoReMi (Xie et al.) instead treats the weight vector itself as something to
+OPTIMIZE: run many small, cheap proxy trainings at different mixtures, score each on held-out loss, and
+search the simplex for the mixture that generalizes best -- then apply that learned mixture to the real,
+much larger run. This module is the small, honest version of that loop, reusing mixle's own optimization
+machinery rather than inventing new search code:
+
+  * :class:`SyntheticDomain` -- a synthetic "domain": a name plus a stand-in data-generating distribution
+    (a fixed periodic token pattern with configurable noise, or pure noise for an unlearnable domain).
+  * :func:`proxy_run_score` -- one proxy run: build a token stream from a mixture of domains, train a real
+    (tiny) :class:`mixle.models.language_model.LM` for a handful of steps, and return the mean held-out
+    NLL across domains (lower is better). This is the "small-run proxy" DoReMi scores mixtures with.
+  * :func:`optimize_mixture` -- the DoReMi search loop: repeated proxy runs scored via
+    :func:`proxy_run_score`, with candidate mixtures proposed by ``mixle.task.bandit``'s
+    :class:`~mixle.task.bandit.ThompsonGaussian` (discrete arms on a simplex-lattice design from
+    ``mixle.doe.mixture``) or ``mixle.doe.optimizer``'s :class:`~mixle.doe.optimizer.BayesianOptimizer`
+    (continuous search over a softmax-reparameterized simplex). No new optimizer machinery -- both paths
+    are the same modules F5/I1/D5 already reuse this session.
+  * :func:`estimate_near_duplicate_rate` -- a minimal, honest corpus dedup/quality receipt: a MinHash
+    estimate of the fraction of documents with a near-duplicate elsewhere in the corpus.
+
+F5 (scaling-law fits) integration point: F5's fitted scaling laws could extrapolate a proxy run's
+held-out loss at *this* scale to a prediction at the real target scale, letting the search compare
+mixtures by extrapolated real-scale loss instead of raw proxy-scale loss. F5's branch was not reachable
+from this worktree at the time F8 was built, so that extrapolation is not wired in here -- the natural
+integration point is inside :func:`proxy_run_score`, mapping its returned proxy-scale loss through a
+fitted ``mixle.task.<f5-module>`` law before it reaches the optimizer. The search loop itself
+(:func:`optimize_mixture`) does not need to change: it only requires a scalar score per mixture, however
+that score is produced.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+
+__all__ = [
+    "SyntheticDomain",
+    "estimate_near_duplicate_rate",
+    "optimize_mixture",
+    "proxy_run_score",
+]
+
+
+@dataclass(frozen=True)
+class SyntheticDomain:
+    """One synthetic "domain": a fixed periodic token pattern, optionally corrupted by noise.
+
+    ``pattern_seed`` fixes a length-``period`` sequence of token ids (drawn once, from ``0..vocab)``)
+    that repeats forever -- the domain's learnable structure. Each sampled token then has independent
+    probability ``noise_p`` of being replaced by a uniform-random token, so ``noise_p=0`` is a perfectly
+    learnable domain and ``noise_p=1`` (or ``period=None``) is pure, irreducible noise: no amount of
+    training data lowers a model's achievable loss on it below ``log(vocab)``. Distinct
+    ``(period, pattern_seed, noise_p)`` triples give genuinely different data-generating distributions,
+    standing in for e.g. "web text" vs "code" vs "books" without needing real corpora.
+    """
+
+    name: str
+    vocab: int
+    period: int | None = 8
+    noise_p: float = 0.0
+    pattern_seed: int = 0
+    _pattern: np.ndarray = field(init=False, repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        if self.vocab < 2:
+            raise ValueError("vocab must be >= 2.")
+        if not 0.0 <= self.noise_p <= 1.0:
+            raise ValueError("noise_p must lie in [0, 1].")
+        if self.period is not None and self.period < 1:
+            raise ValueError("period must be positive (or None for pure noise).")
+        if self.period is None:
+            pattern = np.zeros(0, dtype=np.int64)
+        else:
+            pattern = np.random.RandomState(self.pattern_seed).randint(0, self.vocab, size=int(self.period))
+        object.__setattr__(self, "_pattern", pattern)
+
+    def sample(self, n_tokens: int, *, seed: int = 0) -> np.ndarray:
+        """Draw ``n_tokens`` ids (int64 array) from this domain's distribution."""
+        n_tokens = int(n_tokens)
+        if n_tokens <= 0:
+            return np.zeros(0, dtype=np.int64)
+        rng = np.random.RandomState(seed)
+        if self.period is None:
+            return rng.randint(0, self.vocab, size=n_tokens).astype(np.int64)
+        idx = np.arange(n_tokens) % int(self.period)
+        ids = self._pattern[idx].copy()
+        if self.noise_p > 0.0:
+            corrupt = rng.random_sample(n_tokens) < self.noise_p
+            if np.any(corrupt):
+                ids[corrupt] = rng.randint(0, self.vocab, size=int(corrupt.sum()))
+        return ids.astype(np.int64)
+
+
+def _normalize_weights(mixture_weights: Sequence[float], n_domains: int) -> np.ndarray:
+    w = np.asarray(list(mixture_weights), dtype=np.float64)
+    if w.shape != (n_domains,):
+        raise ValueError(f"mixture_weights must have {n_domains} entries, got shape {w.shape}.")
+    if np.any(w < 0.0):
+        raise ValueError("mixture_weights must be non-negative.")
+    total = float(w.sum())
+    if total <= 0.0:
+        raise ValueError("mixture_weights must sum to a positive total.")
+    return w / total
+
+
+def proxy_run_score(
+    mixture_weights: Sequence[float],
+    domains: Sequence[SyntheticDomain],
+    proxy_steps: int,
+    *,
+    batch_size: int = 16,
+    d_model: int = 16,
+    n_layer: int = 1,
+    n_head: int = 2,
+    block: int = 8,
+    lr: float = 3.0e-3,
+    eval_tokens: int = 512,
+    seed: int = 0,
+    eval_seed: int = 999_000,
+    return_detail: bool = False,
+) -> float | tuple[float, dict[str, float]]:
+    """Run one short proxy training and return the mean held-out NLL across ``domains`` (lower is better).
+
+    Builds a training token stream by drawing ``mixture_weights[i]``-proportional tokens from each domain
+    (concatenated; the number of tokens is chosen so training runs roughly ``proxy_steps`` gradient
+    steps at ``batch_size``), trains a real (tiny) :class:`mixle.models.language_model.LM` on it for one
+    epoch, then scores held-out NLL on ``eval_tokens`` fresh tokens from EACH domain (independent of the
+    mixture) and returns the unweighted mean across domains -- the DoReMi objective is generalizing to
+    every domain, not just the ones the mixture over-samples. ``return_detail=True`` also returns the
+    per-domain NLL dict, keyed by domain name.
+
+    ``seed`` controls the training-data draw (and so varies across repeated proxy runs, e.g. inside
+    :func:`optimize_mixture`'s search loop); ``eval_seed`` controls the held-out draw and is fixed by
+    default so different mixtures proposed during a search are scored against the SAME held-out set --
+    comparing candidate mixtures on a moving eval target would swamp the (often small) between-mixture
+    signal in eval-sampling noise.
+    """
+    import torch
+
+    from mixle.models.language_model import LM
+
+    domains = list(domains)
+    if len(domains) < 2:
+        raise ValueError("need at least two domains to mix.")
+    vocabs = {d.vocab for d in domains}
+    if len(vocabs) != 1:
+        raise ValueError("all domains must share the same vocab.")
+    vocab = domains[0].vocab
+    proxy_steps = max(1, int(proxy_steps))
+    weights = _normalize_weights(mixture_weights, len(domains))
+    torch.manual_seed(int(seed))  # deterministic model init + fit-loop RNG (dropout/etc.) given `seed`
+
+    total_train_tokens = proxy_steps * batch_size + block + 1
+    chunks = []
+    for i, (domain, w) in enumerate(zip(domains, weights)):
+        n_i = int(round(w * total_train_tokens))
+        n_i = max(n_i, 0)
+        if n_i:
+            chunks.append(domain.sample(n_i, seed=seed * 10_000 + i))
+    if not chunks:
+        raise ValueError("mixture assigns zero tokens to every domain.")
+    train_tokens = np.concatenate(chunks)
+    if len(train_tokens) <= block:
+        # a degenerate (near-empty) mixture request; pad with more of whatever domain had weight
+        train_tokens = np.tile(train_tokens, block // max(len(train_tokens), 1) + 2)
+
+    lm = LM(vocab=vocab, d_model=d_model, n_layer=n_layer, n_head=n_head, block=block, device="cpu")
+    lm.fit(train_tokens, epochs=1, batch_size=batch_size, lr=lr, shuffle=True)
+
+    detail: dict[str, float] = {}
+    for i, domain in enumerate(domains):
+        held_out = domain.sample(eval_tokens + block + 1, seed=eval_seed + i)
+        detail[domain.name] = lm.nll(held_out)
+    aggregate = float(np.mean(list(detail.values())))
+    if return_detail:
+        return aggregate, detail
+    return aggregate
+
+
+def _simplex_arms(n_domains: int, budget: int) -> np.ndarray:
+    """Candidate mixture-weight vectors on the ``(n_domains - 1)``-simplex, capped to ``budget`` arms."""
+    from mixle.doe.mixture import simplex_lattice
+
+    arms = simplex_lattice(n_domains, m=2)
+    if len(arms) > budget:
+        idx = np.unique(np.round(np.linspace(0, len(arms) - 1, budget)).astype(int))
+        arms = arms[idx]
+    return arms
+
+
+def _bandit_search(
+    domains: Sequence[SyntheticDomain], proxy_steps: int, budget: int, proxy_kwargs: dict[str, Any], seed: int
+) -> np.ndarray:
+    from mixle.task.bandit import ThompsonGaussian
+
+    arms = _simplex_arms(len(domains), budget)
+    n_arms = len(arms)
+    if n_arms < 2:
+        raise ValueError("budget too small to form at least two mixture-weight arms.")
+    bandit = ThompsonGaussian(n_arms, seed=seed)
+    for t in range(int(budget)):
+        arm = bandit.select()
+        loss = proxy_run_score(arms[arm], domains, proxy_steps, seed=seed * 1000 + t, **proxy_kwargs)
+        bandit.update(arm, reward=-loss)  # higher reward = lower held-out loss
+    best_arm = int(np.argmax(bandit.means))
+    return arms[best_arm]
+
+
+def _softmax(z: np.ndarray) -> np.ndarray:
+    z = z - np.max(z)
+    e = np.exp(z)
+    return e / e.sum()
+
+
+def _doe_search(
+    domains: Sequence[SyntheticDomain], proxy_steps: int, budget: int, proxy_kwargs: dict[str, Any], seed: int
+) -> np.ndarray:
+    from mixle.doe.optimizer import BayesianOptimizer
+
+    n = len(domains)
+    bounds = [(-3.0, 3.0)] * n
+    n_init = min(max(2 * n + 1, 2), max(budget - 1, 2))
+    opt = BayesianOptimizer(bounds, acq="ei", maximize=False, n_init=n_init, seed=seed)
+    for t in range(int(budget)):
+        x = opt.ask()
+        w = _softmax(np.asarray(x, dtype=np.float64))
+        loss = proxy_run_score(w, domains, proxy_steps, seed=seed * 1000 + t, **proxy_kwargs)
+        opt.tell(x, loss)
+    return _softmax(np.asarray(opt.best.best_x, dtype=np.float64))
+
+
+def optimize_mixture(
+    domains: Sequence[SyntheticDomain],
+    proxy_steps: int,
+    budget: int,
+    *,
+    method: str = "bandit",
+    proxy_kwargs: dict[str, Any] | None = None,
+    seed: int = 0,
+) -> np.ndarray:
+    """Learn domain mixture weights via repeated short proxy runs (DoReMi-style search).
+
+    ``budget`` proxy runs (each :func:`proxy_run_score` at ``proxy_steps`` gradient steps) are used to
+    search the mixture-weight simplex. ``method="bandit"`` (default) discretizes the simplex into a
+    lattice of candidate mixtures (``mixle.doe.mixture.simplex_lattice``) and searches them with
+    ``mixle.task.bandit.ThompsonGaussian`` (reward = negative held-out loss); ``method="doe"`` searches
+    continuously via ``mixle.doe.optimizer.BayesianOptimizer`` over a softmax-reparameterized simplex.
+    Returns the learned weight vector (one entry per domain, summing to 1).
+    """
+    domains = list(domains)
+    if len(domains) < 2:
+        raise ValueError("need at least two domains to mix.")
+    if budget < 2:
+        raise ValueError("budget must allow at least two proxy runs.")
+    kwargs = dict(proxy_kwargs or {})
+    if method == "bandit":
+        return _bandit_search(domains, proxy_steps, budget, kwargs, seed)
+    if method == "doe":
+        return _doe_search(domains, proxy_steps, budget, kwargs, seed)
+    raise ValueError(f"unknown method {method!r}; expected 'bandit' or 'doe'.")
+
+
+# --- corpus dedup / quality receipt --------------------------------------------------------------------
+
+
+def _shingles(text: str, k: int) -> frozenset[int]:
+    toks = text.lower().split()
+    if len(toks) < k:
+        return frozenset({hash(tuple(toks))})
+    return frozenset(hash(tuple(toks[i : i + k])) for i in range(len(toks) - k + 1))
+
+
+def _minhash_signature(shingle_set: frozenset[int], a: np.ndarray, b: np.ndarray, prime: int) -> np.ndarray:
+    if not shingle_set:
+        return np.zeros(len(a), dtype=np.int64)
+    hashes = np.array([abs(hash(s)) % prime for s in shingle_set], dtype=np.int64)
+    sig = (np.outer(a, hashes) + b[:, None]) % prime  # (num_hashes, n_shingles)
+    return sig.min(axis=1)
+
+
+def estimate_near_duplicate_rate(
+    corpus: Sequence[str],
+    *,
+    shingle_size: int = 5,
+    num_hashes: int = 64,
+    threshold: float = 0.8,
+    seed: int = 0,
+) -> float:
+    """Estimate the fraction of documents in ``corpus`` that have a near-duplicate elsewhere in it.
+
+    A minimal, honest MinHash quality/dedup receipt: each document is reduced to its set of
+    word-``shingle_size`` shingles, each shingle set to a ``num_hashes``-entry MinHash signature (an
+    unbiased estimator of Jaccard similarity), and two documents are called near-duplicates when their
+    signatures agree on at least ``threshold`` of their entries. Returns
+    ``|{documents with >= 1 near-duplicate partner}| / |corpus|``. ``O(n^2)`` in the corpus size --
+    fine for the receipt-sized corpora this is meant for, not a production LSH dedup pipeline.
+    """
+    docs = list(corpus)
+    n = len(docs)
+    if n == 0:
+        return 0.0
+    if n == 1:
+        return 0.0
+    prime = (1 << 61) - 1
+    rng = np.random.RandomState(seed)
+    a = rng.randint(1, prime - 1, size=int(num_hashes))
+    b = rng.randint(0, prime - 1, size=int(num_hashes))
+    sigs = [_minhash_signature(_shingles(doc, shingle_size), a, b, prime) for doc in docs]
+    has_dup = np.zeros(n, dtype=bool)
+    for i in range(n):
+        for j in range(i + 1, n):
+            sim = float(np.mean(sigs[i] == sigs[j]))
+            if sim >= threshold:
+                has_dup[i] = True
+                has_dup[j] = True
+    return float(has_dup.sum()) / n

--- a/mixle/tests/conftest.py
+++ b/mixle/tests/conftest.py
@@ -36,6 +36,7 @@ FILE_MARKERS: dict[str, MarkerTuple] = {
     "transport_edge_test.py": ("torch", "stochastic", "slow"),
     "transport_proof_test.py": ("torch", "stochastic", "slow"),
     "task_extract_test.py": ("torch", "slow"),
+    "data_mixture_test.py": ("torch", "slow"),
     "task_constrained_test.py": ("torch", "slow"),
     "task_sft_plan_test.py": ("torch", "slow"),
     "task_plan_refine_test.py": ("torch", "slow"),

--- a/mixle/tests/data_mixture_test.py
+++ b/mixle/tests/data_mixture_test.py
@@ -1,0 +1,167 @@
+"""DoReMi-style data mixture optimization (mixle.task.data_mixture, roadmap F8).
+
+The load-bearing claim: a mixture learned by :func:`optimize_mixture` from cheap proxy runs beats a
+uniform mixture at MATCHED total token budget on held-out data from every domain -- and, separately,
+the optimizer really does discover that an informative domain deserves most of the weight when the
+alternative domains are pure noise. All training here is a real (tiny) transformer LM, not a mock.
+"""
+
+import unittest
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from mixle.task.data_mixture import (  # noqa: E402
+    SyntheticDomain,
+    estimate_near_duplicate_rate,
+    optimize_mixture,
+    proxy_run_score,
+)
+
+VOCAB = 20
+BLOCK = 16
+
+
+def _difficulty_domains() -> list[SyntheticDomain]:
+    """Four domains of increasing pattern difficulty (short/clean -> longer/noisier), all comfortably
+    learnable within ``BLOCK`` tokens of context so difficulty comes from sample-efficiency, not from
+    whether the pattern fits in the attention window at all."""
+    return [
+        SyntheticDomain(name="easy", vocab=VOCAB, period=2, noise_p=0.0, pattern_seed=1),
+        SyntheticDomain(name="medium", vocab=VOCAB, period=3, noise_p=0.1, pattern_seed=2),
+        SyntheticDomain(name="hard", vocab=VOCAB, period=4, noise_p=0.2, pattern_seed=3),
+        SyntheticDomain(name="hardest", vocab=VOCAB, period=6, noise_p=0.35, pattern_seed=4),
+    ]
+
+
+class SyntheticDomainTest(unittest.TestCase):
+    def test_pure_noise_domain_is_iid_uniform(self):
+        d = SyntheticDomain(name="noise", vocab=VOCAB, period=None)
+        a = d.sample(2000, seed=0)
+        b = d.sample(2000, seed=0)
+        np.testing.assert_array_equal(a, b)  # deterministic given seed
+        c = d.sample(2000, seed=1)
+        self.assertFalse(np.array_equal(a, c))  # different seed, different draw
+        # roughly uniform over the vocab
+        counts = np.bincount(a, minlength=VOCAB)
+        self.assertLess(counts.std() / counts.mean(), 0.3)
+
+    def test_periodic_domain_is_deterministic_without_noise(self):
+        d = SyntheticDomain(name="clean", vocab=VOCAB, period=4, noise_p=0.0, pattern_seed=0)
+        a = d.sample(40, seed=0)
+        b = d.sample(40, seed=7)  # noise_p=0 -> no randomness at all, any seed matches
+        np.testing.assert_array_equal(a, b)
+        np.testing.assert_array_equal(a[:4], a[4:8])  # repeats with the stated period
+
+
+class OptimizerSanityTest(unittest.TestCase):
+    """One domain is informative (a short, clean, learnable pattern); the rest are pure noise. A
+    DoReMi search should discover this and push most of the weight onto the informative domain."""
+
+    def test_optimizer_finds_the_informative_domain_bandit(self):
+        domains = [
+            SyntheticDomain(name="informative", vocab=VOCAB, period=2, noise_p=0.0, pattern_seed=0),
+            SyntheticDomain(name="noise_a", vocab=VOCAB, period=None),
+            SyntheticDomain(name="noise_b", vocab=VOCAB, period=None),
+        ]
+        weights = optimize_mixture(
+            domains,
+            proxy_steps=20,
+            budget=10,
+            method="bandit",
+            proxy_kwargs={"batch_size": 16, "block": BLOCK, "eval_tokens": 256},
+            seed=0,
+        )
+        self.assertAlmostEqual(float(weights.sum()), 1.0, places=6)
+        self.assertEqual(int(np.argmax(weights)), 0)  # the informative domain wins
+        self.assertGreater(weights[0], 1.0 / len(domains) + 0.1)  # clearly above uniform's share
+
+    def test_optimizer_finds_the_informative_domain_doe(self):
+        domains = [
+            SyntheticDomain(name="informative", vocab=VOCAB, period=2, noise_p=0.0, pattern_seed=0),
+            SyntheticDomain(name="noise_a", vocab=VOCAB, period=None),
+            SyntheticDomain(name="noise_b", vocab=VOCAB, period=None),
+        ]
+        weights = optimize_mixture(
+            domains,
+            proxy_steps=20,
+            budget=10,
+            method="doe",
+            proxy_kwargs={"batch_size": 16, "block": BLOCK, "eval_tokens": 256},
+            seed=0,
+        )
+        self.assertAlmostEqual(float(weights.sum()), 1.0, places=6)
+        self.assertEqual(int(np.argmax(weights)), 0)
+
+
+class LearnedMixtureBeatsUniformTest(unittest.TestCase):
+    """The F8 acceptance criterion: a mixture LEARNED via proxy runs beats UNIFORM weights at matched
+    total token budget, measured as mean held-out NLL across all domains (lower is better)."""
+
+    def test_learned_mixture_beats_uniform_at_matched_tokens(self):
+        domains = _difficulty_domains()
+        n = len(domains)
+
+        # method="doe" (continuous simplex search via softmax-reparameterized BayesianOptimizer) --
+        # unlike the discrete bandit-lattice arms in OptimizerSanityTest, this never drives a domain's
+        # weight all the way to zero, which matters here: every domain in `_difficulty_domains` is
+        # genuinely learnable and starving one outright (a real risk with coarse lattice arms) would
+        # leave it stuck near the log(vocab) baseline and easily lose to uniform on aggregate loss.
+        learned = optimize_mixture(
+            domains,
+            proxy_steps=40,
+            budget=16,
+            method="doe",
+            proxy_kwargs={"batch_size": 16, "block": BLOCK, "eval_tokens": 384},
+            seed=0,
+        )
+        uniform = np.full(n, 1.0 / n)
+
+        # the "real" run: same total token budget (proxy_steps * batch_size, matched) for both mixtures.
+        final_kwargs = dict(proxy_steps=40, batch_size=16, block=BLOCK, eval_tokens=512, seed=42)
+
+        learned_loss, learned_detail = proxy_run_score(learned, domains, return_detail=True, **final_kwargs)
+        uniform_loss, uniform_detail = proxy_run_score(uniform, domains, return_detail=True, **final_kwargs)
+
+        print("\n[F8] learned mixture:", dict(zip((d.name for d in domains), learned.round(3))))
+        print("[F8] uniform mixture:", dict(zip((d.name for d in domains), uniform.round(3))))
+        print("[F8] learned per-domain held-out NLL:", {k: round(v, 4) for k, v in learned_detail.items()})
+        print("[F8] uniform per-domain held-out NLL:", {k: round(v, 4) for k, v in uniform_detail.items()})
+        print(f"[F8] aggregate held-out NLL -- learned: {learned_loss:.4f}  uniform: {uniform_loss:.4f}")
+
+        self.assertLess(learned_loss, uniform_loss)
+
+
+class NearDuplicateReceiptTest(unittest.TestCase):
+    def test_planted_duplicates_are_detected(self):
+        base = "the quick brown fox jumps over the lazy dog near the river bank at dawn"
+        corpus = [
+            base,
+            base,  # exact duplicate
+            base.replace("lazy", "sleepy"),  # near-duplicate (one word changed)
+            "completely unrelated sentence about quarterly revenue and inventory forecasts",
+            "another unrelated sentence discussing orbital mechanics and rocket propulsion systems",
+        ]
+        rate = estimate_near_duplicate_rate(corpus, shingle_size=3, num_hashes=64, threshold=0.5, seed=0)
+        # 3 of 5 documents (the base + its exact and near duplicate) have a near-duplicate partner
+        self.assertAlmostEqual(rate, 3.0 / 5.0, delta=1.0e-9)
+
+    def test_no_duplicates_gives_zero_rate(self):
+        corpus = [
+            "alpha beta gamma delta epsilon zeta eta theta",
+            "quarterly revenue grew steadily across every region this year",
+            "the rocket achieved stable orbit after a nominal ascent profile",
+            "a slow cooker recipe for lentil soup with cumin and lemon",
+        ]
+        rate = estimate_near_duplicate_rate(corpus, shingle_size=3, num_hashes=64, threshold=0.9, seed=0)
+        self.assertEqual(rate, 0.0)
+
+    def test_single_document_corpus_has_zero_rate(self):
+        self.assertEqual(estimate_near_duplicate_rate(["only one document here"]), 0.0)
+        self.assertEqual(estimate_near_duplicate_rate([]), 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements roadmap **F8 (Data mixture optimization)**: treats a pretraining corpus's domain mixture weights as a bandit/DOE search problem (DoReMi-style), scored by cheap small-run proxies, plus a minimal corpus dedup/quality receipt.

New module `mixle/task/data_mixture.py`:

- **`SyntheticDomain`** -- a stand-in data-generating distribution: a fixed periodic token pattern (optionally noise-corrupted), or pure unlearnable noise (`period=None`).
- **`proxy_run_score(mixture_weights, domains, proxy_steps)`** -- one short proxy training run: builds a token stream sampled from the domains in the given proportions, trains a real (tiny) `mixle.models.language_model.LM`, and returns the mean held-out NLL across every domain (held-out data is independent of the mixture, and its sampling seed is fixed by default so repeated proxy runs during a search are scored against the same eval target).
- **`optimize_mixture(domains, proxy_steps, budget, method="bandit"|"doe")`** -- the DoReMi search loop over repeated proxy runs. `method="bandit"` discretizes the mixture simplex via `mixle.doe.mixture.simplex_lattice` and searches it with `mixle.task.bandit.ThompsonGaussian`; `method="doe"` searches continuously via `mixle.doe.optimizer.BayesianOptimizer` over a softmax-reparameterized simplex. No new optimizer machinery -- both are the same modules reused elsewhere this session.
- **`estimate_near_duplicate_rate(corpus)`** -- a minimal, honest MinHash-based dedup/quality receipt (no existing near-duplicate machinery was found under `mixle/data/`).

**F5 (scaling-law fits) integration point:** F5's branch was not reachable from this worktree when F8 was built, so its extrapolation (mapping a proxy run's loss to a predicted real-scale loss) is not wired in. The module docstring documents `proxy_run_score`'s return value as the natural place to plug that in later -- the search loop itself is agnostic to how the scalar score is produced.

## Test plan

New `mixle/tests/data_mixture_test.py` (8 tests, tagged `torch`/`slow`):

- **Acceptance criterion**: 4 synthetic domains of increasing difficulty; `optimize_mixture(method="doe")` learns weights from 16 proxy runs, then a learned-mixture model and a uniform-mixture model are trained at the SAME total token budget and evaluated on held-out data from every domain. Learned aggregate held-out NLL **2.4498** vs uniform **2.6699** (learned wins).
- **Optimizer sanity** (both `bandit` and `doe` methods): one informative domain + two pure-noise domains; confirms the optimizer discovers the informative domain deserves the most weight.
- **Dedup receipt**: a small corpus with planted exact/near duplicates recovers the expected near-duplicate rate; an all-unique corpus and single/empty corpora return 0.

Ran and confirmed green:
- [x] `ruff check --fix` / `ruff format` on all touched files
- [x] `mixle/tests/data_mixture_test.py` (8 passed)
- [x] `mixle/tests/bandit_test.py` (regression, still green)
- [x] `mixle/tests/doe_bayesopt_test.py`, `doe_optimizer_test.py`, `doe_mixture_test.py` (regression, still green)

Also registered the new module's public surface in `mixle/task/__init__.py`, and tagged the new test file `("torch", "slow")` in `mixle/tests/conftest.py` (consistent with other torch-training test files) so it doesn't slow down the default fast gate.
