### PR TITLE
test: harden imagine_test's mixture benchmark against EM local-optima collapse

### DIFF
--- a/mixle/tests/imagine_test.py
+++ b/mixle/tests/imagine_test.py
@@ -26,11 +26,24 @@ def _fit_single_gaussian(data):
     return optimize(data, GaussianEstimator(), out=None)
 
 
-def _fit_two_component_mixture(data):
-    # seeded: EM mixture init is random, and this fit is called more than once (the benchmark's own
-    # probe, then again inside propose_structure) -- must land in the same optimum both times.
-    est = MixtureEstimator([GaussianEstimator(), GaussianEstimator()])
-    return optimize(data, est, out=None, max_its=50, rng=np.random.RandomState(0))
+def _fit_two_component_mixture(data, n_restarts=8, base_seed=0):
+    # Multi-restart EM: a single fixed seed (previously RandomState(0)) is NOT robust -- for this
+    # exact bimodal fixture it collapses to two near-identical, near-zero-mean components (fitting
+    # one wide Gaussian over both modes) roughly a third of the time, a real degenerate local
+    # optimum that the benchmark's old weak `assertGreater` sanity check didn't actually catch (a
+    # degenerate 2-component fit still edges out a single Gaussian on held-out log-density purely
+    # from the extra free parameters, without ever representing genuine bimodality). Multi-restart
+    # keeps the fit -- and this benchmark -- honest regardless of which seed a future edit picks:
+    # try several seeds, keep the one with the best TRAINING log-likelihood (the standard, correct
+    # way to guard against EM local optima), not the one that happens to make an assertion pass.
+    best_fit, best_ll = None, -np.inf
+    for i in range(n_restarts):
+        est = MixtureEstimator([GaussianEstimator(), GaussianEstimator()])
+        candidate = optimize(data, est, out=None, max_its=50, rng=np.random.RandomState(base_seed + i))
+        ll = float(np.mean([candidate.log_density(x) for x in data]))
+        if ll > best_ll:
+            best_ll, best_fit = ll, candidate
+    return best_fit
 
 
 def _fit_wider_single_gaussian(data):
@@ -51,6 +64,19 @@ class ParadigmShiftCeilingTest(unittest.TestCase):
         single_score = float(np.mean([single_probe.log_density(x) for x in self.held_out]))
         two_comp_score = float(np.mean([two_comp_probe.log_density(x) for x in self.held_out]))
         self.assertGreater(two_comp_score, single_score)  # sanity: the benchmark is honest
+        # A degenerate 2-component fit (both components collapsed onto ~the same mean) can still
+        # edge out a single Gaussian on held-out score purely from the extra free parameters,
+        # WITHOUT ever representing genuine bimodality -- the assertGreater above alone does not
+        # catch that failure mode. Directly check the fit actually recovered two well-separated
+        # components (the true generating means are -3.0/+3.0), so this benchmark can't silently
+        # pass on a degenerate mixture.
+        component_means = sorted(c.mu for c in two_comp_probe.components)
+        self.assertGreater(
+            component_means[1] - component_means[0],
+            2.0,
+            "two-component fit did not recover well-separated components -- likely a collapsed "
+            "EM local optimum, not genuine bimodal recovery",
+        )
         self.target = (single_score + two_comp_score) / 2.0
 
     def test_single_gaussian_never_meets_target_no_matter_how_its_tuned(self):


### PR DESCRIPTION
## Summary
Found while implementing L5 (discrepancy->invention loop, PR #175): `imagine_test.py`'s two-component-mixture fit was pinned to `RandomState(0)`, which for this exact bimodal fixture collapses EM into a degenerate local optimum -- both components land on nearly identical N(~0, 9.15) fits (effectively one wide Gaussian spanning both modes) instead of the true well-separated N(-3, 0.16)/N(3, 0.16) structure. The test's own sanity check (`assertGreater` on held-out score vs. a single Gaussian) still passed, since a degenerate 2-component fit edges out a single Gaussian purely from having twice the free parameters -- it wasn't actually verifying genuine bimodal recovery.

- Replaced the single-seed fit with multi-restart EM (try several seeds, keep the best training log-likelihood) -- the standard, correct way to guard against EM local optima, robust regardless of which seed is in play.
- Added an explicit component-separation assertion in `setUp` so a future collapse can't silently pass again.

## Test plan
- [x] `pytest mixle/tests/imagine_test.py -q -n0 -m ""` -- 5/5 passing, run 3x to confirm no flakiness from the multi-restart's own seeding.
- [x] Confirmed the collapse independently first (`RandomState(0)` alone -> two components at mu=0.158/-0.148, sigma2~9.15) before writing the fix.
- [x] `ruff check`/`ruff format` clean.