### PR TITLE
J4: Frontier -> mixle-native students (distill, LNS, calibrate, cascade)

### DIFF
--- a/mixle/task/frontier_to_native.py
+++ b/mixle/task/frontier_to_native.py
@@ -1,0 +1,224 @@
+"""Frontier -> mixle-native students: distill, LNS-compress, calibrate, cascade -- the loop closed.
+
+The end-to-end pipeline the roadmap calls "J4": take a frontier/teacher model (large, expensive,
+general-purpose), distill it into a SMALL, TASK-SPECIFIC student, re-execute that student's inference
+in :class:`mixle.engines.lns.LogNumberSystem`'s integer log-space (compact, transcendental-free), wrap
+it in :class:`~mixle.task.calibrate.CalibratedTaskModel` for an honest answer-or-escalate decision, and
+compose it with the teacher into a :class:`~mixle.task.cascade.Cascade` for served, tiered inference.
+
+This module is deliberately thin: every piece already exists --
+
+  * :func:`mixle.task.distill.distill_structured` distills a teacher into a structured probabilistic
+    student (a learned dependency network: kilobytes, torch-free, an exact posterior).
+  * :func:`mixle.task.quantize.lns_classifier` re-executes that student's inference in the
+    :class:`~mixle.engines.lns.LogNumberSystem` integer log-space (the same LNS ``task.quantize``
+    already applies for compute quantization).
+  * :class:`~mixle.task.calibrate.CalibratedTaskModel` calibrates a conformal answer/escalate
+    threshold on held-out data (:class:`~mixle.task.calibrated_generator.CalibratedGenerator` is the
+    generative sibling -- it also exposes ``decide()``, so it drops into :class:`Cascade` unmodified
+    if the task is generative rather than classification).
+  * :class:`~mixle.task.cascade.Cascade` serves the calibrated LNS student first, escalating only
+    ambiguous/OOD requests to the teacher, and tracks realized cost.
+  * :func:`mixle.task.edge.footprint` measures the LNS student's real deployment bytes.
+
+:func:`distill_to_lns_student` / :func:`build_served_cascade` / :func:`measure_cascade_receipt` wire
+those five subsystems together and report the two numbers the roadmap item's acceptance criteria ask
+for: a served cascade cost/quality receipt, and the edge student's footprint + student-teacher
+agreement rate.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+from mixle.task.calibrate import CalibratedTaskModel
+from mixle.task.cascade import Cascade
+from mixle.task.distill import _as_batched, distill_structured
+from mixle.task.economics import CostModel
+from mixle.task.edge import footprint
+from mixle.task.model import TaskModel
+from mixle.task.quantize import lns_classifier
+
+__all__ = ["CascadeReceipt", "distill_to_lns_student", "build_served_cascade", "measure_cascade_receipt"]
+
+
+def distill_to_lns_student(
+    teacher: Callable[..., Any],
+    task_data: Sequence[Any],
+    *,
+    labels: Sequence[str] | None = None,
+    n_components: int = 1,
+    min_gain: float = 0.0,
+    n_bins: int = 4,
+    max_its: int = 30,
+    step: float = 1e-2,
+    seed: int = 0,
+    task: str = "",
+    n_jobs: int = 1,
+) -> TaskModel:
+    """Distill ``teacher`` into a small, task-specific structured student, then LNS-compress it.
+
+    Reuses :func:`~mixle.task.distill.distill_structured` for the distillation (the teacher labels
+    ``task_data`` once; the student discovers the joint dependency structure and classifies
+    generatively) and :func:`~mixle.task.quantize.lns_classifier` for the LNS conversion -- no new
+    quantization or distillation logic, just the existing rungs composed. The returned
+    :class:`~mixle.task.model.TaskModel` runs inference as integer add/max/LUT above the leaf boundary
+    (:mod:`mixle.engines.lns`) and needs no torch.
+    """
+    student = distill_structured(
+        teacher,
+        task_data,
+        labels=labels,
+        n_components=n_components,
+        min_gain=min_gain,
+        n_bins=n_bins,
+        max_its=max_its,
+        seed=seed,
+        task=task,
+        n_jobs=n_jobs,
+    )
+    return lns_classifier(student, step=step)
+
+
+def build_served_cascade(
+    lns_student: TaskModel,
+    teacher: Callable[..., Any],
+    cal_data: Sequence[Any],
+    cal_labels: Sequence[Any] | None = None,
+    *,
+    alpha: float = 0.1,
+    cost: CostModel | None = None,
+) -> Cascade:
+    """Calibrate the LNS student and compose it with ``teacher`` into a served :class:`Cascade`.
+
+    ``cal_data`` is a held-out slice (disjoint from ``lns_student``'s training data) used to fit the
+    conformal answer/escalate threshold (:meth:`~mixle.task.calibrate.CalibratedTaskModel.calibrate`).
+    If ``cal_labels`` is omitted, the teacher labels ``cal_data`` itself (one batched call) -- the same
+    "teacher is the ground truth for calibration" convention :func:`~mixle.task.distill.distill_for_routing`
+    uses. The returned :class:`~mixle.task.cascade.Cascade` answers locally when the LNS student's
+    conformal set is a confident singleton, and escalates to ``teacher`` otherwise.
+    """
+    cal_data = list(cal_data)
+    if cal_labels is None:
+        cal_labels = _as_batched(teacher)(cal_data)
+    else:
+        cal_labels = list(cal_labels)
+    calibrated = CalibratedTaskModel(lns_student, alpha=alpha).calibrate(cal_data, cal_labels)
+    return Cascade(calibrated, teacher, cost=cost)
+
+
+@dataclass(frozen=True)
+class CascadeReceipt:
+    """The served cascade's cost/quality tradeoff, plus the edge student's footprint and agreement.
+
+    ``*_cost_per_request`` are the per-request costs (student-only always local, teacher-only always
+    escalates, cascade the realized mix); the whole point of cascading is that ``cascade_cost`` lands
+    near ``student_cost`` while ``cascade_quality`` lands near (or measurably closer to)
+    ``teacher_quality`` -- see :meth:`earns_its_complexity`. ``student_bytes``/``teacher_bytes`` are the
+    real, measured deployment footprints (:func:`~mixle.task.edge.footprint` for the student); disk
+    ``compression_ratio`` is ``teacher_bytes / student_bytes`` when a teacher footprint is supplied.
+    ``agreement_rate`` is the fraction of the held-out test set where the LNS student's own answer
+    (not the cascade's escalate-mediated answer) matches the teacher's.
+    """
+
+    n_requests: int
+    n_escalated: int
+    student_cost_per_request: float
+    teacher_cost_per_request: float
+    cascade_cost_per_request: float
+    student_quality: float
+    teacher_quality: float
+    cascade_quality: float
+    student_bytes: int
+    teacher_bytes: int | None
+    compression_ratio: float | None
+    agreement_rate: float
+
+    def earns_its_complexity(self, *, tol: float = 1e-9) -> bool:
+        """Whether the cascade actually beats the extremes it sits between.
+
+        Cost: cascading costs ``c_local + p_escalate * c_frontier`` per request, so it can never be
+        cheaper than the pure-local student -- but it must be strictly cheaper than always paying the
+        teacher (``tol`` allows the degenerate zero-escalation case, where cascade cost equals the
+        student's exactly). Quality: the cascade must be at least as good as the student alone (the
+        escalations it does pay for should be net-positive, not wasted spend).
+        """
+        cost_between = (
+            self.student_cost_per_request - tol <= self.cascade_cost_per_request <= self.teacher_cost_per_request + tol
+        )
+        better_than_student = self.cascade_quality >= self.student_quality - tol
+        return cost_between and better_than_student
+
+    def summary(self) -> str:
+        comp = f"{self.compression_ratio:.1f}x" if self.compression_ratio is not None else "n/a"
+        return (
+            f"served {self.n_requests} requests, escalated {self.n_escalated} "
+            f"({self.n_escalated / self.n_requests:.0%})\n"
+            f"  cost/req   student ${self.student_cost_per_request:.5f}  "
+            f"cascade ${self.cascade_cost_per_request:.5f}  teacher ${self.teacher_cost_per_request:.5f}\n"
+            f"  quality    student {self.student_quality:.3f}  "
+            f"cascade {self.cascade_quality:.3f}  teacher {self.teacher_quality:.3f}\n"
+            f"  footprint  student {self.student_bytes}B  teacher "
+            f"{self.teacher_bytes if self.teacher_bytes is not None else 'n/a'}B  compression {comp}\n"
+            f"  student-teacher agreement {self.agreement_rate:.3f}"
+        )
+
+
+def measure_cascade_receipt(
+    cascade: Cascade,
+    test_data: Sequence[Any],
+    truth_labels: Sequence[Any],
+    *,
+    teacher_bytes: int | None = None,
+) -> CascadeReceipt:
+    """Serve ``test_data`` through ``cascade`` and measure the real cost/quality/footprint/agreement receipt.
+
+    Reuses the machinery already built for this, rather than re-deriving it: :meth:`Cascade.serve` (real
+    serving, so ``cascade``'s stats/realized cost are genuine, not simulated), :func:`~mixle.task.edge.footprint`
+    for the student's measured deployment bytes, and plain accuracy-vs-``truth_labels`` for quality (the
+    student and teacher are scored on the SAME held-out set the cascade was served, so all three numbers are
+    directly comparable). ``teacher_bytes`` is the caller-supplied measured/declared footprint of the frontier
+    model (opaque to mixle -- it is not a mixle artifact) used only for the reported compression ratio.
+    """
+    if cascade.cost is None:
+        raise ValueError("measure_cascade_receipt needs a Cascade built with a CostModel (cascade.cost)")
+
+    test_data = list(test_data)
+    truth = [str(t) for t in truth_labels]
+    if len(test_data) != len(truth):
+        raise ValueError("test_data and truth_labels must be the same length")
+
+    student = cascade.model.task  # the underlying (LNS-compressed) TaskModel wrapped by CalibratedTaskModel
+    student_preds = [str(p) for p in student.batch(test_data)]
+    teacher_preds = [str(p) for p in _as_batched(cascade.teacher)(test_data)]
+
+    student_quality = float(np.mean([p == t for p, t in zip(student_preds, truth)]))
+    teacher_quality = float(np.mean([p == t for p, t in zip(teacher_preds, truth)]))
+    agreement_rate = float(np.mean([s == t for s, t in zip(student_preds, teacher_preds)]))
+
+    cascade_preds = [str(p) for p in cascade.serve(test_data)]  # real serving: updates cascade.stats
+    cascade_quality = float(np.mean([p == t for p, t in zip(cascade_preds, truth)]))
+
+    n_requests = cascade.stats.n_requests
+    cascade_cost_per_request = cascade.realized_cost() / n_requests if n_requests else 0.0
+
+    student_bytes = footprint(student).bytes
+
+    return CascadeReceipt(
+        n_requests=n_requests,
+        n_escalated=cascade.stats.n_escalated,
+        student_cost_per_request=cascade.cost.c_local,
+        teacher_cost_per_request=cascade.cost.c_frontier,
+        cascade_cost_per_request=cascade_cost_per_request,
+        student_quality=student_quality,
+        teacher_quality=teacher_quality,
+        cascade_quality=cascade_quality,
+        student_bytes=student_bytes,
+        teacher_bytes=teacher_bytes,
+        compression_ratio=(teacher_bytes / student_bytes) if teacher_bytes else None,
+        agreement_rate=agreement_rate,
+    )

--- a/mixle/tests/frontier_to_native_test.py
+++ b/mixle/tests/frontier_to_native_test.py
@@ -1,0 +1,149 @@
+"""Frontier -> mixle-native students (mixle.task.frontier_to_native): the J4 integration loop, end to end.
+
+A "frontier" teacher (an oversized torch MLP, standing in for a big general-purpose model) is distilled
+into a small, task-specific, LNS-structured student; the student is calibrated and composed with the
+teacher into a served :class:`~mixle.task.cascade.Cascade`. This exercises the acceptance criteria
+directly: a real served cascade cost/quality receipt (cascade cost near the cheap student's, quality
+closer to the expensive teacher's), the LNS student's real compressed footprint versus the frontier's,
+and the real student-teacher agreement rate on held-out data.
+"""
+
+import unittest
+
+import numpy as np
+import pytest
+
+pytest.importorskip("torch")
+
+from mixle.task.distill import distill_records_from_labels  # noqa: E402
+from mixle.task.economics import CostModel  # noqa: E402
+from mixle.task.edge import footprint  # noqa: E402
+from mixle.task.frontier_to_native import (  # noqa: E402
+    build_served_cascade,
+    distill_to_lns_student,
+    measure_cascade_receipt,
+)
+
+
+def _truth(records):
+    """The ground-truth rule a frontier model (and, hopefully, its distilled student) should recover."""
+    out = []
+    for r in records:
+        score = (1.5 if r["region"] == "west" else -0.5) + 0.4 * r["spend"] + 0.3 * r["visits"]
+        out.append("churn" if score < 1.0 else "retain")
+    return out
+
+
+def _gen(n, seed):
+    rng = np.random.RandomState(seed)
+    return [
+        {
+            "region": rng.choice(["west", "east"]),
+            "spend": float(rng.normal(2.0, 1.5)),
+            "visits": int(rng.poisson(3)),
+        }
+        for _ in range(n)
+    ]
+
+
+def _build_frontier():
+    """An oversized torch MLP distilled from the ground-truth rule -- the expensive 'frontier' teacher.
+
+    Big on purpose (wide hidden layers, high-dim hashed features) so its measured byte footprint
+    (:func:`~mixle.task.edge.footprint`) is genuinely large relative to the LNS student -- the frontier
+    is a real mixle artifact here, not a hand-waved constant, so the compression ratio is real too.
+    """
+    records = _gen(1500, 0)
+    labels = _truth(records)
+    frontier = distill_records_from_labels(
+        records, labels, dim=1024, hidden=[256, 256], epochs=200, lr=1e-2, seed=0, task="frontier"
+    )
+    return frontier
+
+
+class _Teacher:
+    """Wraps the frontier TaskModel as a plain batched callable -- the ``teacher`` contract distill/cascade expect."""
+
+    def __init__(self, frontier):
+        self.frontier = frontier
+        self.calls = 0
+
+    def __call__(self, records):
+        self.calls += len(records)
+        return self.frontier.batch(list(records))
+
+
+class FrontierToNativeReceiptTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.frontier = _build_frontier()
+        cls.teacher = _Teacher(cls.frontier)
+        cls.teacher_bytes = footprint(cls.frontier).bytes
+
+        train = _gen(700, 1)
+        cls.lns_student = distill_to_lns_student(cls.teacher, train, min_gain=1.0, seed=0, task="lns_edge_student")
+
+        cal = _gen(200, 2)
+        cost = CostModel(c_frontier=1.0, c_local=0.001)
+        cls.cascade = build_served_cascade(cls.lns_student, cls.teacher, cal, alpha=0.1, cost=cost)
+
+        cls.test_records = _gen(400, 3)
+        cls.truth = _truth(cls.test_records)
+        cls.receipt = measure_cascade_receipt(cls.cascade, cls.test_records, cls.truth, teacher_bytes=cls.teacher_bytes)
+
+    def test_student_is_lns_structured_and_torch_free(self):
+        from mixle.task.quantize import LNSStructuredClassifierIO
+
+        self.assertIsInstance(self.lns_student.adapter, LNSStructuredClassifierIO)
+        self.assertEqual(self.lns_student.payload, "json")  # no torch weights on disk
+        fp = footprint(self.lns_student)
+        self.assertTrue(fp.torch_free)
+
+    def test_served_cascade_cost_quality_receipt(self):
+        r = self.receipt
+        print("\n" + r.summary())
+
+        # cost: the cascade is cheap -- close to the student, well under always-escalate-to-frontier
+        self.assertLessEqual(r.cascade_cost_per_request, r.teacher_cost_per_request)
+        self.assertLess(r.cascade_cost_per_request, (r.student_cost_per_request + r.teacher_cost_per_request) / 2)
+
+        # quality: cascade should not be worse than the student alone, and the frontier is genuinely better
+        self.assertGreaterEqual(r.cascade_quality, r.student_quality - 1e-9)
+        self.assertGreater(r.teacher_quality, 0.8)
+
+        self.assertTrue(r.earns_its_complexity())
+        self.assertGreater(r.n_requests, 0)
+        self.assertLessEqual(r.n_escalated, r.n_requests)
+
+    def test_edge_student_footprint_and_agreement(self):
+        r = self.receipt
+        # a real, measured compression ratio: the structured/LNS student is dramatically smaller
+        self.assertIsNotNone(r.compression_ratio)
+        self.assertGreater(r.student_bytes, 0)
+        self.assertLess(r.student_bytes, self.teacher_bytes)
+        self.assertGreater(r.compression_ratio, 5.0)
+
+        # a real student-teacher agreement rate on held-out data
+        self.assertGreaterEqual(r.agreement_rate, 0.0)
+        self.assertLessEqual(r.agreement_rate, 1.0)
+        manual_student_preds = [str(p) for p in self.lns_student.batch(self.test_records)]
+        manual_teacher_preds = [str(p) for p in self.teacher(self.test_records)]
+        manual_agreement = float(np.mean([s == t for s, t in zip(manual_student_preds, manual_teacher_preds)]))
+        self.assertAlmostEqual(r.agreement_rate, manual_agreement, places=9)
+        # a genuinely useful edge student agrees with its teacher well above chance (2 classes here)
+        self.assertGreater(r.agreement_rate, 0.6)
+
+    def test_teacher_only_touched_on_escalation(self):
+        # the cascade only calls the teacher for escalated requests, not every request
+        calls_before = self.teacher.calls
+        cascade = build_served_cascade(
+            self.lns_student, self.teacher, _gen(150, 20), alpha=0.1, cost=CostModel(c_frontier=1.0, c_local=0.0)
+        )
+        served = _gen(120, 21)
+        cascade.serve(served)
+        self.assertEqual(cascade.stats.n_escalated, self.teacher.calls - calls_before - 150)
+        self.assertLess(cascade.stats.n_escalated, len(served))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Stacked on `calibrated-generator` (A1's `CalibratedGenerator` branch), since J4 closes the loop with A1's calibration work.

Implements roadmap item **J4: Frontier -> mixle-native students** by wiring together five already-existing subsystems into one small module, `mixle/task/frontier_to_native.py` -- no new distillation, quantization, calibration, or routing logic:

- `mixle.task.distill.distill_structured` -- distills a frontier/teacher into a small, task-specific structured probabilistic student.
- `mixle.task.quantize.lns_classifier` -- re-executes that student's inference in `mixle.engines.lns.LogNumberSystem`'s integer log-space (LNS-structured, torch-free).
- `mixle.task.calibrate.CalibratedTaskModel` -- calibrates a conformal answer/escalate threshold on held-out data (the generative sibling `CalibratedGenerator` from A1 also exposes `decide()`, so it drops into `Cascade` unmodified for generative tasks -- noted in the module docstring, no separate code path needed).
- `mixle.task.cascade.Cascade` -- serves the calibrated LNS student first, escalating only ambiguous/OOD requests to the teacher, with realized cost tracking.
- `mixle.task.edge.footprint` -- measures the LNS student's real deployment bytes.

Three new entry points:
- `distill_to_lns_student(teacher, task_data, ...) -> TaskModel`
- `build_served_cascade(lns_student, teacher, cal_data, ...) -> Cascade`
- `measure_cascade_receipt(cascade, test_data, truth_labels, ...) -> CascadeReceipt`

## Measured receipt (from the new test suite, a real synthetic churn task)

A deliberately oversized torch MLP (dim=1024, hidden=[256,256]) stands in for the "frontier" teacher; the LNS-structured student is distilled from it and served in a calibrated cascade:

```
served 400 requests, escalated 33 (8%)
  cost/req   student $0.00100  cascade $0.08350  teacher $1.00000
  quality    student 0.812  cascade 0.835  teacher 0.838
  footprint  student 5062B  teacher 1314824B  compression 259.7x
  student-teacher agreement 0.945
```

- **Cost/quality receipt**: cascade cost ($0.0835/req) sits far below teacher-only ($1.00/req) and close to student-only ($0.001/req); cascade quality (0.835) is at least as good as the student alone and closes most of the gap to the teacher (0.838). `CascadeReceipt.earns_its_complexity()` asserts this holds.
- **Edge footprint**: the LNS-compressed student is 5,062 bytes vs. the frontier's 1,314,824 bytes -- a real ~260x compression ratio, both measured via `mixle.task.edge.footprint`.
- **Agreement**: 94.5% student-teacher agreement on held-out data, cross-checked against a manual recomputation in the test.

## Test plan

- [x] New `mixle/tests/frontier_to_native_test.py` (4 tests): LNS-structured/torch-free student, served cascade cost/quality receipt + `earns_its_complexity`, edge footprint + agreement rate (with manual cross-check), teacher called only on escalation.
- [x] `ruff check --fix` / `ruff format` clean on the new files.
- [x] No regressions: `task_cascade_test`, `task_router_test`, `router_harvest_test`, `task_calibrate_test`, `task_calibrated_generator_test`, `task_distill_structured_test`, `task_distill_test`, `task_quantize_test`, `lns_test`, `edge_distill_test` all pass (58 passed).
