### PR TITLE
models: F6 memory efficiency for training state (fp8 hardening, G4/8-bit optimizer compression, selective recompute)

### DIFF
--- a/mixle/models/memory_efficient_training.py
+++ b/mixle/models/memory_efficient_training.py
@@ -1,0 +1,752 @@
+"""Memory efficiency for training state (roadmap F6): fp8 hardening + compressed optimizer
+moments + a per-block selective activation-recompute policy.
+
+Three pieces, per the roadmap spec:
+
+1. **fp8 hardening** (:func:`fp8_cast_with_guard`) -- the existing fp8 mention in this codebase
+   (``mixle/utils/parallel/torch_neural.py``'s ``precision`` docstring: ``"fp32"|"bf16" (fp8 =
+   torchao, vendored)``) is, honestly, just a comment: no fp8 code path actually exists there yet.
+   "Hardening" here means building the real thing with real edge-case handling -- using torch's
+   NATIVE ``float8_e4m3fn``/``float8_e5m2`` dtypes (no torchao dependency needed for the guard
+   logic itself) plus explicit overflow detection (values exceeding the format's representable
+   range, which fp8 hardware silently clamps to +/-inf rather than raising), underflow detection
+   (fp8's tiny dynamic range flushing a large fraction of small-but-nonzero values to zero), and a
+   graceful fallback to a wider dtype (bf16/fp32) whenever either guard fires -- rather than
+   accepting a silently-corrupted fp8 tensor.
+
+2. **Optimizer-state compression** (:class:`CompressedOptimizerState`, :class:`CompressedAdam`) --
+   Adam-style optimizers keep two moment buffers (``m``, ``v``) at the SAME size as the parameters
+   they track (states are 2x params fp32, per the F6 spec). This directly reuses G4
+   (``mixle.models.sorted_profile_quantizer.fit_sorted_profile``/``reconstruct``), which was
+   explicitly built with "optimizer states (F6)" as its first named use case, as one compression
+   path, PLUS a simpler/cheaper 8-bit blockwise quantization path (the standard bitsandbytes-style
+   8-bit-Adam technique) as a fast alternative when G4's fuller (and more expensive to fit) sorted-
+   profile machinery is not worth its cost. :func:`choose_compression_method` picks between them
+   per tensor using a goodness-of-fit-based rule (reusing G4's own KS-statistic receipt for the G4
+   path, and a real reconstruction-error check for the int8 path), with a DENSE fallback -- mirroring
+   G4's own "receipt-driven dense fallback" pattern -- when neither compressed representation is
+   trustworthy for a given (possibly adversarial) tensor.
+
+3. **Selective activation-recompute policy** (:class:`SelectiveRecomputePolicy`) -- extends
+   ``mixle.models.transformer.CausalLM``'s previously all-or-nothing ``gradient_checkpointing``
+   bool flag to a PER-BLOCK decision, using a real cost model: a block's stored-activation memory
+   footprint (the benefit of recomputing it instead) versus its recompute FLOP cost. This mirrors
+   the cost/benefit-tradeoff SHAPE of D6's compile economics
+   (``mixle.inference.backend_respecialization.estimate_compile_cost``/``estimate_compile_benefit``,
+   PR #153) -- a fixed/proxy-unit cost estimate compared against a fixed/proxy-unit benefit estimate,
+   with a net-benefit-positive gate -- applied here to a different decision (recompute vs. store,
+   not eager vs. compiled). D6 itself lives on a separate, not-yet-merged branch
+   (``backend-respecialization``) so it is not imported here; the pattern is reapplied standalone.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+from mixle.models.sorted_profile_quantizer import (
+    DEFAULT_GOF_THRESHOLD,
+    SortedProfileEncoding,
+    fit_sorted_profile,
+)
+from mixle.models.sorted_profile_quantizer import (
+    reconstruct as _g4_reconstruct,
+)
+
+try:
+    import torch
+
+    _HAS_TORCH = True
+except ImportError:  # pragma: no cover - torch is optional
+    _HAS_TORCH = False
+
+__all__ = [
+    "fp8_cast_with_guard",
+    "Fp8CastResult",
+    "quantize_int8_blockwise",
+    "dequantize_int8_blockwise",
+    "CompressedMomentEncoding",
+    "choose_compression_method",
+    "compress_moment",
+    "decompress_moment",
+    "CompressedOptimizerState",
+    "CompressedAdam",
+    "RecomputeDecision",
+    "SelectiveRecomputePolicy",
+    "estimate_block_activation_bytes",
+    "estimate_block_recompute_flops",
+    "estimate_recompute_benefit",
+    "estimate_recompute_cost",
+]
+
+# ---------------------------------------------------------------------------------------------
+# 1. fp8 hardening
+# ---------------------------------------------------------------------------------------------
+
+# Representable-magnitude ceilings for torch's two native fp8 formats (IEEE-ish, finite-only for
+# e4m3fn). Values above these are NOT raised on cast -- fp8 hardware/software casts silently clamp
+# to +/-inf (e5m2, which has an inf encoding) or to NaN (e4m3fn, which has no inf encoding and
+# reserves its would-be-inf bit pattern for NaN) -- so an explicit pre-cast magnitude check is the
+# only way to catch this before it silently corrupts a tensor.
+_FP8_FORMAT_MAX = {
+    "float8_e4m3fn": 448.0,
+    "float8_e5m2": 57344.0,
+}
+
+_DEFAULT_UNDERFLOW_FRACTION_THRESHOLD = 0.5
+
+
+@dataclass(frozen=True)
+class Fp8CastResult:
+    """Receipt of one :func:`fp8_cast_with_guard` call -- never silently swallowed.
+
+    Attributes:
+        tensor: The output tensor -- either the fp8-cast tensor (``used_fp8=True``) or the
+            ``fallback_dtype`` cast (``used_fp8=False``).
+        used_fp8 (bool): Whether the fp8 cast was accepted.
+        reason (str): Human-readable reason for the decision (acceptance or the specific guard
+            that fired).
+        max_abs (float): The input tensor's max absolute value (0.0 for an empty tensor) -- the
+            statistic the overflow guard checks.
+        underflow_fraction (float): Fraction of the input's nonzero values that flushed to exactly
+            zero under the fp8 round-trip -- the statistic the underflow guard checks. ``0.0`` when
+            the overflow guard fired first (the round-trip was never attempted).
+    """
+
+    tensor: Any
+    used_fp8: bool
+    reason: str
+    max_abs: float
+    underflow_fraction: float
+
+
+def fp8_cast_with_guard(
+    tensor: Any,
+    fp8_dtype: str = "float8_e4m3fn",
+    fallback_dtype: Any = None,
+    underflow_fraction_threshold: float = _DEFAULT_UNDERFLOW_FRACTION_THRESHOLD,
+) -> Fp8CastResult:
+    """Attempt an fp8 cast of ``tensor``, guarded against the two ways fp8 silently corrupts data.
+
+    Args:
+        tensor: A torch tensor (any float dtype).
+        fp8_dtype (str): ``"float8_e4m3fn"`` (higher precision, smaller range -- the default,
+            matching common fp8-training practice for weights/activations) or ``"float8_e5m2"``
+            (wider range, coarser precision).
+        fallback_dtype: Dtype to fall back to when a guard fires. Defaults to ``torch.bfloat16``
+            (the codebase's existing wide-range training dtype, per
+            ``mixle.utils.parallel.torch_neural``).
+        underflow_fraction_threshold (float): Maximum tolerable fraction of nonzero input values
+            that are allowed to flush to exactly zero under the fp8 round-trip before the underflow
+            guard fires.
+
+    Returns:
+        Fp8CastResult: always carries the real, computed guard statistics, whether or not the fp8
+        cast was ultimately accepted -- consistent with this codebase's receipt-over-silent-
+        assumption convention (see :mod:`mixle.models.sorted_profile_quantizer`'s
+        goodness-of-fit receipt).
+    """
+    if not _HAS_TORCH:
+        raise ImportError("fp8_cast_with_guard requires torch.")
+    if fallback_dtype is None:
+        fallback_dtype = torch.bfloat16
+
+    if not hasattr(torch, fp8_dtype):
+        return Fp8CastResult(
+            tensor=tensor.to(fallback_dtype),
+            used_fp8=False,
+            reason=f"torch build lacks native {fp8_dtype!r} -- falling back to {fallback_dtype}",
+            max_abs=0.0,
+            underflow_fraction=0.0,
+        )
+    torch_fp8_dtype = getattr(torch, fp8_dtype)
+
+    finite_mask = torch.isfinite(tensor)
+    if not bool(finite_mask.all()):
+        return Fp8CastResult(
+            tensor=tensor.to(fallback_dtype),
+            used_fp8=False,
+            reason="input already contains non-finite (inf/nan) values -- refusing to fp8-cast",
+            max_abs=float("inf"),
+            underflow_fraction=0.0,
+        )
+
+    max_abs = float(tensor.detach().abs().max().item()) if tensor.numel() else 0.0
+    fmt_max = _FP8_FORMAT_MAX[fp8_dtype]
+    if max_abs > fmt_max:
+        return Fp8CastResult(
+            tensor=tensor.to(fallback_dtype),
+            used_fp8=False,
+            reason=f"max abs value {max_abs:.6g} exceeds {fp8_dtype} format max {fmt_max:.6g} -- overflow risk",
+            max_abs=max_abs,
+            underflow_fraction=0.0,
+        )
+
+    cast = tensor.to(torch_fp8_dtype)
+    round_tripped = cast.to(tensor.dtype)
+
+    nonzero_before = tensor != 0
+    n_nonzero = int(nonzero_before.sum().item())
+    if n_nonzero > 0:
+        flushed = int(((round_tripped == 0) & nonzero_before).sum().item())
+        underflow_fraction = flushed / n_nonzero
+    else:
+        underflow_fraction = 0.0
+
+    if underflow_fraction > underflow_fraction_threshold:
+        return Fp8CastResult(
+            tensor=tensor.to(fallback_dtype),
+            used_fp8=False,
+            reason=(
+                f"{underflow_fraction:.1%} of nonzero values flushed to zero under the fp8 round-trip "
+                f"(threshold {underflow_fraction_threshold:.1%}) -- underflow risk"
+            ),
+            max_abs=max_abs,
+            underflow_fraction=underflow_fraction,
+        )
+
+    if not bool(torch.isfinite(round_tripped).all()):
+        return Fp8CastResult(
+            tensor=tensor.to(fallback_dtype),
+            used_fp8=False,
+            reason="fp8 round-trip produced non-finite values despite passing the magnitude guard",
+            max_abs=max_abs,
+            underflow_fraction=underflow_fraction,
+        )
+
+    return Fp8CastResult(
+        tensor=cast,
+        used_fp8=True,
+        reason="fp8 cast accepted -- within representable range, underflow within tolerance",
+        max_abs=max_abs,
+        underflow_fraction=underflow_fraction,
+    )
+
+
+# ---------------------------------------------------------------------------------------------
+# 2. Optimizer-state compression: G4 (sorted-profile) + 8-bit blockwise moments
+# ---------------------------------------------------------------------------------------------
+
+# Blockwise int8 quantization is the fast, cheap alternative to G4's full sorted-profile fit
+# (which pays a real cost: a distribution fit via mixle.inference.estimate plus a KS goodness-of-
+# fit test, both O(n log n) or worse). Per-block dynamic scaling (rather than one global scale)
+# bounds the damage a single outlier block can do to the rest of the tensor's resolution -- the
+# same reasoning bitsandbytes' 8-bit optimizers use.
+_DEFAULT_INT8_BLOCK_SIZE = 2048
+
+# Below this element count, G4's fixed per-tensor overhead (a distribution fit, a KS test, a
+# permutation array) is not worth paying relative to a tensor this small -- int8 (or dense) is
+# cheaper and, at this size, comparably accurate.
+_DEFAULT_MIN_SIZE_FOR_G4 = 4096
+
+# Fraction of a tensor's elements carved out as G4's head-exact top-k outliers when this module
+# picks the G4 path -- kept small and proportional (rather than a fixed count) so it scales with
+# tensor size while staying negligible relative to the tail.
+_DEFAULT_G4_TOP_K_FRACTION = 0.001
+
+# Above this relative-L2 reconstruction error, an int8 quantization is treated as untrustworthy
+# and the dense fallback engages -- mirroring G4's own receipt-driven dense-fallback pattern, just
+# with a reconstruction-error receipt instead of a KS-statistic receipt. On its own this catches
+# global magnitude blowups, but NOT a single-outlier-crushes-its-block failure mode: when one
+# extreme value sets a block's scale, the outlier itself still reconstructs almost exactly (its
+# own quantization error is tiny relative to ITS OWN magnitude), so it also dominates the
+# tensor-wide L2 norm and can mask a large fraction of the block's other values being flushed to
+# zero. :data:`_DEFAULT_INT8_FLUSHED_FRACTION_THRESHOLD` (below) is the second, independent guard
+# that catches exactly that case -- the same "fraction of nonzero values flushed to zero" idea
+# :func:`fp8_cast_with_guard` already uses for its own underflow guard, reused here.
+_DEFAULT_INT8_ADVERSARIAL_RELATIVE_ERROR = 0.5
+
+# Above this fraction of nonzero input values reconstructing as exactly zero, an int8
+# quantization is treated as untrustworthy regardless of the global relative-L2 error (see the
+# note above) -- e.g. a block dominated by one extreme outlier that flushes most of the rest of
+# the block to zero while barely moving the tensor-wide L2 norm.
+_DEFAULT_INT8_FLUSHED_FRACTION_THRESHOLD = 0.3
+
+
+def _flatten_to_numpy(tensor: Any) -> np.ndarray:
+    if hasattr(tensor, "detach"):  # torch.Tensor
+        return tensor.detach().cpu().numpy().reshape(-1).astype(np.float64)
+    return np.asarray(tensor).reshape(-1).astype(np.float64)
+
+
+def _tensor_shape(tensor: Any) -> tuple:
+    if hasattr(tensor, "shape"):
+        return tuple(tensor.shape)
+    return (np.asarray(tensor).size,)
+
+
+def quantize_int8_blockwise(
+    flat: np.ndarray, block_size: int = _DEFAULT_INT8_BLOCK_SIZE
+) -> tuple[np.ndarray, np.ndarray]:
+    """Dynamic per-block symmetric int8 quantization (bitsandbytes-style 8-bit-Adam technique).
+
+    Each contiguous block of ``block_size`` elements gets its own scale (``absmax / 127``), so one
+    extreme value only degrades the resolution of ITS OWN block rather than the whole tensor.
+
+    Returns:
+        tuple[np.ndarray, np.ndarray]: ``(codes, scales)`` -- ``codes`` is ``int8`` and the same
+        length as ``flat``; ``scales`` is one ``float32`` per block.
+    """
+    flat = np.asarray(flat, dtype=np.float64).reshape(-1)
+    n = flat.size
+    block_size = max(int(block_size), 1)
+    n_blocks = int(np.ceil(n / block_size)) if n else 0
+    codes = np.zeros(n, dtype=np.int8)
+    scales = np.zeros(n_blocks, dtype=np.float32)
+    for b in range(n_blocks):
+        lo, hi = b * block_size, min((b + 1) * block_size, n)
+        block = flat[lo:hi]
+        absmax = float(np.abs(block).max()) if block.size else 0.0
+        scale = absmax / 127.0 if absmax > 0 else 1.0
+        scales[b] = scale
+        codes[lo:hi] = np.clip(np.round(block / scale), -127, 127).astype(np.int8)
+    return codes, scales
+
+
+def dequantize_int8_blockwise(
+    codes: np.ndarray, scales: np.ndarray, block_size: int = _DEFAULT_INT8_BLOCK_SIZE
+) -> np.ndarray:
+    """Invert :func:`quantize_int8_blockwise`. Returns a ``float32`` array the same length as ``codes``."""
+    codes = np.asarray(codes)
+    n = codes.size
+    block_size = max(int(block_size), 1)
+    out = np.zeros(n, dtype=np.float32)
+    for b, scale in enumerate(scales):
+        lo, hi = b * block_size, min((b + 1) * block_size, n)
+        out[lo:hi] = codes[lo:hi].astype(np.float32) * float(scale)
+    return out
+
+
+@dataclass
+class CompressedMomentEncoding:
+    """Storage format for ONE moment tensor (``m`` or ``v``), compressed by exactly one of the
+    three available methods -- only the fields for ``method`` are populated, mirroring
+    :class:`~mixle.models.sorted_profile_quantizer.SortedProfileEncoding`'s single-active-branch
+    convention.
+
+    Attributes:
+        method (str): ``"g4"`` (sorted-profile, :mod:`mixle.models.sorted_profile_quantizer`),
+            ``"int8"`` (blockwise quantization), or ``"dense"`` (fallback -- neither compressed
+            representation was trustworthy for this tensor).
+        shape (tuple[int, ...]): Original tensor shape.
+        g4_encoding: Populated iff ``method == "g4"``.
+        int8_codes / int8_scales / int8_block_size: Populated iff ``method == "int8"``.
+        dense_values: Populated iff ``method == "dense"``.
+    """
+
+    method: str
+    shape: tuple
+    g4_encoding: SortedProfileEncoding | None = None
+    int8_codes: np.ndarray | None = None
+    int8_scales: np.ndarray | None = None
+    int8_block_size: int = _DEFAULT_INT8_BLOCK_SIZE
+    dense_values: np.ndarray | None = None
+
+    def nbytes(self) -> int:
+        """Measured storage footprint, in bytes -- delegates to G4's own receipt-carrying
+        ``nbytes()`` for the G4 branch; computes int8/dense directly."""
+        if self.method == "g4":
+            return self.g4_encoding.nbytes()
+        if self.method == "int8":
+            return int(self.int8_codes.nbytes + self.int8_scales.astype(np.float32).nbytes)
+        return int(self.dense_values.astype(np.float32).nbytes)
+
+
+def choose_compression_method(
+    tensor: Any,
+    *,
+    min_size_for_g4: int = _DEFAULT_MIN_SIZE_FOR_G4,
+    g4_top_k_fraction: float = _DEFAULT_G4_TOP_K_FRACTION,
+    g4_gof_threshold: float = DEFAULT_GOF_THRESHOLD,
+    tail_family: Any = None,
+) -> str:
+    """Goodness-of-fit-based per-tensor method picker (the "one level down" method-picker pattern
+    I1 uses for its own picker -- ``mixle.task.bandit`` is a reasonable fit for a LEARNED, reward-
+    driven picker, but the choice here is cheaper and just as principled as a fixed rule: G4 already
+    computes a real KS goodness-of-fit receipt as part of fitting, so reusing THAT receipt directly
+    is simpler than bolting on a bandit that would need to learn what the receipt already tells us
+    for free).
+
+    Rule: for tensors at or above ``min_size_for_g4`` (below which G4's fixed per-tensor fitting
+    overhead is not worth it), attempt a G4 fit; if it does not dense-fall-back on its own
+    goodness-of-fit receipt, use G4 (the more accurate, more expensive path). Otherwise, use int8
+    (the cheap path) -- callers should still check :func:`compress_moment`'s returned
+    ``method`` for a possible further downgrade to ``"dense"`` if int8 itself proves untrustworthy
+    for this specific tensor (see :data:`_DEFAULT_INT8_ADVERSARIAL_RELATIVE_ERROR`).
+    """
+    flat = _flatten_to_numpy(tensor)
+    n = flat.size
+    if n >= min_size_for_g4:
+        top_k = max(0, int(g4_top_k_fraction * n))
+        g4_encoding = fit_sorted_profile(tensor, top_k=top_k, tail_family=tail_family, gof_threshold=g4_gof_threshold)
+        if not g4_encoding.used_dense_fallback:
+            return "g4"
+    return "int8"
+
+
+def compress_moment(
+    tensor: Any,
+    method: str = "auto",
+    *,
+    min_size_for_g4: int = _DEFAULT_MIN_SIZE_FOR_G4,
+    g4_top_k_fraction: float = _DEFAULT_G4_TOP_K_FRACTION,
+    g4_gof_threshold: float = DEFAULT_GOF_THRESHOLD,
+    int8_block_size: int = _DEFAULT_INT8_BLOCK_SIZE,
+    int8_adversarial_relative_error: float = _DEFAULT_INT8_ADVERSARIAL_RELATIVE_ERROR,
+    int8_flushed_fraction_threshold: float = _DEFAULT_INT8_FLUSHED_FRACTION_THRESHOLD,
+    tail_family: Any = None,
+) -> CompressedMomentEncoding:
+    """Compress one Adam moment tensor (``m`` or ``v``) via G4, int8, or dense storage.
+
+    Args:
+        tensor: A torch tensor or numpy array (one Adam moment buffer, any shape).
+        method (str): ``"auto"`` (use :func:`choose_compression_method`), ``"g4"``, ``"int8"``, or
+            ``"dense"`` to force a specific path. A forced ``"g4"``/``"int8"`` still honestly
+            downgrades to ``"dense"`` if the chosen method's own receipt (G4's KS statistic, or
+            int8's reconstruction error) rejects the fit -- this function never returns a silently
+            bad compressed representation.
+
+    Returns:
+        CompressedMomentEncoding
+    """
+    flat = _flatten_to_numpy(tensor)
+    shape = _tensor_shape(tensor)
+
+    chosen = method
+    if chosen == "auto":
+        chosen = choose_compression_method(
+            tensor,
+            min_size_for_g4=min_size_for_g4,
+            g4_top_k_fraction=g4_top_k_fraction,
+            g4_gof_threshold=g4_gof_threshold,
+            tail_family=tail_family,
+        )
+
+    if chosen == "g4":
+        top_k = max(0, int(g4_top_k_fraction * flat.size))
+        g4_encoding = fit_sorted_profile(tensor, top_k=top_k, tail_family=tail_family, gof_threshold=g4_gof_threshold)
+        if g4_encoding.used_dense_fallback:
+            # G4's own receipt rejected the fit -- honor it rather than force a bad G4 encoding.
+            return CompressedMomentEncoding(method="dense", shape=shape, dense_values=flat.astype(np.float32))
+        return CompressedMomentEncoding(method="g4", shape=shape, g4_encoding=g4_encoding)
+
+    if chosen == "int8":
+        codes, scales = quantize_int8_blockwise(flat, block_size=int8_block_size)
+        recon = dequantize_int8_blockwise(codes, scales, block_size=int8_block_size)
+        denom = float(np.linalg.norm(flat))
+        rel_error = float(np.linalg.norm(recon - flat) / denom) if denom > 0 else 0.0
+        nonzero_before = flat != 0
+        n_nonzero = int(nonzero_before.sum())
+        flushed_fraction = float(((recon == 0) & nonzero_before).sum()) / n_nonzero if n_nonzero > 0 else 0.0
+        if rel_error > int8_adversarial_relative_error or flushed_fraction > int8_flushed_fraction_threshold:
+            # Adversarial tensor for blockwise int8 -- either a global magnitude blowup (caught by
+            # rel_error) or a single-outlier-dominated block flushing most of its OTHER values to
+            # zero while barely moving the tensor-wide L2 norm (caught by flushed_fraction) -- fall
+            # back to dense.
+            return CompressedMomentEncoding(method="dense", shape=shape, dense_values=flat.astype(np.float32))
+        return CompressedMomentEncoding(
+            method="int8",
+            shape=shape,
+            int8_codes=codes,
+            int8_scales=scales.astype(np.float32),
+            int8_block_size=int8_block_size,
+        )
+
+    return CompressedMomentEncoding(method="dense", shape=shape, dense_values=flat.astype(np.float32))
+
+
+def decompress_moment(encoding: CompressedMomentEncoding) -> np.ndarray:
+    """Invert :func:`compress_moment`. Returns a ``float32`` array reshaped to ``encoding.shape``."""
+    if encoding.method == "g4":
+        return _g4_reconstruct(encoding.g4_encoding)
+    if encoding.method == "int8":
+        flat = dequantize_int8_blockwise(encoding.int8_codes, encoding.int8_scales, encoding.int8_block_size)
+        return flat.reshape(encoding.shape)
+    return encoding.dense_values.reshape(encoding.shape)
+
+
+class CompressedOptimizerState:
+    """Adam-style ``m``/``v`` moment storage for ONE parameter tensor, held COMPRESSED between
+    optimizer steps (rather than as two dense fp32 buffers).
+
+    ``set`` compresses; ``get`` decompresses back to plain tensors for the optimizer math to use.
+
+    ``v`` (Adam's second moment, an EMA of squared gradients) is stored as its COMPRESSED SQUARE
+    ROOT rather than compressed directly. This is a real, load-bearing design choice, not
+    cosmetic: ``v`` routinely spans many orders of magnitude within one parameter tensor (a few
+    large-gradient elements next to many near-zero ones), which is exactly the dynamic range that
+    defeats both compression paths -- linear int8 quantization sets one block-wide scale from the
+    block's max, so any element more than ~127x smaller than that max quantizes to LITERALLY zero;
+    G4's Gaussian tail fit is symmetric and can reconstruct small true values as slightly negative.
+    Either failure, fed straight into Adam's ``1/(sqrt(v_hat) + eps)`` denominator, produces a
+    step blown up by orders of magnitude (empirically confirmed: an early version of this module,
+    compressing ``v`` directly with int8, diverged to a >100x loss spike within ~5 steps on the
+    tiny transformer this module's own test suite trains). ``sqrt(v)`` roughly halves the dynamic
+    range in log-space (Adam's own second-moment buffer already tracks squared gradients FOR this
+    reason -- ``sqrt(v)`` is the RMS gradient-magnitude scale, the quantity Adam's update actually
+    normalizes by), and squaring the reconstructed value back on :meth:`get` is a nonnegative
+    projection for free -- it can never reconstruct a negative ``v``, closing the negative-v/NaN
+    failure mode without a separate clamp needing to paper over it (a defensive ``clamp_min(0.0)``
+    is still applied as a last line of defense in :class:`CompressedAdam`, since callers of
+    ``CompressedOptimizerState`` directly should not have to know this internal detail to stay safe).
+    """
+
+    def __init__(self, shape: tuple, method: str = "auto", **compress_kwargs: Any) -> None:
+        self.shape = tuple(shape)
+        self.method = method
+        self._compress_kwargs = compress_kwargs
+        self._m: CompressedMomentEncoding | None = None
+        self._v: CompressedMomentEncoding | None = None
+
+    def set(self, m: Any, v: Any) -> None:
+        self._m = compress_moment(m, method=self.method, **self._compress_kwargs)
+        sqrt_v = v.clamp_min(0.0).sqrt() if hasattr(v, "clamp_min") else np.sqrt(np.clip(v, 0.0, None))
+        self._v = compress_moment(sqrt_v, method=self.method, **self._compress_kwargs)
+
+    def get(self, device: Any = None, dtype: Any = None) -> tuple[Any, Any]:
+        if self._m is None or self._v is None:
+            raise RuntimeError("CompressedOptimizerState.get() called before set()")
+        if not _HAS_TORCH:
+            raise ImportError("CompressedOptimizerState.get requires torch.")
+        m = torch.from_numpy(decompress_moment(self._m))
+        sqrt_v = torch.from_numpy(decompress_moment(self._v))
+        v = sqrt_v * sqrt_v  # nonnegative by construction, regardless of any reconstruction noise
+        if dtype is not None:
+            m, v = m.to(dtype), v.to(dtype)
+        if device is not None:
+            m, v = m.to(device), v.to(device)
+        return m, v
+
+    def nbytes(self) -> int:
+        """Total measured compressed footprint of both moment buffers, in bytes."""
+        m_bytes = self._m.nbytes() if self._m is not None else 0
+        v_bytes = self._v.nbytes() if self._v is not None else 0
+        return m_bytes + v_bytes
+
+    @property
+    def methods(self) -> tuple[str | None, str | None]:
+        """``(m_method, v_method)`` -- the ACTUAL method used for each buffer (post any honest
+        downgrade-to-dense), not just the one requested."""
+        return (
+            self._m.method if self._m is not None else None,
+            self._v.method if self._v is not None else None,
+        )
+
+
+if _HAS_TORCH:
+
+    class CompressedAdam(torch.optim.Optimizer):
+        """Adam whose per-parameter ``m``/``v`` moment buffers are held COMPRESSED
+        (:class:`CompressedOptimizerState`) between steps, instead of as two dense fp32 buffers --
+        the "optimizer-state compression" half of F6.
+
+        Mirrors the well-known 8-bit-Adam pattern (bitsandbytes): decompress -> take the exact Adam
+        update in the parameter's own dtype -> recompress. The per-step update math is byte-for-byte
+        standard Adam; only the AT-REST storage between steps differs, so :class:`CompressedAdam`
+        with ``compression_method="dense"`` is Adam with no approximation at all (a useful sanity
+        check, exercised by the loss-parity test).
+
+        Honest cost note: this reference implementation recompresses BOTH moment buffers every
+        step, including (for ``compression_method="g4"``/``"auto"``) re-fitting G4's distribution
+        and KS test every step -- far more compute than a real deployment would spend (a production
+        system would compress at a coarser cadence, e.g. only on optimizer-state checkpoint/
+        offload, not every step). Nothing here changes the per-step Adam math itself; only the
+        wall-clock cost of this particular reference cadence differs from a production one.
+        """
+
+        def __init__(
+            self,
+            params: Any,
+            lr: float = 1e-3,
+            betas: tuple[float, float] = (0.9, 0.999),
+            eps: float = 1e-8,
+            weight_decay: float = 0.0,
+            compression_method: str = "auto",
+            **compress_kwargs: Any,
+        ) -> None:
+            defaults = dict(lr=lr, betas=betas, eps=eps, weight_decay=weight_decay)
+            super().__init__(params, defaults)
+            self.compression_method = compression_method
+            self._compress_kwargs = compress_kwargs
+
+        @torch.no_grad()
+        def step(self, closure: Any = None) -> Any:
+            loss = None
+            if closure is not None:
+                with torch.enable_grad():
+                    loss = closure()
+
+            for group in self.param_groups:
+                lr = group["lr"]
+                beta1, beta2 = group["betas"]
+                eps = group["eps"]
+                weight_decay = group["weight_decay"]
+                for p in group["params"]:
+                    if p.grad is None:
+                        continue
+                    grad = p.grad
+                    if weight_decay != 0:
+                        grad = grad.add(p, alpha=weight_decay)
+
+                    state = self.state[p]
+                    if "step" not in state:
+                        state["step"] = 0
+                        state["compressed"] = CompressedOptimizerState(
+                            tuple(p.shape), method=self.compression_method, **self._compress_kwargs
+                        )
+                        state["compressed"].set(torch.zeros_like(p), torch.zeros_like(p))
+
+                    state["step"] += 1
+                    t = state["step"]
+                    compressed: CompressedOptimizerState = state["compressed"]
+                    m, v = compressed.get(device=p.device, dtype=p.dtype)
+                    # v is Adam's second-moment buffer -- strictly non-negative by construction --
+                    # but a symmetric-family compression path (G4's default GaussianEstimator tail
+                    # fit is unbounded) can reconstruct a near-zero true v as a small NEGATIVE
+                    # value. Clamp before it ever reaches v_hat.sqrt(): an unclamped negative v_hat
+                    # produces NaN there, which then poisons every future step irrecoverably.
+                    v = v.clamp_min(0.0)
+
+                    m = beta1 * m + (1.0 - beta1) * grad
+                    v = beta2 * v + (1.0 - beta2) * grad * grad
+
+                    bias_correction1 = 1.0 - beta1**t
+                    bias_correction2 = 1.0 - beta2**t
+                    m_hat = m / bias_correction1
+                    v_hat = v / bias_correction2
+
+                    p.add_(-lr * m_hat / (v_hat.sqrt() + eps))
+                    compressed.set(m, v)
+
+            return loss
+
+    __all__.append("CompressedAdam")
+
+
+# ---------------------------------------------------------------------------------------------
+# 3. Selective, per-block activation-recompute policy
+# ---------------------------------------------------------------------------------------------
+
+# Proxy units (not wall-clock/real bytes-of-value), same convention as D6's compile-economics
+# constants (mixle.inference.backend_respecialization, PR #153): callers with real measured
+# per-byte memory value / per-FLOP compute cost should pass them explicitly.
+_DEFAULT_MEMORY_VALUE_PER_BYTE = 1.0
+_DEFAULT_FLOP_COST_PER_UNIT = 2e-9
+
+
+def estimate_block_activation_bytes(batch: int, seq_len: int, d_model: int, dtype_bytes: int = 4) -> float:
+    """Estimate the memory footprint of ONE transformer block's stored output activation
+    (``mixle.models.transformer.Block``'s output, shape ``(batch, seq_len, d_model)``) -- the
+    memory that activation checkpointing (recomputing instead of storing) frees."""
+    return float(batch) * float(seq_len) * float(d_model) * float(dtype_bytes)
+
+
+def estimate_block_recompute_flops(batch: int, seq_len: int, d_model: int) -> float:
+    """Estimate the FLOP cost of recomputing ONE transformer block's forward pass, tied directly
+    to ``mixle.models.transformer.Block``'s actual layer shapes: ``qkv`` (``d -> 3d``), ``proj``
+    (``d -> d``), and the two MLP linears (``d -> 4d -> d``) give ``3d^2 + d^2 + 4d^2 + 4d^2 =
+    12*d_model^2`` linear-layer parameters per block; the standard "2 FLOPs per parameter per
+    token" forward-pass heuristic turns that into a FLOP estimate, plus the attention score/value
+    matmuls (``QK^T`` and ``attn @ V``, each ``~2*batch*seq_len^2*d_model`` FLOPs) that scale with
+    ``seq_len^2`` rather than with parameter count."""
+    params_per_block = 12.0 * float(d_model) ** 2
+    linear_flops = 2.0 * float(batch) * float(seq_len) * params_per_block
+    attn_score_flops = 4.0 * float(batch) * float(seq_len) ** 2 * float(d_model)
+    return linear_flops + attn_score_flops
+
+
+def estimate_recompute_benefit(
+    activation_bytes: float, memory_value_per_byte: float = _DEFAULT_MEMORY_VALUE_PER_BYTE
+) -> float:
+    """The value of the memory freed by recomputing (rather than storing) one block's activation."""
+    return float(activation_bytes) * float(memory_value_per_byte)
+
+
+def estimate_recompute_cost(recompute_flops: float, flop_cost_per_unit: float = _DEFAULT_FLOP_COST_PER_UNIT) -> float:
+    """The cost of the extra compute spent recomputing one block's activation during backward."""
+    return float(recompute_flops) * float(flop_cost_per_unit)
+
+
+@dataclass(frozen=True)
+class RecomputeDecision:
+    """The cost/benefit tradeoff and chosen action for ONE block's activation-recompute policy --
+    mirrors D6's :class:`~mixle.inference.backend_respecialization.RespecializationDecision`
+    shape: a flat, inspectable dataclass carrying both the raw estimates and the derived decision,
+    not just a boolean.
+    """
+
+    block_index: int
+    should_recompute: bool
+    estimated_cost: float
+    estimated_benefit: float
+    activation_bytes: float
+    recompute_flops: float
+    rationale: str
+
+    @property
+    def net_benefit(self) -> float:
+        """``estimated_benefit - estimated_cost`` -- positive iff recomputing this block is worth it."""
+        return self.estimated_benefit - self.estimated_cost
+
+
+class SelectiveRecomputePolicy:
+    """Per-block, cost-model-driven activation-checkpointing decision -- extends
+    ``mixle.models.transformer.CausalLM``'s previously all-or-nothing ``gradient_checkpointing``
+    bool flag (see that module's ``forward``, which now also accepts a per-block list) to a
+    PER-BLOCK decision.
+
+    A block is recommended for recompute when the value of the memory freed (its stored-
+    activation footprint, valued at ``memory_value_per_byte``) exceeds the cost of the extra
+    compute spent recomputing it (its recompute FLOPs, valued at ``flop_cost_per_unit``) -- the
+    same cost-vs-benefit tradeoff SHAPE as D6's compile economics, applied to this different
+    decision (recompute-vs-store, not eager-vs-compiled).
+    """
+
+    def __init__(
+        self,
+        memory_value_per_byte: float = _DEFAULT_MEMORY_VALUE_PER_BYTE,
+        flop_cost_per_unit: float = _DEFAULT_FLOP_COST_PER_UNIT,
+    ) -> None:
+        self.memory_value_per_byte = float(memory_value_per_byte)
+        self.flop_cost_per_unit = float(flop_cost_per_unit)
+
+    def decide_block(self, block_index: int, activation_bytes: float, recompute_flops: float) -> RecomputeDecision:
+        benefit = estimate_recompute_benefit(activation_bytes, self.memory_value_per_byte)
+        cost = estimate_recompute_cost(recompute_flops, self.flop_cost_per_unit)
+        should_recompute = benefit > cost
+        rationale = (
+            f"block {block_index}: benefit(memory freed)={benefit:.4g} "
+            f"{'>' if should_recompute else '<='} cost(recompute flops)={cost:.4g} "
+            f"-> {'recompute' if should_recompute else 'store'}"
+        )
+        return RecomputeDecision(
+            block_index=block_index,
+            should_recompute=should_recompute,
+            estimated_cost=cost,
+            estimated_benefit=benefit,
+            activation_bytes=float(activation_bytes),
+            recompute_flops=float(recompute_flops),
+            rationale=rationale,
+        )
+
+    def decide_model(self, lm: Any, batch: int, seq_len: int, dtype_bytes: int = 4) -> list[RecomputeDecision]:
+        """Decide per-block recompute for every block of a ``CausalLM``
+        (``mixle.models.transformer.build_causal_lm``), using its own ``d_model``/``n_layer``."""
+        d_model = int(lm.d_model)
+        n_layer = int(lm.n_layer)
+        decisions = []
+        for i in range(n_layer):
+            activation_bytes = estimate_block_activation_bytes(batch, seq_len, d_model, dtype_bytes)
+            recompute_flops = estimate_block_recompute_flops(batch, seq_len, d_model)
+            decisions.append(self.decide_block(i, activation_bytes, recompute_flops))
+        return decisions
+
+    def apply_to_model(self, lm: Any, batch: int, seq_len: int, dtype_bytes: int = 4) -> list[RecomputeDecision]:
+        """Compute the per-block decisions and set them directly as ``lm.gradient_checkpointing``
+        (a per-block bool list -- see ``mixle.models.transformer.CausalLM.forward``, which accepts
+        either a single bool for all blocks or a per-block list)."""
+        decisions = self.decide_model(lm, batch, seq_len, dtype_bytes)
+        lm.gradient_checkpointing = [d.should_recompute for d in decisions]
+        return decisions

--- a/mixle/models/transformer.py
+++ b/mixle/models/transformer.py
@@ -73,15 +73,25 @@ if _HAS_TORCH:
             # activation (gradient) checkpointing: recompute block activations in backward instead of
             # storing them -- the standard memory/compute trade for long blocks or deep stacks. A plain
             # attribute (not a ctor arg) so modules saved before the flag existed rebuild unchanged.
+            # Either a single bool (all-or-nothing, the original behavior) or a per-block list/tuple of
+            # bools of length n_layer (F6's selective per-block policy -- see
+            # mixle.models.memory_efficient_training.SelectiveRecomputePolicy.apply_to_model, which sets
+            # exactly this attribute from a real memory-vs-recompute-FLOPs cost model).
             self.gradient_checkpointing = False
+
+        def _checkpoint_block(self, i: int) -> bool:
+            gc = getattr(self, "gradient_checkpointing", False)
+            if isinstance(gc, bool):
+                return gc
+            return bool(gc[i])  # per-block list/tuple, one entry per self.blocks
 
         def forward(self, x: Any) -> Any:
             x = x.long()
             t = x.shape[1]
             pos = torch.arange(t, device=x.device)
             h = self.tok(x) + self.pos(pos)[None, :, :]
-            for blk in self.blocks:
-                if getattr(self, "gradient_checkpointing", False) and self.training and torch.is_grad_enabled():
+            for i, blk in enumerate(self.blocks):
+                if self._checkpoint_block(i) and self.training and torch.is_grad_enabled():
                     h = torch.utils.checkpoint.checkpoint(blk, h, use_reentrant=False)
                 else:
                     h = blk(h)
@@ -105,7 +115,9 @@ def build_causal_lm(
 
     ``gradient_checkpointing=True`` recomputes block activations during backward instead of storing them --
     identical gradients (pinned by test) for a large activation-memory cut on deep stacks or long blocks.
-    The flag is a plain module attribute, so it can also be toggled on an existing model.
+    The flag is a plain module attribute, so it can also be toggled on an existing model -- including to a
+    per-block list/tuple of bools (one per ``n_layer``) rather than a single all-or-nothing bool, for F6's
+    cost-model-driven selective policy (``mixle.models.memory_efficient_training.SelectiveRecomputePolicy``).
     """
     from mixle.models.embedding import resolve_embedding
 

--- a/mixle/tests/memory_efficient_training_test.py
+++ b/mixle/tests/memory_efficient_training_test.py
@@ -1,0 +1,331 @@
+"""Acceptance tests for mixle.models.memory_efficient_training (roadmap F6: memory efficiency for
+training state).
+
+Each test class targets one line of the F6 acceptance criteria directly:
+
+1. ``LossParityTest`` -- train the same small model for the same steps on the same data with
+   plain fp32 Adam vs. ``CompressedAdam`` (G4/int8-compressed moments); final loss within a stated
+   tolerance.
+2. ``MeasuredMemoryCutTest`` -- a real byte-count comparison of compressed vs. fp32 optimizer
+   state for a realistic (Adam-second-moment-like) tensor.
+3. ``AdversarialFallbackTest`` -- both compression paths (G4 and int8) correctly fall back to
+   dense storage on tensors that are genuinely hostile to them.
+4. ``SelectiveRecomputePolicyTest`` -- the cost model recommends recompute for a memory-heavy/
+   cheap-to-recompute block and NOT for a memory-light/expensive-to-recompute block (a real
+   decision-boundary test), plus fp8 hardening's overflow/underflow/fallback guards.
+"""
+
+import unittest
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from mixle.models.memory_efficient_training import (  # noqa: E402
+    CompressedAdam,
+    CompressedOptimizerState,
+    RecomputeDecision,
+    SelectiveRecomputePolicy,
+    compress_moment,
+    decompress_moment,
+    dequantize_int8_blockwise,
+    fp8_cast_with_guard,
+    quantize_int8_blockwise,
+)
+from mixle.models.transformer import build_causal_lm  # noqa: E402
+
+
+def _adam_second_moment_like(rng: np.random.RandomState, n: int, steps: int = 50, beta2: float = 0.98) -> np.ndarray:
+    """Same synthetic Adam second-moment construction as G4's own acceptance test
+    (mixle.tests.sorted_profile_quantizer_test) -- an EMA of squared heavy-tailed gradients, strictly
+    positive and bounded away from zero, matching a real optimizer buffer far better than a single
+    squared-Gaussian draw."""
+    v = np.zeros(n)
+    for _ in range(steps):
+        g = rng.normal(0.0, 1.0, size=n) * (1.0 + 0.15 * np.abs(rng.standard_t(df=4, size=n)))
+        v = beta2 * v + (1.0 - beta2) * g * g
+    return v
+
+
+class LossParityTest(unittest.TestCase):
+    """Train a tiny CausalLM two ways -- plain fp32 AdamW vs. CompressedAdam -- for the SAME steps
+    on the SAME data, and confirm final loss is within a stated tolerance."""
+
+    def _train(self, optimizer_factory, steps: int = 40):
+        torch.manual_seed(0)
+        model = build_causal_lm(vocab=13, d_model=16, n_layer=2, n_head=2, block=8)
+        opt = optimizer_factory(model.parameters())
+
+        gen = torch.Generator().manual_seed(1234)
+        xs = [torch.randint(0, 13, (4, 8), generator=gen).float() for _ in range(steps)]
+        ys = [torch.randint(0, 13, (4,), generator=gen) for _ in range(steps)]
+
+        model.train()
+        losses = []
+        for x, y in zip(xs, ys):
+            opt.zero_grad()
+            loss = torch.nn.functional.cross_entropy(model(x), y)
+            loss.backward()
+            opt.step()
+            losses.append(float(loss.detach()))
+        return losses
+
+    def test_compressed_adam_matches_fp32_adam_loss(self):
+        # torch.optim.Adam (not AdamW): CompressedAdam implements plain Adam (no decoupled weight
+        # decay), so the fp32 baseline must be the SAME algorithm -- AdamW's default
+        # weight_decay=0.01 would make this an apples-to-oranges comparison unrelated to
+        # compression.
+        fp32_losses = self._train(lambda params: torch.optim.Adam(params, lr=3e-3))
+        compressed_losses = self._train(
+            lambda params: CompressedAdam(params, lr=3e-3, compression_method="auto", min_size_for_g4=32)
+        )
+
+        fp32_final = fp32_losses[-1]
+        compressed_final = compressed_losses[-1]
+        rel_diff = abs(compressed_final - fp32_final) / max(abs(fp32_final), 1e-8)
+        # Loose but real: compressed moments are lossy (int8 for these small per-layer tensors,
+        # since min_size_for_g4=32 keeps most of them under G4's own G4-worth-it floor), so exact
+        # match is not expected -- a 25% relative final-loss tolerance is the stated bound.
+        self.assertLess(
+            rel_diff,
+            0.25,
+            f"fp32 final loss={fp32_final:.4f}, compressed final loss={compressed_final:.4f}, rel_diff={rel_diff:.3f}",
+        )
+        # Both runs should actually be learning (loss decreasing), not just coincidentally close.
+        self.assertLess(compressed_final, compressed_losses[0])
+        self.assertLess(fp32_final, fp32_losses[0])
+
+    def test_dense_compression_state_round_trip_is_lossless(self):
+        """compression_method='dense' takes no lossy shortcut at all: a CompressedOptimizerState
+        set with real (Adam-second-moment-like) m/v tensors and immediately read back should
+        recover them to float32 precision (~1e-6 relative), not the ~1e-2-scale error int8/G4
+        introduce (see MeasuredMemoryCutTest). This is checked at the STATE level (compress then
+        immediately decompress) rather than through a multi-step training loop: Adam's own update
+        is chaotically sensitive to ANY floating-point perturbation once a parameter's v_hat
+        approaches eps^2 scale (empirically confirmed independently of this module -- even
+        torch.optim.Adam's different-but-mathematically-equivalent internal operation order
+        diverges measurably from a manual same-formula loop after a few steps), so a training-loop
+        comparison would be testing float64<->float32 rounding noise amplified by chaos, not
+        whether dense compression itself is lossy.
+        """
+        rng = np.random.RandomState(4)
+        shape = (24,)  # matches a real Block's qkv bias shape (3 * d_model for d_model=8)
+        m = torch.from_numpy(rng.normal(0.0, 0.1, size=shape)).float()
+        v = torch.from_numpy(_adam_second_moment_like(rng, shape[0])).float()
+
+        state = CompressedOptimizerState(shape, method="dense")
+        state.set(m, v)
+        m_back, v_back = state.get(dtype=torch.float32)
+
+        np.testing.assert_allclose(m_back.numpy(), m.numpy(), rtol=1e-6, atol=1e-8)
+        # v round-trips through CompressedOptimizerState's sqrt(v)-then-square transform (see that
+        # class's docstring): still float32-precision lossless, just not literally bit-identical
+        # to the untransformed input at the very last ULP.
+        np.testing.assert_allclose(v_back.numpy(), v.numpy(), rtol=1e-5, atol=1e-8)
+
+    def test_dense_compression_end_to_end_tracks_fp32_adam_closely(self):
+        """A short (5-step) end-to-end sanity check that CompressedAdam(dense) tracks a real
+        fp32 Adam training run closely -- not bit-exact (see the state-level test above for why),
+        but far tighter than the lossy int8/G4 paths get in LossParityTest (25% final-loss
+        tolerance): dense compression should track to within a few percent of fp32 Adam's loss at
+        every step, not just the final one.
+        """
+        fp32_losses = self._train(lambda params: torch.optim.Adam(params, lr=3e-3), steps=5)
+        dense_losses = self._train(lambda params: CompressedAdam(params, lr=3e-3, compression_method="dense"), steps=5)
+        for i, (fp32_loss, dense_loss) in enumerate(zip(fp32_losses, dense_losses)):
+            rel_diff = abs(dense_loss - fp32_loss) / max(abs(fp32_loss), 1e-8)
+            self.assertLess(rel_diff, 0.05, f"step {i}: fp32={fp32_loss:.4f} dense={dense_loss:.4f}")
+
+
+class MeasuredMemoryCutTest(unittest.TestCase):
+    """Real byte-count comparison, compressed vs. fp32, for a realistic optimizer-state tensor."""
+
+    def test_g4_and_int8_both_cut_memory_vs_fp32(self):
+        rng = np.random.RandomState(0)
+        n = 16384  # < 2**16 so G4's permutation indices fit in uint16, per its own module docstring
+        v = _adam_second_moment_like(rng, n)
+        fp32_bytes = v.astype(np.float32).nbytes
+        self.assertEqual(fp32_bytes, n * 4)
+
+        g4_encoding = compress_moment(v, method="g4", min_size_for_g4=1)
+        self.assertEqual(g4_encoding.method, "g4")
+        g4_bytes = g4_encoding.nbytes()
+        self.assertLess(g4_bytes, fp32_bytes)
+        g4_ratio = fp32_bytes / g4_bytes
+        self.assertGreater(g4_ratio, 1.5)
+
+        int8_encoding = compress_moment(v, method="int8")
+        self.assertEqual(int8_encoding.method, "int8")
+        int8_bytes = int8_encoding.nbytes()
+        self.assertLess(int8_bytes, fp32_bytes)
+        int8_ratio = fp32_bytes / int8_bytes
+        self.assertGreater(int8_ratio, 3.5)  # ~4x: int8 codes + small per-block scale overhead
+
+        # Reconstruction stays close for both -- a real, measured relative error, not just a size claim.
+        g4_recon = decompress_moment(g4_encoding)
+        int8_recon = decompress_moment(int8_encoding)
+        g4_rel_err = np.linalg.norm(g4_recon - v) / np.linalg.norm(v)
+        int8_rel_err = np.linalg.norm(int8_recon - v) / np.linalg.norm(v)
+        self.assertLess(g4_rel_err, 0.15)
+        self.assertLess(int8_rel_err, 0.15)
+
+    def test_compressed_optimizer_state_reports_combined_nbytes(self):
+        rng = np.random.RandomState(1)
+        shape = (128, 128)
+        m = torch.zeros(shape)
+        v = torch.from_numpy(_adam_second_moment_like(rng, m.numel()).reshape(shape)).float()
+
+        state = CompressedOptimizerState(shape, method="auto", min_size_for_g4=1)
+        state.set(m, v)
+        fp32_state_bytes = 2 * m.numel() * 4  # m + v, both fp32 -- "states are 2x params fp32" per F6 spec
+        self.assertLess(state.nbytes(), fp32_state_bytes)
+
+
+class AdversarialFallbackTest(unittest.TestCase):
+    """Construct tensors genuinely hostile to each compression path and confirm the dense
+    fallback correctly engages -- mirroring G4's own dense-fallback test pattern
+    (mixle.tests.sorted_profile_quantizer_test.DenseFallbackTest)."""
+
+    def test_g4_falls_back_on_bimodal_tensor(self):
+        rng = np.random.RandomState(0)
+        # Well-separated bimodal data: a unimodal Gaussian tail fit cannot match this, exactly the
+        # scenario G4's own dense-fallback test uses.
+        bimodal = np.concatenate([rng.normal(-10.0, 0.5, 5000), rng.normal(10.0, 0.5, 5000)])
+        encoding = compress_moment(bimodal, method="g4", min_size_for_g4=1)
+        self.assertEqual(encoding.method, "dense")
+        recon = decompress_moment(encoding)
+        np.testing.assert_allclose(recon, bimodal.astype(np.float32), rtol=1e-5)
+
+    def test_int8_falls_back_on_single_outlier_block(self):
+        # One block dominated by a single extreme outlier: the block's dynamic scale is set by
+        # the outlier, crushing every other value in that block to (or near) zero -- genuinely
+        # hostile to blockwise int8, unlike G4's per-tensor distribution fit which is untouched by
+        # a single-value spike this small relative to the whole tensor.
+        block_size = 256
+        block = np.full(block_size, 1e-6)
+        block[0] = 1e6
+        encoding = compress_moment(block, method="int8", int8_block_size=block_size)
+        self.assertEqual(encoding.method, "dense")
+
+    def test_int8_does_not_fall_back_on_well_behaved_tensor(self):
+        rng = np.random.RandomState(2)
+        tame = rng.normal(0.0, 1.0, size=4096)
+        encoding = compress_moment(tame, method="int8")
+        self.assertEqual(encoding.method, "int8")
+
+    def test_auto_picker_falls_back_all_the_way_to_dense_on_a_tensor_hostile_to_both(self):
+        # A tensor built to defeat BOTH G4 (multi-modal -> bad KS fit) AND int8 (each mode's block
+        # dominated by within-block magnitude spread) -- the auto picker should still land on a
+        # trustworthy (dense) representation rather than silently accepting a bad compressed one.
+        rng = np.random.RandomState(3)
+        block_size = 256
+        n_blocks = 20
+        chunks = []
+        for i in range(n_blocks):
+            center = -10.0 if i % 2 == 0 else 10.0
+            chunk = rng.normal(center, 0.01, block_size)
+            chunk[0] = center * 1000.0  # per-block outlier spike, on top of the bimodal structure
+            chunks.append(chunk)
+        hostile = np.concatenate(chunks)
+        encoding = compress_moment(hostile, method="auto", min_size_for_g4=1, int8_block_size=block_size)
+        self.assertEqual(encoding.method, "dense")
+        recon = decompress_moment(encoding)
+        np.testing.assert_allclose(recon, hostile.astype(np.float32), rtol=1e-5)
+
+
+class Fp8HardeningTest(unittest.TestCase):
+    """fp8 hardening: real overflow/underflow detection with graceful fallback."""
+
+    def test_well_behaved_tensor_uses_fp8(self):
+        t = torch.randn(1024) * 0.1
+        result = fp8_cast_with_guard(t)
+        self.assertTrue(result.used_fp8)
+        self.assertEqual(str(result.tensor.dtype), "torch.float8_e4m3fn")
+
+    def test_overflow_triggers_fallback(self):
+        t = torch.tensor([1.0, 1.0e5, -3.0])  # 1e5 exceeds float8_e4m3fn's ~448 max
+        result = fp8_cast_with_guard(t)
+        self.assertFalse(result.used_fp8)
+        self.assertIn("overflow", result.reason)
+        self.assertEqual(result.tensor.dtype, torch.bfloat16)
+
+    def test_underflow_triggers_fallback(self):
+        # float8_e4m3fn's smallest representable magnitudes are ~1e-3 (subnormals) to ~2e-2
+        # (normals); a tensor of mostly ~1e-4-scale nonzero values flushes almost entirely to zero.
+        t = torch.full((2048,), 1.0e-4)
+        result = fp8_cast_with_guard(t)
+        self.assertFalse(result.used_fp8)
+        self.assertIn("underflow", result.reason)
+        self.assertGreater(result.underflow_fraction, 0.5)
+
+    def test_non_finite_input_triggers_fallback(self):
+        t = torch.tensor([1.0, float("inf"), 2.0])
+        result = fp8_cast_with_guard(t)
+        self.assertFalse(result.used_fp8)
+        self.assertEqual(result.tensor.dtype, torch.bfloat16)
+
+
+class SelectiveRecomputePolicyTest(unittest.TestCase):
+    """Cost-model decision-boundary test: memory-heavy/cheap-to-recompute -> recompute;
+    memory-light/expensive-to-recompute -> do not recompute -- mirroring D6's own compile-
+    economics decision-boundary test pattern."""
+
+    def test_memory_heavy_cheap_block_is_recommended_for_recompute(self):
+        policy = SelectiveRecomputePolicy()
+        decision = policy.decide_block(block_index=0, activation_bytes=1.0e9, recompute_flops=1.0)
+        self.assertIsInstance(decision, RecomputeDecision)
+        self.assertTrue(decision.should_recompute)
+        self.assertGreater(decision.net_benefit, 0.0)
+
+    def test_memory_light_expensive_block_is_not_recommended_for_recompute(self):
+        policy = SelectiveRecomputePolicy()
+        decision = policy.decide_block(block_index=1, activation_bytes=1.0, recompute_flops=1.0e9)
+        self.assertFalse(decision.should_recompute)
+        self.assertLess(decision.net_benefit, 0.0)
+
+    def test_apply_to_model_sets_a_per_block_list_and_forward_still_works(self):
+        model = build_causal_lm(vocab=11, d_model=64, n_layer=3, n_head=4, block=512)
+        policy = SelectiveRecomputePolicy(memory_value_per_byte=1.0, flop_cost_per_unit=1e-12)
+        decisions = policy.apply_to_model(model, batch=8, seq_len=512)
+
+        self.assertEqual(len(decisions), 3)
+        self.assertIsInstance(model.gradient_checkpointing, list)
+        self.assertEqual(len(model.gradient_checkpointing), 3)
+        # A tiny recompute-cost weight relative to a large batch*seq_len activation footprint
+        # should make recompute worth it for at least one block -- otherwise this test would not
+        # actually be exercising the per-block-list code path in transformer.py's forward.
+        self.assertTrue(any(model.gradient_checkpointing))
+
+        model.train()
+        x = torch.randint(0, 11, (2, 512)).float()
+        out = model(x)
+        self.assertEqual(tuple(out.shape), (2, 11))
+        loss = torch.nn.functional.cross_entropy(out, torch.randint(0, 11, (2,)))
+        loss.backward()  # must not raise -- the per-block list path must be backward-compatible
+
+    def test_bool_flag_still_works_after_per_block_extension(self):
+        """Regression: the original all-or-nothing bool flag (mixle.tests.grad_control_test) must
+        still work unchanged after extending forward() to also accept a per-block list."""
+        model = build_causal_lm(vocab=11, d_model=16, n_layer=2, n_head=2, block=8, gradient_checkpointing=True)
+        self.assertTrue(model.gradient_checkpointing)
+        model.train()
+        out = model(torch.randint(0, 11, (3, 8)).float())
+        self.assertEqual(tuple(out.shape), (3, 11))
+
+
+class Int8BlockwiseUnitTest(unittest.TestCase):
+    """Direct unit coverage of the int8 quantize/dequantize round trip, independent of the
+    higher-level compress_moment picker."""
+
+    def test_round_trip_is_low_error_on_smooth_data(self):
+        rng = np.random.RandomState(0)
+        flat = rng.normal(0.0, 2.0, size=5000)
+        codes, scales = quantize_int8_blockwise(flat, block_size=512)
+        recon = dequantize_int8_blockwise(codes, scales, block_size=512)
+        rel_err = np.linalg.norm(recon - flat) / np.linalg.norm(flat)
+        self.assertLess(rel_err, 0.02)  # 8-bit blockwise quantization is a tight fit for smooth data
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements roadmap F6 (Frontier training infrastructure -> Memory efficiency for training state). **Stacked on #158** (`sorted-profile-quantizer`, G4) -- base branch is `sorted-profile-quantizer`, not `main`.

Adds `mixle/models/memory_efficient_training.py`, three pieces per the F6 spec:

- **fp8 hardening** (`fp8_cast_with_guard`): the existing fp8 mention in `mixle/utils/parallel/torch_neural.py` (`precision: "fp32"|"bf16" (fp8 = torchao, vendored)`) was just a comment -- no real code path existed. This adds a real one using torch's native `float8_e4m3fn`/`float8_e5m2` dtypes: explicit overflow detection (magnitude exceeds the format's representable range, which fp8 silently clamps rather than raising), underflow detection (fraction of nonzero values flushed to exactly zero), and a graceful fallback to bf16/fp32 -- always returning a receipt (`Fp8CastResult`), never silently accepting a corrupted cast.

- **Optimizer-state compression** (`CompressedOptimizerState`, `CompressedAdam`): directly reuses G4 (`mixle.models.sorted_profile_quantizer.fit_sorted_profile`/`reconstruct`), which was explicitly built with "optimizer states (F6)" as its first named use case, as one compression path for Adam's `m`/`v` moment buffers, plus a new bitsandbytes-style **8-bit blockwise quantization** path as a cheaper alternative. `choose_compression_method` picks per-tensor via a goodness-of-fit rule (reusing G4's own KS receipt), and `compress_moment` adds an int8-specific "flushed fraction" guard (same idea as fp8's underflow guard) that downgrades to dense storage when a compressed representation isn't trustworthy. `CompressedAdam` is a real, usable `torch.optim.Optimizer`.

  Notable finding during implementation: `v` (Adam's second moment) has to be stored as its compressed **square root**, not directly -- `v`'s wide dynamic range otherwise defeats both compression paths (linear int8 quantizes small-but-real values to literal zero; G4's symmetric Gaussian tail fit can reconstruct near-zero `v` as slightly negative), and either failure fed into `1/(sqrt(v_hat)+eps)` blows up training by orders of magnitude within a handful of steps. Confirmed empirically (an early version diverged >100x within 5 steps) and fixed.

- **Selective per-block activation-recompute policy** (`SelectiveRecomputePolicy`): extends `CausalLM.gradient_checkpointing` (`mixle/models/transformer.py`) from an all-or-nothing bool to also accept a per-block bool list (backward compatible), plus a cost model -- stored-activation memory bytes vs. recompute FLOPs, tied directly to `Block`'s actual `qkv`/`proj`/mlp layer shapes -- that decides per block whether recomputing is worth it. Mirrors D6's compile-economics cost/benefit shape (PR #153, `backend-respecialization` branch, not merged here since it's not reachable from this branch) applied to a different decision.

## Measured results

- **Loss parity**: `CompressedAdam(compression_method="auto")` vs. plain fp32 `torch.optim.Adam`, same 40 steps/same data on a small `CausalLM` -- final loss within a stated 25% relative tolerance (test asserts and reports the real numbers); a tighter dense-compression-only check tracks fp32 Adam within 5% at every step over 5 steps.
- **Measured memory cut** (synthetic Adam second-moment tensor, n=16384, fp32 = 65536 bytes):
  - G4: 32900 bytes -> **~2.0x**
  - int8 (blockwise): 16416 bytes -> **~4.0x**
- **Adversarial fallback**: confirmed for G4 (well-separated bimodal data defeats the Gaussian tail fit) and for int8 (a single-outlier-dominated block, caught by the new "flushed fraction" guard even though the outlier itself keeps the naive relative-L2 error deceptively small).
- **Recompute-policy decision boundary**: a memory-heavy/cheap-to-recompute block is recommended for recompute (positive net benefit); a memory-light/expensive-to-recompute block is not (negative net benefit).

## Test plan

- [x] `mixle/tests/memory_efficient_training_test.py` (18 new cases) -- all pass
- [x] `mixle/tests/sorted_profile_quantizer_test.py` (G4 regression) -- all pass, unmodified
- [x] `mixle/tests/grad_control_test.py` (gradient-checkpointing regression, since `transformer.py`'s `forward` was extended) -- all pass, unmodified
- [x] `ruff check` / `ruff format` clean on all touched files
