### PR TITLE
fix: 3 real bugs surfaced by the batch PR merge (QAT import, vine tie-break, lint)

### DIFF
--- a/mixle/inference/estimation.py
+++ b/mixle/inference/estimation.py
@@ -121,7 +121,14 @@ def _maybe_structured_model(data: Any, max_its: int, out: Any, rng: RandomState 
             candidates.extend(copula_candidates(rows, composite, comp_params, comp_bic, n_log, max_its, rng))
         if not candidates:
             return None
-        best_bic, best_model, desc = min(candidates, key=lambda u: u[0])
+        # a later, more complex candidate (e.g. a vine) only displaces an earlier, simpler one (e.g. the
+        # plain Gaussian copula core it can degenerate to exactly on low-dimensional data) when it wins by
+        # more than floating-point noise -- otherwise a sub-ulp BIC difference from platform/BLAS variance
+        # would nondeterministically pick the more complex, mathematically-equivalent model.
+        best_bic, best_model, desc = candidates[0]
+        for bic, model, name in candidates[1:]:
+            if bic < best_bic - 1e-6 * max(1.0, abs(best_bic)):
+                best_bic, best_model, desc = bic, model, name
         if best_bic >= comp_bic:
             return None
         if out is not None:

--- a/mixle/models/qat.py
+++ b/mixle/models/qat.py
@@ -122,6 +122,17 @@ if _HAS_TORCH:
         def extra_repr(self) -> str:
             return f"bits={self.bits}, in={self.base.in_features}, out={self.base.out_features}"
 
+else:  # pragma: no cover - torch is optional
+
+    class QATWrapper:  # type: ignore[no-redef]
+        """Torch-absent stand-in: keeps ``QATWrapper`` always importable (``mixle.models`` imports it
+        unconditionally, matching every other torch-optional model in this package -- see
+        :class:`~mixle.models.gaussian_process.GaussianProcessRegressor`), raising only when actually
+        constructed, since it must subclass ``nn.Module`` to be real and ``nn`` does not exist here."""
+
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            raise ImportError("QATWrapper requires torch.")
+
 
 def fake_quantize(x: Any, *, bits: int = 4, clip_percentile: float | None = None) -> Any:
     """Straight-through fake-quantize ``x`` to ``bits`` (int4 or int8, per

--- a/mixle/tests/peft_lora_grad_leaf_smoke_test.py
+++ b/mixle/tests/peft_lora_grad_leaf_smoke_test.py
@@ -37,9 +37,7 @@ class PeftLoraGradLeafSmokeTest(unittest.TestCase):
         rng = np.random.RandomState(0)
         module = build_peft_wrapped_module(seed=0)
 
-        base_before = {
-            k: v.clone() for k, v in module.lm.base_model.model.state_dict().items() if "lora_" not in k
-        }
+        base_before = {k: v.clone() for k, v in module.lm.base_model.model.state_dict().items() if "lora_" not in k}
 
         data = toy_token_sequences(vocab=module.lm.config.vocab_size, block=8, n=32, rng=rng)
         leaf = GradLeaf(module, m_steps=40, lr=0.1)


### PR DESCRIPTION
Three real bugs from the recent batch of ~27 PR merges into release, found by running the actual CI suite end to end:

1. **`mixle/models/qat.py`** — `QATWrapper` was only defined inside `if _HAS_TORCH:` (it must subclass `nn.Module`), but `mixle/models/__init__.py` imports it unconditionally at the top level — breaking the entire `mixle.models` package (and everything transitively importing it) whenever torch is absent. This is why `capability_test`, `namespaces_test`, and `numerical_guards_test` all failed with an unrelated-looking `ImportError: cannot import name 'QATWrapper'`. Added a torch-absent stand-in (always importable, raises `ImportError` on construction) — the same convention `GaussianProcessRegressor` already uses.

2. **`mixle/inference/estimation.py`** — the copula/vine candidate selection used plain `min(candidates, key=bic)`, but on low-dimensional data a single-edge vine is mathematically **identical** to the plain Gaussian copula core it degenerates to — their BICs are exactly tied in exact arithmetic, and a sub-ulp floating-point difference from platform/BLAS variance can flip which one wins nondeterministically. `automatic_vine_core_test::test_elliptical_data_keeps_the_gaussian_copula` failed on the CI runner (selected a vine) but passed locally (selected Gaussian). Fixed selection to only let a later, more complex candidate displace an earlier, simpler one when it wins by more than floating-point noise.

3. `peft_lora_grad_leaf_smoke_test.py` — ruff format.

Verified: `mixle.models` imports cleanly without torch and `QATWrapper()` raises correctly; `automatic_vine_core_test` + `automatic_copula_structure_test` + `estimation_structure_default_test` + `structure_learning_test` (40 tests) pass; `peft_lora_grad_leaf_smoke_test` passes.