### PR TITLE
lint: fix unsorted import block in automatic_copula_structure_test.py

### DIFF
--- a/mixle/tests/automatic_copula_structure_test.py
+++ b/mixle/tests/automatic_copula_structure_test.py
@@ -12,8 +12,8 @@ from scipy.stats import gamma as spgamma
 from scipy.stats import norm
 
 from mixle.inference import optimize
-from mixle.stats.combinator.copula import CopulaDistribution
 from mixle.stats.combinator.composite import CompositeDistribution
+from mixle.stats.combinator.copula import CopulaDistribution
 
 
 def _dependent_heterogeneous(seed, n=1500, r=0.75):


### PR DESCRIPTION
Left over from an earlier batch merge; broke the lint job (ruff check) on the release tip. Verified: ruff check + format --check pass on the whole mixle tree; the affected test file's 5 tests still pass.