### PR TITLE
tests: guard training_health_test.py against torch being absent

### DIFF
--- a/mixle/tests/automatic_copula_structure_test.py
+++ b/mixle/tests/automatic_copula_structure_test.py
@@ -12,8 +12,8 @@ from scipy.stats import gamma as spgamma
 from scipy.stats import norm
 
 from mixle.inference import optimize
-from mixle.stats.combinator.copula import CopulaDistribution
 from mixle.stats.combinator.composite import CompositeDistribution
+from mixle.stats.combinator.copula import CopulaDistribution
 
 
 def _dependent_heterogeneous(seed, n=1500, r=0.75):

--- a/mixle/tests/training_health_test.py
+++ b/mixle/tests/training_health_test.py
@@ -10,10 +10,12 @@ from __future__ import annotations
 import time
 import unittest
 
-import torch
+import pytest
 
-from mixle.models.transformer import build_causal_lm
-from mixle.utils.parallel.training_health import (
+torch = pytest.importorskip("torch")
+
+from mixle.models.transformer import build_causal_lm  # noqa: E402
+from mixle.utils.parallel.training_health import (  # noqa: E402
     RollingBaseline,
     TrainingHealthMonitor,
     flop_config_from_causal_lm,


### PR DESCRIPTION
Unconditional `import torch` at module scope had no skip guard, so pytest ERRORED during collection (not a clean skip) in the no-torch fast CI lane, failing the whole run. Added `pytest.importorskip('torch')`, matching the convention used across the rest of the suite.

Verified: 16 tests pass with torch installed; skips cleanly (1 skipped, no error) without it.