### PR TITLE
tests: torch-guard eval_harness_test.py and scaling_laws_test.py

### DIFF
--- a/mixle/tests/eval_harness_test.py
+++ b/mixle/tests/eval_harness_test.py
@@ -15,16 +15,18 @@ from __future__ import annotations
 import unittest
 
 import numpy as np
-import torch
+import pytest
 
-from mixle.models.eval_harness import (
+torch = pytest.importorskip("torch")
+
+from mixle.models.eval_harness import (  # noqa: E402
     EvalReport,
     TaskResult,
     evaluate_checkpoint,
     markov_transition_matrix,
     track_regression,
 )
-from mixle.models.transformer import build_causal_lm
+from mixle.models.transformer import build_causal_lm  # noqa: E402
 
 VOCAB = 16
 BLOCK = 8

--- a/mixle/tests/scaling_laws_test.py
+++ b/mixle/tests/scaling_laws_test.py
@@ -20,6 +20,13 @@ from __future__ import annotations
 
 import unittest
 
+try:
+    import torch  # noqa: F401
+
+    _HAS_TORCH = True
+except ImportError:
+    _HAS_TORCH = False
+
 from mixle.ppl.scaling_laws import (
     CHINCHILLA_ALPHA,
     CHINCHILLA_BETA,
@@ -56,6 +63,7 @@ class ReproducesKnownExponentsTest(unittest.TestCase):
         self.assertTrue(beta_lo - 0.02 <= CHINCHILLA_BETA <= beta_hi + 0.02)
 
 
+@unittest.skipUnless(_HAS_TORCH, "allocate_compute fits a GaussianProcessRegressor (torch)")
 class AllocatorBeatsHeuristicTest(unittest.TestCase):
     def test_doe_allocator_beats_fixed_20to1_heuristic_at_matched_compute(self):
         records = generate_synthetic_chinchilla_data(n_points=60, seed=1, noise_sd=0.015)
@@ -112,6 +120,7 @@ class UncertaintyReceiptsTest(unittest.TestCase):
         self.assertGreaterEqual(hits_beta, 6)
 
 
+@unittest.skipUnless(_HAS_TORCH, "allocate_compute_learned fits a GaussianProcessRegressor (torch)")
 class LearnedAllocationControllerTest(unittest.TestCase):
     """Smoke test for the optional D5-pattern (mixle.inference.conditional_jit_controller)
     allocation controller -- not the primary acceptance path (that is AllocatorBeatsHeuristicTest


### PR DESCRIPTION
Two more unguarded-torch failures from the last batch of PR merges (F10 eval harness #184, F5 scaling laws #180):

- `eval_harness_test.py`: unconditional `import torch` errored during collection (not a clean skip) in the no-torch fast/full CI lanes. Switched to `pytest.importorskip('torch')`.
- `scaling_laws_test.py`: `AllocatorBeatsHeuristicTest` and `LearnedAllocationControllerTest` call `allocate_compute`/`allocate_compute_learned`, which fit a `GaussianProcessRegressor` (torch) — failed with "GaussianProcessRegressor requires torch" instead of skipping. Added the standard `_HAS_TORCH` + `@unittest.skipUnless` guard.

Verified: both files pass in full with torch installed (9 + 5 tests); skip cleanly without it instead of erroring/failing.