### PR TITLE
docs: example gallery index with one-line receipts (C3)

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -5,6 +5,9 @@ Runnable examples live in ``examples/``. They are plain Python scripts, so the
 fastest way to learn a workflow is to run the script under the same environment
 you use for tests.
 
+For a shorter, receipt-focused index of the newer applied adapter and
+multimodal-pretraining workflows, see :doc:`examples_gallery`.
+
 Start with the base-install examples. Move to Torch, task, or real-data workflows
 only after the core distribution and inference path is clear.
 

--- a/docs/examples_gallery.rst
+++ b/docs/examples_gallery.rst
@@ -1,0 +1,57 @@
+Example Gallery
+================
+
+A fast index into the newer end-to-end examples: one entry per script, what
+pattern it demonstrates, and the concrete **receipt** it prints and asserts --
+a real measured number or invariant, not a restatement of the description. Each
+example is paired with a smoke test under ``mixle/tests/`` that pins the same
+receipt programmatically.
+
+For the full, general example inventory (distribution families, HMMs,
+enumeration, engines, and so on) see :doc:`examples`. This page covers the
+newer applied adapter and multimodal-pretraining workflows, each landing as
+its own example.
+
+Adapter and Multimodal Pretraining Patterns
+--------------------------------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 28 36 36
+
+   * - Example
+     - Pattern
+     - Receipt
+   * - ``examples/peft_lora_grad_leaf.py``
+     - A real HuggingFace checkpoint (``hf-internal-testing/tiny-random-gpt2``),
+       wrapped with actual ``peft.get_peft_model`` LoRA adapters, dropped into
+       :class:`~mixle.models.GradLeaf` unchanged -- next-token log-likelihood
+       summed over a sequence is the log density ``GradLeaf`` expects.
+     - Base checkpoint weights are bitwise unchanged after fitting (drift
+       ``0.0``); only the LoRA adapter parameters move; mean sequence
+       log-density rises from ``-48.27`` to ``-46.18``.
+   * - ``examples/multimodal_stage1_demo.py``
+     - LLaVA-style stage-1 pretraining on synthetic volumes: a frozen 3-D
+       ``Conv3d`` encoder and a frozen toy LM (embedding + GRU cell + head)
+       bridged by a thin trainable projection, fit end to end through one
+       ``GradLeaf``/``optimize`` call.
+     - All 11 frozen backbone tensors are bitwise unchanged
+       (``torch.equal`` before/after); the 4 projection tensors move; mean
+       caption log-likelihood improves from ``-3.21`` to ``-0.60``.
+
+Running the Examples
+---------------------
+
+.. code-block:: sh
+
+   python examples/peft_lora_grad_leaf.py
+   python examples/multimodal_stage1_demo.py
+
+``peft_lora_grad_leaf.py`` additionally needs ``pip install "mixle[torch]" transformers peft``
+(example-only dependencies, not a package extra, since ``GradLeaf`` has no
+opinion on what module it is handed). ``multimodal_stage1_demo.py`` needs only
+``mixle[torch]``.
+
+Every receipt above is pinned by a paired smoke test:
+``mixle/tests/peft_lora_grad_leaf_smoke_test.py`` and
+``mixle/tests/multimodal_stage1_demo_smoke_test.py``.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -218,6 +218,7 @@ human map for finding the right import.
    utilities-and-parallelism
    experimental-program
    examples
+   examples_gallery
    troubleshooting
    glossary
    extending


### PR DESCRIPTION
## Summary
- Adds `docs/examples_gallery.rst`, a receipt-focused index of the newer applied adapter/multimodal-pretraining examples, cross-linked from `docs/examples.rst` and added to the toctree in `docs/index.rst`.
- Scoped to what has actually landed on this branch: `examples/peft_lora_grad_leaf.py` and `examples/multimodal_stage1_demo.py`, each with a paired smoke test. An earlier draft of this page also referenced `calibrated_report_demo.py`, `label_economics_demo.py`, and `vlm_trust_receipts_demo.py` as "landing via open PRs" -- those PRs (#134, #131, #137) were closed rather than merged, and the files don't exist in the tree, so those entries are dropped.

## Test plan
- [x] `ls examples/*.py` cross-checked against the gallery's entries -- every referenced path exists in the tree.
- [x] Re-ran both examples directly and confirmed the printed receipts match the doc: `peft_lora_grad_leaf.py` -> drift `0.0`, log-density `-48.2665 -> -46.1762`; `multimodal_stage1_demo.py` -> 11 frozen / 4 moved tensors, log-likelihood `-3.2115 -> -0.5984`.
- [x] `pytest mixle/tests/peft_lora_grad_leaf_smoke_test.py mixle/tests/multimodal_stage1_demo_smoke_test.py -m "slow or not slow"` -- 2 passed.
- [x] `sphinx -b html docs /tmp/mixle-docs-build -q` -- builds warning-free; `examples_gallery.html` renders and cross-references from `examples.html` resolve.