### PR TITLE
G2: Sigma-weighted structured projections (reland of #144)

### DIFF
--- a/mixle/models/sigma_weighted_projection.py
+++ b/mixle/models/sigma_weighted_projection.py
@@ -1,0 +1,287 @@
+"""Sigma-weighted structured projections (roadmap G2): thin solvers over borrowed primitives.
+
+Given a weight matrix ``W`` (``out_dim x in_dim``) and the covariance ``Sigma`` (``in_dim x in_dim``,
+PSD) of the activations it will actually be multiplied against -- e.g. the propagated-law covariance
+coming out of :mod:`mixle.models.moment_propagation` (roadmap G1) -- the objective that matters for
+preserving downstream behavior is NOT plain Frobenius compression (``||W - What||_F^2``, which treats
+every input direction as equally important) but the SIGMA-WEIGHTED version
+
+    min_What  tr((W - What) @ Sigma @ (W - What)^T)
+
+which penalizes reconstruction error in input directions the real data varies along more, and tolerates
+more error in directions the data barely explores (the "optimal brain damage" / Fisher-weighted pruning
+idea, generalized from a diagonal Hessian approximation to a full covariance weighting).
+
+Per the roadmap's build-vs-borrow note, this module BORROWS the heavy primitives rather than
+reimplementing them:
+
+* the low-rank case has a real closed-form solution via a whiten/SVD/un-whiten reduction to plain
+  Eckart-Young truncated SVD (:func:`sigma_weighted_low_rank`) -- no iterative solver needed;
+* the block-sparse / 2:4 case has no closed form, so :func:`sigma_weighted_block_sparse` uses a
+  textbook projected-gradient ("alternating projection") scheme: a gradient step on the (convex,
+  quadratic-in-What) weighted objective, alternated with a hard projection onto the structural
+  constraint set (a fixed support mask, or a dynamically re-selected 2:4 pattern);
+* the permutation case is solved with Sinkhorn's algorithm -- the standard entropic-OT relaxation of a
+  linear assignment problem. ``torchsort``/POT/``geomloss`` were checked (see the PR description) and
+  are not installed in this environment; Sinkhorn itself is a well-known ~10-line fixed-point iteration
+  (alternating row/column normalization of a Gibbs kernel in log-domain for numerical stability), so it
+  is implemented directly here rather than pulling in a heavy optional dependency for a few lines of
+  numpy. This is also the differentiable "profile . arrangement" building block roadmap item G4 (later,
+  not this item) reuses for permutation x profile quantization.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+from scipy.optimize import linear_sum_assignment
+
+__all__ = [
+    "sigma_weighted_error",
+    "sigma_weighted_low_rank",
+    "sigma_weighted_block_sparse",
+    "sigma_weighted_permutation",
+]
+
+
+# --------------------------------------------------------------------------------------------------------
+# shared objective
+# --------------------------------------------------------------------------------------------------------
+
+
+def sigma_weighted_error(w: Any, w_hat: Any, sigma: Any) -> float:
+    """``tr((W - What) @ Sigma @ (What - W)^T)`` -- the Sigma-weighted reconstruction objective itself.
+
+    Used both as the convergence check inside the iterative solvers below and as the metric the tests
+    compare solvers against each other with. ``Sigma`` is assumed PSD (a covariance matrix); this
+    function does not itself validate that -- callers pass a real covariance (e.g. from
+    :func:`mixle.models.moment_propagation.propagate_moments`) or a synthetic ``A @ A.T`` construction.
+    """
+    diff = np.asarray(w, dtype=np.float64) - np.asarray(w_hat, dtype=np.float64)
+    sigma = np.asarray(sigma, dtype=np.float64)
+    return float(np.trace(diff @ sigma @ diff.T))
+
+
+def _symmetric_sqrt_and_pinv_sqrt(sigma: np.ndarray, rcond: float = 1e-10) -> tuple[np.ndarray, np.ndarray]:
+    """Eigendecompose a symmetric PSD ``Sigma`` into its symmetric matrix square root and the
+    (pseudo-inverse) square root, clipping numerically-negative eigenvalues to zero and treating
+    near-zero eigenvalues as exactly rank-deficient directions (their pseudo-inverse contribution is
+    zero, matching the fact that ``Sigma`` assigns no weight/cost to those directions at all).
+    """
+    sigma = 0.5 * (sigma + sigma.T)
+    eigval, eigvec = np.linalg.eigh(sigma)
+    eigval = np.clip(eigval, 0.0, None)
+    sqrt_eigval = np.sqrt(eigval)
+    threshold = rcond * float(sqrt_eigval.max() if sqrt_eigval.size else 0.0)
+    inv_sqrt_eigval = np.where(sqrt_eigval > threshold, np.reciprocal(np.where(sqrt_eigval > 0, sqrt_eigval, 1.0)), 0.0)
+    sigma_half = eigvec @ np.diag(sqrt_eigval) @ eigvec.T
+    sigma_half_pinv = eigvec @ np.diag(inv_sqrt_eigval) @ eigvec.T
+    return sigma_half, sigma_half_pinv
+
+
+# --------------------------------------------------------------------------------------------------------
+# 1. low-rank -- exact closed-form generalized SVD (whiten / SVD / un-whiten)
+# --------------------------------------------------------------------------------------------------------
+
+
+def sigma_weighted_low_rank(w: Any, sigma: Any, rank: int) -> np.ndarray:
+    """Exact closed-form solver for ``min_{rank(What)<=rank} tr((W-What) Sigma (W-What)^T)``.
+
+    Derivation (generalized SVD via whitening): for symmetric PSD ``Sigma`` with symmetric square root
+    ``Sigma^(1/2)`` (``Sigma = Sigma^(1/2) Sigma^(1/2)``, itself symmetric so ``(Sigma^(1/2))^T =
+    Sigma^(1/2)``),
+
+        tr((W-What) Sigma (W-What)^T) = tr((W-What) Sigma^(1/2) Sigma^(1/2) (W-What)^T)
+                                       = || (W-What) @ Sigma^(1/2) ||_F^2 .
+
+    Substituting ``B = W @ Sigma^(1/2)`` and ``Bhat = What @ Sigma^(1/2)``, the constraint
+    ``rank(What) <= rank`` becomes (for full-rank ``Sigma^(1/2)``) exactly ``rank(Bhat) <= rank``, and the
+    objective becomes the PLAIN (unweighted) Frobenius low-rank problem ``min ||B - Bhat||_F^2``, whose
+    exact global optimum is the truncated SVD of ``B`` (Eckart-Young). Un-whitening
+    ``What = Bhat @ Sigma^(1/2)^+`` (pseudo-inverse, needed if ``Sigma`` is rank-deficient) recovers the
+    optimal ``What`` in the ORIGINAL objective. When ``Sigma`` has a null space, those input directions
+    contribute nothing to the objective regardless of ``What``'s value there, so the pseudo-inverse
+    un-whitening (which zeroes ``What`` on that null space) is one particular optimum among many -- still
+    provably attaining the true minimum objective value, which is all the stated objective can see.
+
+    This is the SAME closed form used for Fisher/Hessian-weighted low-rank compression (a diagonal
+    special case of this is "optimal brain damage"-style weighted SVD); here it is implemented for a
+    full (non-diagonal) ``Sigma``.
+    """
+    w = np.asarray(w, dtype=np.float64)
+    sigma = np.asarray(sigma, dtype=np.float64)
+    if w.shape[1] != sigma.shape[0] or sigma.shape[0] != sigma.shape[1]:
+        raise ValueError(f"Sigma must be square with side == W.shape[1]; got W {w.shape}, Sigma {sigma.shape}")
+
+    sigma_half, sigma_half_pinv = _symmetric_sqrt_and_pinv_sqrt(sigma)
+
+    b = w @ sigma_half
+    u, s, vt = np.linalg.svd(b, full_matrices=False)
+    r = int(max(0, min(rank, s.shape[0])))
+    b_hat = (u[:, :r] * s[:r]) @ vt[:r, :]
+    return b_hat @ sigma_half_pinv
+
+
+# --------------------------------------------------------------------------------------------------------
+# 2. block-sparse / 2:4 -- alternating projection (projected gradient onto a structural constraint set)
+# --------------------------------------------------------------------------------------------------------
+
+
+def _project_mask(w: np.ndarray, mask: np.ndarray) -> np.ndarray:
+    return w * mask
+
+
+def _project_2_4(w: np.ndarray) -> np.ndarray:
+    """Hard-project onto the 2:4 structured-sparsity pattern: within every contiguous group of 4 entries
+    along the last (input) axis, keep the 2 largest-magnitude entries and zero the rest -- the standard
+    NVIDIA-style 2:4 semi-structured sparsity constraint (dense 2:4 GEMM / cuSPARSELt kernels consume
+    exactly this format). The pattern is RE-SELECTED from the current iterate's magnitudes every call,
+    which is what makes this a genuine alternating-projection scheme rather than a one-shot mask.
+    """
+    d_out, d_in = w.shape
+    if d_in % 4 != 0:
+        raise ValueError(f"2:4 sparsity requires the input dim to be a multiple of 4; got {d_in}")
+    groups = w.reshape(d_out, d_in // 4, 4)
+    order = np.argsort(-np.abs(groups), axis=-1)
+    keep = order[..., :2]
+    mask = np.zeros_like(groups, dtype=bool)
+    np.put_along_axis(mask, keep, True, axis=-1)
+    return np.where(mask, groups, 0.0).reshape(d_out, d_in)
+
+
+def sigma_weighted_block_sparse(
+    w: Any,
+    sigma: Any,
+    block_pattern_or_2_4: Any,
+    max_iter: int = 200,
+    tol: float = 1e-10,
+) -> np.ndarray:
+    """Alternating-projection solver for ``min_{What in S} tr((W-What) Sigma (W-What)^T)`` where ``S`` is
+    a structural constraint set with no closed form: a fixed block-sparse/arbitrary support mask, or the
+    2:4 semi-structured pattern.
+
+    ``block_pattern_or_2_4``:
+        * the literal string ``"2:4"`` -- 2:4 semi-structured sparsity (pattern re-selected every step,
+          see :func:`_project_2_4`);
+        * a boolean array shaped like ``W`` -- an explicit (e.g. block-sparse) fixed support pattern.
+
+    Algorithm: projected gradient descent on the (convex, quadratic-in-``What``) objective --
+    ``grad_What = -2 (W - What) Sigma`` -- with step size ``1 / (2 * lambda_max(Sigma))`` (the standard
+    Lipschitz-safe step for a quadratic with Hessian ``2*Sigma`` acting on the right), alternated with a
+    HARD projection onto the structural constraint set after every gradient step. Convergence contract:
+    for a FIXED mask the constraint set is a linear subspace, so this is plain convex projected gradient
+    descent and converges to the GLOBAL optimum of that subspace-constrained problem (matches the
+    closed-form per-row constrained-least-squares solution -- see the optimality test). For 2:4 the
+    constraint set is a finite, non-convex union of subspaces (the pattern itself is re-chosen every
+    step), so only convergence to a LOCAL optimum of the alternating scheme is guaranteed -- NOT global
+    optimality over all possible 2:4 masks (that combinatorial problem is not attempted here).
+    """
+    w = np.asarray(w, dtype=np.float64)
+    sigma = np.asarray(sigma, dtype=np.float64)
+    sigma = 0.5 * (sigma + sigma.T)
+
+    if isinstance(block_pattern_or_2_4, str):
+        if block_pattern_or_2_4 != "2:4":
+            raise ValueError(f"unrecognized structured-sparsity literal {block_pattern_or_2_4!r}, expected '2:4'")
+        project = _project_2_4
+    else:
+        mask = np.asarray(block_pattern_or_2_4, dtype=bool)
+        if mask.shape != w.shape:
+            raise ValueError(f"mask shape {mask.shape} must match W shape {w.shape}")
+        project = lambda x: _project_mask(x, mask)  # noqa: E731 - trivial closure, clearer inline than def
+
+    lambda_max = float(np.linalg.eigvalsh(sigma).max()) if sigma.size else 0.0
+    step = 1.0 / (2.0 * max(lambda_max, 1e-12))
+
+    w_hat = project(w.copy())
+    prev_err = sigma_weighted_error(w, w_hat, sigma)
+    for _ in range(max_iter):
+        grad = 2.0 * (w_hat - w) @ sigma
+        w_hat = project(w_hat - step * grad)
+        err = sigma_weighted_error(w, w_hat, sigma)
+        if abs(prev_err - err) <= tol * max(1.0, prev_err):
+            prev_err = err
+            break
+        prev_err = err
+    return w_hat
+
+
+# --------------------------------------------------------------------------------------------------------
+# 3. permutation -- Sinkhorn soft-permutation solver (feeds G4's "profile . arrangement")
+# --------------------------------------------------------------------------------------------------------
+
+
+def _sinkhorn_log_domain(log_kernel: np.ndarray, n_iter: int) -> np.ndarray:
+    """Standard log-domain Sinkhorn fixed point: alternately renormalize rows/columns of a Gibbs kernel
+    (in log-space, for numerical stability) until the coupling is (approximately) doubly stochastic.
+    Uniform marginals (``1/n`` each) since we are relaxing a square PERMUTATION matrix, whose row/column
+    sums are all exactly 1.
+    """
+    n = log_kernel.shape[0]
+    log_u = np.zeros(n)
+    log_v = np.zeros(n)
+    log_marginal = -np.log(n)
+    for _ in range(n_iter):
+        log_u = log_marginal - _logsumexp(log_kernel + log_v[None, :], axis=1)
+        log_v = log_marginal - _logsumexp(log_kernel + log_u[:, None], axis=0)
+    return np.exp(log_u[:, None] + log_kernel + log_v[None, :])
+
+
+def _logsumexp(a: np.ndarray, axis: int) -> np.ndarray:
+    m = np.max(a, axis=axis, keepdims=True)
+    m = np.where(np.isfinite(m), m, 0.0)
+    out = m + np.log(np.sum(np.exp(a - m), axis=axis, keepdims=True))
+    return np.squeeze(out, axis=axis)
+
+
+def sigma_weighted_permutation(
+    w: Any,
+    sigma: Any,
+    target_profile: Any,
+    temperature: float = 0.1,
+    max_iter: int = 100,
+) -> np.ndarray:
+    """Sinkhorn-based soft-permutation solver for ``What = P @ target_profile`` -- the "profile o
+    arrangement" pattern (roadmap H4/R1, feeding G4's permutation x profile quantization): find the
+    ROW-permutation ``P`` of a fixed canonical ``target_profile`` that best matches ``W`` under the
+    Sigma-weighted objective ``min_P tr((W - P @ target_profile) Sigma (W - P @ target_profile)^T)``.
+
+    This is a linear assignment problem in disguise: it decomposes over ROW-PAIRS (row ``i`` of ``W``
+    matched to row ``j`` of ``target_profile``) with pairwise cost
+    ``cost[i,j] = (W_i - profile_j) @ Sigma @ (W_i - profile_j)^T``, so the discrete problem
+    ``min_{P permutation} sum_i cost[i, perm(i)]`` is EXACTLY a linear assignment problem. We solve it
+    with the differentiable Sinkhorn relaxation the roadmap asks for (a Gibbs kernel
+    ``K = exp(-cost/temperature)``, alternately row/column normalized in log-domain -- this is the
+    ``torchsort``/POT-style soft-permutation building block G4 later reuses for a jointly-differentiable
+    profile+arrangement objective), THEN round the converged soft doubly-stochastic coupling to a hard
+    permutation via linear-sum-assignment (Hungarian) on the SAME cost matrix -- a standard, exact
+    final-rounding step (the Sinkhorn relaxation supplies the differentiable pattern; committing to a
+    hard answer is a separate, exact combinatorial step, not claimed to itself be "the Sinkhorn
+    solution"). Convergence contract: the returned answer is the exact optimum of the linear assignment
+    problem (Hungarian rounding is exact for assignment problems); the SINKHORN PLAN itself only
+    converges to the true permutation in the low-temperature limit -- what "converged Sinkhorn solution"
+    means here is that repeated Sinkhorn normalization has converged to a fixed doubly-stochastic
+    coupling for the given ``temperature``, not that temperature itself has been annealed to zero.
+    """
+    w = np.asarray(w, dtype=np.float64)
+    sigma = np.asarray(sigma, dtype=np.float64)
+    sigma = 0.5 * (sigma + sigma.T)
+    profile = np.asarray(target_profile, dtype=np.float64)
+    if w.shape != profile.shape:
+        raise ValueError(f"target_profile shape {profile.shape} must match W shape {w.shape}")
+    n = w.shape[0]
+
+    # pairwise Sigma-weighted cost between every row of W and every row of the profile
+    diff = w[:, None, :] - profile[None, :, :]  # (n, n, d_in)
+    cost = np.einsum("ijk,kl,ijl->ij", diff, sigma, diff)
+
+    log_kernel = -cost / max(temperature, 1e-8)
+    soft_plan = _sinkhorn_log_domain(log_kernel, n_iter=max_iter)
+
+    row_ind, col_ind = linear_sum_assignment(cost)
+    perm = np.zeros((n, n), dtype=np.float64)
+    perm[row_ind, col_ind] = 1.0
+
+    _ = soft_plan  # the differentiable relaxation this function demonstrates; hard rounding uses `cost` directly
+    return perm @ profile

--- a/mixle/tests/sigma_weighted_projection_test.py
+++ b/mixle/tests/sigma_weighted_projection_test.py
@@ -1,0 +1,288 @@
+"""Acceptance tests for mixle.models.sigma_weighted_projection (roadmap G2: Sigma-weighted structured
+projections).
+
+Each solver family gets an "optimality" test whose meaning is stated precisely up front (see each test's
+docstring -- exact for low-rank, global-optimum-of-the-convex-subproblem for fixed-mask block-sparse,
+local-optimum-of-the-alternating-scheme for 2:4, exact-linear-assignment for permutation), plus one
+end-to-end acceptance test: a REAL propagated Sigma from G1 (mixle.models.moment_propagation) beats plain
+unweighted SVD, at equal rank, on a real small transformer's weight matrix.
+"""
+
+import itertools
+import unittest
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from mixle.models.moment_propagation import GaussianLaw, attention_law, layernorm_law
+from mixle.models.sigma_weighted_projection import (
+    _project_2_4,
+    sigma_weighted_block_sparse,
+    sigma_weighted_error,
+    sigma_weighted_low_rank,
+    sigma_weighted_permutation,
+)
+from mixle.models.transformer import build_causal_lm
+
+pytestmark = pytest.mark.fast
+
+
+def _random_sigma(rng: np.random.Generator, d: int, scale: float = 1.0) -> np.ndarray:
+    a = rng.normal(size=(d, d)) * scale
+    return a @ a.T + 0.1 * np.eye(d)
+
+
+class LowRankOptimalityTest(unittest.TestCase):
+    """Optimality meaning for the low-rank solver: EXACT. The whiten/SVD/un-whiten reduction is a genuine
+    closed-form solution (Eckart-Young in the whitened space), so it must (a) match plain unweighted SVD
+    exactly when Sigma = I (the objective degenerates to plain Frobenius low-rank), and (b) strictly beat
+    plain SVD under the SAME weighted metric whenever Sigma is anisotropic.
+    """
+
+    def test_reduces_to_plain_svd_when_sigma_is_identity(self):
+        rng = np.random.default_rng(0)
+        d_out, d_in, rank = 6, 5, 3
+        w = rng.normal(size=(d_out, d_in))
+
+        what = sigma_weighted_low_rank(w, np.eye(d_in), rank)
+
+        u, s, vt = np.linalg.svd(w, full_matrices=False)
+        what_plain = (u[:, :rank] * s[:rank]) @ vt[:rank, :]
+        np.testing.assert_allclose(what, what_plain, atol=1e-8)
+
+    def test_beats_plain_svd_under_the_weighted_metric_on_anisotropic_sigma(self):
+        rng = np.random.default_rng(1)
+        d_out, d_in, rank = 8, 6, 2
+        w = rng.normal(size=(d_out, d_in))
+        sigma = _random_sigma(rng, d_in)
+
+        what = sigma_weighted_low_rank(w, sigma, rank)
+        err_weighted = sigma_weighted_error(w, what, sigma)
+
+        u, s, vt = np.linalg.svd(w, full_matrices=False)
+        what_plain = (u[:, :rank] * s[:rank]) @ vt[:rank, :]
+        err_plain = sigma_weighted_error(w, what_plain, sigma)
+
+        print(f"[low_rank] sigma-weighted solver error: {err_weighted:.6f}, plain-SVD error: {err_plain:.6f}")
+        self.assertLess(err_weighted, err_plain)
+        self.assertLessEqual(np.linalg.matrix_rank(what), rank)
+
+    def test_matches_a_gradient_descent_refined_reference(self):
+        """Independent numerical cross-check of the closed form: refine a random-init rank-r factorization
+        by many steps of plain gradient descent directly on the stated objective and confirm it cannot beat
+        (does no better than, within optimizer noise) the closed-form answer.
+        """
+        rng = np.random.default_rng(2)
+        d_out, d_in, rank = 5, 4, 2
+        w_np = rng.normal(size=(d_out, d_in))
+        sigma_np = _random_sigma(rng, d_in, scale=0.7)
+
+        closed_form_err = sigma_weighted_error(w_np, sigma_weighted_low_rank(w_np, sigma_np, rank), sigma_np)
+
+        torch.manual_seed(0)
+        w = torch.tensor(w_np, dtype=torch.float64)
+        sigma = torch.tensor(sigma_np, dtype=torch.float64)
+        u = torch.randn(d_out, rank, dtype=torch.float64, requires_grad=True)
+        v = torch.randn(d_in, rank, dtype=torch.float64, requires_grad=True)
+        opt = torch.optim.Adam([u, v], lr=0.05)
+        for _ in range(4000):
+            opt.zero_grad()
+            what = u @ v.T
+            diff = w - what
+            loss = torch.trace(diff @ sigma @ diff.T)
+            loss.backward()
+            opt.step()
+        gd_err = float(loss.detach())
+
+        print(f"[low_rank] closed-form error: {closed_form_err:.6f}, gradient-descent-refined error: {gd_err:.6f}")
+        # the closed form is the TRUE optimum, so gradient descent -- a local, noisy search -- should not
+        # beat it by more than a small numerical-optimization slack
+        self.assertGreater(gd_err, closed_form_err - 1e-4)
+
+
+class BlockSparseOptimalityTest(unittest.TestCase):
+    """Optimality meaning for the block-sparse solver: for a FIXED support mask, the constraint set is a
+    linear subspace and the objective is convex-quadratic, so alternating projection is plain convex
+    projected-gradient descent -- it converges to the GLOBAL optimum of that (convex) subproblem, which has
+    an independent closed form (per-output-row constrained weighted least squares) checked directly below.
+    For the (non-convex, pattern-re-selected-every-step) 2:4 case, only convergence to a LOCAL optimum of
+    the alternating scheme is claimed -- checked instead against a naive magnitude-only 2:4 baseline that
+    does not adjust surviving weight VALUES for Sigma.
+    """
+
+    def test_fixed_mask_matches_closed_form_constrained_least_squares(self):
+        rng = np.random.default_rng(3)
+        d_out, d_in = 5, 7
+        w = rng.normal(size=(d_out, d_in))
+        sigma = _random_sigma(rng, d_in)
+        mask = rng.random((d_out, d_in)) < 0.6
+        # guarantee every row keeps at least one entry so the per-row closed form below is well posed
+        for i in range(d_out):
+            if not mask[i].any():
+                mask[i, 0] = True
+
+        what = sigma_weighted_block_sparse(w, sigma, mask, max_iter=1000, tol=1e-14)
+        self.assertTrue(np.all(what[~mask] == 0.0))
+
+        sigma_sym = 0.5 * (sigma + sigma.T)
+        what_ref = np.zeros_like(w)
+        for i in range(d_out):
+            support = mask[i]
+            rest = ~support
+            if rest.any():
+                sigma_ss = sigma_sym[np.ix_(support, support)]
+                sigma_s_rest = sigma_sym[np.ix_(support, rest)]
+                c = w[i, rest]
+                d_support = -np.linalg.solve(sigma_ss, sigma_s_rest @ c)
+                what_ref[i, support] = w[i, support] - d_support
+            else:
+                what_ref[i, support] = w[i, support]
+
+        err_solver = sigma_weighted_error(w, what, sigma)
+        err_ref = sigma_weighted_error(w, what_ref, sigma)
+        print(f"[block_sparse/fixed_mask] solver error: {err_solver:.8f}, closed-form reference: {err_ref:.8f}")
+        self.assertAlmostEqual(err_solver, err_ref, places=5)
+
+    def test_two_four_beats_naive_magnitude_only_baseline(self):
+        rng = np.random.default_rng(4)
+        d_out, d_in = 4, 12
+        w = rng.normal(size=(d_out, d_in))
+        sigma = _random_sigma(rng, d_in, scale=1.5)
+
+        what = sigma_weighted_block_sparse(w, sigma, "2:4", max_iter=300)
+        # structural constraint respected: at most 2 nonzeros per contiguous group of 4
+        groups_nnz = (what.reshape(d_out, d_in // 4, 4) != 0).sum(axis=-1)
+        self.assertTrue(np.all(groups_nnz <= 2))
+
+        naive = _project_2_4(w)  # magnitude-only baseline: picks the pattern but never re-optimizes values
+        err_solver = sigma_weighted_error(w, what, sigma)
+        err_naive = sigma_weighted_error(w, naive, sigma)
+        print(f"[block_sparse/2:4] solver error: {err_solver:.6f}, naive-magnitude-only baseline: {err_naive:.6f}")
+        self.assertLess(err_solver, err_naive)
+
+        # convergence check: the alternating scheme should be monotonically non-increasing at the end
+        what_more = sigma_weighted_block_sparse(w, sigma, "2:4", max_iter=600)
+        self.assertLessEqual(
+            sigma_weighted_error(w, what_more, sigma) + 1e-9,
+            err_solver + 1e-6,
+        )
+
+
+class PermutationOptimalityTest(unittest.TestCase):
+    """Optimality meaning for the permutation solver: the row-to-row matching problem is exactly a linear
+    assignment problem, so the returned answer (Sinkhorn relaxation converged, then rounded by exact
+    Hungarian assignment on the same cost matrix) is checked against true global optimality via brute-force
+    enumeration over all n! permutations for small n.
+    """
+
+    def test_exact_recovery_of_a_known_permutation(self):
+        rng = np.random.default_rng(5)
+        n, d = 5, 4
+        profile = rng.normal(size=(n, d))
+        true_perm = rng.permutation(n)
+        w = np.eye(n)[true_perm] @ profile
+        sigma = _random_sigma(rng, d)
+
+        what = sigma_weighted_permutation(w, sigma, profile, temperature=0.05, max_iter=200)
+        np.testing.assert_allclose(what, w, atol=1e-8)
+        self.assertAlmostEqual(sigma_weighted_error(w, what, sigma), 0.0, places=8)
+
+    def test_matches_brute_force_global_optimum_on_a_noisy_case(self):
+        rng = np.random.default_rng(6)
+        n, d = 5, 4
+        profile = rng.normal(size=(n, d))
+        true_perm = rng.permutation(n)
+        w = np.eye(n)[true_perm] @ profile + rng.normal(scale=0.3, size=(n, d))
+        sigma = _random_sigma(rng, d)
+
+        best_err = min(
+            sigma_weighted_error(w, np.eye(n)[list(perm)] @ profile, sigma) for perm in itertools.permutations(range(n))
+        )
+        what = sigma_weighted_permutation(w, sigma, profile, temperature=0.05, max_iter=200)
+        solver_err = sigma_weighted_error(w, what, sigma)
+
+        print(f"[permutation] solver error: {solver_err:.6f}, brute-force global optimum: {best_err:.6f}")
+        self.assertAlmostEqual(solver_err, best_err, places=6)
+
+
+def _law(mu, covar) -> GaussianLaw:
+    return GaussianLaw(mu=np.asarray(mu, dtype=float), covar=np.asarray(covar, dtype=float))
+
+
+def _to_numpy(t) -> np.ndarray:
+    return t.detach().cpu().numpy().astype(np.float64)
+
+
+def _block0_mlp_input_law(model, input_law: GaussianLaw) -> GaussianLaw:
+    """Exact input law to ``model.blocks[0].mlp[0]`` -- i.e. the propagated law AFTER block 0's residual
+    attention branch and its second LayerNorm -- replicating (by hand, from the same public G1 primitives
+    :func:`propagate_moments` itself calls) the first half of one transformer block's forward pass. This
+    is the REAL data-free covariance that ``blk.mlp[0].weight`` gets multiplied against.
+    """
+    blk = model.blocks[0]
+    ln1_w, ln1_b = _to_numpy(blk.ln1.weight), _to_numpy(blk.ln1.bias)
+    ln1_law, j_ln1 = layernorm_law(input_law, ln1_w, ln1_b, eps=blk.ln1.eps)
+
+    qkv_w = _to_numpy(blk.attn.qkv.weight)
+    qkv_b = _to_numpy(blk.attn.qkv.bias)
+    proj_w = _to_numpy(blk.attn.proj.weight)
+    proj_b = _to_numpy(blk.attn.proj.bias)
+    attn_law, j_attn = attention_law(ln1_law, qkv_w, qkv_b, proj_w, proj_b, n_head=blk.attn.h)
+
+    j_branch = j_attn @ j_ln1
+    cross = input_law.covar @ j_branch.T
+    mu1 = input_law.mu + attn_law.mu
+    cov1 = input_law.covar + attn_law.covar + cross + cross.T
+    x1 = _law(mu1, cov1)
+
+    ln2_w, ln2_b = _to_numpy(blk.ln2.weight), _to_numpy(blk.ln2.bias)
+    ln2_law, _ = layernorm_law(x1, ln2_w, ln2_b, eps=blk.ln2.eps)
+    return ln2_law
+
+
+class DataFreeSigmaBeatsPlainSvdTest(unittest.TestCase):
+    """The G2 acceptance criterion: data-free Sigma (from G1's moment propagation) beats plain SVD at equal
+    rank on a real small transformer's weight matrix, measured by the ACTUAL objective a data-free Sigma is
+    supposed to optimize for -- the Sigma-weighted reconstruction error -- on the real ``blk.mlp[0].weight``
+    of ``mixle.models.transformer.build_causal_lm``'s first block.
+    """
+
+    def test_sigma_weighted_solver_beats_plain_svd_on_real_mlp_weight(self):
+        torch.manual_seed(11)
+        model = build_causal_lm(vocab=12, d_model=16, n_layer=2, n_head=4, block=16)
+
+        rng = np.random.default_rng(12)
+        d_model = model.d_model
+        mu0 = rng.normal(size=d_model) * 0.3
+        a0 = rng.normal(size=(d_model, d_model)) * 0.2
+        cov0 = a0 @ a0.T + 0.2 * np.eye(d_model)
+        input_law = _law(mu0, cov0)
+
+        sigma = _block0_mlp_input_law(model, input_law).covar
+        w = _to_numpy(model.blocks[0].mlp[0].weight)  # (4*d_model, d_model)
+        rank = 4
+
+        what_weighted = sigma_weighted_low_rank(w, sigma, rank)
+        err_weighted = sigma_weighted_error(w, what_weighted, sigma)
+
+        u, s, vt = np.linalg.svd(w, full_matrices=False)
+        what_plain = (u[:, :rank] * s[:rank]) @ vt[:rank, :]
+        err_plain = sigma_weighted_error(w, what_plain, sigma)
+
+        improvement = 1.0 - err_weighted / err_plain
+        print(
+            f"[acceptance/G2] real blocks[0].mlp[0].weight ({w.shape}), rank={rank}: "
+            f"sigma-weighted error={err_weighted:.6f}, plain-SVD error={err_plain:.6f}, "
+            f"relative improvement={improvement:.2%}"
+        )
+
+        self.assertLess(err_weighted, err_plain)
+        # the real propagated Sigma off a genuine LayerNorm is meaningfully anisotropic -- require the
+        # data-free solver to actually matter, not just win by float noise
+        self.assertGreater(improvement, 0.05)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Relands #144, which was closed without merging even though its own prerequisite (#142, G1 moment-propagation) already landed on release and this content was never re-targeted. Reconstructed by diffing #144's own head against its original base (avoiding the squash-merge ancestry break a straight base-retarget would hit) and replaying that diff cleanly onto the current release tip.

Closes the chain that PRs #151, #158, #164 (and their own descendants) are stacked on.