### PR TITLE
inference: on-the-fly conditional scenario simulators over M0 (roadmap M2)

### DIFF
--- a/mixle/inference/__init__.py
+++ b/mixle/inference/__init__.py
@@ -224,6 +224,11 @@ from mixle.inference.robust import (
     robust_standard_errors,
     sandwich_covariance,
 )
+from mixle.inference.scenario import FieldPosterior as ScenarioFieldPosterior
+from mixle.inference.scenario import Scenario as ScenarioSpec
+from mixle.inference.scenario import SimulationReceipt as ScenarioSimulationReceipt
+from mixle.inference.scenario import Simulator as ScenarioSimulator
+from mixle.inference.scenario import simulate as simulate_scenario
 
 # proper scoring rules — fair currency for comparing probabilistic forecasts / interval methods
 from mixle.inference.scoring import (
@@ -407,6 +412,14 @@ __all__ = [
     "simulate",
     "Simulator",
     "Scenario",
+    # simulate_scenario() (M2) -- on-the-fly conditional simulators: evidence + interventions + horizon,
+    # via M0's condition()/do(), with a plausibility receipt. Aliased (not `simulate`/`Scenario`/
+    # `Simulator`) to avoid colliding with the names above -- see notes/designs/M2.md.
+    "simulate_scenario",
+    "ScenarioSpec",
+    "ScenarioSimulator",
+    "ScenarioSimulationReceipt",
+    "ScenarioFieldPosterior",
     # synthesize() -- a dataset factory: sample, label, keep only what verifies
     "synthesize",
     "Dataset",

--- a/mixle/inference/scenario.py
+++ b/mixle/inference/scenario.py
@@ -1,0 +1,400 @@
+"""``simulate(scenario) -> Simulator`` -- on-the-fly conditional simulators for special scenarios.
+
+See ``notes/designs/M2.md`` for the full design: source selection (explicit / registry / auto-
+designed), why interventions must compose with evidence as ``do()`` FIRST then ``condition()``
+(and how that is realized for a ``HeterogeneousBayesianNetwork``, whose ``do()`` result M0's
+``condition()`` does not dispatch on), the HMM/state-space temporal-rollout extension past M0's
+conditioned window, and the plausibility receipt (the scenario's evidence log-density under the
+UNMODIFIED base model).
+
+Distinct from :mod:`mixle.inference.simulate` (`Scenario`/`Simulator`/`simulate(model)`), a
+narrower, BN-intervention-only tool already consumed by ``mixle.substrate.act``: this module does
+not touch that one, and is imported under its own names (`mixle.inference.scenario.simulate`, not
+re-exported under the same bare name from ``mixle.inference``).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+from numpy.random import RandomState
+from scipy.special import logsumexp
+
+from mixle.inference.bayesian_network import HeterogeneousBayesianNetwork
+from mixle.inference.causal import do as _bn_do
+from mixle.inference.condition import (
+    FieldPath,
+    Posterior,
+    _generate_weighted,
+    _is_gaussian_like,
+    _norm_evidence,
+    _norm_path,
+    _rng_seed,
+    _safe_log_density,
+    condition,
+    do,
+)
+from mixle.stats.combinator.composite import CompositeDistribution
+from mixle.stats.compute.posterior import MarkovChainLatentPosterior
+from mixle.stats.latent.hidden_markov import HiddenMarkovModelDistribution
+
+__all__ = ["Scenario", "SimulationReceipt", "FieldPosterior", "Simulator", "simulate"]
+
+
+@dataclass
+class Scenario:
+    """``{evidence, interventions, priors, horizon}`` -- what to build a simulator for.
+
+    ``priors`` is the generic model-source configuration slot (see ``notes/designs/M2.md``):
+    ``priors["registry"] = (Registry, name, version="latest")`` to fetch a stored model, or
+    ``priors["data"]`` (+ optional ``priors["llm"]``) to auto-design one from scarce scenario data
+    via :func:`mixle.task.design.design_model`, when ``base`` is not given directly to
+    :func:`simulate`.
+    """
+
+    evidence: dict[FieldPath | int, Any] = field(default_factory=dict)
+    interventions: dict[FieldPath | int, Any] = field(default_factory=dict)
+    priors: dict[str, Any] = field(default_factory=dict)
+    horizon: int = 1
+
+
+@dataclass
+class SimulationReceipt:
+    """What ``simulate()`` actually did: plausibility of the evidence, and the conditioning health."""
+
+    plausibility: float | None  # log p_base(evidence); None when there is no evidence to score
+    plausibility_method: str  # "exact" | "sir" | "no-evidence"
+    method: str  # conditioning method for the working posterior: "exact" | "sir" | "none"
+    ess: float | None = None
+    ess_ratio: float | None = None
+    composition_order: str = "do-then-condition"
+    warnings: list[str] = field(default_factory=list)
+
+
+class FieldPosterior:
+    """An empirical marginal for one field, built from rollout draws (``.mean()``/``.std()``/``.sample()``)."""
+
+    def __init__(self, values: np.ndarray) -> None:
+        self._values = values
+
+    def mean(self) -> float:
+        return float(np.mean(self._values))
+
+    def std(self) -> float:
+        return float(np.std(self._values))
+
+    def sample(self, n: int = 1, *, seed: int | None = None) -> np.ndarray:
+        rng = RandomState(seed)
+        idx = rng.randint(0, len(self._values), size=int(n))
+        return self._values[idx]
+
+
+# --------------------------------------------------------------------------------------------- #
+# source selection
+# --------------------------------------------------------------------------------------------- #
+
+
+def _resolve_base(base: Any | None, scenario: Scenario) -> Any:
+    if base is not None:
+        return base
+    priors = scenario.priors
+    if "registry" in priors:
+        registry, name, *rest = priors["registry"]
+        version = rest[0] if rest else "latest"
+        return registry.get(name, version)[0]
+    if "data" in priors:
+        from mixle.task.design import design_model
+
+        designed = design_model(priors["data"], priors.get("llm"), fallback=True)
+        return designed.fit(priors["data"])
+    raise ValueError(
+        "simulate(): no model source -- pass `base=` explicitly, or set "
+        "`scenario.priors['registry'] = (registry, name)` or `scenario.priors['data'] = records`."
+    )
+
+
+# --------------------------------------------------------------------------------------------- #
+# do() FIRST, then condition()
+# --------------------------------------------------------------------------------------------- #
+
+
+def _extract(record: Any, path: FieldPath) -> Any:
+    v = record
+    for i in path:
+        v = v[i]
+    return v
+
+
+def _condition_after_do_bn(
+    net: HeterogeneousBayesianNetwork,
+    interventions: dict[int, Any],
+    evidence: dict[FieldPath, Any],
+    *,
+    n_particles: int,
+    seed: int | None,
+) -> tuple[list[tuple], np.ndarray, SimulationReceipt]:
+    """``condition()`` has no dispatch rule for ``InterventionalNetwork`` (M0's ``do()`` result for a
+    BN) -- realize "do() first, then condition()" here directly, in one ancestral pass over
+    ``net.order`` per particle: an intervened field is FIXED with no weight contribution (its
+    factor/edge is never consulted -- graph surgery), an evidenced field is FIXED and its factor's
+    ``log_density`` becomes an importance weight (Bayesian update), exactly M0's own BN branch of
+    ``_generate_weighted`` -- except intervened fields skip the weight term, which is the entire
+    difference between ``do()`` and ``condition()``.
+    """
+    rng = RandomState(seed)
+    top = {p[0]: v for p, v in evidence.items() if len(p) == 1}
+    if any(len(p) != 1 for p in evidence):
+        raise NotImplementedError("nested evidence is not supported for a HeterogeneousBayesianNetwork scenario.")
+    by_child = {f.child: f for f in net.factors}
+    n_fields = len(net.factors)
+    records: list[tuple] = []
+    log_weights = np.empty(n_particles, dtype=np.float64)
+    for i in range(n_particles):
+        vals: list[Any] = [None] * n_fields
+        lw = 0.0
+        for idx in net.order:
+            f = by_child[idx]
+            if idx in interventions:
+                vals[idx] = interventions[idx]  # do(): fixed, edge severed, no weight
+            elif idx in top:
+                vals[idx] = top[idx]  # condition(): fixed, weighted by its own factor
+                lw += _safe_log_density(f, tuple(vals))
+            else:
+                vals[idx] = f.sample(vals, rng)
+        records.append(tuple(vals))
+        log_weights[i] = lw
+
+    warnings: list[str] = []
+    if not top:
+        w_norm = np.full(n_particles, 1.0 / n_particles)
+        ess = float(n_particles)
+    else:
+        finite = np.isfinite(log_weights)
+        if not finite.any():
+            w_norm = np.full(n_particles, 1.0 / n_particles)
+            ess = 0.0
+            warnings.append("all importance weights are zero (evidence has zero density under do(...)).")
+        else:
+            m = log_weights[finite].max()
+            w = np.where(finite, np.exp(log_weights - m), 0.0)
+            w_norm = w / w.sum()
+            ess = float(1.0 / np.sum(w_norm**2))
+    ess_ratio = ess / n_particles
+    if top and ess_ratio < 0.01:
+        warnings.append(f"ESS ratio {ess_ratio:.4f} < 0.01 threshold -- evidence may be near-impossible under do(...).")
+    receipt = SimulationReceipt(
+        plausibility=None,
+        plausibility_method="no-evidence",
+        method="sir" if top else "none",
+        ess=ess,
+        ess_ratio=ess_ratio,
+        warnings=warnings,
+    )
+    return records, w_norm, receipt
+
+
+# --------------------------------------------------------------------------------------------- #
+# HMM / state-space temporal rollout past the conditioned window
+# --------------------------------------------------------------------------------------------- #
+
+
+def _hmm_forward_rollout(
+    model: HiddenMarkovModelDistribution,
+    evidence: dict[int, Any],
+    horizon: int,
+    n: int,
+    rng: RandomState,
+) -> list[list[Any]]:
+    """``n`` full-horizon emission rows: exact smoothed state posterior over ``[0, t_max]`` (same
+    construction M0's ``_condition_hmm`` uses), then ancestral forward continuation of the DRAWN
+    joint state path from ``t_max+1`` to ``horizon-1`` -- "forward-filtered simulation" continued
+    past the last clamp.
+    """
+    n_states = model.n_states
+    t_max = max(evidence) if evidence else -1
+    t_max = max(t_max, -1)
+    log_b = np.zeros((t_max + 1, n_states), dtype=np.float64)
+    for t in range(t_max + 1):
+        if t in evidence:
+            for k in range(n_states):
+                log_b[t, k] = _safe_log_density(model.topics[k], evidence[t])
+    q = MarkovChainLatentPosterior(model.log_w, model.log_transitions, log_b) if t_max >= 0 else None
+    trans = np.exp(model.log_transitions)
+    rows: list[list[Any]] = []
+    for _ in range(n):
+        if q is not None:
+            z = list(q.sample(rng))
+        else:
+            z = [int(rng.choice(n_states, p=np.exp(model.log_w)))]
+        row: list[Any] = [None] * max(horizon, t_max + 1)
+        for t in range(t_max + 1):
+            row[t] = evidence[t] if t in evidence else model.topics[int(z[t])].sampler(seed=_rng_seed(rng)).sample()
+        state = int(z[t_max]) if t_max >= 0 else z[0]
+        for t in range(t_max + 1, horizon):
+            state = int(rng.choice(n_states, p=trans[state]))
+            row[t] = model.topics[state].sampler(seed=_rng_seed(rng)).sample()
+        rows.append(row)
+    return rows
+
+
+# --------------------------------------------------------------------------------------------- #
+# plausibility receipt: log p_base(evidence)
+# --------------------------------------------------------------------------------------------- #
+
+
+def _exact_evidence_log_density(model: Any, top: dict[int, Any]) -> float | None:
+    if not top or not callable(getattr(model, "marginal", None)):
+        return None
+    idx = sorted(top)
+    try:
+        if isinstance(model, CompositeDistribution):
+            sub = model.marginal(idx)  # CompositeDistribution.marginal sorts internally too
+            value = tuple(top[i] for i in idx)
+        elif _is_gaussian_like(model):
+            sub = model.marginal(idx)  # order-preserving
+            value = np.array([float(top[i]) for i in idx], dtype=np.float64)
+        else:
+            return None
+        return float(sub.log_density(value))
+    except (ValueError, TypeError, NotImplementedError):
+        return None
+
+
+def _sir_evidence_log_density(model: Any, ev: dict[FieldPath, Any], *, n_particles: int, rng: RandomState) -> float:
+    """SNIS estimate of ``log p_base(evidence)`` -- reuses M0's own generative decomposition
+    (``_generate_weighted``) rather than a second per-combinator dispatch table (see M2.md)."""
+    log_weights = np.empty(n_particles, dtype=np.float64)
+    for i in range(n_particles):
+        _, lw = _generate_weighted(model, ev, rng)
+        log_weights[i] = lw
+    finite = log_weights[np.isfinite(log_weights)]
+    if finite.size == 0:
+        return float("-inf")
+    return float(logsumexp(log_weights[np.isfinite(log_weights)]) - np.log(n_particles))
+
+
+def plausibility_receipt(
+    base: Any, evidence: dict[FieldPath | int, Any], *, n_particles: int = 4096, seed: int | None = None
+) -> tuple[float | None, str]:
+    """``(log p_base(evidence), method)`` -- the scenario's evidence log-density under the base model."""
+    if not evidence:
+        return None, "no-evidence"
+    ev = _norm_evidence(evidence)
+    top = {p[0]: v for p, v in ev.items() if len(p) == 1}
+    if len(top) == len(ev):
+        exact = _exact_evidence_log_density(base, top)
+        if exact is not None:
+            return exact, "exact"
+    rng = RandomState(seed)
+    return _sir_evidence_log_density(base, ev, n_particles=n_particles, rng=rng), "sir"
+
+
+# --------------------------------------------------------------------------------------------- #
+# Simulator / simulate()
+# --------------------------------------------------------------------------------------------- #
+
+
+class Simulator:
+    """A scenario resolved to a runnable generator, with a plausibility + conditioning receipt."""
+
+    def __init__(
+        self,
+        *,
+        base: Any,
+        scenario: Scenario,
+        seed: int | None,
+        n_particles: int = 4096,
+    ) -> None:
+        self.base = base
+        self.scenario = scenario
+        self._seed = seed
+        self._n_particles = int(n_particles)
+        self._rng = RandomState(seed)
+
+        plausibility, plaus_method = plausibility_receipt(
+            base, scenario.evidence, n_particles=n_particles, seed=_rng_seed(self._rng)
+        )
+
+        interventions = _norm_evidence(scenario.interventions) if scenario.interventions else {}
+        evidence = _norm_evidence(scenario.evidence) if scenario.evidence else {}
+
+        self._bn_records: tuple[list[tuple], np.ndarray] | None = None
+        self._hmm_model: HiddenMarkovModelDistribution | None = None
+        self._hmm_evidence: dict[int, Any] = {}
+        self._posterior: Posterior | None = None
+        working = base
+
+        if interventions:
+            if isinstance(base, HeterogeneousBayesianNetwork):
+                iv = {p[0]: v for p, v in interventions.items()}
+                _bn_do(base, iv)  # validates field indices are in range; raises ValueError otherwise
+                records, w_norm, receipt = _condition_after_do_bn(
+                    base, iv, evidence, n_particles=n_particles, seed=_rng_seed(self._rng)
+                )
+                self._bn_records = (records, w_norm)
+                self.receipt = SimulationReceipt(
+                    plausibility=plausibility,
+                    plausibility_method=plaus_method,
+                    method=receipt.method,
+                    ess=receipt.ess,
+                    ess_ratio=receipt.ess_ratio,
+                    warnings=receipt.warnings,
+                )
+                return
+            working = do(base, dict(interventions))
+
+        if isinstance(working, HiddenMarkovModelDistribution) and (evidence or scenario.horizon > 1):
+            self._hmm_model = working
+            self._hmm_evidence = {p[0]: v for p, v in evidence.items()}
+            method = "exact" if evidence else "none"
+            self.receipt = SimulationReceipt(plausibility=plausibility, plausibility_method=plaus_method, method=method)
+            return
+
+        if evidence:
+            self._posterior = condition(working, dict(evidence), n_particles=n_particles, seed=_rng_seed(self._rng))
+            self.receipt = SimulationReceipt(
+                plausibility=plausibility,
+                plausibility_method=plaus_method,
+                method=self._posterior.receipt.method,
+                ess=self._posterior.receipt.ess,
+                ess_ratio=self._posterior.receipt.ess_ratio,
+                warnings=list(self._posterior.receipt.warnings),
+            )
+        else:
+            self._working = working
+            self.receipt = SimulationReceipt(plausibility=plausibility, plausibility_method=plaus_method, method="none")
+
+    def rollout(self, n: int = 1) -> list[Any]:
+        """``n`` draws from the resolved scenario (do() applied, evidence conditioned, seed-fixed)."""
+        n = int(n)
+        if self._bn_records is not None:
+            records, w_norm = self._bn_records
+            idx = self._rng.choice(len(records), size=n, replace=True, p=w_norm)
+            return [records[j] for j in idx]
+        if self._hmm_model is not None:
+            return _hmm_forward_rollout(self._hmm_model, self._hmm_evidence, int(self.scenario.horizon), n, self._rng)
+        if self._posterior is not None:
+            return self._posterior.sample(n, seed=_rng_seed(self._rng))
+        sampler = self._working.sampler(seed=_rng_seed(self._rng))
+        out = sampler.sample(n)
+        return list(out) if not isinstance(out, list) else out
+
+    def posterior(self, field: FieldPath | int, *, n: int = 2000) -> FieldPosterior:
+        """An empirical marginal for one field, from ``n`` rollout draws (see class docstring)."""
+        path = _norm_path(field)
+        rows = self.rollout(n)
+        values = np.array([float(_extract(r, path)) for r in rows], dtype=np.float64)
+        return FieldPosterior(values)
+
+
+def simulate(scenario: Scenario, *, base: Any | None = None, seed: int | None = None) -> Simulator:
+    """Assemble a generative model for ``scenario`` and package it as a :class:`Simulator`.
+
+    Source selection (explicit ``base``, registry, or auto-designed from ``scenario.priors``),
+    ``do()``-then-``condition()`` composition, HMM temporal rollout, and the plausibility receipt
+    are all covered in ``notes/designs/M2.md``.
+    """
+    resolved = _resolve_base(base, scenario)
+    return Simulator(base=resolved, scenario=scenario, seed=seed)

--- a/mixle/tests/scenario_test.py
+++ b/mixle/tests/scenario_test.py
@@ -1,0 +1,170 @@
+"""simulate()/Simulator (M2): on-the-fly conditional simulators for special scenarios.
+
+Acceptance receipts, one per test:
+  (a) BN fixture, clamp + intervention: do()-then-condition() rollout matches the closed-form
+      interventional-conditional Gaussian; the wrong order (condition then do) differs by a stated
+      margin.
+  (b) plausibility receipt separates in-support from off-support scenarios by a stated margin.
+  (c) HMM horizon rollout matches an independently forward-filtered projection past the clamped
+      window.
+  (d) seed-determinism of both the BN (SIR) and HMM (forward-rollout) paths.
+"""
+
+import numpy as np
+
+from mixle.inference.bayesian_network import HeterogeneousBayesianNetwork, _LinearGaussianFactor, _MarginalFactor
+from mixle.inference.condition import condition as m0_condition
+from mixle.inference.scenario import Scenario, simulate
+from mixle.stats import GaussianDistribution, HiddenMarkovModelDistribution
+from mixle.stats.combinator.composite import CompositeDistribution
+from mixle.stats.compute.posterior import MarkovChainLatentPosterior
+
+# --------------------------------------------------------------------------------------------- #
+# (a) BN fixture: Z -> X -> Y, Z -> Y direct.  do(X=x0) THEN condition(Y=y0) vs the wrong order.
+# --------------------------------------------------------------------------------------------- #
+
+
+def _mediator_confounder_bn():
+    # Z ~ N(0, 1); X = a*Z + eps_x; Y = c*X + d*Z + eps_y.
+    a, c, d, sigma_x, sigma_y = 1.5, 0.8, 1.2, 0.6, 0.5
+    f_z = _MarginalFactor(0, GaussianDistribution(0.0, 1.0))
+    f_x = _LinearGaussianFactor(1, [0], {}, np.array([a, 0.0]), sigma_x)
+    f_y = _LinearGaussianFactor(2, [0, 1], {}, np.array([d, c, 0.0]), sigma_y)
+    net = HeterogeneousBayesianNetwork([f_z, f_x, f_y])
+    return net, a, c, d, sigma_x, sigma_y
+
+
+def test_bn_do_then_condition_matches_closed_form_and_order_matters():
+    net, a, c, d, sigma_x, sigma_y = _mediator_confounder_bn()
+    # x0 chosen large so the do()-intervened mean offset (c*x0) clearly separates the two orders --
+    # the wrong order's closed form does not depend on x0 at all (it ignores the intervention).
+    x0, y0 = 5.0, 3.0
+
+    scenario = Scenario(interventions={1: x0}, evidence={2: y0})
+    sim = simulate(scenario, base=net, seed=0)
+    rollout = sim.rollout(60000)
+    z_vals = np.array([row[0] for row in rollout], dtype=np.float64)
+    got_mean, got_var = float(np.mean(z_vals)), float(np.var(z_vals))
+
+    # Closed form for Z | do(X=x0), Y=y0: after do(X), Y = c*x0 + d*Z + eps_y (the a*Z->X->c edge is
+    # severed), so (Z, Y) are jointly Gaussian with Cov(Z,Y) = d, Var(Y) = d^2 + sigma_y^2.
+    var_y_do = d**2 + sigma_y**2
+    mean_y_do = c * x0
+    want_mean = (d / var_y_do) * (y0 - mean_y_do)
+    want_var = 1.0 - d**2 / var_y_do
+
+    assert abs(got_mean - want_mean) < 0.05
+    assert abs(got_var - want_var) < 0.05
+    assert sim.receipt.composition_order == "do-then-condition"
+
+    # The WRONG order: condition on Y in the ORIGINAL (non-intervened) network first, then "do" X.
+    # Z | Y=y0 in the original model: Y = (c*a+d)*Z + c*eps_x + eps_y (X marginalized out).
+    cov_zy = c * a + d
+    var_y = cov_zy**2 + c**2 * sigma_x**2 + sigma_y**2
+    wrong_mean = (cov_zy / var_y) * y0
+    wrong_var = 1.0 - cov_zy**2 / var_y
+
+    # Independently verify the wrong-order number too, via condition() directly on the original net.
+    wrong_post = m0_condition(net, {2: y0}, method="sir", n_particles=60000, seed=1)
+    wrong_got_mean = wrong_post.mean(0)
+    assert abs(wrong_got_mean - wrong_mean) < 0.1
+    assert abs(wrong_var - want_var) > 0.05  # the two orders give a meaningfully different variance too
+    assert abs(wrong_mean - want_mean) > 1.0  # and a meaningfully different mean -- order matters
+
+
+# --------------------------------------------------------------------------------------------- #
+# (b) plausibility receipt separates in-support from off-support scenarios
+# --------------------------------------------------------------------------------------------- #
+
+
+def _fitted_gaussian_composite():
+    leaves = [GaussianDistribution(0.0, 1.0), GaussianDistribution(5.0, 2.0)]
+    return CompositeDistribution(leaves), leaves
+
+
+def test_plausibility_receipt_separates_in_support_from_off_support():
+    model, leaves = _fitted_gaussian_composite()
+
+    in_support = Scenario(evidence={0: 0.0, 1: 5.0})
+    off_support = Scenario(evidence={0: 20.0, 1: -30.0})
+
+    sim_in = simulate(in_support, base=model, seed=0)
+    sim_off = simulate(off_support, base=model, seed=0)
+
+    assert sim_in.receipt.plausibility_method == "exact"
+    assert sim_off.receipt.plausibility_method == "exact"
+
+    want_in = sum(leaf.log_density(v) for leaf, v in zip(leaves, [0.0, 5.0]))
+    want_off = sum(leaf.log_density(v) for leaf, v in zip(leaves, [20.0, -30.0]))
+    assert abs(sim_in.receipt.plausibility - want_in) < 1e-8
+    assert abs(sim_off.receipt.plausibility - want_off) < 1e-8
+
+    assert sim_in.receipt.plausibility - sim_off.receipt.plausibility > 50.0  # a real, stated margin
+
+
+# --------------------------------------------------------------------------------------------- #
+# (c) HMM horizon rollout past the clamped evidence window
+# --------------------------------------------------------------------------------------------- #
+
+
+def _hmm_fixture():
+    return HiddenMarkovModelDistribution(
+        [GaussianDistribution(-2.0, 1.0), GaussianDistribution(2.0, 1.0), GaussianDistribution(6.0, 1.0)],
+        [0.5, 0.3, 0.2],
+        [[0.7, 0.2, 0.1], [0.1, 0.8, 0.1], [0.2, 0.2, 0.6]],
+    )
+
+
+def test_hmm_horizon_rollout_matches_forward_filtered_projection():
+    hmm = _hmm_fixture()
+    v0, v1 = -1.8, 2.1
+    horizon = 5
+    scenario = Scenario(evidence={0: v0, 1: v1}, horizon=horizon)
+    sim = simulate(scenario, base=hmm, seed=3)
+    rows = sim.rollout(40000)
+
+    # (i) the clamped positions reproduce the evidence exactly, on every draw.
+    assert all(row[0] == v0 and row[1] == v1 for row in rows)
+
+    # (ii) t=4 (beyond the evidenced window [0,1]) matches an independently forward-filtered
+    # projection: smoothed state marginal at t=1, propagated forward through the transition matrix
+    # (horizon - 1 - t_max) times, then the state-weighted topic mean.
+    log_b = np.zeros((2, 3))
+    for t, val in {0: v0, 1: v1}.items():
+        for k, topic in enumerate(hmm.topics):
+            log_b[t, k] = topic.log_density(val)
+    q = MarkovChainLatentPosterior(hmm.log_w, hmm.log_transitions, log_b)
+    marginals = q.marginals()
+    trans = np.exp(np.asarray(hmm.log_transitions))
+    state_at_4 = marginals[1] @ np.linalg.matrix_power(trans, 3)
+    means = np.array([-2.0, 2.0, 6.0])
+    want_mean_t4 = float(state_at_4 @ means)
+
+    got_mean_t4 = float(np.mean([row[4] for row in rows]))
+    assert abs(got_mean_t4 - want_mean_t4) < 0.15
+
+
+# --------------------------------------------------------------------------------------------- #
+# (d) determinism
+# --------------------------------------------------------------------------------------------- #
+
+
+def test_bn_rollout_is_deterministic_given_seed():
+    net, *_ = _mediator_confounder_bn()
+    scenario = Scenario(interventions={1: 2.0}, evidence={2: 3.0})
+    sim1 = simulate(scenario, base=net, seed=11)
+    sim2 = simulate(scenario, base=net, seed=11)
+    r1 = sim1.rollout(50)
+    r2 = sim2.rollout(50)
+    assert r1 == r2
+    assert sim1.receipt.plausibility == sim2.receipt.plausibility
+
+
+def test_hmm_rollout_is_deterministic_given_seed():
+    hmm = _hmm_fixture()
+    scenario = Scenario(evidence={0: -1.8}, horizon=4)
+    sim1 = simulate(scenario, base=hmm, seed=21)
+    sim2 = simulate(scenario, base=hmm, seed=21)
+    r1 = sim1.rollout(30)
+    r2 = sim2.rollout(30)
+    assert r1 == r2


### PR DESCRIPTION
## Summary

`simulate(scenario: Scenario, *, base=None, seed=None) -> Simulator` (`mixle/inference/scenario.py`),
implementing roadmap item M2. A `Scenario` is `{evidence, interventions, priors, horizon}`;
`Simulator` gives `.rollout(n)`, `.posterior(field)`, and `.receipt`.

- **Source selection**: explicit `base`, or (via `scenario.priors`) a registry-fetched model, or
  one auto-designed from scarce scenario data through `mixle.task.design.design_model` (falls back
  to the heuristic `recommend_model` with no LLM).
- **Composition order**: `do()` FIRST, then `condition()` — causally required, not a convenience.
  Tested against the reversed (incorrect) order on a `Z -> X -> Y`, `Z -> Y` mediator+confounder
  Bayesian-network fixture, where the two orders give closed-form-verifiably different answers.
  `HeterogeneousBayesianNetwork`'s `do()` result (`InterventionalNetwork`) isn't a type M0's
  `condition()` dispatches on, so this composition is realized directly as one ancestral pass per
  particle (intervened fields fixed with no weight; evidenced fields fixed and weighted by their
  own factor — exactly M0's own BN SIR weighting, minus the weight term for intervened fields).
- **Temporal rollout**: an HMM/state-space scenario's evidenced window is exactly-smoothed the way
  M0's `condition()` already does, then a drawn joint state path is continued ancestrally through
  the transition matrix out to `scenario.horizon` — "forward-filtered simulation" past the last
  clamp.
- **Plausibility receipt**: `log p_base(scenario.evidence)` — the evidence's log-density under the
  *unmodified* base model (before `do()`/`condition()`), computed exactly via `.marginal()` when
  available, or via a self-normalized-importance-sampling marginal-likelihood estimator that reuses
  M0's own generative decomposition (`condition.py`'s `_generate_weighted`) otherwise.

Lives in a **new** module (`mixle/inference/scenario.py`), not the existing
`mixle/inference/simulate.py` (a narrower, BN-intervention-only tool already consumed by
`mixle.substrate.act`/`simulate_action` with an incompatible `simulate(model)`-first signature —
see `notes/designs/M2.md`'s Discovery section). New symbols are additively aliased from
`mixle/inference/__init__.py` as `simulate_scenario` / `ScenarioSpec` / `ScenarioSimulator` /
`ScenarioSimulationReceipt` / `ScenarioFieldPosterior`, leaving the existing `simulate` / `Scenario`
/ `Simulator` exports untouched.

Design note: `notes/designs/M2.md` (workspace-local, matching the existing `notes/designs/M0.md`
convention — `notes/` is gitignored in this repo, so it is not part of this diff).

**Base branch note:** this PR targets `m0-conditioning` (PR #192, not yet merged) since M2 is built
directly on M0's `condition()`/`do()`. It should be retargeted to
`release/0.6.3-generic-capabilities` once #192 merges.

## Real receipts (computed, not hand-waved)

```
BN Z|do(X=5),Y=3: mean=-0.7066 var=0.1436
  receipt: method=sir ess=1655.19 ess_ratio=0.4041 composition_order=do-then-condition
  (closed form: mean=-0.7101, var=0.1479 -- matches within Monte Carlo error)

plausibility receipt: in-support=-2.1845  off-support=-508.4345  margin=506.25
  (exact .marginal() path, matches sum of independent leaf log-densities to 1e-8)

HMM horizon rollout: t=4 (3 steps past the evidenced window) rolled-out mean=1.8509
  (independently forward-filtered projection matches within stated Monte Carlo error)
  clamp fidelity: evidenced t=0,1 reproduced exactly on every one of 40000 draws
```

## Test plan

- [x] `mixle/tests/scenario_test.py` — 5 tests, all passing: (a) BN do-then-condition vs wrong
      order matches closed form and differs by a stated margin; (b) plausibility receipt separates
      in-/off-support scenarios by a stated margin, matches an independent exact re-derivation to
      1e-8; (c) HMM horizon rollout matches an independently forward-filtered projection; (d)
      determinism on both the BN (SIR) and HMM (forward-rollout) paths.
- [x] Consumer suites: `mixle/tests/condition_test.py` (M0, unmodified), `mixle/tests/simulate_test.py`,
      `mixle/tests/reasoner_facade_test.py`, `mixle/tests/act_test.py` (existing `simulate.py`
      consumers) — all still pass (46/46 across the five files).
- [x] `ruff check` / `ruff format` clean on every touched file.
- [x] Full suite NOT run, per repo convention — only the tests above.