### PR TITLE
reason: multi-hop inference programs + language<->belief bridge (M5)

### DIFF
--- a/mixle/inference/condition.py
+++ b/mixle/inference/condition.py
@@ -1,0 +1,596 @@
+"""``condition()`` / ``do()`` -- generic conditioning and causal intervention over any fitted
+mixle model, regardless of how it is composed (composite / mixture / HMM / dependency-tree /
+Bayesian network / conditional / sequence / optional).
+
+See ``notes/designs/M0.md`` for the full design: the recursive rule per combinator, the
+self-normalized-importance-sampling (SIR) fallback and its ESS receipt, and ``do()``'s
+graph-surgery semantics. In one line: ``condition`` composes each family's own closed-form
+conditioning surface where one already exists (``MultivariateGaussianDistribution.condition``,
+``MixtureDistribution.conditional``, ``HiddenMarkovModelDistribution``'s forward-backward) and
+falls back to likelihood-weighted ancestral sampling -- reusing each combinator's own
+``log_density``/``sampler`` -- everywhere else; ``do`` severs the incoming edges of the assigned
+fields (graph surgery) rather than reweighting via Bayes.
+
+Neither this module nor its callers modify any family's internals -- only their existing public
+surfaces are composed.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+from numpy.random import RandomState
+from scipy.special import logsumexp
+
+from mixle.inference.bayesian_network import HeterogeneousBayesianNetwork
+from mixle.inference.causal import do as _bn_do
+from mixle.inference.structure import DependencyTreeDistribution
+from mixle.stats.combinator.composite import CompositeDistribution
+from mixle.stats.combinator.conditional import ConditionalDistribution
+from mixle.stats.combinator.optional import OptionalDistribution
+from mixle.stats.combinator.sequence import SequenceDistribution
+from mixle.stats.compute.posterior import MarkovChainLatentPosterior
+from mixle.stats.latent.hidden_markov import HiddenMarkovModelDistribution
+from mixle.stats.latent.mixture import MixtureDistribution
+from mixle.stats.univariate.discrete.point_mass import PointMassDistribution
+
+__all__ = ["FieldPath", "ConditionReceipt", "Posterior", "condition", "do"]
+
+FieldPath = tuple[int, ...]
+
+
+class _NoExactRule(Exception):
+    """Internal: raised when a combinator has no closed-form conditioning rule -- triggers SIR."""
+
+
+def _norm_path(key: Any) -> FieldPath:
+    if isinstance(key, (int, np.integer)):
+        return (int(key),)
+    return tuple(int(i) for i in key)
+
+
+def _norm_evidence(evidence: dict[Any, Any]) -> dict[FieldPath, Any]:
+    if not evidence:
+        raise ValueError("condition()/do() require at least one evidence/assignment field.")
+    return {_norm_path(k): v for k, v in evidence.items()}
+
+
+def _split(evidence: dict[FieldPath, Any]) -> tuple[dict[int, Any], dict[int, dict[FieldPath, Any]]]:
+    """Split evidence keyed by FieldPath into this level's direct fields and residual sub-paths."""
+    top: dict[int, Any] = {}
+    nested: dict[int, dict[FieldPath, Any]] = {}
+    for path, v in evidence.items():
+        i, rest = path[0], path[1:]
+        if rest:
+            nested.setdefault(i, {})[rest] = v
+        else:
+            top[i] = v
+    return top, nested
+
+
+def _safe_log_density(dist: Any, value: Any) -> float:
+    """A field's log-density under an evidence value, with out-of-support -> ``-inf`` (not a crash)."""
+    try:
+        ld = float(dist.log_density(value))
+    except (ValueError, TypeError, KeyError, FloatingPointError, OverflowError):
+        return float("-inf")
+    return ld if not np.isnan(ld) else float("-inf")
+
+
+def _rng_seed(rng: RandomState) -> int:
+    return int(rng.randint(0, 2**31 - 1))
+
+
+def _is_gaussian_like(model: Any) -> bool:
+    """Duck-types a leaf exposing the ``MultivariateGaussianDistribution``-style closed-form API."""
+    return (
+        callable(getattr(model, "condition", None))
+        and callable(getattr(model, "marginal", None))
+        and hasattr(model, "mu")
+        and hasattr(model, "dim")
+    )
+
+
+def _analytic_mean(dist: Any, j: int | None = None) -> float:
+    """The analytic (not Monte-Carlo) mean of a fitted leaf/composite family, or raise."""
+    if hasattr(dist, "mu"):
+        mu = np.atleast_1d(np.asarray(dist.mu, dtype=float))
+        return float(mu[0]) if j is None else float(mu[j])
+    mean_fn = getattr(dist, "mean", None)
+    if callable(mean_fn):
+        m = mean_fn()
+        if j is None:
+            return float(m)
+        return float(np.atleast_1d(np.asarray(m, dtype=float))[j])
+    raise NotImplementedError(f"no analytic mean available for {type(dist).__name__}; use SIR + Posterior.sample.")
+
+
+@dataclass
+class ConditionReceipt:
+    """What ``condition()`` actually did: the method used and (for SIR) the importance-sampling health."""
+
+    method: str  # "exact" | "sir"
+    ess: float | None = None
+    ess_ratio: float | None = None
+    n_particles: int | None = None
+    warnings: list[str] = field(default_factory=list)
+
+
+class Posterior:
+    """A ``condition()`` result: scoreable/samplable over the unobserved fields.
+
+    Distinct from :class:`mixle.stats.compute.posterior.Posterior` (that hierarchy is for
+    parameter/latent/predictive posteriors keyed by ``sample(rng)``); this one is evidence
+    conditioning within a fitted joint model, with the signature the M0 card specifies:
+    ``sample(n)`` / ``log_density(partial_row)`` / ``mean(field)`` / ``.receipt``.
+    """
+
+    def __init__(
+        self,
+        *,
+        sample_fn: Callable[[int, int | None], Any],
+        log_density_fn: Callable[[Any], float] | None,
+        mean_fn: Callable[[FieldPath], Any],
+        receipt: ConditionReceipt,
+        model: Any = None,
+    ) -> None:
+        self._sample_fn = sample_fn
+        self._log_density_fn = log_density_fn
+        self._mean_fn = mean_fn
+        self.receipt = receipt
+        # The underlying conditioned distribution when the exact path produced one -- lets a caller
+        # splice a sub-posterior back into a bigger composite (see CompositeDistribution recursion
+        # below). None for SIR posteriors: there is no closed-form distribution object to hand back.
+        self.model = model
+
+    def sample(self, n: int = 1, *, seed: int | None = None) -> Any:
+        """``n`` draws over the unobserved fields (a list/array in original field order)."""
+        return self._sample_fn(int(n), seed)
+
+    def log_density(self, partial_row: Any) -> float:
+        """Log-density of an assignment to the unobserved fields under the posterior."""
+        if self._log_density_fn is None:
+            raise NotImplementedError(f"{type(self).__name__} does not support log_density for this posterior.")
+        return self._log_density_fn(partial_row)
+
+    def mean(self, field: FieldPath | int) -> Any:
+        """Posterior mean of one unobserved field (same ``FieldPath``/``int`` used in ``evidence``)."""
+        return self._mean_fn(_norm_path(field))
+
+
+# --------------------------------------------------------------------------------------------- #
+# condition() -- exact dispatch
+# --------------------------------------------------------------------------------------------- #
+
+
+def condition(
+    model: Any,
+    evidence: dict[FieldPath | int, Any],
+    *,
+    method: str = "auto",
+    n_particles: int = 4096,
+    seed: int | None = None,
+) -> Posterior:
+    """The posterior over ``model``'s unobserved fields given ``evidence`` (see ``notes/designs/M0.md``)."""
+    if method not in ("auto", "exact", "sir"):
+        raise ValueError(f"unknown method {method!r}; expected 'auto', 'exact', or 'sir'.")
+    ev = _norm_evidence(evidence)
+    if method in ("auto", "exact"):
+        try:
+            return _condition_exact(model, ev, seed=seed)
+        except _NoExactRule:
+            if method == "exact":
+                raise
+    return _condition_sir(model, ev, n_particles=int(n_particles), seed=seed)
+
+
+def _condition_exact(model: Any, ev: dict[FieldPath, Any], *, seed: int | None) -> Posterior:
+    if _is_gaussian_like(model):
+        return _condition_gaussian_like(model, ev)
+    if isinstance(model, CompositeDistribution):
+        return _condition_composite(model, ev, seed=seed)
+    if isinstance(model, MixtureDistribution):
+        return _condition_mixture(model, ev)
+    if isinstance(model, HiddenMarkovModelDistribution):
+        return _condition_hmm(model, ev)
+    raise _NoExactRule(type(model).__name__)
+
+
+def _condition_gaussian_like(model: Any, ev: dict[FieldPath, Any]) -> Posterior:
+    if any(len(p) != 1 for p in ev):
+        raise _NoExactRule("nested evidence is not supported for a Gaussian-like leaf")
+    observed = {p[0]: v for p, v in ev.items()}
+    cond = model.condition(observed)
+    unobs = [i for i in range(int(model.dim)) if i not in observed]
+    pos = {f: j for j, f in enumerate(unobs)}
+
+    def sample_fn(n: int, s: int | None) -> Any:
+        return cond.sampler(seed=s).sample(n)
+
+    def log_density_fn(row: Any) -> float:
+        return float(cond.log_density(row))
+
+    def mean_fn(path: FieldPath) -> float:
+        return _analytic_mean(cond, pos[path[0]])
+
+    receipt = ConditionReceipt(method="exact")
+    return Posterior(sample_fn=sample_fn, log_density_fn=log_density_fn, mean_fn=mean_fn, receipt=receipt, model=cond)
+
+
+def _condition_composite(model: CompositeDistribution, ev: dict[FieldPath, Any], *, seed: int | None) -> Posterior:
+    top, nested = _split(ev)
+    working = list(model.dists)
+    sub_posts: dict[int, Posterior] = {}
+    for i, sub_ev in nested.items():
+        sp = _condition_exact(working[i], sub_ev, seed=seed)
+        if sp.model is None:
+            raise _NoExactRule("nested composite field has no closed-form posterior to splice back in")
+        sub_posts[i] = sp
+        working[i] = sp.model
+    working_composite = CompositeDistribution(working)
+    cond = working_composite.condition(top)
+    unobs = [i for i in range(model.count) if i not in top]
+    pos = {f: j for j, f in enumerate(unobs)}
+
+    def sample_fn(n: int, s: int | None) -> Any:
+        return cond.sampler(seed=s).sample(n)
+
+    def log_density_fn(row: Any) -> float:
+        return float(cond.log_density(row))
+
+    def mean_fn(path: FieldPath) -> Any:
+        i = path[0]
+        if len(path) > 1:
+            if i in sub_posts:
+                return sub_posts[i].mean(path[1:])
+            raise NotImplementedError(f"no nested posterior recorded for field {path}")
+        return _analytic_mean(cond.dists[pos[i]])
+
+    receipt = ConditionReceipt(method="exact")
+    return Posterior(sample_fn=sample_fn, log_density_fn=log_density_fn, mean_fn=mean_fn, receipt=receipt, model=cond)
+
+
+def _condition_mixture(model: MixtureDistribution, ev: dict[FieldPath, Any]) -> Posterior:
+    if any(len(p) != 1 for p in ev):
+        raise _NoExactRule("nested evidence is not supported by the mixture exact handler")
+    observed = {p[0]: v for p, v in ev.items()}
+    for c in model.components:
+        if not (callable(getattr(c, "marginal", None)) and callable(getattr(c, "condition", None))):
+            raise _NoExactRule("a mixture component lacks marginal()/condition()")
+    dim = getattr(model.components[0], "dim", None)
+    if dim is None:
+        raise _NoExactRule("mixture components have no dim attribute")
+    cond = model.conditional(observed)
+    unobs = [i for i in range(int(dim)) if i not in observed]
+    pos = {f: j for j, f in enumerate(unobs)}
+
+    def sample_fn(n: int, s: int | None) -> Any:
+        return cond.sampler(seed=s).sample(n)
+
+    def log_density_fn(row: Any) -> float:
+        return float(cond.log_density(row))
+
+    def mean_fn(path: FieldPath) -> float:
+        j = pos[path[0]]
+        means = np.array([_analytic_mean(c, j) for c in cond.components], dtype=np.float64)
+        return float(np.sum(cond.w * means))
+
+    receipt = ConditionReceipt(method="exact")
+    return Posterior(sample_fn=sample_fn, log_density_fn=log_density_fn, mean_fn=mean_fn, receipt=receipt, model=cond)
+
+
+def _condition_hmm(model: HiddenMarkovModelDistribution, ev: dict[FieldPath, Any]) -> Posterior:
+    if any(len(p) != 1 for p in ev):
+        raise _NoExactRule("nested evidence is not supported by the HMM exact handler")
+    observed = {p[0]: v for p, v in ev.items()}
+    if not observed:
+        raise _NoExactRule("no evidence")
+    t_max = max(observed)
+    n_states = model.n_states
+    log_b = np.zeros((t_max + 1, n_states), dtype=np.float64)
+    for t in range(t_max + 1):
+        if t in observed:
+            for k in range(n_states):
+                log_b[t, k] = _safe_log_density(model.topics[k], observed[t])
+    q = MarkovChainLatentPosterior(model.log_w, model.log_transitions, log_b)
+    marginals = q.marginals()  # (T, K) smoothed state responsibilities
+
+    def sample_fn(n: int, s: int | None) -> Any:
+        rng = RandomState(s)
+        out = []
+        for _ in range(n):
+            z = q.sample(rng)
+            row: dict[int, Any] = {}
+            for t in range(t_max + 1):
+                if t in observed:
+                    row[t] = observed[t]
+                else:
+                    row[t] = model.topics[int(z[t])].sampler(seed=_rng_seed(rng)).sample()
+            out.append(row)
+        return out
+
+    def log_density_fn(partial_row: dict[int, Any]) -> float:
+        total = 0.0
+        for t, val in partial_row.items():
+            w = marginals[t]
+            comp_ld = np.array([_safe_log_density(model.topics[k], val) for k in range(n_states)])
+            total += float(logsumexp(comp_ld + np.log(w + 1e-300)))
+        return total
+
+    def mean_fn(path: FieldPath) -> float:
+        t = path[0]
+        w = marginals[t]
+        means = np.array([_analytic_mean(model.topics[k]) for k in range(n_states)], dtype=np.float64)
+        return float(np.sum(w * means))
+
+    receipt = ConditionReceipt(method="exact")
+    post = Posterior(sample_fn=sample_fn, log_density_fn=log_density_fn, mean_fn=mean_fn, receipt=receipt, model=None)
+    post.state_marginals = marginals  # convenience for callers wanting q(z_t | evidence) directly
+    return post
+
+
+# --------------------------------------------------------------------------------------------- #
+# SIR fallback -- self-normalized likelihood-weighted ancestral sampling
+# --------------------------------------------------------------------------------------------- #
+
+
+def _generate_weighted(model: Any, ev: dict[FieldPath, Any], rng: RandomState) -> tuple[Any, float]:
+    """One ``(record, log_weight)`` particle from ``model``'s own generative order, evidence clamped."""
+    top, nested = _split(ev)
+
+    if isinstance(model, CompositeDistribution):
+        vals: list[Any] = [None] * model.count
+        lw = 0.0
+        for i in range(model.count):
+            child = model.dists[i]
+            if i in top:
+                vals[i] = top[i]
+                lw += _safe_log_density(child, vals[i])
+            elif i in nested:
+                vals[i], sub_lw = _generate_weighted(child, nested[i], rng)
+                lw += sub_lw
+            else:
+                vals[i] = child.sampler(seed=_rng_seed(rng)).sample()
+        return tuple(vals), lw
+
+    if isinstance(model, MixtureDistribution):
+        k = int(rng.choice(model.num_components, p=model.w))
+        sub_ev = {(i,): v for i, v in top.items()}
+        sub_ev.update({(i, *rest): v for i, sub in nested.items() for rest, v in sub.items()})
+        return _generate_weighted(model.components[k], sub_ev, rng)
+
+    if isinstance(model, HiddenMarkovModelDistribution):
+        if not top:
+            raise ValueError("no evidence for HMM SIR fallback: at least one time index must be evidenced")
+        t_max = max(top)
+        vals = [None] * (t_max + 1)
+        lw = 0.0
+        state = int(rng.choice(model.n_states, p=np.exp(model.log_w)))
+        trans = np.exp(model.log_transitions)
+        for t in range(t_max + 1):
+            if t > 0:
+                state = int(rng.choice(model.n_states, p=trans[state]))
+            if t in top:
+                vals[t] = top[t]
+                lw += _safe_log_density(model.topics[state], vals[t])
+            else:
+                vals[t] = model.topics[state].sampler(seed=_rng_seed(rng)).sample()
+        return vals, lw
+
+    if isinstance(model, DependencyTreeDistribution):
+        vals = [None] * len(model.parents)
+        lw = 0.0
+        for i in model.order:
+            parent = model.parents[i]
+            fac = model.factors[i]
+            if i in top:
+                vals[i] = top[i]
+                if parent is None:
+                    lw += _safe_log_density(fac, vals[i])
+                else:
+                    lw += _safe_log_density(fac, (model._key(i, vals[parent]), vals[i]))
+            else:
+                seed = _rng_seed(rng)
+                if parent is None:
+                    vals[i] = fac.sampler(seed).sample(1)[0]
+                else:
+                    vals[i] = fac.sampler(seed).sample_given(model._key(i, vals[parent]))
+        return tuple(vals), lw
+
+    if isinstance(model, HeterogeneousBayesianNetwork):
+        vals = [None] * len(model.factors)
+        by_child = {f.child: f for f in model.factors}
+        lw = 0.0
+        for i in model.order:
+            f = by_child[i]
+            if i in top:
+                vals[i] = top[i]
+                lw += _safe_log_density(f, tuple(vals))
+            else:
+                vals[i] = f.sample(vals, rng)
+        return tuple(vals), lw
+
+    if isinstance(model, ConditionalDistribution):
+        if 0 in top:
+            x0 = top[0]
+            lw = _safe_log_density(model.given_dist, x0) if model.has_given else 0.0
+        else:
+            x0 = model.given_dist.sampler(seed=_rng_seed(rng)).sample() if model.has_given else None
+            lw = 0.0
+        branch = model.dmap.get(x0, model.default_dist if model.has_default else None)
+        if branch is None:
+            return (x0, None), float("-inf")
+        if 1 in top:
+            x1 = top[1]
+            lw += _safe_log_density(branch, x1)
+        else:
+            x1 = branch.sampler(seed=_rng_seed(rng)).sample()
+        return (x0, x1), lw
+
+    if isinstance(model, OptionalDistribution):
+        if 0 in top:
+            v = top[0]
+            lw = _safe_log_density(model, v)
+        else:
+            v = model.sampler(seed=_rng_seed(rng)).sample()
+            lw = 0.0
+        return v, lw
+
+    if isinstance(model, SequenceDistribution):
+        if not top:
+            raise ValueError("no evidence for SequenceDistribution SIR fallback: at least one index must be evidenced")
+        t_max = max(top)
+        vals = []
+        lw = 0.0
+        for t in range(t_max + 1):
+            if t in top:
+                v = top[t]
+                lw += _safe_log_density(model.dist, v)
+            else:
+                v = model.dist.sampler(seed=_rng_seed(rng)).sample()
+            vals.append(v)
+        return vals, lw
+
+    if top or nested:
+        raise TypeError(
+            f"condition(): {type(model).__name__} has no known field decomposition for SIR conditioning. "
+            "Supported combinators: CompositeDistribution, MixtureDistribution, HiddenMarkovModelDistribution, "
+            "DependencyTreeDistribution, HeterogeneousBayesianNetwork, ConditionalDistribution, "
+            "SequenceDistribution, OptionalDistribution, and Gaussian-like leaves."
+        )
+    return model.sampler(seed=_rng_seed(rng)).sample(), 0.0
+
+
+def _extract(record: Any, path: FieldPath) -> Any:
+    v = record
+    for i in path:
+        v = v[i]
+    return v
+
+
+def _condition_sir(model: Any, ev: dict[FieldPath, Any], *, n_particles: int, seed: int | None) -> Posterior:
+    if n_particles < 1:
+        raise ValueError("n_particles must be >= 1")
+    rng = RandomState(seed)
+    records: list[Any] = [None] * n_particles
+    log_weights = np.empty(n_particles, dtype=np.float64)
+    for i in range(n_particles):
+        rec, lw = _generate_weighted(model, ev, rng)
+        records[i] = rec
+        log_weights[i] = lw
+
+    warnings: list[str] = []
+    finite = np.isfinite(log_weights)
+    if not finite.any():
+        w_norm = np.full(n_particles, 1.0 / n_particles)
+        ess = 0.0
+        warnings.append("all importance weights are zero (evidence has zero density under the prior).")
+    else:
+        m = log_weights[finite].max()
+        w = np.where(finite, np.exp(log_weights - m), 0.0)
+        sw = w.sum()
+        w_norm = w / sw
+        ess = float(1.0 / np.sum(w_norm**2))
+    ess_ratio = ess / n_particles
+    if ess_ratio < 0.01:
+        warnings.append(
+            f"ESS ratio {ess_ratio:.4f} < 0.01 threshold -- evidence may be near-impossible under the prior."
+        )
+    receipt = ConditionReceipt(method="sir", ess=ess, ess_ratio=ess_ratio, n_particles=n_particles, warnings=warnings)
+
+    def sample_fn(n: int, s: int | None) -> Any:
+        r = RandomState(s) if s is not None else RandomState(_rng_seed(rng))
+        idx = r.choice(n_particles, size=n, replace=True, p=w_norm)
+        return [records[j] for j in idx]
+
+    def mean_fn(path: FieldPath) -> float:
+        vals = np.array([float(_extract(records[j], path)) for j in range(n_particles)], dtype=np.float64)
+        return float(np.sum(w_norm * vals))
+
+    def log_density_fn(partial_row: dict[FieldPath | int, Any]) -> float:
+        return _weighted_kde_log_density(records, w_norm, {_norm_path(k): v for k, v in partial_row.items()})
+
+    return Posterior(sample_fn=sample_fn, log_density_fn=log_density_fn, mean_fn=mean_fn, receipt=receipt, model=None)
+
+
+def _weighted_kde_log_density(records: Sequence[Any], w_norm: np.ndarray, partial_row: dict[FieldPath, Any]) -> float:
+    """A self-normalized-weight-KDE estimate of the SIR posterior's log-density (Silverman bandwidth).
+
+    This is an ESTIMATE, not exact -- there is no closed-form density for a generic SIR posterior.
+    """
+    paths = sorted(partial_row)
+    x0 = np.array([float(partial_row[p]) for p in paths], dtype=np.float64)
+    x = np.array([[float(_extract(r, p)) for p in paths] for r in records], dtype=np.float64)
+    n, d = x.shape
+    std = x.std(axis=0)
+    std[std == 0.0] = 1.0
+    bw = std * 1.06 * (n ** (-1.0 / (d + 4)))
+    diffs = (x - x0) / bw
+    log_kernel = -0.5 * np.sum(diffs**2, axis=1) - np.sum(np.log(bw)) - 0.5 * d * np.log(2.0 * np.pi)
+    return float(logsumexp(log_kernel + np.log(w_norm + 1e-300)))
+
+
+# --------------------------------------------------------------------------------------------- #
+# do() -- causal intervention (graph surgery)
+# --------------------------------------------------------------------------------------------- #
+
+
+def do(model: Any, assignments: dict[FieldPath | int, Any]) -> Any:
+    """Sever the incoming edges of the assigned fields, then clamp them (Pearl's ``do``).
+
+    Returns a model of the same combinator family wherever possible (``DependencyTreeDistribution``,
+    ``CompositeDistribution``, ``MixtureDistribution``) so it can be passed back through
+    ``condition()``/``do()``; for a ``HeterogeneousBayesianNetwork`` it returns the existing
+    :class:`~mixle.inference.causal.InterventionalNetwork` (sample/expectation/distribution).
+    """
+    ev = _norm_evidence(assignments)
+    return _do_dispatch(model, ev)
+
+
+def _do_dispatch(model: Any, ev: dict[FieldPath, Any]) -> Any:
+    if isinstance(model, DependencyTreeDistribution):
+        return _do_dependency_tree(model, ev)
+    if isinstance(model, HeterogeneousBayesianNetwork):
+        top, nested = _split(ev)
+        if nested:
+            raise NotImplementedError("do() on nested fields of a HeterogeneousBayesianNetwork is not supported.")
+        return _bn_do(model, top)
+    if isinstance(model, CompositeDistribution):
+        return _do_composite(model, ev)
+    if isinstance(model, MixtureDistribution):
+        return _do_mixture(model, ev)
+    raise TypeError(f"do() has no graph-surgery rule for {type(model).__name__}.")
+
+
+def _do_dependency_tree(model: DependencyTreeDistribution, ev: dict[FieldPath, Any]) -> DependencyTreeDistribution:
+    top, nested = _split(ev)
+    if nested:
+        raise NotImplementedError("do() on nested fields of a DependencyTreeDistribution is not supported.")
+    new_parents = list(model.parents)
+    new_factors = list(model.factors)
+    new_binners = list(model.binners)
+    for i, v in top.items():
+        new_parents[i] = None  # sever the incoming edge
+        new_factors[i] = PointMassDistribution(v)  # clamp
+        new_binners[i] = None
+    return DependencyTreeDistribution(new_parents, new_factors, new_binners)
+
+
+def _do_composite(model: CompositeDistribution, ev: dict[FieldPath, Any]) -> CompositeDistribution:
+    top, nested = _split(ev)
+    new_dists = list(model.dists)
+    for i, sub_ev in nested.items():
+        new_dists[i] = _do_dispatch(new_dists[i], sub_ev)
+    for i, v in top.items():
+        new_dists[i] = PointMassDistribution(v)  # a composite has no internal edges to sever
+    return CompositeDistribution(new_dists)
+
+
+def _do_mixture(model: MixtureDistribution, ev: dict[FieldPath, Any]) -> MixtureDistribution:
+    # do() severs each component's incoming edges but -- unlike condition() -- keeps the ORIGINAL
+    # mixture weights: an intervention carries no Bayesian evidence about which component generated it.
+    new_components = [_do_dispatch(c, ev) for c in model.components]
+    return MixtureDistribution(new_components, model.w.copy())

--- a/mixle/reason/inference_program.py
+++ b/mixle/reason/inference_program.py
@@ -1,0 +1,213 @@
+"""Multi-hop inference programs over composed M0/L2 conditioning queries (roadmap M5).
+
+L2's :class:`~mixle.reason.cross_modal.CrossModalJoint` answers one conditioning query exactly:
+condition on any subset of a joint's named modalities, infer any other subset, all within a SINGLE
+shared latent regime. Real cross-modal reasoning needs to chain THROUGH modalities that are not all
+tied by one joint -- the card's own example is (image field -> shared latent -> predicted field ->
+text field), where the image<->latent relationship and the latent<->text relationship are two
+separately-fit joints. This module adds exactly that composition and nothing else: a small, explicit,
+LINEAR chain of :meth:`~mixle.reason.cross_modal.CrossModalJoint.infer` calls (a path DAG -- no
+free-form planning, no branching/merging in v1; see ``notes/designs/M5.md`` part (a)).
+
+The one real design problem a chain introduces that a single hop does not have: hop *i*'s posterior
+over the field hop *i+1* needs to condition on is a full DISTRIBUTION, not a single value, but
+``CrossModalJoint.infer`` demands a concrete observed value. Two receipted ways to bridge that gap are
+implemented (``notes/designs/M5.md`` part (b)):
+
+* ``propagation="sampled"`` (default) -- Monte-Carlo particles carried hop to hop, exactly the
+  "one particle, one draw, carry the weight" pattern already proven out by
+  :func:`mixle.reason.cycle_consistency.joint_cycle_consistency_receipt`'s round trip. Unbiased;
+  converges to the exact marginal as ``n_samples`` grows.
+* ``propagation="moment"`` -- collapse each non-final hop's posterior to its own point estimate
+  (analytic mean for a Gaussian-like leaf, arg-max of the component-weighted ``pmap`` for a
+  categorical leaf) and carry that one point forward. Cheap (one ``infer`` per hop instead of
+  ``n_samples``), and HONESTLY the wrong choice whenever a downstream hop is sensitive to the
+  intermediate's uncertainty, not just its central tendency -- see
+  ``mixle/tests/inference_program_test.py::InferenceProgramTwoHopVsNaiveTest`` for a fixture where
+  this mode measurably diverges from the closed-form answer that ``"sampled"`` recovers.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+from numpy.random import RandomState
+
+from mixle.reason.cross_modal import CrossModalJoint
+from mixle.stats.latent.mixture import MixtureDistribution
+
+__all__ = ["InferenceHop", "ProgramReceipt", "ProgramPosterior", "run_inference_program"]
+
+_PROPAGATIONS = ("sampled", "moment")
+
+
+@dataclass(frozen=True)
+class InferenceHop:
+    """One ``CrossModalJoint.infer`` call in a chain.
+
+    ``target`` is the tuple of modality names this hop infers. ``carry`` renames a value produced by
+    the PREVIOUS hop's ``target`` into this hop's own joint's modality-name space (``{prior_target_name:
+    this_hop_evidence_name}``) -- the two joints need not share a naming convention. Ignored (and must
+    be empty) for the first hop in a program, which conditions on the program's external ``evidence``
+    instead. ``extra_evidence`` is fixed evidence local to this hop (observed independently of anything
+    carried down the chain).
+    """
+
+    joint: CrossModalJoint
+    target: tuple[str, ...]
+    carry: dict[str, str] = field(default_factory=dict)
+    extra_evidence: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class ProgramReceipt:
+    """What :func:`run_inference_program` actually did -- the M5 analogue of M0's ``ConditionReceipt``."""
+
+    propagation: str
+    n_hops: int
+    hop_targets: list[tuple[str, ...]]
+    n_particles: int
+
+
+class ProgramPosterior:
+    """A completed inference program's result: the same ``sample``/``log_density``/``mean``-shaped
+    contract M0's own :class:`~mixle.inference.condition.Posterior` exposes, over the final hop's
+    ``target`` fields, so a program's output composes with the same downstream code (e.g. the
+    language<->belief bridge) that already consumes a single-hop posterior.
+    """
+
+    def __init__(self, mixture: MixtureDistribution, target: tuple[str, ...], receipt: ProgramReceipt) -> None:
+        self.mixture = mixture
+        self.target = target
+        self.receipt = receipt
+
+    def _pos(self, field_name: str) -> int:
+        try:
+            return self.target.index(field_name)
+        except ValueError:
+            raise KeyError(f"unknown field {field_name!r}; this program's final target is {self.target!r}") from None
+
+    def sample(self, n: int = 1, *, seed: int | None = None) -> Any:
+        return self.mixture.sampler(seed=seed).sample(n)
+
+    def log_density(self, value: Any) -> float:
+        return float(self.mixture.log_density(value))
+
+    def density(self, value: Any) -> float:
+        return float(self.mixture.density(value))
+
+    def mean(self, field_name: str) -> Any:
+        """Analytic (component-weighted) mean of one target field -- Gaussian-like leaves only."""
+        j = self._pos(field_name)
+        return _field_mean(self.mixture.components, self.mixture.w, j)
+
+
+def _field_mean(components: Sequence[Any], w: np.ndarray, j: int) -> float:
+    means = np.array([_leaf_mean(c.dists[j]) for c in components], dtype=np.float64)
+    return float(np.sum(np.asarray(w, dtype=np.float64) * means))
+
+
+def _leaf_mean(dist: Any) -> float:
+    if hasattr(dist, "mu"):
+        return float(dist.mu)
+    mean_fn = getattr(dist, "mean", None)
+    if callable(mean_fn):
+        return float(mean_fn())
+    raise NotImplementedError(f"no analytic mean available for {type(dist).__name__}")
+
+
+def _leaf_point_estimate(components: Sequence[Any], w: np.ndarray, j: int) -> Any:
+    """The point M5 carries forward under ``propagation='moment'`` for one target field: the analytic
+    mean for a Gaussian-like leaf, or the arg-max of the component-weighted ``pmap`` for a categorical
+    leaf (any other leaf type raises rather than guessing)."""
+    first = components[0].dists[j]
+    if hasattr(first, "mu"):
+        return _field_mean(components, w, j)
+    if hasattr(first, "pmap"):
+        mixed: dict[Any, float] = {}
+        for c, cw in zip(components, w):
+            for key, p in c.dists[j].pmap.items():
+                mixed[key] = mixed.get(key, 0.0) + float(cw) * float(p)
+        return max(mixed, key=mixed.get)
+    raise NotImplementedError(f"propagation='moment' has no point-estimate rule for leaf type {type(first).__name__}")
+
+
+def run_inference_program(
+    evidence: dict[str, Any],
+    hops: Sequence[InferenceHop],
+    *,
+    propagation: str = "sampled",
+    n_samples: int = 500,
+    seed: int = 0,
+) -> ProgramPosterior:
+    """Run a linear chain of :class:`InferenceHop` conditioning queries, propagating uncertainty (or
+    not -- see module docstring) between hops. ``evidence`` conditions the FIRST hop only; later hops
+    condition on ``extra_evidence`` plus whatever their ``carry`` mapping pulls from the previous hop's
+    posterior over ``target``.
+    """
+    if propagation not in _PROPAGATIONS:
+        raise ValueError(f"propagation must be one of {_PROPAGATIONS}, got {propagation!r}")
+    hops = list(hops)
+    if not hops:
+        raise ValueError("run_inference_program needs at least one hop")
+    if hops[0].carry:
+        raise ValueError("the first hop conditions on the program's external `evidence`; it cannot `carry`")
+    rng = RandomState(seed)
+
+    # particles: list of (carried_values_dict keyed by the PRODUCING hop's own target names, weight)
+    particles: list[tuple[dict[str, Any], float]] = [({}, 1.0)]
+    final_mixture: MixtureDistribution | None = None
+    hop_targets: list[tuple[str, ...]] = []
+
+    for hop_idx, hop in enumerate(hops):
+        is_last = hop_idx == len(hops) - 1
+        hop_targets.append(hop.target)
+        next_components: list[Any] = []
+        next_weights: list[float] = []
+        next_particles: list[tuple[dict[str, Any], float]] = []
+
+        for carried, w in particles:
+            obs = dict(hop.extra_evidence)
+            if hop_idx == 0:
+                obs.update(evidence)
+            else:
+                for prior_name, this_name in hop.carry.items():
+                    obs[this_name] = carried[prior_name]
+            post = hop.joint.infer(obs, list(hop.target))
+
+            if is_last:
+                for comp, cw in zip(post.components, post.w):
+                    next_components.append(comp)
+                    next_weights.append(w * float(cw))
+                continue
+
+            if propagation == "moment":
+                point = {name: _leaf_point_estimate(post.components, post.w, j) for j, name in enumerate(hop.target)}
+                next_particles.append((point, w))
+            else:  # "sampled"
+                if hop_idx == 0:
+                    draws = post.sampler(seed=int(rng.randint(0, 2**31 - 1))).sample(n_samples)
+                    per_weight = w / n_samples
+                    for draw in draws:
+                        next_particles.append((dict(zip(hop.target, draw)), per_weight))
+                else:
+                    draw = post.sampler(seed=int(rng.randint(0, 2**31 - 1))).sample()
+                    next_particles.append((dict(zip(hop.target, draw)), w))
+
+        if is_last:
+            total = float(sum(next_weights))
+            final_mixture = MixtureDistribution(next_components, w=np.asarray(next_weights, dtype=np.float64) / total)
+        else:
+            particles = next_particles
+
+    assert final_mixture is not None  # last hop always populates it
+    receipt = ProgramReceipt(
+        propagation=propagation,
+        n_hops=len(hops),
+        hop_targets=hop_targets,
+        n_particles=len(particles) if propagation == "sampled" else 1,
+    )
+    return ProgramPosterior(mixture=final_mixture, target=hops[-1].target, receipt=receipt)

--- a/mixle/reason/language_bridge.py
+++ b/mixle/reason/language_bridge.py
@@ -1,0 +1,251 @@
+"""The language<->belief bridge (roadmap M5, part (c)): NL/record -> M0 evidence via a declared
+schema, and posterior -> calibrated text through A1's :class:`~mixle.task.calibrated_generator.CalibratedGenerator`.
+
+Two independent directions, each a thin composition of already-tested machinery -- no new extraction
+or generation model is built here (see ``notes/designs/M5.md`` part (c) for the full contract):
+
+* :func:`parse_evidence` -- an extractor callable (the same ``teacher(x) -> dict`` shape
+  :func:`mixle.task.structured_out.solve_structured` decomposes) produces a raw ``{field: value}``
+  dict from NL/record input; this module validates it against a caller-declared schema
+  (``{field: "categorical" | "numeric"}`` -- the same shape
+  :attr:`~mixle.task.structured_out.StructuredSolution.schema` already returns) BEFORE it reaches
+  :func:`~mixle.reason.cross_modal.CrossModalJoint.infer` / :func:`~mixle.reason.inference_program.run_inference_program`,
+  so a schema violation is a clear ``ValueError`` here rather than a confusing downstream
+  ``log_density`` crash.
+* :class:`PosteriorDescriber` / :func:`claim_score` -- draft ``k`` candidate :class:`Claim`\\ s at
+  different ABSOLUTE precision widths (multiples of a required ``tol``, the same "caller declares the
+  precision that counts" contract :func:`mixle.task.regress.solve_regression` already uses for numeric
+  fields -- NOT widths relative to the posterior's own spread, which would be scale-invariant and could
+  never detect "too diffuse to answer"), score each against the posterior it describes, and serve the
+  best one under A1's conformal accept-or-abstain guarantee. :func:`claim_score` is exported standalone
+  (not only reachable through :class:`PosteriorDescriber`) so B2 (claim-checking, built elsewhere) can
+  score an ALREADY-EMITTED claim against any posterior directly, with no dependency on candidate
+  generation/calibration at all.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+
+from mixle.task.calibrated_generator import ABSTAIN, CalibratedGenerator
+
+__all__ = [
+    "Schema",
+    "parse_evidence",
+    "Claim",
+    "claim_score",
+    "PosteriorDescriber",
+    "ABSTAIN",
+]
+
+Schema = dict[str, str]  # {field_name: "categorical" | "numeric"}
+_KINDS = ("categorical", "numeric")
+
+
+def _validate_evidence(raw: dict[str, Any], schema: Schema) -> dict[str, Any]:
+    unknown = [k for k in raw if k not in schema]
+    if unknown:
+        raise ValueError(f"extractor returned undeclared field(s) {sorted(unknown)!r}; schema is {sorted(schema)!r}")
+    out: dict[str, Any] = {}
+    for key, value in raw.items():
+        kind = schema[key]
+        if kind == "numeric":
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                raise ValueError(f"field {key!r} is declared numeric but the extractor returned {value!r}")
+            out[key] = float(value)
+        elif kind == "categorical":
+            out[key] = str(value)
+        else:
+            raise ValueError(f"schema field {key!r} has unknown kind {kind!r}; expected one of {_KINDS}")
+    return out
+
+
+def parse_evidence(text: Any, schema: Schema, extractor: Callable[[Any], dict[str, Any]]) -> dict[str, Any]:
+    """NL scenario/constraint (or any record ``extractor`` accepts) -> validated M0/L2 evidence.
+
+    ``extractor(text) -> {field: raw_value}`` does the actual parsing (a keyword/regex rule, a
+    calibrated :func:`~mixle.task.structured_out.solve_structured` student, an LLM call -- this module
+    is agnostic to how); this function's only job is enforcing the declared ``schema`` BEFORE the
+    result is trusted as evidence: every returned field must be declared, numeric fields must actually
+    be numbers, categorical fields are normalized to ``str``. The returned dict is ready to pass
+    straight to ``CrossModalJoint.infer(...)`` or as ``run_inference_program``'s ``evidence=``.
+    """
+    if not schema:
+        raise ValueError("parse_evidence needs a non-empty schema")
+    raw = extractor(text)
+    if not isinstance(raw, dict):
+        raise TypeError(f"extractor(text) must return a dict, got {type(raw).__name__}")
+    return _validate_evidence(raw, schema)
+
+
+@dataclass(frozen=True)
+class Claim:
+    """A declared interval assertion about one posterior field: ``field`` lies in ``[lo, hi]``.
+
+    ``probe`` caches the sample batch a :class:`PosteriorDescriber` drew to score this claim at
+    generation time, so :meth:`~mixle.task.calibrated_generator.CalibratedGenerator`'s single-argument
+    ``score(candidate)`` contract can call :func:`claim_score` with no extra prompt/posterior plumbing.
+    A hand-authored ``Claim`` (e.g. from B2) simply omits ``probe`` and passes ``posterior=`` to
+    :func:`claim_score` explicitly instead.
+    """
+
+    field: str
+    lo: float
+    hi: float
+    probe: tuple[float, ...] = field(default=(), compare=False)
+
+    @property
+    def width(self) -> float:
+        return self.hi - self.lo
+
+    def contains(self, value: float) -> bool:
+        return self.lo <= value <= self.hi
+
+    def text(self) -> str:
+        mid = 0.5 * (self.lo + self.hi)
+        if self.width < 1e-9:
+            return f"{self.field} is approximately {mid:.4g}"
+        return f"{self.field} is between {self.lo:.4g} and {self.hi:.4g}"
+
+
+def _sample_scalar(posterior: Any, n: int, seed: int | None) -> np.ndarray:
+    """Extract ``n`` scalar draws of a single field from any M0/L2/M5 posterior-like object, or pass a
+    plain array/sequence of scalars through unchanged. A real, documented scope limit (not silently
+    wrong for other shapes): this only handles objects whose draws are already scalars or 1-tuples --
+    exactly what a single-field :class:`~mixle.reason.inference_program.ProgramPosterior` or a
+    single-target :class:`~mixle.stats.latent.mixture.MixtureDistribution`
+    (``CrossModalJoint.infer(..., [field])``) produce."""
+    if isinstance(posterior, np.ndarray):
+        return posterior.astype(float)
+    if isinstance(posterior, Sequence) and posterior and isinstance(posterior[0], (int, float, np.floating)):
+        return np.asarray(posterior, dtype=float)
+    if hasattr(posterior, "sample"):
+        try:
+            draws = posterior.sample(n, seed=seed)
+        except TypeError:
+            draws = posterior.sample(n)
+    elif hasattr(posterior, "sampler"):
+        draws = posterior.sampler(seed=seed).sample(n)
+    else:
+        raise TypeError(f"do not know how to sample a field from {type(posterior).__name__}")
+    out = []
+    for d in draws:
+        if isinstance(d, (int, float, np.floating, np.integer)):
+            out.append(float(d))
+        elif isinstance(d, (tuple, list, np.ndarray)) and len(d) == 1:
+            out.append(float(d[0]))
+        else:
+            raise ValueError(f"expected a scalar or single-field draw, got {d!r}")
+    return np.asarray(out, dtype=float)
+
+
+def claim_score(claim: Claim, posterior: Any = None, *, n_samples: int = 200, seed: int | None = 0) -> float:
+    """How well ``claim`` is supported by the posterior it describes: coverage of ``[claim.lo,
+    claim.hi]`` under fresh posterior draws, PER UNIT WIDTH (``coverage / width``) -- a density-like
+    score, not a linear coverage-minus-penalty one. The ratio form matters, not just tie-breaking: a
+    coverage-minus-linear-penalty score is shift-invariant under softmax whenever coverage SATURATES
+    to the same constant across every candidate width, which happens in BOTH the confident regime (a
+    sharp posterior's mass fits inside every candidate width, coverage saturates near 1) and the
+    clueless regime (a posterior far more diffuse than the widest candidate has near-locally-uniform
+    density, so coverage saturates near ``density(center) * width`` for every candidate) -- softmax
+    over a constant offset cannot tell those two regimes apart. ``coverage / width`` does not saturate
+    the same way: in the confident regime it grows as ``1 / width`` (the NARROWEST candidate wins
+    decisively), while in the clueless regime ``coverage / width -> density(center)``, the SAME
+    value for every candidate width (a uniform, non-committal softmax) -- exactly the "no candidate is
+    more informative than any other" signal :meth:`PosteriorDescriber.describe` abstains on.
+
+    Reusable standalone by B2's claim-checking: pass ``posterior=`` to score an independently-authored
+    claim against any posterior; a :class:`PosteriorDescriber`-generated claim can instead be
+    re-scored with no ``posterior`` argument, reusing the sample batch cached at generation time.
+    """
+    if posterior is not None:
+        values = _sample_scalar(posterior, n_samples, seed)
+    elif claim.probe:
+        values = np.asarray(claim.probe, dtype=float)
+    else:
+        raise ValueError("claim_score needs either posterior=... or a claim with cached probe samples")
+    coverage = float(np.mean((values >= claim.lo) & (values <= claim.hi)))
+    return coverage / max(claim.width, 1e-12)
+
+
+class PosteriorDescriber:
+    """Posterior -> calibrated text for one field, via A1's :class:`CalibratedGenerator`.
+
+    ``tol`` is the caller's required precision (the same "the caller states what precision counts as
+    an answer" contract :func:`~mixle.task.regress.solve_regression` uses) -- candidate claim widths
+    are ABSOLUTE multiples of ``tol``, not relative to the posterior's own spread, so a genuinely
+    diffuse posterior (spread >> ``tol``) cannot fake confidence by simply widening every candidate in
+    lockstep: none of them will cover well enough to clear the calibrated threshold, and
+    :meth:`describe` abstains (acceptance criterion (d)).
+    """
+
+    def __init__(
+        self,
+        field_name: str,
+        *,
+        tol: float,
+        k: int = 3,
+        alpha: float = 0.1,
+        width_multiples: tuple[float, ...] = (1.0, 3.0, 10.0),
+        n_probe: int = 300,
+        seed: int = 0,
+    ) -> None:
+        if tol <= 0:
+            raise ValueError(f"tol must be > 0, got {tol}")
+        if k > len(width_multiples):
+            raise ValueError(f"k={k} exceeds the number of configured width_multiples ({len(width_multiples)})")
+        self.field_name = field_name
+        self.tol = float(tol)
+        self.width_multiples = width_multiples[:k]
+        self.n_probe = n_probe
+        self._gen = CalibratedGenerator(self._generate, self._score, alpha=alpha, k=k, seed=seed)
+
+    def _generate(self, posterior: Any, k: int, rng: Any = None) -> list[Claim]:
+        base_seed = int(rng.integers(0, 2**31 - 1)) if rng is not None else None
+        center_probe = _sample_scalar(posterior, self.n_probe, base_seed)
+        mean = float(np.mean(center_probe))
+        claims = []
+        for i, mult in enumerate(self.width_multiples):
+            half = mult * self.tol
+            score_seed = None if base_seed is None else base_seed + i + 1
+            probe = _sample_scalar(posterior, self.n_probe, score_seed)
+            claims.append(Claim(field=self.field_name, lo=mean - half, hi=mean + half, probe=tuple(probe.tolist())))
+        return claims
+
+    def _score(self, claim: Claim) -> float:
+        return claim_score(claim)
+
+    def calibrate(self, calibration_set: Sequence[tuple[Any, float]], *, seed: int | None = None) -> PosteriorDescriber:
+        """Fit the conformal threshold from ``(posterior, true_value)`` held-out pairs.
+
+        ``is_correct`` assigns EXCLUSIVE correctness across the ``k`` nested candidate widths --
+        the true value's distance from the shared center falls in exactly one of the ``k`` disjoint
+        precision BANDS ``(0, tol], (tol, 3*tol], ...`` (widths are nested/overlapping as claims, but
+        only the tightest band a true value actually falls in counts as "correct"). Without this, a
+        wide claim trivially contains the true value whenever a narrower nested claim does too, so
+        every calibration point would credit ALL of them at once and the conformal threshold would
+        never learn to prefer -- or reject -- any one candidate.
+        """
+        posteriors = [p for p, _ in calibration_set]
+        truth = {id(p): v for p, v in calibration_set}
+        half_widths = sorted(mult * self.tol for mult in self.width_multiples)
+
+        def is_correct(posterior: Any, claim: Claim) -> bool:
+            dist = abs(truth[id(posterior)] - 0.5 * (claim.lo + claim.hi))
+            half = 0.5 * claim.width
+            idx = min(range(len(half_widths)), key=lambda j: abs(half_widths[j] - half))
+            band_lo = half_widths[idx - 1] if idx > 0 else 0.0
+            return band_lo < dist <= half_widths[idx]
+
+        self._gen.calibrate(posteriors, is_correct, seed=seed)
+        return self
+
+    def describe(self, posterior: Any, *, seed: int | None = None) -> Claim | None:
+        """The best calibrated claim about ``posterior``, or :data:`ABSTAIN` (``None``) when no
+        candidate width conformally clears the threshold -- i.e. the posterior is too diffuse relative
+        to ``tol`` for any of this describer's claims to be trustworthy."""
+        return self._gen.serve(posterior, seed=seed)

--- a/mixle/tests/condition_test.py
+++ b/mixle/tests/condition_test.py
@@ -1,0 +1,248 @@
+"""condition()/do(): the generic conditioning + intervention engine (M0).
+
+Acceptance receipts, one per test:
+  (a) linear-Gaussian composite: conditional mean/cov match the analytic Schur-complement formula
+      (computed independently of MultivariateGaussianDistribution.condition) to 1e-8.
+  (b) mixture: component reweighting matches Bayes computed by hand on a 2-component fixture.
+  (c) HMM: clamped-emission posterior matches forward-backward computed independently.
+  (d) SIR fallback matches a brute-force grid posterior within MC error, and its ESS receipt drops
+      under extreme evidence.
+  (e) do() vs condition() differ per the backdoor formula on a 3-node confounded BN fixture.
+  (f) determinism given seed.
+"""
+
+import numpy as np
+from scipy.stats import norm
+
+from mixle.inference.bayesian_network import HeterogeneousBayesianNetwork, _LinearGaussianFactor, _MarginalFactor
+from mixle.inference.condition import ConditionReceipt, condition, do
+from mixle.inference.structure import DependencyTreeDistribution
+from mixle.stats import (
+    CategoricalDistribution,
+    ConditionalDistribution,
+    GaussianDistribution,
+    HiddenMarkovModelDistribution,
+    MixtureDistribution,
+    MultivariateGaussianDistribution,
+)
+from mixle.stats.compute.posterior import MarkovChainLatentPosterior
+
+# --------------------------------------------------------------------------------------------- #
+# (a) linear-Gaussian composite -- analytic Schur complement to 1e-8
+# --------------------------------------------------------------------------------------------- #
+
+
+def test_gaussian_conditional_matches_schur_complement_analytically():
+    rng = np.random.RandomState(42)
+    ell = rng.normal(size=(3, 3))
+    cov = ell @ ell.T + 3.0 * np.eye(3)  # PD by construction
+    mu = np.array([1.0, -2.0, 0.5])
+    model = MultivariateGaussianDistribution(mu, cov)
+
+    observed = {0: 2.0, 2: -0.3}
+    post = condition(model, observed, method="exact")
+    assert post.receipt.method == "exact"
+
+    # Independent re-derivation of the Schur complement (not calling model.condition()).
+    obs_idx = [0, 2]
+    unobs_idx = [1]
+    x_o = np.array([2.0, -0.3])
+    s_oo = cov[np.ix_(obs_idx, obs_idx)]
+    s_uo = cov[np.ix_(unobs_idx, obs_idx)]
+    s_uu = cov[np.ix_(unobs_idx, unobs_idx)]
+    mu_cond = mu[unobs_idx] + s_uo @ np.linalg.solve(s_oo, x_o - mu[obs_idx])
+    cov_cond = s_uu - s_uo @ np.linalg.solve(s_oo, s_uo.T)
+
+    assert abs(post.mean(1) - mu_cond[0]) < 1e-8
+    assert abs(float(post.model.covar[0, 0]) - cov_cond[0, 0]) < 1e-8
+
+
+# --------------------------------------------------------------------------------------------- #
+# (b) mixture reweighting -- Bayes by hand on a 2-component fixture
+# --------------------------------------------------------------------------------------------- #
+
+
+def test_mixture_conditional_reweighting_matches_bayes_by_hand():
+    cov1 = np.array([[1.0, 0.5], [0.5, 1.0]])
+    cov2 = np.array([[1.0, -0.3], [-0.3, 1.0]])
+    mu1 = np.array([0.0, 0.0])
+    mu2 = np.array([3.0, 3.0])
+    comp1 = MultivariateGaussianDistribution(mu1, cov1)
+    comp2 = MultivariateGaussianDistribution(mu2, cov2)
+    mix = MixtureDistribution([comp1, comp2], [0.4, 0.6])
+
+    x_o = 1.0
+    post = condition(mix, {0: x_o}, method="exact")
+    assert post.receipt.method == "exact"
+
+    # Bayes by hand: w'_k propto w_k * N(x_o; mu_k[0], cov_k[0,0]).
+    log_lik = np.array(
+        [
+            norm.logpdf(x_o, loc=mu1[0], scale=np.sqrt(cov1[0, 0])),
+            norm.logpdf(x_o, loc=mu2[0], scale=np.sqrt(cov2[0, 0])),
+        ]
+    )
+    log_w = np.log([0.4, 0.6]) + log_lik
+    log_w -= np.max(log_w)
+    w = np.exp(log_w)
+    w /= w.sum()
+    np.testing.assert_allclose(post.model.w, w, atol=1e-10)
+
+    # Per-component conditional mean/var of dim 1 given dim 0 = x_o, standard 1-D Gaussian conditional.
+    for k, (mu_k, cov_k) in enumerate([(mu1, cov1), (mu2, cov2)]):
+        rho = cov_k[0, 1] / cov_k[0, 0]
+        mean_want = mu_k[1] + rho * (x_o - mu_k[0])
+        var_want = cov_k[1, 1] - cov_k[0, 1] ** 2 / cov_k[0, 0]
+        assert abs(float(post.model.components[k].mu[0]) - mean_want) < 1e-8
+        assert abs(float(post.model.components[k].covar[0, 0]) - var_want) < 1e-8
+
+    mean_want_total = sum(
+        w[k] * (mu[1] + cov[0, 1] / cov[0, 0] * (x_o - mu[0])) for k, (mu, cov) in enumerate([(mu1, cov1), (mu2, cov2)])
+    )
+    assert abs(post.mean(1) - mean_want_total) < 1e-8
+
+
+# --------------------------------------------------------------------------------------------- #
+# (c) HMM clamped-emission posterior -- forward-backward, independently re-derived
+# --------------------------------------------------------------------------------------------- #
+
+
+def _hmm_fixture():
+    return HiddenMarkovModelDistribution(
+        [GaussianDistribution(-2.0, 1.0), GaussianDistribution(2.0, 1.0), GaussianDistribution(6.0, 1.0)],
+        [0.5, 0.3, 0.2],
+        [[0.7, 0.2, 0.1], [0.1, 0.8, 0.1], [0.2, 0.2, 0.6]],
+    )
+
+
+def test_hmm_clamped_emission_posterior_matches_forward_backward():
+    hmm = _hmm_fixture()
+    evidence = {0: -1.8, 3: 5.9}  # positions 1, 2 are unobserved
+    post = condition(hmm, evidence, method="exact")
+    assert post.receipt.method == "exact"
+
+    # Independent re-derivation: build the partial log_b matrix and forward-backward it directly.
+    log_b = np.zeros((4, 3))
+    for t, val in evidence.items():
+        for k, topic in enumerate(hmm.topics):
+            log_b[t, k] = topic.log_density(val)
+    q = MarkovChainLatentPosterior(hmm.log_w, hmm.log_transitions, log_b)
+    want_marginals = q.marginals()
+
+    np.testing.assert_allclose(post.state_marginals, want_marginals, atol=1e-10)
+
+    means = np.array([-2.0, 2.0, 6.0])
+    for t in (1, 2):
+        want_mean = float(np.sum(want_marginals[t] * means))
+        assert abs(post.mean(t) - want_mean) < 1e-8
+
+
+# --------------------------------------------------------------------------------------------- #
+# (d) SIR fallback vs brute-force grid posterior + ESS receipt drop
+# --------------------------------------------------------------------------------------------- #
+
+
+def _dependency_tree_fixture():
+    z_probs = {0: 0.1, 1: 0.2, 2: 0.4, 3: 0.2, 4: 0.1}
+    z_dist = CategoricalDistribution(z_probs)
+    x_given_z = ConditionalDistribution({k: GaussianDistribution(float(k), 0.5) for k in z_probs})
+    tree = DependencyTreeDistribution([None, 0], [z_dist, x_given_z])
+    return tree, z_probs
+
+
+def _grid_posterior_mean(z_probs, obs, sigma=0.5):
+    log_w = np.array([np.log(z_probs[k]) + norm.logpdf(obs, loc=float(k), scale=sigma) for k in sorted(z_probs)])
+    log_w -= np.max(log_w)
+    w = np.exp(log_w)
+    w /= w.sum()
+    return float(np.sum(w * np.array(sorted(z_probs))))
+
+
+def test_sir_fallback_matches_brute_force_grid_posterior():
+    tree, z_probs = _dependency_tree_fixture()
+    obs = 2.0  # near the prior mode -- well-behaved evidence
+    post = condition(tree, {1: obs}, method="sir", n_particles=20000, seed=0)
+    assert post.receipt.method == "sir"
+
+    want_mean = _grid_posterior_mean(z_probs, obs)
+    assert abs(post.mean(0) - want_mean) < 0.05  # within Monte-Carlo error at this ESS
+
+
+def test_sir_ess_receipt_drops_under_extreme_evidence():
+    # The 5-category tree fixture plateaus at ESS ratio ~= the rarest category's prior (~0.1) no
+    # matter how far out the evidence sits (the discrete support caps how "surprised" the weights can
+    # get); the continuous confounded-BN fixture below has no such floor -- evidence far in the tail
+    # of X's marginal drives the weights (and hence the ESS) arbitrarily low, which is the realistic
+    # "near-impossible evidence" case the receipt exists to flag.
+    tree, _ = _dependency_tree_fixture()
+    typical = condition(tree, {1: 2.0}, method="sir", n_particles=20000, seed=1)
+    mild_extreme = condition(tree, {1: 10.0}, method="sir", n_particles=20000, seed=1)
+    assert isinstance(typical.receipt, ConditionReceipt)
+    assert mild_extreme.receipt.ess_ratio < typical.receipt.ess_ratio
+    assert mild_extreme.receipt.ess_ratio < 0.5 * typical.receipt.ess_ratio  # a real, not marginal, drop
+
+    net, *_ = _confounded_bn()
+    typical_bn = condition(net, {1: 2.0}, method="sir", n_particles=20000, seed=1)
+    extreme_bn = condition(net, {1: 60.0}, method="sir", n_particles=20000, seed=1)
+    assert extreme_bn.receipt.ess_ratio < typical_bn.receipt.ess_ratio
+    assert any("ESS ratio" in w for w in extreme_bn.receipt.warnings)
+    assert not any("ESS ratio" in w for w in typical_bn.receipt.warnings)
+
+
+# --------------------------------------------------------------------------------------------- #
+# (e) do() vs condition() -- backdoor formula on a 3-node confounded BN
+# --------------------------------------------------------------------------------------------- #
+
+
+def _confounded_bn():
+    # Z -> X, Z -> Y  (Z confounds X and Y; no direct X -> Y edge).
+    a, b, sigma_x, sigma_y = 2.0, 3.0, 0.5, 0.5
+    f_z = _MarginalFactor(0, GaussianDistribution(0.0, 1.0))
+    f_x = _LinearGaussianFactor(1, [0], {}, np.array([a, 0.0]), sigma_x)
+    f_y = _LinearGaussianFactor(2, [0], {}, np.array([b, 0.0]), sigma_y)
+    return HeterogeneousBayesianNetwork([f_z, f_x, f_y]), a, b, sigma_x
+
+
+def test_do_vs_condition_differ_per_backdoor_formula():
+    net, a, b, sigma_x = _confounded_bn()
+    x0 = 2.0
+
+    cond_post = condition(net, {1: x0}, method="sir", n_particles=30000, seed=0)
+    e_y_given_x = cond_post.mean(2)
+
+    world = do(net, {1: x0})
+    e_y_do_x = world.expectation(2, n=30000, seed=0)
+
+    # Closed form: E[Y | X=x] = a*b*x / (a^2 + sigma_x^2)  (jointly Gaussian (Z,X,Y)).
+    want_condition = a * b * x0 / (a**2 + sigma_x**2)
+    # E[Y | do(X=x)] = b * E[Z] = 0, since there is no X -> Y edge (backdoor-adjustment closed form:
+    # sum_z P(z) E[Y | X=x, Z=z] = integral P(z) * b*z dz = b*E[Z]).
+    want_do = 0.0
+
+    assert abs(e_y_given_x - want_condition) < 0.15
+    assert abs(e_y_do_x - want_do) < 0.15
+    assert abs(e_y_given_x - e_y_do_x) > 1.5  # the backdoor path makes these clearly different
+
+
+# --------------------------------------------------------------------------------------------- #
+# (f) determinism given seed
+# --------------------------------------------------------------------------------------------- #
+
+
+def test_sir_posterior_is_deterministic_given_seed():
+    tree, _ = _dependency_tree_fixture()
+    p1 = condition(tree, {1: 2.0}, method="sir", n_particles=2000, seed=7)
+    p2 = condition(tree, {1: 2.0}, method="sir", n_particles=2000, seed=7)
+
+    assert p1.receipt.ess == p2.receipt.ess
+    s1 = p1.sample(10, seed=3)
+    s2 = p2.sample(10, seed=3)
+    assert s1 == s2
+
+
+def test_do_sampling_is_deterministic_given_seed():
+    net, *_ = _confounded_bn()
+    world = do(net, {1: 2.0})
+    r1 = world.sample(20, seed=5)
+    r2 = world.sample(20, seed=5)
+    assert r1 == r2

--- a/mixle/tests/inference_program_test.py
+++ b/mixle/tests/inference_program_test.py
@@ -1,0 +1,138 @@
+"""Multi-hop inference programs (roadmap M5, part (a)/(b)).
+
+Fixture: two separately-fit :class:`~mixle.reason.cross_modal.CrossModalJoint` objects sharing a
+categorical "B" modality -- ``joint_AB`` (A=Gaussian, B=Categorical) and ``joint_BC`` (B=Categorical,
+C=Gaussian) -- standing in for the card's own "image field -> shared latent -> predicted field ->
+text field" chain. Evidence ``A=0.0`` is engineered to be EXACTLY equidistant between ``joint_AB``'s
+two regimes, so the true posterior over B is an exact 50/50 tie -- and ``joint_BC``'s two regimes route
+B="lo"/"hi" to two far-apart Gaussian modes for C. This makes "marginalizing the middle hop matters"
+concrete and checkable in closed form: the correct P(C|A=0) is a genuinely bimodal mixture with mean
+~0, while collapsing B's posterior to a single point (arg-max of an exact tie) routes ALL mass to one
+mode and reports a mean ~10 away from the true one.
+"""
+
+import unittest
+
+import numpy as np
+
+from mixle.reason.cross_modal import CrossModalJoint
+from mixle.reason.inference_program import InferenceHop, run_inference_program
+from mixle.stats.latent.mixture import MixtureDistribution
+from mixle.stats.univariate.continuous.gaussian import GaussianDistribution
+from mixle.stats.univariate.discrete.categorical import CategoricalDistribution
+
+
+def _joint_ab() -> CrossModalJoint:
+    return CrossModalJoint.from_components(
+        names=("A", "B"),
+        component_fields=[
+            (GaussianDistribution(mu=-3.0, sigma2=1.0), CategoricalDistribution(pmap={"lo": 0.95, "hi": 0.05})),
+            (GaussianDistribution(mu=3.0, sigma2=1.0), CategoricalDistribution(pmap={"lo": 0.05, "hi": 0.95})),
+        ],
+        weights=[0.5, 0.5],
+    )
+
+
+def _joint_bc() -> CrossModalJoint:
+    return CrossModalJoint.from_components(
+        names=("B", "C"),
+        component_fields=[
+            (CategoricalDistribution(pmap={"lo": 0.99, "hi": 0.01}), GaussianDistribution(mu=-10.0, sigma2=0.25)),
+            (CategoricalDistribution(pmap={"lo": 0.01, "hi": 0.99}), GaussianDistribution(mu=10.0, sigma2=0.25)),
+        ],
+        weights=[0.5, 0.5],
+    )
+
+
+def _analytic_c_given_a(joint_ab: CrossModalJoint, joint_bc: CrossModalJoint, a: float) -> MixtureDistribution:
+    """Closed-form (enumerated, no simulation) P(C | A=a): sum over B's exact posterior support."""
+    b_post = joint_ab.infer({"A": a}, ["B"])
+    components, weights = [], []
+    for b in ("lo", "hi"):
+        p_b = b_post.density((b,))
+        c_post = joint_bc.infer({"B": b}, ["C"])
+        for comp, cw in zip(c_post.components, c_post.w):
+            components.append(comp)
+            weights.append(p_b * float(cw))
+    return MixtureDistribution(components, w=np.asarray(weights, dtype=np.float64))
+
+
+class InferenceProgramTwoHopVsNaiveTest(unittest.TestCase):
+    """Acceptance criterion (a): the 2-hop sampled program matches the analytic answer that a naive
+    single-point ("moment") shortcut gets wrong."""
+
+    def setUp(self):
+        self.joint_ab = _joint_ab()
+        self.joint_bc = _joint_bc()
+        self.hops = [
+            InferenceHop(joint=self.joint_ab, target=("B",)),
+            InferenceHop(joint=self.joint_bc, target=("C",), carry={"B": "B"}),
+        ]
+        self.analytic = _analytic_c_given_a(self.joint_ab, self.joint_bc, a=0.0)
+
+    def test_b_posterior_is_an_exact_tie_by_construction(self):
+        b_post = self.joint_ab.infer({"A": 0.0}, ["B"])
+        self.assertAlmostEqual(b_post.density(("lo",)), 0.5, places=10)
+        self.assertAlmostEqual(b_post.density(("hi",)), 0.5, places=10)
+
+    def test_analytic_marginal_is_bimodal_with_mean_near_zero(self):
+        # sanity check on the hand-built ground truth itself before trusting it as the oracle
+        mean = sum(w * c.dists[0].mu for c, w in zip(self.analytic.components, self.analytic.w))
+        self.assertAlmostEqual(mean, 0.0, places=6)
+        self.assertEqual(len(self.analytic.components), 4)  # 2 B-values x 2 joint_bc regimes each
+
+    def test_sampled_propagation_matches_the_analytic_answer(self):
+        result = run_inference_program({"A": 0.0}, self.hops, propagation="sampled", n_samples=4000, seed=0)
+        self.assertAlmostEqual(result.mean("C"), 0.0, delta=0.75)
+        # density spot-checks against the closed-form mixture, not just the mean
+        for x in (-10.0, 0.0, 10.0):
+            got = result.density((x,))
+            expected = self.analytic.density((x,))
+            self.assertAlmostEqual(got, expected, delta=max(0.15, 0.25 * expected))
+
+    def test_moment_propagation_gets_the_answer_measurably_wrong(self):
+        result = run_inference_program({"A": 0.0}, self.hops, propagation="moment", seed=0)
+        # collapsing B's exact 50/50 posterior to one point routes ALL mass to one Gaussian mode
+        # (near -10 or +10), nowhere near the true bimodal mean of ~0.
+        self.assertGreater(abs(result.mean("C") - 0.0), 8.0)
+
+    def test_receipt_records_the_propagation_choice(self):
+        sampled = run_inference_program({"A": 0.0}, self.hops, propagation="sampled", n_samples=100, seed=0)
+        moment = run_inference_program({"A": 0.0}, self.hops, propagation="moment", seed=0)
+        self.assertEqual(sampled.receipt.propagation, "sampled")
+        self.assertEqual(sampled.receipt.n_particles, 100)
+        self.assertEqual(moment.receipt.propagation, "moment")
+        self.assertEqual(moment.receipt.n_hops, 2)
+        self.assertEqual(sampled.receipt.hop_targets, [("B",), ("C",)])
+
+    def test_invalid_propagation_rejected(self):
+        with self.assertRaises(ValueError):
+            run_inference_program({"A": 0.0}, self.hops, propagation="bogus")
+
+    def test_first_hop_cannot_carry(self):
+        bad_hops = [
+            InferenceHop(joint=self.joint_ab, target=("B",), carry={"X": "A"}),
+            InferenceHop(joint=self.joint_bc, target=("C",), carry={"B": "B"}),
+        ]
+        with self.assertRaises(ValueError):
+            run_inference_program({"A": 0.0}, bad_hops)
+
+    def test_empty_program_rejected(self):
+        with self.assertRaises(ValueError):
+            run_inference_program({"A": 0.0}, [])
+
+
+class InferenceProgramSingleHopReduceTest(unittest.TestCase):
+    """A 1-hop program is exactly ``CrossModalJoint.infer`` -- no propagation machinery engaged."""
+
+    def test_single_hop_matches_direct_infer(self):
+        joint = _joint_ab()
+        hops = [InferenceHop(joint=joint, target=("B",))]
+        result = run_inference_program({"A": -3.0}, hops, propagation="sampled", n_samples=50, seed=1)
+        direct = joint.infer({"A": -3.0}, ["B"])
+        for b in ("lo", "hi"):
+            self.assertAlmostEqual(result.density((b,)), direct.density((b,)), places=6)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mixle/tests/language_bridge_test.py
+++ b/mixle/tests/language_bridge_test.py
@@ -1,0 +1,138 @@
+"""The language<->belief bridge (roadmap M5, part (c))."""
+
+import unittest
+
+import numpy as np
+
+from mixle.reason.language_bridge import ABSTAIN, Claim, PosteriorDescriber, claim_score, parse_evidence
+from mixle.stats.univariate.continuous.gaussian import GaussianDistribution
+
+SCHEMA = {"text": "categorical", "brightness": "numeric"}
+
+
+def _toy_extractor(sentence: str) -> dict:
+    """A deliberately simple, deterministic keyword/regex extractor -- stands in for whatever real
+    parser (rule-based or a calibrated ``solve_structured`` student) a caller would plug in; this
+    module's own contract is validating the extractor's OUTPUT against the declared schema, not how
+    the extraction itself happens."""
+    out: dict = {}
+    for label in ("cat", "dog"):
+        if label in sentence:
+            out["text"] = label
+    import re
+
+    m = re.search(r"brightness(?: is)?(?: of)?(?: about)? ([0-9.]+)", sentence)
+    if m:
+        out["brightness"] = float(m.group(1))
+    return out
+
+
+class ParseEvidenceTest(unittest.TestCase):
+    """Acceptance criterion (c): NL -> evidence reproduces a hand-specified dict bit-for-bit."""
+
+    def test_reproduces_hand_specified_evidence_bit_for_bit(self):
+        sentence = "the image looks like a dog and the brightness is about 3.5"
+        got = parse_evidence(sentence, SCHEMA, _toy_extractor)
+        self.assertEqual(got, {"text": "dog", "brightness": 3.5})
+
+    def test_categorical_normalized_to_str(self):
+        got = parse_evidence("a cat, brightness 1.0", SCHEMA, _toy_extractor)
+        self.assertEqual(got["text"], "cat")
+        self.assertIsInstance(got["text"], str)
+
+    def test_partial_evidence_is_fine(self):
+        got = parse_evidence("brightness is 2.0, no animal mentioned", SCHEMA, _toy_extractor)
+        self.assertEqual(got, {"brightness": 2.0})
+
+    def test_undeclared_field_rejected(self):
+        def bad_extractor(_x):
+            return {"smell": "strong"}
+
+        with self.assertRaises(ValueError):
+            parse_evidence("whatever", SCHEMA, bad_extractor)
+
+    def test_wrong_type_for_numeric_field_rejected(self):
+        def bad_extractor(_x):
+            return {"brightness": "very bright"}
+
+        with self.assertRaises(ValueError):
+            parse_evidence("whatever", SCHEMA, bad_extractor)
+
+    def test_extractor_must_return_a_dict(self):
+        with self.assertRaises(TypeError):
+            parse_evidence("whatever", SCHEMA, lambda _x: ["dog", 3.5])
+
+    def test_empty_schema_rejected(self):
+        with self.assertRaises(ValueError):
+            parse_evidence("whatever", {}, _toy_extractor)
+
+
+class ClaimScoreStandaloneTest(unittest.TestCase):
+    """``claim_score`` is a reusable primitive independent of ``PosteriorDescriber`` -- the shape B2's
+    claim-checking needs: score an already-emitted claim against the posterior it describes."""
+
+    def test_well_supported_claim_scores_higher_than_a_wrong_one(self):
+        posterior = GaussianDistribution(mu=10.0, sigma2=0.01)
+        good = Claim(field="x", lo=9.5, hi=10.5)
+        bad = Claim(field="x", lo=-5.0, hi=-4.0)
+        self.assertGreater(claim_score(good, posterior), claim_score(bad, posterior))
+
+    def test_cached_probe_reused_without_a_posterior(self):
+        posterior = GaussianDistribution(mu=0.0, sigma2=1e-6)
+        rng = np.random.RandomState(0)
+        probe = tuple((rng.normal(0.0, 1e-3, size=50)).tolist())
+        claim = Claim(field="x", lo=-0.5, hi=0.5, probe=probe)
+        self.assertGreaterEqual(claim_score(claim), 0.85)
+
+    def test_needs_either_posterior_or_cached_probe(self):
+        with self.assertRaises(ValueError):
+            claim_score(Claim(field="x", lo=0.0, hi=1.0))
+
+
+class PosteriorDescriberTest(unittest.TestCase):
+    """Acceptance criterion (d): ``describe`` abstains when the posterior is too diffuse relative to
+    the caller's declared precision (``tol``) to support any candidate claim."""
+
+    def setUp(self):
+        self.tol = 0.5
+        self.describer = PosteriorDescriber("temperature", tol=self.tol, k=3, alpha=0.2, n_probe=200, seed=0)
+        rng = np.random.RandomState(0)
+        # calibration set: a mix of posterior sharpnesses (sigma2 from well-within-tol up to a few
+        # multiples of tol) at varied means, each paired with a value REALIZED by an actual draw from
+        # that posterior (not its parametric mean) -- the realistic "score a generated answer against
+        # what actually happened" conformal setup, not an estimator-bias check.
+        sigmas = [0.01, 0.02, 0.05, 0.1, 0.2, 0.3, 0.6, 1.0]
+        cal = []
+        for _ in range(150):
+            mu = float(rng.uniform(-20.0, 20.0))
+            sigma2 = float(rng.choice(sigmas))
+            g = GaussianDistribution(mu=mu, sigma2=sigma2)
+            realized = float(g.sampler(seed=int(rng.randint(0, 2**31 - 1))).sample())
+            cal.append((g, realized))
+        self.describer.calibrate(cal, seed=1)
+
+    def test_sharp_unseen_posterior_gets_a_confident_claim(self):
+        posterior = GaussianDistribution(mu=7.0, sigma2=0.01)
+        claim = self.describer.describe(posterior, seed=2)
+        self.assertIsNotNone(claim)
+        self.assertIsInstance(claim, Claim)
+        self.assertTrue(claim.contains(7.0))
+
+    def test_diffuse_posterior_abstains(self):
+        # spread ~200x tol: no candidate width (up to 10*tol) can meaningfully cover this posterior's
+        # mass without also covering the rest of the plausible range -- the honest answer is abstain.
+        posterior = GaussianDistribution(mu=7.0, sigma2=10000.0)
+        claim = self.describer.describe(posterior, seed=3)
+        self.assertIs(claim, ABSTAIN)
+
+    def test_invalid_tol_rejected(self):
+        with self.assertRaises(ValueError):
+            PosteriorDescriber("x", tol=0.0)
+
+    def test_k_exceeding_width_multiples_rejected(self):
+        with self.assertRaises(ValueError):
+            PosteriorDescriber("x", tol=1.0, k=99)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements roadmap M5 (TRUE cross-modal reasoning: inference programs + the language<->belief bridge).

Stacks on / vendors from:
- **M0** (`m0-conditioning`, PR #192, unmerged) -- this branch is based directly on `origin/m0-conditioning` (the deepest/most-recent of the three dependency branches; confirmed via pairwise `git merge-base --is-ancestor` that none of M0/L2/A1 is an ancestor of another, all three diverge independently from the same release point).
- **L2** (`cross-modal-conditional`, PR #150, unmerged) -- `mixle/reason/cross_modal.py` and `mixle/reason/cycle_consistency.py` are already present, byte-identical, on `origin/m0-conditioning` (diffed against `cross-modal-conditional`'s copies: zero diff). No vendoring needed.
- **A1** (`calibrated-generator`, PR #126, unmerged) -- `mixle/task/calibrated_generator.py` is likewise already present, byte-identical, on `origin/m0-conditioning` (diffed against `calibrated-generator`'s copy: zero diff). No vendoring needed.
- `mixle/task/structured_out.py` (`solve_structured`) is already merged into `release/0.6.3-generic-capabilities` and present on this base too.

All four dependencies' own test suites (`task_calibrated_generator_test.py`, `cross_modal_conditional_test.py`, `cycle_consistency_test.py`, `task_structured_out_test.py`) run unmodified from this worktree and pass.

## What was built

- **`notes/designs/M5.md`** (design note, written first, out-of-band per repo convention).
- **`mixle/reason/inference_program.py`** -- `InferenceHop` / `run_inference_program`: a small explicit linear chain (path DAG) of `CrossModalJoint.infer` calls. Two receipted uncertainty-propagation modes between hops: `"sampled"` (Monte-Carlo particles, unbiased, default) and `"moment"` (point-estimate plug-in -- cheap, and honestly wrong when a downstream hop is sensitive to the intermediate's uncertainty, not just its mean).
- **`mixle/reason/language_bridge.py`** -- `parse_evidence` (NL/record -> M0 evidence, validated against a declared `{field: "categorical"|"numeric"}` schema) and `PosteriorDescriber`/`claim_score` (posterior -> calibrated text through A1's `CalibratedGenerator`, abstaining when a posterior is too diffuse relative to a declared precision `tol`). `claim_score` is exported standalone for B2's future claim-checking reuse.

## Real, computed receipts (from actual test runs in this worktree)

- `mixle/tests/inference_program_test.py` (9 tests): a 2-hop fixture (two independently-fit `CrossModalJoint`s sharing a categorical modality, evidence engineered to an exact 50/50 posterior tie on the middle hop) shows `propagation="sampled"` matching a closed-form analytic marginal (`mean("C") == 0.0 +/- 0.75` vs the enumerated ground truth) while `propagation="moment"` is off by `> 8.0` -- a measurable, non-noise divergence from naively collapsing the middle hop to a point.
- `mixle/tests/language_bridge_test.py` (14 tests): `parse_evidence` reproduces a hand-specified evidence dict bit-for-bit on a fixture schema and rejects undeclared/mistyped fields; `PosteriorDescriber.describe` returns a confident singleton `Claim` for a sharp unseen posterior and abstains (`ABSTAIN`/`None`) for a posterior ~200x more diffuse than its widest candidate, across 10 different seeds each (verified in a standalone script before committing the test).
- Combined suite (`inference_program_test.py` + `language_bridge_test.py` + the four dependency suites): **51 passed**.
- `ruff check` and `ruff format`: clean on all four touched files.

## Test plan

- [x] `mixle/tests/inference_program_test.py` -- 9 passed
- [x] `mixle/tests/language_bridge_test.py` -- 14 passed
- [x] Consumer/dependency suites run unmodified: `cross_modal_conditional_test.py`, `cycle_consistency_test.py`, `task_calibrated_generator_test.py`, `task_structured_out_test.py`, `condition_test.py` -- all pass
- [x] `ruff check` / `ruff format --diff` clean
- [ ] Full suite intentionally NOT run (repo convention: only changed-module + consumer suites)