### PR TITLE
inference: D3 block-EM scheduler (reland of #152)

### DIFF
--- a/mixle/inference/block_em.py
+++ b/mixle/inference/block_em.py
@@ -1,0 +1,327 @@
+"""Block-coordinate-ascent EM scheduler -- greedy gain-per-cost block selection (workstream D3).
+
+Frame (see the ConditionalJIT track, D1-D6): **the estimator tree is an IR**. D1
+(:mod:`mixle.inference.node_report`) instruments every node with a per-round residual/Q-gain
+report, an ``update_kind`` classification, and an E/M cost proxy. D2
+(:mod:`mixle.inference.freeze_rollup`) spent that report on one particular schedule: freeze a
+subtree once it looks converged and skip it forever after. D3 generalizes the scheduling
+question one level up: on EVERY round, rank the blocks (mixture components) that are NOT
+already D2-frozen by D1's gain-per-cost (``q_gain / (e_step_cost + m_step_cost)``) and update
+only the highest-value ones within a per-round cost budget, leaving the rest untouched for that
+round -- a genuine block-coordinate-ascent / ECM schedule, not just "freeze forever".
+
+Correctness backbone (unchanged from the rest of the D-track): this module is a SCHEDULING
+optimization only. Any interleaving of a partial E-step (fresh log-density for the active
+blocks, cached log-density for the inactive ones) and a per-block conditional M-step (only the
+active blocks are re-estimated; every other block's model object is carried forward byte-for-
+byte unchanged) is still coordinate ascent on the SAME Neal-Hinton free energy F vanilla EM
+climbs -- so an accept/reject gate on the round's candidate objective (identical in spirit to
+:class:`mixle.inference.em.MonotonicEM` and D2's own ``run_em_freeze_rollup``) is what turns
+"should be monotone" into "IS monotone, mechanically, every round" here too.
+
+Composition with D2: a component D2's :class:`~mixle.inference.freeze_rollup.FreezeRollupCache`
+already reports frozen (:func:`mixle.inference.freeze_rollup.detect_frozen`) is, from this
+scheduler's point of view, exactly a "zero e-step cost, zero m-step cost" block -- it is excluded
+from the gain-per-cost ranking entirely (nothing to rank: it costs nothing and is never
+scheduled to move) and is served for free from the SAME cache this module reuses for its own
+this-round-only inactive blocks. A block the scheduler chooses not to update THIS round is, from
+:class:`FreezeRollupCache`'s point of view, indistinguishable from a D2-frozen block for exactly
+one round: its parameter signature has not moved, so the cached per-datum log-density is still a
+byte-identical cache hit -- no separate caching mechanism is needed for D3, only a wider set of
+"don't touch this round" indices fed into the same ``frozen=`` parameter D2 already threads
+through :func:`~mixle.inference.freeze_rollup._component_log_density_matrix` and
+:func:`~mixle.inference.freeze_rollup._m_step`.
+
+Gain estimate, documented per the D1 module's own note that later track items may re-estimate
+a cheap proxy fresh every round rather than reuse a stale report: this module calls
+:func:`mixle.inference.node_report.node_report` on every eligible component EVERY round (a small,
+fixed-size Monte-Carlo self-residual -- ``_DEFAULT_MC_SAMPLES`` samples, not a real-data pass),
+always with the SAME seed across components (unlike :func:`mixle.inference.node_report.
+flat_report_table`, which offsets the seed per row for a deduplicated tree walk) so that
+structurally-identical components draw directly-comparable residuals -- this is what makes the
+"no useful discrimination to make" acceptance criterion (identical components => identical
+scores => no real ranking) hold deterministically rather than by RNG luck.
+
+Degeneration to vanilla full-tree EM: when every eligible block's gain-per-cost score is the
+same (within ``tie_tol``) -- either because the blocks truly are indistinguishable, or because
+the caller passes ``full_tree_every_round=True`` as an explicit escape hatch -- the scheduler has
+no real choice to make, so it updates every eligible block, exactly like a plain full-tree EM
+round would. See ``mixle.tests.block_em_test`` for a literal test of this property.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+from mixle.inference.freeze_rollup import (
+    FreezeRollupCache,
+    _combine,
+    _component_log_density_matrix,
+    _m_step,
+    _resolve_payload,
+    detect_frozen,
+)
+from mixle.inference.node_report import node_report
+from mixle.stats.latent.mixture import MixtureDistribution, MixtureEstimator
+
+_DEFAULT_ACCEPT_TOLERANCE = 1.0e-9
+_DEFAULT_BUDGET_FRACTION = 0.5
+_DEFAULT_TIE_TOL = 1.0e-9
+_SCORE_SEED = 0  # fixed, shared across every component -- see module docstring on the tie test.
+
+
+@dataclass
+class BlockEMStats:
+    """One round's accounting for the block-EM scheduler -- the acceptance-criteria receipt.
+
+    Mirrors :class:`mixle.inference.freeze_rollup.FreezeRollupStats` (same
+    ``n_log_density_evals`` wall-clock proxy and real Neal-Hinton ``objective``), plus the extra
+    fields specific to gain-per-cost SCHEDULING within a round rather than permanent freezing.
+    """
+
+    round_index: int
+    n_components: int
+    n_active: int
+    n_frozen: int
+    n_zero_weight: int
+    n_scheduled_inactive: int
+    n_log_density_evals: int
+    objective: float
+    accepted: bool = True
+    degenerate_round: bool = False
+
+    @property
+    def active_fraction(self) -> float:
+        """Fraction of components genuinely (re-)evaluated this round, out of all components."""
+        return self.n_active / self.n_components if self.n_components else 1.0
+
+
+def _block_scores(
+    model: MixtureDistribution,
+    eligible: list[int],
+    prev_residual: dict[int, float],
+) -> tuple[dict[int, float], dict[int, float]]:
+    """Return ``(gain_per_cost, cost)`` for each ``eligible`` component index.
+
+    ``gain`` is the D1 Q-gain (residual improvement since the last round this component was
+    scored) when available, else the raw residual itself (a component never scored before has an
+    unknown Q-gain but a high residual is still a legitimate "there is a lot of room to improve
+    here" proxy for round 1). ``cost`` is D1's E-step-cost + M-step-cost proxy. Every component
+    is scored with the SAME fixed seed (see module docstring) so structurally-identical
+    components are directly comparable -- required for the degenerate-to-vanilla-EM test to be
+    deterministic rather than RNG-dependent.
+    """
+    gain_per_cost: dict[int, float] = {}
+    cost: dict[int, float] = {}
+    for idx in eligible:
+        report = node_report(
+            model.components[idx],
+            field_path=str(idx),
+            seed=_SCORE_SEED,
+            nobs=1.0,
+            prev_residual=prev_residual.get(idx),
+        )
+        prev_residual[idx] = report.residual
+        gain = report.q_gain if report.q_gain is not None else report.residual
+        if not np.isfinite(gain):
+            gain = 0.0
+        block_cost = max(report.e_step_cost + report.m_step_cost, 1.0e-12)
+        cost[idx] = block_cost
+        gain_per_cost[idx] = gain / block_cost
+    return gain_per_cost, cost
+
+
+def _select_active(
+    eligible: list[int],
+    scores: dict[int, float],
+    cost: dict[int, float],
+    *,
+    budget_fraction: float,
+    full_tree_every_round: bool,
+    tie_tol: float,
+) -> tuple[set[int], bool]:
+    """Return ``(active_indices, degenerate)`` -- the block-selection decision for this round.
+
+    ``degenerate`` is True whenever the scheduler had no real choice to make (see module
+    docstring): ``full_tree_every_round`` was requested, there is nothing eligible to schedule,
+    or every eligible score is indistinguishable within ``tie_tol``. In every such case the whole
+    eligible set is selected -- the literal "reduces to vanilla full-tree EM" behavior.
+    """
+    if not eligible:
+        return set(), True
+    if full_tree_every_round:
+        return set(eligible), True
+
+    values = [scores[idx] for idx in eligible]
+    spread = max(values) - min(values)
+    if spread < tie_tol:
+        return set(eligible), True
+
+    ranked = sorted(eligible, key=lambda i: -scores[i])
+    total_cost = sum(cost[idx] for idx in eligible)
+    budget = max(budget_fraction, 0.0) * total_cost
+
+    active: set[int] = set()
+    spent = 0.0
+    for idx in ranked:
+        if active and spent >= budget:
+            break
+        active.add(idx)
+        spent += cost[idx]
+    return active, False
+
+
+def is_block_em_eligible(model: Any, estimator: Any) -> bool:
+    """Whether ``model``/``estimator`` are a plain ``MixtureDistribution``/``MixtureEstimator`` pair
+    the D3 scheduler can drive. Lives here (not in estimation.py) so the high-level estimation driver
+    never imports a concrete distribution type -- see compute_metadata_test.py's layering check."""
+    return isinstance(model, MixtureDistribution) and isinstance(estimator, MixtureEstimator)
+
+
+def run_block_em(
+    enc_data: Any,
+    estimator: MixtureEstimator,
+    initial_model: MixtureDistribution,
+    *,
+    max_its: int = 10,
+    delta: float | None = 1.0e-9,
+    cache: FreezeRollupCache | None = None,
+    budget_fraction: float = _DEFAULT_BUDGET_FRACTION,
+    full_tree_every_round: bool = False,
+    tie_tol: float = _DEFAULT_TIE_TOL,
+    accept_tolerance: float = _DEFAULT_ACCEPT_TOLERANCE,
+    q_gain_tol: float = 1.0e-6,  # keep in sync w/ FreezeRollupCache defaults
+    weight_tol: float = 1.0e-4,
+    weight_delta_tol: float = 1.0e-8,
+    freeze_patience: int = 3,
+    stall_patience: int = 5,
+    max_skip_rounds: int = 2,
+) -> tuple[MixtureDistribution, list[BlockEMStats]]:
+    """Run block-coordinate-ascent EM over a :class:`MixtureDistribution` (workstream D3).
+
+    Each round: rank every component D2 does not already report frozen by D1 gain-per-cost,
+    select the highest-value ones within ``budget_fraction`` of the round's total eligible cost
+    (the rest are left untouched for this round), do a fresh partial E-step (cached log-density
+    reused for every untouched/frozen component -- same mechanism D2's
+    :class:`~mixle.inference.freeze_rollup.FreezeRollupCache` already provides), a per-block
+    conditional M-step over only the active components, and an accept/reject gate on the round's
+    real objective -- exactly D2's own monotone-F machinery, reused rather than reimplemented.
+
+    ``schedule="auto"`` at the :func:`mixle.inference.estimation.optimize` layer dispatches here;
+    ``budget_fraction=1.0`` or ``full_tree_every_round=True`` both degenerate this to (numerically
+    indistinguishable from) vanilla full-tree EM -- see ``mixle.tests.block_em_test`` for a test
+    of that literal property.
+
+    ``delta`` convergence is gated by ``stall_patience`` consecutive small-gain rounds rather
+    than a single one: a partial (budget-throttled) round can legitimately show a tiny total-F
+    gain even while a still-improving block simply wasn't scheduled that round (its turn is
+    coming), so a single-round ``delta`` check -- fine for vanilla EM, where every round touches
+    every block -- would risk declaring convergence early here. Requiring the plateau to persist
+    for ``stall_patience`` rounds is the same style of robustness D2's own ``freeze_patience``
+    already uses for its (structurally identical) "has this genuinely stopped moving" question.
+
+    ``max_skip_rounds`` bounds STARVATION: a purely greedy top-score-wins ranking can, on a real
+    fixture, rank the same eligible block last round after round (its own gain-per-cost score
+    stays a little below its rivals') and never actually get a turn -- which is still valid
+    coordinate ascent (F still only goes up), but converges to a WORSE fixed point than vanilla
+    EM would reach in the same number of rounds, since a legitimately-still-moving block is
+    parked indefinitely instead of merely delayed. Any eligible block skipped
+    ``max_skip_rounds`` rounds in a row is therefore force-included in ``active`` regardless of
+    its score (an aging boost) -- guaranteeing every eligible block gets a turn at least once
+    every ``max_skip_rounds + 1`` rounds, which is what makes "same target F, fewer evals" (as
+    opposed to just "monotone but permanently stuck") an honest comparison against vanilla EM.
+
+    Returns ``(final_model, history)`` where ``history[i]`` is round ``i``'s
+    :class:`BlockEMStats`.
+    """
+    if not isinstance(initial_model, MixtureDistribution):
+        raise TypeError("run_block_em requires a MixtureDistribution model.")
+    cache = (
+        FreezeRollupCache(
+            q_gain_tol=q_gain_tol,
+            weight_tol=weight_tol,
+            weight_delta_tol=weight_delta_tol,
+            freeze_patience=freeze_patience,
+        )
+        if cache is None
+        else cache
+    )
+    enc_payload = _resolve_payload(enc_data)
+
+    model = initial_model
+    history: list[BlockEMStats] = []
+    old_value: float | None = None
+    prev_residual: dict[int, float] = {}
+    skip_streak: dict[int, int] = {}
+    stall_streak = 0
+
+    for round_index in range(max(1, int(max_its))):
+        frozen_idx = detect_frozen(cache, model)
+        eligible = [idx for idx in range(model.num_components) if idx not in frozen_idx and not model.zw[idx]]
+        scores, cost = _block_scores(model, eligible, prev_residual)
+        active, degenerate = _select_active(
+            eligible,
+            scores,
+            cost,
+            budget_fraction=budget_fraction,
+            full_tree_every_round=full_tree_every_round,
+            tie_tol=tie_tol,
+        )
+        starved = {idx for idx in eligible if skip_streak.get(idx, 0) >= max(0, int(max_skip_rounds))}
+        if starved - active:
+            active = active | starved
+        for idx in eligible:
+            skip_streak[idx] = 0 if idx in active else skip_streak.get(idx, 0) + 1
+        for idx in list(skip_streak):
+            if idx not in eligible:
+                del skip_streak[idx]
+        scheduled_inactive = frozen_idx | (set(eligible) - active)
+
+        ll_mat, evals_e = _component_log_density_matrix(model, enc_payload, cache, scheduled_inactive)
+        log_density, gamma = _combine(ll_mat, model.log_w)
+        current_value = float(np.sum(log_density))
+        if old_value is None:
+            old_value = current_value
+
+        candidate = _m_step(enc_payload, estimator, model, gamma, scheduled_inactive)
+        candidate_frozen = detect_frozen(cache, candidate)
+        candidate_inactive = candidate_frozen | (set(eligible) - active)
+        ll_mat_c, evals_c = _component_log_density_matrix(candidate, enc_payload, cache, candidate_inactive)
+        candidate_log_density, _ = _combine(ll_mat_c, candidate.log_w)
+        candidate_value = float(np.sum(candidate_log_density))
+
+        accepted = np.isfinite(candidate_value) and candidate_value + accept_tolerance >= current_value
+        if accepted:
+            model = candidate
+            round_value = candidate_value
+        else:
+            round_value = current_value
+
+        n_zero = int(np.count_nonzero(model.zw)) if not accepted else int(np.count_nonzero(candidate.zw))
+        history.append(
+            BlockEMStats(
+                round_index=round_index,
+                n_components=model.num_components,
+                n_active=len(active),
+                n_frozen=len(frozen_idx),
+                n_zero_weight=n_zero,
+                n_scheduled_inactive=len(set(eligible) - active),
+                n_log_density_evals=evals_e + evals_c,
+                objective=round_value,
+                accepted=accepted,
+                degenerate_round=degenerate,
+            )
+        )
+
+        if delta is not None and 0.0 <= round_value - old_value < delta:
+            stall_streak += 1
+            if stall_streak >= max(1, int(stall_patience)):
+                break
+        else:
+            stall_streak = 0
+        old_value = round_value
+
+    return model, history

--- a/mixle/inference/estimation.py
+++ b/mixle/inference/estimation.py
@@ -644,6 +644,7 @@ def optimize(
     objective: str = "auto",
     on_step: Any | None = None,
     structure: str = "auto",
+    schedule: str = "full",
 ) -> SequenceEncodableProbabilityDistribution:
     """Fit ``estimator`` to ``data`` by a generalized-EM loop, for ``max_its`` iterations or until the
         objective improves by less than ``delta``.
@@ -740,6 +741,19 @@ def optimize(
             the historical automatic-composite path proceeds untouched. ``'off'`` restores the
             unconditional historical behavior. Only consulted when ``estimator`` is ``None`` and no
             ``prev_estimate``/``init_estimator``/``strategy``/``enc_data`` is supplied.
+        schedule (str): ``'full'`` (default) -- unchanged vanilla full-tree EM, every round scores
+            and re-estimates every component. ``'auto'`` engages the D3 block-coordinate-ascent
+            scheduler (:mod:`mixle.inference.block_em`): each round, D1 node reports rank the
+            components NOT already D2-frozen by gain-per-cost, and only the highest-value ones
+            (within a per-round cost budget) are actually re-estimated -- composing with D2's
+            freeze/roll-up cache rather than duplicating it. This is a SPEED-only scheduling
+            choice: F (the Neal-Hinton free energy) is still gated non-decreasing every round, and
+            when there is no useful ranking to do (e.g. every component looks equally worth
+            updating) the scheduler degenerates to doing exactly what ``'full'`` does. Only
+            engaged when the model is a plain local-backend ``MixtureDistribution``/
+            ``MixtureEstimator`` MLE fit with no explicit ``strategy``/``engine``/``resources``/
+            ``placement`` -- anything else silently falls back to ``'full'`` (never an error, never
+            a behavior change beyond scheduling).
 
     Returns:
         SequenceEncodableProbabilityDistribution corresponding to estimator when stopping criteria of EM algorithm
@@ -849,6 +863,38 @@ def optimize(
         # the plain log-likelihood otherwise. So a Bayesian estimator converges/selects on the right
         # objective whether the caller reaches for optimize() or fit().
         resolved_objective = _resolve_objective(objective, estimator, mm)
+
+        # D3 block-EM scheduler: 'auto' dispatches to mixle.inference.block_em's greedy
+        # gain-per-cost scheduler when the fit is a plain local MLE MixtureDistribution/
+        # MixtureEstimator fit with none of the other execution knobs engaged (those all need
+        # the standard _em_loop path); everything else silently keeps the 'full' behavior below
+        # -- schedule='auto' never errors or changes what is computed, only how it is scheduled.
+        if schedule == "auto":
+            from mixle.inference.block_em import is_block_em_eligible
+
+            if (
+                is_block_em_eligible(mm, estimator)
+                and strategy is None
+                and resolved_objective == "mle"
+                and engine is None
+                and resources is None
+                and placement is None
+                and backend_name == "local"
+            ):
+                from mixle.inference.block_em import run_block_em
+
+                best_model, block_history = run_block_em(enc_data, estimator, mm, max_its=max_its, delta=delta)
+                if out is not None and block_history:
+                    last = block_history[-1]
+                    out.write(
+                        "block-em: %d rounds, final F=%.6f, mean active fraction=%.3f\n"
+                        % (
+                            len(block_history),
+                            last.objective,
+                            float(np.mean([h.active_fraction for h in block_history])),
+                        )
+                    )
+                return best_model
 
         # Cost-model auto-fusion: with no explicit engine, switch a large-enough local MLE fit of a
         # fusible model onto the single-pass fused numba kernel (parity-identical, ~1.7x once warm).

--- a/mixle/tests/block_em_test.py
+++ b/mixle/tests/block_em_test.py
@@ -1,0 +1,259 @@
+"""Tests for the D3 block-coordinate-ascent EM scheduler (mixle.inference.block_em).
+
+Acceptance criteria under test (see the ConditionalJIT track's D3 item):
+
+1. Monotone-F test -- F (the real Neal-Hinton free energy / observed-data log-likelihood) never
+   decreases round-to-round under ``schedule="auto"``, the same coordinate-ascent guarantee
+   vanilla EM has, in the same style as D2's own monotone-F test.
+2. Beats full-tree EM on the D2 fixture -- ``schedule="auto"`` reaches the SAME target F as
+   vanilla full-tree EM using measurably fewer per-datum log-density evaluations.
+3. Degenerates to vanilla EM -- when every eligible block's gain-per-cost score is
+   indistinguishable, ``schedule="auto"``'s behavior is numerically indistinguishable from
+   vanilla full-tree EM's.
+"""
+
+import unittest
+
+import numpy as np
+
+from mixle.inference.block_em import run_block_em
+from mixle.inference.em import PosteriorTransformEM, observed_log_likelihood, run_em
+from mixle.inference.estimation import optimize
+from mixle.stats import GaussianDistribution, GaussianEstimator, MixtureDistribution, MixtureEstimator, seq_encode
+
+
+def _make_problem(seed=42, nobs=400):
+    """A mixture with 2 slow-converging real components plus 6 far-away decoy components.
+
+    Identical to the D2 fixture (``mixle.tests.freeze_rollup_test._make_problem``) -- reused
+    directly per the roadmap item's instruction to mirror D2's own test fixture, rather than
+    importing across test modules (test modules are not meant to be a shared library surface).
+    """
+    truth = MixtureDistribution([GaussianDistribution(-5.0, 0.6), GaussianDistribution(5.0, 0.6)], [0.5, 0.5])
+    data = truth.sampler(seed=seed).sample(size=nobs)
+    start_components = [
+        GaussianDistribution(-0.3, 3.0),
+        GaussianDistribution(0.3, 3.0),
+        GaussianDistribution(-14.0, 3.0),
+        GaussianDistribution(14.0, 3.0),
+        GaussianDistribution(-40.0, 3.0),
+        GaussianDistribution(40.0, 3.0),
+        GaussianDistribution(-70.0, 3.0),
+        GaussianDistribution(70.0, 3.0),
+    ]
+    start = MixtureDistribution(start_components, [0.4, 0.4] + [0.025] * 6)
+    estimator = MixtureEstimator([GaussianEstimator() for _ in range(8)])
+    enc = seq_encode(data, model=start)
+    return start, estimator, enc
+
+
+def _make_symmetric_problem(seed=3, nobs=200, num_components=4):
+    """A mixture of ``num_components`` BYTE-IDENTICAL components at equal weight.
+
+    Every component has the exact same distribution and the exact same weight, so D1's
+    gain-per-cost report (residual, cost) is identical across every component every round (the
+    scheduler scores with a fixed shared seed -- see ``block_em._SCORE_SEED`` -- specifically so
+    this holds deterministically, not by RNG luck). This is the literal "no useful discrimination
+    to make" scenario the degeneration acceptance criterion asks for.
+    """
+    truth = GaussianDistribution(0.0, 1.5)
+    data = truth.sampler(seed=seed).sample(size=nobs)
+    start = MixtureDistribution(
+        [GaussianDistribution(0.1, 2.0) for _ in range(num_components)],
+        [1.0 / num_components] * num_components,
+    )
+    estimator = MixtureEstimator([GaussianEstimator() for _ in range(num_components)])
+    enc = seq_encode(data, model=start)
+    return start, estimator, enc
+
+
+class BlockEMMonotonicityTestCase(unittest.TestCase):
+    def test_free_energy_is_monotone_round_to_round(self):
+        """F (observed-data log-likelihood) never decreases round-to-round under schedule='auto'.
+
+        Same style/assertion as D2's ``FreezeRollupMonotonicityTestCase`` -- the D-track's
+        correctness backbone is that a learned/greedy scheduling decision changes SPEED, never
+        whether F goes up; ``run_block_em`` enforces this with an accept/reject gate on every
+        round's real objective, so this test checks that gate is wired correctly end to end.
+        """
+        start, estimator, enc = _make_problem(seed=7, nobs=300)
+        _, history = run_block_em(enc, estimator, start, max_its=150, delta=1.0e-10, budget_fraction=0.5)
+
+        self.assertGreater(len(history), 1)
+        objectives = [h.objective for h in history]
+        for i in range(1, len(objectives)):
+            self.assertGreaterEqual(
+                objectives[i],
+                objectives[i - 1] - 1.0e-9,
+                "F decreased from round %d to %d: %r -> %r" % (i - 1, i, objectives[i - 1], objectives[i]),
+            )
+        # At least one round should actually have scheduled a genuine subset (n_active <
+        # n_components - n_frozen) -- otherwise the monotonicity check is vacuous (every round
+        # behaved like full-tree EM and the scheduler was never really exercised).
+        self.assertTrue(
+            any(h.n_active < h.n_components - h.n_frozen and not h.degenerate_round for h in history),
+            "scheduler never actually chose a proper subset of blocks during this run",
+        )
+
+
+class BlockEMSpeedupTestCase(unittest.TestCase):
+    def test_evaluation_count_speedup_matches_active_fraction(self):
+        """schedule='auto' reaches the SAME target F using far fewer log-density evaluations
+        than vanilla full-tree EM, on the same fixture D2 used for its own speedup receipt.
+
+        Honesty note (same as D2's own test): wall-clock is what the roadmap item names, but a
+        per-datum log-density-evaluation count is a direct, deterministic, CI-safe proxy for it
+        -- it IS the operation whose count wall-clock would otherwise be approximating.
+        """
+        start, estimator, enc = _make_problem()
+        num_components = start.num_components
+
+        _, block_history = run_block_em(
+            enc,
+            estimator,
+            start,
+            max_its=400,
+            delta=None,  # run the full budget -- target-F crossing is measured from the trace itself
+            budget_fraction=0.5,
+            weight_tol=0.05,
+            q_gain_tol=1.0e-5,
+            weight_delta_tol=1.0e-11,
+            freeze_patience=10,
+        )
+
+        # Vanilla's own per-round trace, over the same number of rounds, so both traces are
+        # measured the same way. PosteriorTransformEM's own E-step (K components) plus run_em's
+        # explicit objective(candidate) convergence check (another K components) is the same
+        # 2-evaluations-per-component-per-round structure D2's own speedup test accounts for.
+        strategy = PosteriorTransformEM()
+        objective = observed_log_likelihood(enc)
+        vanilla_model = start
+        vanilla_trace = [objective(vanilla_model)]
+        for _ in range(len(block_history)):
+            vanilla_model = strategy.step(enc, estimator, vanilla_model, objective=objective).model
+            vanilla_trace.append(objective(vanilla_model))
+        vanilla_cum_evals = [2 * num_components * (i + 1) for i in range(len(vanilla_trace))]
+
+        block_trace = [h.objective for h in block_history]
+        block_cum_evals = list(np.cumsum([h.n_log_density_evals for h in block_history]))
+
+        # Pick a target F both traces actually reach (a small margin below whichever trajectory's
+        # own final value is smaller), rather than demanding the two runs land on the EXACT same
+        # final fixed point -- block-coordinate EM on a real (non-synthetic-for-this-test) mixture
+        # can legitimately settle into a very slightly different local optimum than vanilla EM
+        # depending on update order (both are still valid coordinate ascent -- see the
+        # monotone-F test); "reaches the same target F in fewer evaluations" is the honest,
+        # order-independent form of the roadmap item's acceptance criterion.
+        target = min(vanilla_trace[-1], block_trace[-1]) - 1.0e-3
+
+        def _evals_to_target(trace, cum_evals):
+            for value, evals in zip(trace, cum_evals):
+                if value >= target:
+                    return evals
+            self.fail("trace never reached the target F")
+
+        vanilla_evals = _evals_to_target(vanilla_trace, vanilla_cum_evals)
+        block_evals = _evals_to_target(block_trace, block_cum_evals)
+
+        self.assertLess(
+            block_evals, vanilla_evals, "block-EM needed at least as many log-density evals as vanilla EM would"
+        )
+        ratio = vanilla_evals / block_evals
+        self.assertGreater(ratio, 1.1)
+        print(
+            "\nblock-EM speedup: target F=%.4f reached in %d vs %d log-density evals, ratio=%.3fx"
+            % (target, block_evals, vanilla_evals, ratio)
+        )
+
+
+class BlockEMDegenerationTestCase(unittest.TestCase):
+    def test_degenerates_to_vanilla_em_when_blocks_are_indistinguishable(self):
+        """When every eligible block has the same gain-per-cost, schedule='auto' must do exactly
+        what vanilla full-tree EM does -- a literal test of the "degenerates to vanilla EM"
+        acceptance criterion, not just an assumption.
+        """
+        start, estimator, enc = _make_symmetric_problem()
+        max_its = 40
+
+        model, history = run_block_em(
+            enc,
+            estimator,
+            start,
+            max_its=max_its,
+            delta=None,  # run every round, so this exactly matches run_em's fixed max_its loop
+            budget_fraction=0.5,  # a real budget cap -- the degeneration must come from the TIE, not from a trivially permissive budget
+        )
+        reference = run_em(enc, estimator, start, strategy=PosteriorTransformEM(), max_its=max_its, delta=None)
+
+        objective = observed_log_likelihood(enc)
+        self.assertAlmostEqual(objective(model), objective(reference), places=6)
+        np.testing.assert_allclose(model.w, reference.w, atol=1.0e-8)
+        np.testing.assert_allclose(
+            sorted(c.mu for c in model.components), sorted(c.mu for c in reference.components), atol=1.0e-6
+        )
+
+        # Every round in this run should have been recognized as having no useful discrimination
+        # to make (all-identical components => all-identical gain-per-cost scores).
+        self.assertTrue(len(history) > 0)
+        self.assertTrue(all(h.degenerate_round for h in history), "expected every round to be a degenerate round")
+        self.assertTrue(all(h.n_active == h.n_components - h.n_frozen for h in history))
+
+    def test_full_tree_every_round_escape_hatch_matches_vanilla_em(self):
+        """The explicit ``full_tree_every_round=True`` escape hatch is a second, independent way
+        to hit the same degeneration property (spec: "or a full_tree_every_round=True-style
+        escape hatch"), even on a fixture where components genuinely differ (so a real budget
+        WOULD otherwise produce a proper subset -- see BlockEMSpeedupTestCase).
+        """
+        start, estimator, enc = _make_problem(seed=99, nobs=200)
+        max_its = 25
+
+        model, history = run_block_em(
+            enc, estimator, start, max_its=max_its, delta=None, budget_fraction=0.1, full_tree_every_round=True
+        )
+        reference = run_em(enc, estimator, start, strategy=PosteriorTransformEM(), max_its=max_its, delta=None)
+
+        objective = observed_log_likelihood(enc)
+        self.assertAlmostEqual(objective(model), objective(reference), places=6)
+        np.testing.assert_allclose(model.w, reference.w, atol=1.0e-8)
+        self.assertTrue(all(h.degenerate_round for h in history))
+
+
+class BlockEMOptimizeDispatchTestCase(unittest.TestCase):
+    def test_optimize_schedule_auto_is_a_real_dispatchable_api(self):
+        """``optimize(..., schedule="auto")`` is the real, top-level, user-facing entry point the
+        roadmap item asks for -- not just an internal ``run_block_em`` function nobody calls.
+        """
+        start, estimator, enc = _make_problem(seed=13, nobs=200)
+
+        fitted = optimize(
+            None,
+            estimator,
+            enc_data=enc,
+            prev_estimate=start,
+            max_its=30,
+            delta=1.0e-9,
+            schedule="auto",
+            out=None,
+        )
+        self.assertIsInstance(fitted, MixtureDistribution)
+        self.assertEqual(fitted.num_components, start.num_components)
+        # A legitimate fit: total responsibility-weighted mass should be non-trivial and finite.
+        objective = observed_log_likelihood(enc)
+        self.assertTrue(np.isfinite(objective(fitted)))
+
+    def test_optimize_schedule_auto_falls_back_for_non_mixture_models(self):
+        """``schedule='auto'`` on a model block-EM does not know how to schedule (anything that
+        isn't a plain local MLE MixtureDistribution/MixtureEstimator fit) must silently behave
+        like ``schedule='full'`` -- never error, never silently do nothing.
+        """
+        data = GaussianDistribution(0.0, 1.0).sampler(seed=1).sample(size=200)
+        estimator = GaussianEstimator()
+
+        fitted_auto = optimize(data, estimator, max_its=10, delta=1.0e-9, schedule="auto", out=None, rng=None)
+        fitted_full = optimize(data, estimator, max_its=10, delta=1.0e-9, schedule="full", out=None, rng=None)
+        self.assertAlmostEqual(fitted_auto.mu, fitted_full.mu, places=8)
+        self.assertAlmostEqual(fitted_auto.sigma2, fitted_full.sigma2, places=8)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Relands #152, stacked on the closed-unmerged #148 (now landed via #202). estimation.py needed manual reconciliation since optimize()'s signature grew new parameters from other interim work; reapplied the schedule='full'/'auto' parameter, docstring, and D3 dispatch block by hand at their current locations. Verified against 5 existing estimation/mixture test files (39 passed) plus the new block_em_test.py (6 passed).