### PR TITLE
task: amortized inverse posteriors with calibration receipts (M3)

### DIFF
--- a/mixle/inference/condition.py
+++ b/mixle/inference/condition.py
@@ -1,0 +1,596 @@
+"""``condition()`` / ``do()`` -- generic conditioning and causal intervention over any fitted
+mixle model, regardless of how it is composed (composite / mixture / HMM / dependency-tree /
+Bayesian network / conditional / sequence / optional).
+
+See ``notes/designs/M0.md`` for the full design: the recursive rule per combinator, the
+self-normalized-importance-sampling (SIR) fallback and its ESS receipt, and ``do()``'s
+graph-surgery semantics. In one line: ``condition`` composes each family's own closed-form
+conditioning surface where one already exists (``MultivariateGaussianDistribution.condition``,
+``MixtureDistribution.conditional``, ``HiddenMarkovModelDistribution``'s forward-backward) and
+falls back to likelihood-weighted ancestral sampling -- reusing each combinator's own
+``log_density``/``sampler`` -- everywhere else; ``do`` severs the incoming edges of the assigned
+fields (graph surgery) rather than reweighting via Bayes.
+
+Neither this module nor its callers modify any family's internals -- only their existing public
+surfaces are composed.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+from numpy.random import RandomState
+from scipy.special import logsumexp
+
+from mixle.inference.bayesian_network import HeterogeneousBayesianNetwork
+from mixle.inference.causal import do as _bn_do
+from mixle.inference.structure import DependencyTreeDistribution
+from mixle.stats.combinator.composite import CompositeDistribution
+from mixle.stats.combinator.conditional import ConditionalDistribution
+from mixle.stats.combinator.optional import OptionalDistribution
+from mixle.stats.combinator.sequence import SequenceDistribution
+from mixle.stats.compute.posterior import MarkovChainLatentPosterior
+from mixle.stats.latent.hidden_markov import HiddenMarkovModelDistribution
+from mixle.stats.latent.mixture import MixtureDistribution
+from mixle.stats.univariate.discrete.point_mass import PointMassDistribution
+
+__all__ = ["FieldPath", "ConditionReceipt", "Posterior", "condition", "do"]
+
+FieldPath = tuple[int, ...]
+
+
+class _NoExactRule(Exception):
+    """Internal: raised when a combinator has no closed-form conditioning rule -- triggers SIR."""
+
+
+def _norm_path(key: Any) -> FieldPath:
+    if isinstance(key, (int, np.integer)):
+        return (int(key),)
+    return tuple(int(i) for i in key)
+
+
+def _norm_evidence(evidence: dict[Any, Any]) -> dict[FieldPath, Any]:
+    if not evidence:
+        raise ValueError("condition()/do() require at least one evidence/assignment field.")
+    return {_norm_path(k): v for k, v in evidence.items()}
+
+
+def _split(evidence: dict[FieldPath, Any]) -> tuple[dict[int, Any], dict[int, dict[FieldPath, Any]]]:
+    """Split evidence keyed by FieldPath into this level's direct fields and residual sub-paths."""
+    top: dict[int, Any] = {}
+    nested: dict[int, dict[FieldPath, Any]] = {}
+    for path, v in evidence.items():
+        i, rest = path[0], path[1:]
+        if rest:
+            nested.setdefault(i, {})[rest] = v
+        else:
+            top[i] = v
+    return top, nested
+
+
+def _safe_log_density(dist: Any, value: Any) -> float:
+    """A field's log-density under an evidence value, with out-of-support -> ``-inf`` (not a crash)."""
+    try:
+        ld = float(dist.log_density(value))
+    except (ValueError, TypeError, KeyError, FloatingPointError, OverflowError):
+        return float("-inf")
+    return ld if not np.isnan(ld) else float("-inf")
+
+
+def _rng_seed(rng: RandomState) -> int:
+    return int(rng.randint(0, 2**31 - 1))
+
+
+def _is_gaussian_like(model: Any) -> bool:
+    """Duck-types a leaf exposing the ``MultivariateGaussianDistribution``-style closed-form API."""
+    return (
+        callable(getattr(model, "condition", None))
+        and callable(getattr(model, "marginal", None))
+        and hasattr(model, "mu")
+        and hasattr(model, "dim")
+    )
+
+
+def _analytic_mean(dist: Any, j: int | None = None) -> float:
+    """The analytic (not Monte-Carlo) mean of a fitted leaf/composite family, or raise."""
+    if hasattr(dist, "mu"):
+        mu = np.atleast_1d(np.asarray(dist.mu, dtype=float))
+        return float(mu[0]) if j is None else float(mu[j])
+    mean_fn = getattr(dist, "mean", None)
+    if callable(mean_fn):
+        m = mean_fn()
+        if j is None:
+            return float(m)
+        return float(np.atleast_1d(np.asarray(m, dtype=float))[j])
+    raise NotImplementedError(f"no analytic mean available for {type(dist).__name__}; use SIR + Posterior.sample.")
+
+
+@dataclass
+class ConditionReceipt:
+    """What ``condition()`` actually did: the method used and (for SIR) the importance-sampling health."""
+
+    method: str  # "exact" | "sir"
+    ess: float | None = None
+    ess_ratio: float | None = None
+    n_particles: int | None = None
+    warnings: list[str] = field(default_factory=list)
+
+
+class Posterior:
+    """A ``condition()`` result: scoreable/samplable over the unobserved fields.
+
+    Distinct from :class:`mixle.stats.compute.posterior.Posterior` (that hierarchy is for
+    parameter/latent/predictive posteriors keyed by ``sample(rng)``); this one is evidence
+    conditioning within a fitted joint model, with the signature the M0 card specifies:
+    ``sample(n)`` / ``log_density(partial_row)`` / ``mean(field)`` / ``.receipt``.
+    """
+
+    def __init__(
+        self,
+        *,
+        sample_fn: Callable[[int, int | None], Any],
+        log_density_fn: Callable[[Any], float] | None,
+        mean_fn: Callable[[FieldPath], Any],
+        receipt: ConditionReceipt,
+        model: Any = None,
+    ) -> None:
+        self._sample_fn = sample_fn
+        self._log_density_fn = log_density_fn
+        self._mean_fn = mean_fn
+        self.receipt = receipt
+        # The underlying conditioned distribution when the exact path produced one -- lets a caller
+        # splice a sub-posterior back into a bigger composite (see CompositeDistribution recursion
+        # below). None for SIR posteriors: there is no closed-form distribution object to hand back.
+        self.model = model
+
+    def sample(self, n: int = 1, *, seed: int | None = None) -> Any:
+        """``n`` draws over the unobserved fields (a list/array in original field order)."""
+        return self._sample_fn(int(n), seed)
+
+    def log_density(self, partial_row: Any) -> float:
+        """Log-density of an assignment to the unobserved fields under the posterior."""
+        if self._log_density_fn is None:
+            raise NotImplementedError(f"{type(self).__name__} does not support log_density for this posterior.")
+        return self._log_density_fn(partial_row)
+
+    def mean(self, field: FieldPath | int) -> Any:
+        """Posterior mean of one unobserved field (same ``FieldPath``/``int`` used in ``evidence``)."""
+        return self._mean_fn(_norm_path(field))
+
+
+# --------------------------------------------------------------------------------------------- #
+# condition() -- exact dispatch
+# --------------------------------------------------------------------------------------------- #
+
+
+def condition(
+    model: Any,
+    evidence: dict[FieldPath | int, Any],
+    *,
+    method: str = "auto",
+    n_particles: int = 4096,
+    seed: int | None = None,
+) -> Posterior:
+    """The posterior over ``model``'s unobserved fields given ``evidence`` (see ``notes/designs/M0.md``)."""
+    if method not in ("auto", "exact", "sir"):
+        raise ValueError(f"unknown method {method!r}; expected 'auto', 'exact', or 'sir'.")
+    ev = _norm_evidence(evidence)
+    if method in ("auto", "exact"):
+        try:
+            return _condition_exact(model, ev, seed=seed)
+        except _NoExactRule:
+            if method == "exact":
+                raise
+    return _condition_sir(model, ev, n_particles=int(n_particles), seed=seed)
+
+
+def _condition_exact(model: Any, ev: dict[FieldPath, Any], *, seed: int | None) -> Posterior:
+    if _is_gaussian_like(model):
+        return _condition_gaussian_like(model, ev)
+    if isinstance(model, CompositeDistribution):
+        return _condition_composite(model, ev, seed=seed)
+    if isinstance(model, MixtureDistribution):
+        return _condition_mixture(model, ev)
+    if isinstance(model, HiddenMarkovModelDistribution):
+        return _condition_hmm(model, ev)
+    raise _NoExactRule(type(model).__name__)
+
+
+def _condition_gaussian_like(model: Any, ev: dict[FieldPath, Any]) -> Posterior:
+    if any(len(p) != 1 for p in ev):
+        raise _NoExactRule("nested evidence is not supported for a Gaussian-like leaf")
+    observed = {p[0]: v for p, v in ev.items()}
+    cond = model.condition(observed)
+    unobs = [i for i in range(int(model.dim)) if i not in observed]
+    pos = {f: j for j, f in enumerate(unobs)}
+
+    def sample_fn(n: int, s: int | None) -> Any:
+        return cond.sampler(seed=s).sample(n)
+
+    def log_density_fn(row: Any) -> float:
+        return float(cond.log_density(row))
+
+    def mean_fn(path: FieldPath) -> float:
+        return _analytic_mean(cond, pos[path[0]])
+
+    receipt = ConditionReceipt(method="exact")
+    return Posterior(sample_fn=sample_fn, log_density_fn=log_density_fn, mean_fn=mean_fn, receipt=receipt, model=cond)
+
+
+def _condition_composite(model: CompositeDistribution, ev: dict[FieldPath, Any], *, seed: int | None) -> Posterior:
+    top, nested = _split(ev)
+    working = list(model.dists)
+    sub_posts: dict[int, Posterior] = {}
+    for i, sub_ev in nested.items():
+        sp = _condition_exact(working[i], sub_ev, seed=seed)
+        if sp.model is None:
+            raise _NoExactRule("nested composite field has no closed-form posterior to splice back in")
+        sub_posts[i] = sp
+        working[i] = sp.model
+    working_composite = CompositeDistribution(working)
+    cond = working_composite.condition(top)
+    unobs = [i for i in range(model.count) if i not in top]
+    pos = {f: j for j, f in enumerate(unobs)}
+
+    def sample_fn(n: int, s: int | None) -> Any:
+        return cond.sampler(seed=s).sample(n)
+
+    def log_density_fn(row: Any) -> float:
+        return float(cond.log_density(row))
+
+    def mean_fn(path: FieldPath) -> Any:
+        i = path[0]
+        if len(path) > 1:
+            if i in sub_posts:
+                return sub_posts[i].mean(path[1:])
+            raise NotImplementedError(f"no nested posterior recorded for field {path}")
+        return _analytic_mean(cond.dists[pos[i]])
+
+    receipt = ConditionReceipt(method="exact")
+    return Posterior(sample_fn=sample_fn, log_density_fn=log_density_fn, mean_fn=mean_fn, receipt=receipt, model=cond)
+
+
+def _condition_mixture(model: MixtureDistribution, ev: dict[FieldPath, Any]) -> Posterior:
+    if any(len(p) != 1 for p in ev):
+        raise _NoExactRule("nested evidence is not supported by the mixture exact handler")
+    observed = {p[0]: v for p, v in ev.items()}
+    for c in model.components:
+        if not (callable(getattr(c, "marginal", None)) and callable(getattr(c, "condition", None))):
+            raise _NoExactRule("a mixture component lacks marginal()/condition()")
+    dim = getattr(model.components[0], "dim", None)
+    if dim is None:
+        raise _NoExactRule("mixture components have no dim attribute")
+    cond = model.conditional(observed)
+    unobs = [i for i in range(int(dim)) if i not in observed]
+    pos = {f: j for j, f in enumerate(unobs)}
+
+    def sample_fn(n: int, s: int | None) -> Any:
+        return cond.sampler(seed=s).sample(n)
+
+    def log_density_fn(row: Any) -> float:
+        return float(cond.log_density(row))
+
+    def mean_fn(path: FieldPath) -> float:
+        j = pos[path[0]]
+        means = np.array([_analytic_mean(c, j) for c in cond.components], dtype=np.float64)
+        return float(np.sum(cond.w * means))
+
+    receipt = ConditionReceipt(method="exact")
+    return Posterior(sample_fn=sample_fn, log_density_fn=log_density_fn, mean_fn=mean_fn, receipt=receipt, model=cond)
+
+
+def _condition_hmm(model: HiddenMarkovModelDistribution, ev: dict[FieldPath, Any]) -> Posterior:
+    if any(len(p) != 1 for p in ev):
+        raise _NoExactRule("nested evidence is not supported by the HMM exact handler")
+    observed = {p[0]: v for p, v in ev.items()}
+    if not observed:
+        raise _NoExactRule("no evidence")
+    t_max = max(observed)
+    n_states = model.n_states
+    log_b = np.zeros((t_max + 1, n_states), dtype=np.float64)
+    for t in range(t_max + 1):
+        if t in observed:
+            for k in range(n_states):
+                log_b[t, k] = _safe_log_density(model.topics[k], observed[t])
+    q = MarkovChainLatentPosterior(model.log_w, model.log_transitions, log_b)
+    marginals = q.marginals()  # (T, K) smoothed state responsibilities
+
+    def sample_fn(n: int, s: int | None) -> Any:
+        rng = RandomState(s)
+        out = []
+        for _ in range(n):
+            z = q.sample(rng)
+            row: dict[int, Any] = {}
+            for t in range(t_max + 1):
+                if t in observed:
+                    row[t] = observed[t]
+                else:
+                    row[t] = model.topics[int(z[t])].sampler(seed=_rng_seed(rng)).sample()
+            out.append(row)
+        return out
+
+    def log_density_fn(partial_row: dict[int, Any]) -> float:
+        total = 0.0
+        for t, val in partial_row.items():
+            w = marginals[t]
+            comp_ld = np.array([_safe_log_density(model.topics[k], val) for k in range(n_states)])
+            total += float(logsumexp(comp_ld + np.log(w + 1e-300)))
+        return total
+
+    def mean_fn(path: FieldPath) -> float:
+        t = path[0]
+        w = marginals[t]
+        means = np.array([_analytic_mean(model.topics[k]) for k in range(n_states)], dtype=np.float64)
+        return float(np.sum(w * means))
+
+    receipt = ConditionReceipt(method="exact")
+    post = Posterior(sample_fn=sample_fn, log_density_fn=log_density_fn, mean_fn=mean_fn, receipt=receipt, model=None)
+    post.state_marginals = marginals  # convenience for callers wanting q(z_t | evidence) directly
+    return post
+
+
+# --------------------------------------------------------------------------------------------- #
+# SIR fallback -- self-normalized likelihood-weighted ancestral sampling
+# --------------------------------------------------------------------------------------------- #
+
+
+def _generate_weighted(model: Any, ev: dict[FieldPath, Any], rng: RandomState) -> tuple[Any, float]:
+    """One ``(record, log_weight)`` particle from ``model``'s own generative order, evidence clamped."""
+    top, nested = _split(ev)
+
+    if isinstance(model, CompositeDistribution):
+        vals: list[Any] = [None] * model.count
+        lw = 0.0
+        for i in range(model.count):
+            child = model.dists[i]
+            if i in top:
+                vals[i] = top[i]
+                lw += _safe_log_density(child, vals[i])
+            elif i in nested:
+                vals[i], sub_lw = _generate_weighted(child, nested[i], rng)
+                lw += sub_lw
+            else:
+                vals[i] = child.sampler(seed=_rng_seed(rng)).sample()
+        return tuple(vals), lw
+
+    if isinstance(model, MixtureDistribution):
+        k = int(rng.choice(model.num_components, p=model.w))
+        sub_ev = {(i,): v for i, v in top.items()}
+        sub_ev.update({(i, *rest): v for i, sub in nested.items() for rest, v in sub.items()})
+        return _generate_weighted(model.components[k], sub_ev, rng)
+
+    if isinstance(model, HiddenMarkovModelDistribution):
+        if not top:
+            raise ValueError("no evidence for HMM SIR fallback: at least one time index must be evidenced")
+        t_max = max(top)
+        vals = [None] * (t_max + 1)
+        lw = 0.0
+        state = int(rng.choice(model.n_states, p=np.exp(model.log_w)))
+        trans = np.exp(model.log_transitions)
+        for t in range(t_max + 1):
+            if t > 0:
+                state = int(rng.choice(model.n_states, p=trans[state]))
+            if t in top:
+                vals[t] = top[t]
+                lw += _safe_log_density(model.topics[state], vals[t])
+            else:
+                vals[t] = model.topics[state].sampler(seed=_rng_seed(rng)).sample()
+        return vals, lw
+
+    if isinstance(model, DependencyTreeDistribution):
+        vals = [None] * len(model.parents)
+        lw = 0.0
+        for i in model.order:
+            parent = model.parents[i]
+            fac = model.factors[i]
+            if i in top:
+                vals[i] = top[i]
+                if parent is None:
+                    lw += _safe_log_density(fac, vals[i])
+                else:
+                    lw += _safe_log_density(fac, (model._key(i, vals[parent]), vals[i]))
+            else:
+                seed = _rng_seed(rng)
+                if parent is None:
+                    vals[i] = fac.sampler(seed).sample(1)[0]
+                else:
+                    vals[i] = fac.sampler(seed).sample_given(model._key(i, vals[parent]))
+        return tuple(vals), lw
+
+    if isinstance(model, HeterogeneousBayesianNetwork):
+        vals = [None] * len(model.factors)
+        by_child = {f.child: f for f in model.factors}
+        lw = 0.0
+        for i in model.order:
+            f = by_child[i]
+            if i in top:
+                vals[i] = top[i]
+                lw += _safe_log_density(f, tuple(vals))
+            else:
+                vals[i] = f.sample(vals, rng)
+        return tuple(vals), lw
+
+    if isinstance(model, ConditionalDistribution):
+        if 0 in top:
+            x0 = top[0]
+            lw = _safe_log_density(model.given_dist, x0) if model.has_given else 0.0
+        else:
+            x0 = model.given_dist.sampler(seed=_rng_seed(rng)).sample() if model.has_given else None
+            lw = 0.0
+        branch = model.dmap.get(x0, model.default_dist if model.has_default else None)
+        if branch is None:
+            return (x0, None), float("-inf")
+        if 1 in top:
+            x1 = top[1]
+            lw += _safe_log_density(branch, x1)
+        else:
+            x1 = branch.sampler(seed=_rng_seed(rng)).sample()
+        return (x0, x1), lw
+
+    if isinstance(model, OptionalDistribution):
+        if 0 in top:
+            v = top[0]
+            lw = _safe_log_density(model, v)
+        else:
+            v = model.sampler(seed=_rng_seed(rng)).sample()
+            lw = 0.0
+        return v, lw
+
+    if isinstance(model, SequenceDistribution):
+        if not top:
+            raise ValueError("no evidence for SequenceDistribution SIR fallback: at least one index must be evidenced")
+        t_max = max(top)
+        vals = []
+        lw = 0.0
+        for t in range(t_max + 1):
+            if t in top:
+                v = top[t]
+                lw += _safe_log_density(model.dist, v)
+            else:
+                v = model.dist.sampler(seed=_rng_seed(rng)).sample()
+            vals.append(v)
+        return vals, lw
+
+    if top or nested:
+        raise TypeError(
+            f"condition(): {type(model).__name__} has no known field decomposition for SIR conditioning. "
+            "Supported combinators: CompositeDistribution, MixtureDistribution, HiddenMarkovModelDistribution, "
+            "DependencyTreeDistribution, HeterogeneousBayesianNetwork, ConditionalDistribution, "
+            "SequenceDistribution, OptionalDistribution, and Gaussian-like leaves."
+        )
+    return model.sampler(seed=_rng_seed(rng)).sample(), 0.0
+
+
+def _extract(record: Any, path: FieldPath) -> Any:
+    v = record
+    for i in path:
+        v = v[i]
+    return v
+
+
+def _condition_sir(model: Any, ev: dict[FieldPath, Any], *, n_particles: int, seed: int | None) -> Posterior:
+    if n_particles < 1:
+        raise ValueError("n_particles must be >= 1")
+    rng = RandomState(seed)
+    records: list[Any] = [None] * n_particles
+    log_weights = np.empty(n_particles, dtype=np.float64)
+    for i in range(n_particles):
+        rec, lw = _generate_weighted(model, ev, rng)
+        records[i] = rec
+        log_weights[i] = lw
+
+    warnings: list[str] = []
+    finite = np.isfinite(log_weights)
+    if not finite.any():
+        w_norm = np.full(n_particles, 1.0 / n_particles)
+        ess = 0.0
+        warnings.append("all importance weights are zero (evidence has zero density under the prior).")
+    else:
+        m = log_weights[finite].max()
+        w = np.where(finite, np.exp(log_weights - m), 0.0)
+        sw = w.sum()
+        w_norm = w / sw
+        ess = float(1.0 / np.sum(w_norm**2))
+    ess_ratio = ess / n_particles
+    if ess_ratio < 0.01:
+        warnings.append(
+            f"ESS ratio {ess_ratio:.4f} < 0.01 threshold -- evidence may be near-impossible under the prior."
+        )
+    receipt = ConditionReceipt(method="sir", ess=ess, ess_ratio=ess_ratio, n_particles=n_particles, warnings=warnings)
+
+    def sample_fn(n: int, s: int | None) -> Any:
+        r = RandomState(s) if s is not None else RandomState(_rng_seed(rng))
+        idx = r.choice(n_particles, size=n, replace=True, p=w_norm)
+        return [records[j] for j in idx]
+
+    def mean_fn(path: FieldPath) -> float:
+        vals = np.array([float(_extract(records[j], path)) for j in range(n_particles)], dtype=np.float64)
+        return float(np.sum(w_norm * vals))
+
+    def log_density_fn(partial_row: dict[FieldPath | int, Any]) -> float:
+        return _weighted_kde_log_density(records, w_norm, {_norm_path(k): v for k, v in partial_row.items()})
+
+    return Posterior(sample_fn=sample_fn, log_density_fn=log_density_fn, mean_fn=mean_fn, receipt=receipt, model=None)
+
+
+def _weighted_kde_log_density(records: Sequence[Any], w_norm: np.ndarray, partial_row: dict[FieldPath, Any]) -> float:
+    """A self-normalized-weight-KDE estimate of the SIR posterior's log-density (Silverman bandwidth).
+
+    This is an ESTIMATE, not exact -- there is no closed-form density for a generic SIR posterior.
+    """
+    paths = sorted(partial_row)
+    x0 = np.array([float(partial_row[p]) for p in paths], dtype=np.float64)
+    x = np.array([[float(_extract(r, p)) for p in paths] for r in records], dtype=np.float64)
+    n, d = x.shape
+    std = x.std(axis=0)
+    std[std == 0.0] = 1.0
+    bw = std * 1.06 * (n ** (-1.0 / (d + 4)))
+    diffs = (x - x0) / bw
+    log_kernel = -0.5 * np.sum(diffs**2, axis=1) - np.sum(np.log(bw)) - 0.5 * d * np.log(2.0 * np.pi)
+    return float(logsumexp(log_kernel + np.log(w_norm + 1e-300)))
+
+
+# --------------------------------------------------------------------------------------------- #
+# do() -- causal intervention (graph surgery)
+# --------------------------------------------------------------------------------------------- #
+
+
+def do(model: Any, assignments: dict[FieldPath | int, Any]) -> Any:
+    """Sever the incoming edges of the assigned fields, then clamp them (Pearl's ``do``).
+
+    Returns a model of the same combinator family wherever possible (``DependencyTreeDistribution``,
+    ``CompositeDistribution``, ``MixtureDistribution``) so it can be passed back through
+    ``condition()``/``do()``; for a ``HeterogeneousBayesianNetwork`` it returns the existing
+    :class:`~mixle.inference.causal.InterventionalNetwork` (sample/expectation/distribution).
+    """
+    ev = _norm_evidence(assignments)
+    return _do_dispatch(model, ev)
+
+
+def _do_dispatch(model: Any, ev: dict[FieldPath, Any]) -> Any:
+    if isinstance(model, DependencyTreeDistribution):
+        return _do_dependency_tree(model, ev)
+    if isinstance(model, HeterogeneousBayesianNetwork):
+        top, nested = _split(ev)
+        if nested:
+            raise NotImplementedError("do() on nested fields of a HeterogeneousBayesianNetwork is not supported.")
+        return _bn_do(model, top)
+    if isinstance(model, CompositeDistribution):
+        return _do_composite(model, ev)
+    if isinstance(model, MixtureDistribution):
+        return _do_mixture(model, ev)
+    raise TypeError(f"do() has no graph-surgery rule for {type(model).__name__}.")
+
+
+def _do_dependency_tree(model: DependencyTreeDistribution, ev: dict[FieldPath, Any]) -> DependencyTreeDistribution:
+    top, nested = _split(ev)
+    if nested:
+        raise NotImplementedError("do() on nested fields of a DependencyTreeDistribution is not supported.")
+    new_parents = list(model.parents)
+    new_factors = list(model.factors)
+    new_binners = list(model.binners)
+    for i, v in top.items():
+        new_parents[i] = None  # sever the incoming edge
+        new_factors[i] = PointMassDistribution(v)  # clamp
+        new_binners[i] = None
+    return DependencyTreeDistribution(new_parents, new_factors, new_binners)
+
+
+def _do_composite(model: CompositeDistribution, ev: dict[FieldPath, Any]) -> CompositeDistribution:
+    top, nested = _split(ev)
+    new_dists = list(model.dists)
+    for i, sub_ev in nested.items():
+        new_dists[i] = _do_dispatch(new_dists[i], sub_ev)
+    for i, v in top.items():
+        new_dists[i] = PointMassDistribution(v)  # a composite has no internal edges to sever
+    return CompositeDistribution(new_dists)
+
+
+def _do_mixture(model: MixtureDistribution, ev: dict[FieldPath, Any]) -> MixtureDistribution:
+    # do() severs each component's incoming edges but -- unlike condition() -- keeps the ORIGINAL
+    # mixture weights: an intervention carries no Bayesian evidence about which component generated it.
+    new_components = [_do_dispatch(c, ev) for c in model.components]
+    return MixtureDistribution(new_components, model.w.copy())

--- a/mixle/models/grad_leaf.py
+++ b/mixle/models/grad_leaf.py
@@ -52,6 +52,29 @@ def _torch() -> Any:
     return torch
 
 
+def _resolve_device(device: Any, torch: Any) -> Any:
+    """Where to run a leaf's module, in priority order (shared by every gradient-fit leaf --
+    ``neural_leaf.py`` imports this rather than redefining it, so the priority order is one place):
+
+    1. an explicit ``device=`` on the leaf/estimator (always wins);
+    2. the device of the **active compute engine** -- so ``optimize(engine=TorchEngine(device="mps"))``
+       (or ``"cuda"``) drives the M-step onto that device, matching mixle's engine philosophy
+       (set the device once on the engine, the leaf follows);
+    3. otherwise CUDA if available, else CPU -- the implicit default (note: not MPS, so existing local
+       CPU behaviour and tests are unchanged; reach MPS explicitly or via the engine)."""
+    if device is not None:
+        return torch.device(device)
+    from mixle.engines.base import active_engine
+
+    eng_dev = getattr(active_engine(), "device", None)
+    if eng_dev is not None and str(eng_dev) != "cpu":
+        try:
+            return torch.device(eng_dev)
+        except (TypeError, RuntimeError):
+            pass
+    return torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+
 def looks_like_torch_module(obj: Any) -> bool:
     """A bare torch density module: scores batches and carries parameters -- coercible to a leaf."""
     return (
@@ -74,7 +97,9 @@ class GradLeaf(SequenceEncodableProbabilityDistribution):
         *,
         m_steps: int = 60,
         lr: float = 5e-3,
-        device: str = "cpu",
+        device: Any = None,
+        batch_size: int | None = None,
+        precision: str = "fp32",
         name: str | None = None,
         loss: Any = None,
         optimizer: Any = None,
@@ -82,7 +107,9 @@ class GradLeaf(SequenceEncodableProbabilityDistribution):
         self.module = module
         self.m_steps = int(m_steps)
         self.lr = float(lr)
-        self.device = device
+        self.device = device  # None => active engine's device, else CUDA if available, else CPU (_resolve_device)
+        self.batch_size = None if batch_size is None else int(batch_size)
+        self.precision = precision
         self.name = name
         self.loss = loss
         self.optimizer = optimizer
@@ -91,15 +118,28 @@ class GradLeaf(SequenceEncodableProbabilityDistribution):
         return f"{type(self).__name__}({type(self.module).__name__})"
 
     def log_density(self, x: Any) -> float:
-        return float(self.seq_log_density(np.atleast_2d(np.asarray(x, dtype=float)))[0])
+        fields = x if isinstance(x, tuple) else (x,)
+        rows = tuple(np.atleast_2d(np.asarray(f, dtype=float)) for f in fields)
+        return float(self.seq_log_density(rows if isinstance(x, tuple) else rows[0])[0])
 
     def seq_log_density(self, x: Any) -> np.ndarray:
         torch = _torch()
-        xx = check_finite(np.atleast_2d(np.asarray(x, dtype=float)), f"{type(self).__name__}.seq_log_density")
-        self.module.to(self.device).eval()
-        xt = torch.as_tensor(xx, dtype=torch.float32, device=self.device)
+        # a bare unconditional module sees one field (x); a bare CONDITIONAL module (log_density(x, y, ...))
+        # sees a tuple of fields (GradLeafEncoder.seq_encode's arity-generalized output) -- unpack with
+        # ``*`` either way, same tuple-default pattern GradEstimator.estimate uses for the M-step.
+        fields = x if isinstance(x, tuple) else (x,)
+        dev = _resolve_device(self.device, torch)
+        self.module.to(dev).eval()
+        xts = tuple(
+            torch.as_tensor(
+                check_finite(np.atleast_2d(np.asarray(f, dtype=float)), f"{type(self).__name__}.seq_log_density"),
+                dtype=torch.float32,
+                device=dev,
+            )
+            for f in fields
+        )
         with torch.no_grad():
-            return self.module.log_density(xt).cpu().numpy().reshape(-1)
+            return self.module.log_density(*xts).cpu().numpy().reshape(-1)
 
     def sampler(self, seed: int | None = None) -> GradLeafSampler:
         return GradLeafSampler(self, seed)
@@ -110,6 +150,8 @@ class GradLeaf(SequenceEncodableProbabilityDistribution):
             m_steps=self.m_steps,
             lr=self.lr,
             device=self.device,
+            batch_size=self.batch_size,
+            precision=self.precision,
             name=self.name,
             loss=self.loss,
             optimizer=self.optimizer,
@@ -141,7 +183,8 @@ class GradLeafSampler(DistributionSampler):
             )
         torch = _torch()
         n = int(size or 1)
-        self.dist.module.to(self.dist.device).eval()
+        dev = _resolve_device(self.dist.device, torch)
+        self.dist.module.to(dev).eval()
         torch.manual_seed(int(self.rng.randint(0, 2**31 - 1)))
         with torch.no_grad():
             out = self.dist.module.sample(n).cpu().numpy()
@@ -157,7 +200,14 @@ class GradLeafEncoder(DataSequenceEncoder):
     def __eq__(self, other: object) -> bool:
         return isinstance(other, GradLeafEncoder)
 
-    def seq_encode(self, data: list) -> np.ndarray:
+    def seq_encode(self, data: list) -> Any:
+        # a bare unconditional module sees one field (x); a bare CONDITIONAL module (log_density(x, y, ...))
+        # sees rows as tuples -- split into one contiguous array per position, same shape-preserving contract
+        # DataBufferAccumulator already documents ("a single array ... a tuple like (x, y)"), just generalized
+        # to arbitrary arity instead of hand-picking n_fields=2 per family.
+        if len(data) and isinstance(data[0], tuple):
+            n = len(data[0])
+            return tuple(np.array([np.atleast_1d(np.asarray(row[i], dtype=float)) for row in data]) for i in range(n))
         return np.array([np.atleast_1d(np.asarray(x, dtype=float)) for x in data])
 
 
@@ -178,6 +228,11 @@ class DataBufferAccumulator(SequenceEncodableStatisticAccumulator):
     # Contiguous batch arrays concatenated once at value() (shape-preserving) rather than one ndarray per row.
     def _append(self, enc: Any, weights: np.ndarray) -> None:
         fields = enc if isinstance(enc, tuple) else (enc,)
+        # the declared n_fields is a default, not a ceiling: a generic bridge (GradLeaf) doesn't know a bare
+        # module's arity until the first real batch arrives, so widen once, from empty, to match it.
+        if len(fields) != len(self.parts) and not any(self.parts):
+            self.parts = [[] for _ in fields]
+            self.n_fields = len(fields)
         for buf, f in zip(self.parts, fields):
             fb = np.asarray(f, dtype=float)
             buf.append(fb.reshape(fb.shape[0], 1) if fb.ndim == 1 else fb)
@@ -239,7 +294,9 @@ class GradEstimator(ParameterEstimator):
         *,
         m_steps: int = 60,
         lr: float = 5e-3,
-        device: str = "cpu",
+        device: Any = None,
+        batch_size: int | None = None,
+        precision: str = "fp32",
         name: str | None = None,
         loss: Any = None,
         optimizer: Any = None,
@@ -248,6 +305,8 @@ class GradEstimator(ParameterEstimator):
         self.m_steps = int(m_steps)
         self.lr = float(lr)
         self.device = device
+        self.batch_size = None if batch_size is None else int(batch_size)
+        self.precision = precision
         self.name = name
         self.loss = loss
         self.optimizer = optimizer
@@ -258,6 +317,8 @@ class GradEstimator(ParameterEstimator):
             m_steps=self.m_steps,
             lr=self.lr,
             device=self.device,
+            batch_size=self.batch_size,
+            precision=self.precision,
             name=self.name,
             loss=self.loss,
             optimizer=self.optimizer,
@@ -269,23 +330,37 @@ class GradEstimator(ParameterEstimator):
     def estimate(self, nobs: float | None, suff_stat: tuple) -> GradLeaf:
         torch = _torch()
         *fields, ws = suff_stat
-        xs = fields[0]
         params = [p for p in self.module.parameters() if p.requires_grad]
-        if len(xs) == 0 or not params:  # nothing to fit, or a fully frozen (fixed) module
+        if not fields or len(fields[0]) == 0 or not params:  # nothing to fit, or a fully frozen (fixed) module
             return self._leaf()
-        x = torch.as_tensor(np.asarray(xs, dtype=float), dtype=torch.float32, device=self.device)
-        w = torch.as_tensor(np.asarray(ws, dtype=float), dtype=torch.float32, device=self.device)
-        w = w / w.sum().clamp(min=1e-8)
-        self.module.to(self.device).train()
+        dev = _resolve_device(self.device, torch)
+        # data stays on CPU (mirrors softmax_leaf.py) -- each minibatch is moved to the device, so a
+        # larger-than-device-memory dataset still fits; batch_size=None keeps today's single full-batch pass.
+        xs = tuple(torch.as_tensor(np.asarray(f, dtype=float), dtype=torch.float32) for f in fields)
+        w = torch.as_tensor(np.asarray(ws, dtype=float), dtype=torch.float32)
+        w = w / w.sum().clamp(min=1e-8)  # normalized once, up front -- batch_size=None reproduces the old math exactly
+        n = xs[0].shape[0]
+        bs = self.batch_size or n
+        self.module.to(dev).train()
         opt = self.optimizer(params) if self.optimizer is not None else torch.optim.Adam(params, lr=self.lr)
-        for _ in range(self.m_steps):
-            opt.zero_grad()
-            if self.loss is not None:
-                loss = self.loss(self.module, x, w)
-            else:
-                loss = -(w * self.module.log_density(x)).sum()  # weighted negative log-likelihood
-            loss.backward()
-            opt.step()
+        autocast_dev = "cuda" if str(dev).startswith("cuda") else "cpu"
+        use_bf16 = self.precision == "bf16"
+        for _ in range(self.m_steps):  # m_steps passes over the data (full-batch when batch_size is None)
+            perm = torch.randperm(n) if bs < n else torch.arange(n)
+            for k in range(0, n, bs):
+                idx = perm[k : k + bs]
+                xb = tuple(xt[idx].to(dev) for xt in xs)
+                wb = w[idx].to(dev)
+                opt.zero_grad()
+                with torch.autocast(device_type=autocast_dev, dtype=torch.bfloat16, enabled=use_bf16):
+                    if self.loss is not None:
+                        loss = self.loss(self.module, *xb, wb)
+                    else:
+                        # tuple default: log_density(*fields) -- a single field unpacks to log_density(x),
+                        # identical to before; a conditional bare module's log_density(x, y, ...) just works.
+                        loss = -(wb * self.module.log_density(*xb)).sum()  # weighted negative log-likelihood
+                loss.backward()
+                opt.step()
         return self._leaf()
 
 

--- a/mixle/task/__init__.py
+++ b/mixle/task/__init__.py
@@ -125,6 +125,7 @@ from mixle.task.imagine import (
     ceiling_report,
     propose_structure,
 )
+from mixle.task.inverse import InverseModel, InverseReceipts, learn_inverse
 from mixle.task.irl import MaxEntIRLResult, max_ent_irl, rollout_states, state_features
 from mixle.task.llm import (
     CallableLLM,
@@ -266,6 +267,9 @@ __all__ = [
     "StructuralCandidate",
     "ceiling_report",
     "propose_structure",
+    "InverseModel",
+    "InverseReceipts",
+    "learn_inverse",
     "FieldChoice",
     "GenerativeTextIO",
     "extractive_capture_profile",

--- a/mixle/task/inverse.py
+++ b/mixle/task/inverse.py
@@ -1,0 +1,462 @@
+"""``learn_inverse`` -- amortized posteriors ``q(theta | y)`` for a simulator, with calibration receipts.
+
+Simulation-based inference done the mixle way: given a forward simulator ``g: theta -> y`` (a bare
+Python callable -- no ``mixle.task.imagine``/M2 program required) and a prior ``p(theta)`` (any
+fitted mixle ``Model``), :func:`learn_inverse` trains a torch CONDITIONAL density student
+``q(theta | y)`` on simulated ``(theta, y)`` pairs, then ships it wrapped as an
+:class:`~mixle.inference.condition.Posterior` (M0's type) so downstream ``condition``/``do``
+composition and B7 treat a learned inverse exactly like an exactly-conditioned one -- except its
+``.receipt`` carries an explicit amortization warning plus a pointer to :class:`InverseReceipts`,
+because a trained student is an APPROXIMATION and the whole point of this module is to ship the
+numbers that say whether to trust it.
+
+Convention (matches ``build_mdn``/``build_conditional_flow``'s own ``log_density(x, y)``/
+``sample_given(x)`` contract): ``theta`` -- the quantity being inferred -- is the student's
+``y``-ARGUMENT, and the observed data ``y`` is its ``x``-argument. So ``q(theta | y_obs)`` is
+``module.sample_given(y_obs) -> theta`` and its density is ``module.log_density(y_obs, theta)`` --
+the inverse of the simulator's own arrow.
+
+The student is trained through the vendored :class:`~mixle.models.grad_leaf.GradLeaf` (a bare torch
+module IS the model), not the simpler :class:`~mixle.models.mixture_density.NeuralConditionalDensity`
+adapter -- see ``notes/designs/M3.md`` for why: sequential refinement (below) re-scores the module
+against freshly generated round data before the next fit commits, which wants the generic
+``seq_log_density`` path ``GradLeaf`` gives any bare module (warm-started across ``optimize()``
+calls via the SAME underlying ``nn.Module`` object) rather than a second bespoke accumulator.
+``NeuralConditionalDensity`` remains the simpler documented alternative for callers who don't need
+round-conditioned rescoring.
+
+Algorithm (``notes/designs/M3.md``):
+
+1. **Pair generation (round 1).** ``theta_i ~ p(theta)`` via the prior's own sampler; ``y_i =
+   simulator(theta_i)`` in a plain Python loop (no batching assumed on ``simulator``).
+2. **Student.** ``build_conditional_flow``/``build_mdn`` wrapped in :class:`GradLeaf`, fit via
+   ``optimize(list(zip(y_pairs, theta_pairs)), leaf, ...)`` -- A4.4's tuple-default-loss fix is what
+   lets the bare module's two-arg ``log_density(x, y)`` score straight off tuple observations.
+3. **Sequential refinement (rounds 2..R).** Resolved decision (was open in the design note): eager,
+   via an optional ``y_obs`` keyword to THIS function. When ``y_obs`` is given, each subsequent
+   round draws ``theta ~ q(theta | y_obs)`` from the CURRENT round's student, re-runs the simulator,
+   and retrains warm-started from the previous round's module weights (same object, so ``optimize``
+   continues training it in place -- the same warm-start pattern ``GradLeaf``'s own M-step uses
+   across EM iterations). ``rounds > 1`` without ``y_obs`` has no observation to sharpen toward, so
+   it raises ``ValueError`` rather than silently doing nothing -- round 1 alone (unconditional pair
+   generation) is valid without ``y_obs``.
+4. **Optional exactness stage.** ``reweight=True`` with ``true_log_likelihood(theta, y_obs) ->
+   float`` (a LOG likelihood) treats the final round's ``q(theta | y_obs)`` as a self-normalized-
+   importance-sampling proposal: ``log w_j = log p(theta_j) + true_log_likelihood(theta_j, y_obs) -
+   log q(theta_j | y_obs)``, normalized by log-sum-exp (the same construction
+   ``mixle.inference.condition``'s SIR fallback uses), with ``ESS = 1 / sum(w_norm^2)`` reported so a
+   low ESS visibly says "don't trust this reweighted posterior" instead of silently returning a
+   degenerate one.
+5. **Calibration receipts (always computed).**
+   - **SBC.** Resolved decision (was open): a chi-square uniformity test on binned ranks (Talts et
+     al.), ``bins = min(20, n_sbc_replications // 5)`` (clamped to >= 2), one chi-square statistic
+     per ``theta`` dimension SUMMED (valid under the standard independence-across-dimensions
+     simplification -- a sum of independent chi-square variables is chi-square with summed degrees
+     of freedom), against threshold ``p-value > 0.01`` (no rejection of uniformity).
+   - **Coverage.** Per-dimension, per-replication credible interval containment vs nominal level,
+     averaged; pass when within +/-5% of nominal.
+   - **Prior-predictive.** Empirical mean/std of the round-1 simulated ``y_i``'s, plus (when
+     ``y_obs`` is given) its per-dimension z-score against that empirical distribution -- a
+     caller-facing warning, not a gate.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+from scipy.stats import chi2
+
+from mixle.inference.condition import ConditionReceipt, Posterior
+from mixle.inference.estimation import optimize
+from mixle.models.grad_leaf import GradLeaf
+
+__all__ = ["InverseModel", "InverseReceipts", "learn_inverse"]
+
+
+def _torch() -> Any:
+    import torch
+
+    return torch
+
+
+def _next_seed(rng: np.random.RandomState) -> int:
+    return int(rng.randint(0, 2**31 - 1))
+
+
+def _as_rows(arr: Any, n: int) -> np.ndarray:
+    """Normalize a sampler's ``sample(n)`` output to shape ``(n, d)``. A univariate sampler
+    (e.g. ``GaussianDistribution``) returns a flat ``(n,)`` array of scalar draws -- ``atleast_2d``
+    on that would misread it as ONE row of ``n`` dimensions instead of ``n`` rows of one dimension,
+    so a 1-D result of length ``n`` is reshaped to ``(n, 1)`` explicitly rather than via ``atleast_2d``."""
+    a = np.asarray(arr, dtype=float)
+    if a.ndim == 1:
+        return a.reshape(n, 1)
+    return a
+
+
+def _build_student(family: str, *, x_dim: int, y_dim: int, hidden: int, seed: int | None) -> Any:
+    from mixle.models.mixture_density import build_conditional_flow, build_mdn
+
+    # nn.Module weight init draws from torch's GLOBAL rng, not our own seeded RandomState -- seed it
+    # explicitly here so a given `seed=` to learn_inverse determines the student's starting weights
+    # too (determinism is a contract, rule 0.2.4), independent of whatever global torch state a
+    # caller/earlier test left behind.
+    torch = _torch()
+    torch.manual_seed(int(seed) if seed is not None else 0)
+    if family == "flow":
+        return build_conditional_flow(x_dim, y_dim, hidden=hidden)
+    if family == "mdn":
+        return build_mdn(x_dim, y_dim, hidden=hidden)
+    raise ValueError(f"family must be 'flow' or 'mdn', got {family!r}")
+
+
+def _generate_pairs(
+    prior: Any, simulator: Callable[[Any], Any], n: int, seed: int | None
+) -> tuple[np.ndarray, np.ndarray]:
+    """``n`` fresh ``(theta_i, y_i)`` pairs: ``theta_i ~ prior``, ``y_i = simulator(theta_i)`` (a plain
+    Python loop -- no batching assumption on ``simulator``)."""
+    thetas = _as_rows(prior.sampler(seed=seed).sample(int(n)), int(n))
+    ys = np.asarray([np.atleast_1d(np.asarray(simulator(theta), dtype=float)) for theta in thetas], dtype=float)
+    return thetas, ys
+
+
+def _sample_given(module: Any, x_row: np.ndarray, n: int, *, seed: int | None) -> np.ndarray:
+    """``n`` draws of ``theta ~ q(theta | x_row)`` from a fitted student ``module``."""
+    torch = _torch()
+    module.eval()
+    rng = np.random.RandomState(seed)
+    torch.manual_seed(_next_seed(rng))
+    xt = torch.as_tensor(np.tile(np.atleast_1d(np.asarray(x_row, dtype=float)), (int(n), 1)), dtype=torch.float32)
+    with torch.no_grad():
+        return module.sample_given(xt).cpu().numpy()
+
+
+def _log_density_given(module: Any, x_row: np.ndarray, theta_batch: np.ndarray) -> np.ndarray:
+    """``log q(theta | x_row)`` for every row of ``theta_batch`` (shape ``(n, theta_dim)``)."""
+    torch = _torch()
+    module.eval()
+    theta_batch = np.atleast_2d(np.asarray(theta_batch, dtype=float))
+    n = theta_batch.shape[0]
+    xt = torch.as_tensor(np.tile(np.atleast_1d(np.asarray(x_row, dtype=float)), (n, 1)), dtype=torch.float32)
+    yt = torch.as_tensor(theta_batch, dtype=torch.float32)
+    with torch.no_grad():
+        return module.log_density(xt, yt).cpu().numpy().reshape(-1)
+
+
+def _fit_round(module: Any, ys: np.ndarray, thetas: np.ndarray, *, m_steps: int, lr: float, max_its: int) -> Any:
+    """One ``optimize()`` call against ``(y, theta)`` pairs, warm-started from ``module``'s own weights
+    (same underlying ``nn.Module`` object -- ``GradEstimator.estimate`` mutates it in place)."""
+    data = list(zip(ys.tolist(), thetas.tolist()))
+    leaf = GradLeaf(module, m_steps=m_steps, lr=lr)
+    fitted = optimize(data, leaf, max_its=max_its, out=None)
+    return fitted.module
+
+
+def _posterior_sharpness(module: Any, y_obs: np.ndarray, theta_dim: int, *, n: int, seed: int | None) -> float:
+    """A scalar "how spread out is q(theta | y_obs)" receipt -- sum of per-dimension sample variance.
+    Lower is sharper; used to assert refinement rounds measurably sharpen the posterior (test (e))."""
+    samples = _sample_given(module, y_obs, n, seed=seed)
+    return float(np.sum(np.var(samples, axis=0)))
+
+
+def _calibration_receipts(
+    module: Any,
+    prior: Any,
+    simulator: Callable[[Any], Any],
+    *,
+    theta_dim: int,
+    n_replications: int,
+    n_posterior_samples: int,
+    coverage_levels: tuple[float, ...],
+    seed: int | None,
+) -> tuple[float, float, int, dict[float, float]]:
+    """SBC (chi-square on binned ranks) + per-level coverage, sharing the same replications."""
+    rng = np.random.RandomState(seed)
+    ranks = np.zeros((n_replications, theta_dim), dtype=int)
+    covered = {c: np.zeros((n_replications, theta_dim), dtype=bool) for c in coverage_levels}
+    for r in range(n_replications):
+        theta_star = np.atleast_1d(np.asarray(prior.sampler(seed=_next_seed(rng)).sample(1), dtype=float)).reshape(-1)[
+            :theta_dim
+        ]
+        y_star = np.atleast_1d(np.asarray(simulator(theta_star), dtype=float))
+        samples = _sample_given(module, y_star, n_posterior_samples, seed=_next_seed(rng))
+        for d in range(theta_dim):
+            ranks[r, d] = int(np.sum(samples[:, d] < theta_star[d]))
+            for c in coverage_levels:
+                lo_q, hi_q = (1.0 - c) / 2.0, (1.0 + c) / 2.0
+                lo, hi = np.quantile(samples[:, d], [lo_q, hi_q])
+                covered[c][r, d] = bool(lo <= theta_star[d] <= hi)
+
+    # SBC: bins = min(20, n_sbc_replications // 5), clamped to >= 2 -- the resolved binning choice
+    # (design note "Resolved" section / mixle.task.inverse docstring).
+    bins = max(2, min(20, n_replications // 5))
+    edges = np.linspace(0.0, float(n_posterior_samples), bins + 1)
+    stat_total, df_total = 0.0, 0
+    for d in range(theta_dim):
+        hist, _ = np.histogram(ranks[:, d], bins=edges)
+        expected = n_replications / bins
+        stat_total += float(np.sum((hist - expected) ** 2 / expected))
+        df_total += bins - 1
+    pvalue = float(chi2.sf(stat_total, df_total)) if df_total > 0 else 1.0
+
+    coverage_emp = {c: float(np.mean(covered[c])) for c in coverage_levels}
+    return stat_total, pvalue, bins, coverage_emp
+
+
+def _prior_predictive_receipt(ys: np.ndarray, y_obs: np.ndarray | None) -> dict[str, Any]:
+    mean = ys.mean(axis=0)
+    std = ys.std(axis=0) + 1e-12
+    report: dict[str, Any] = {"y_mean": mean.tolist(), "y_std": std.tolist(), "n": int(ys.shape[0])}
+    if y_obs is None:
+        report["y_obs_zscore"] = None
+        report["in_distribution_warning"] = None
+        return report
+    y_obs_arr = np.atleast_1d(np.asarray(y_obs, dtype=float))
+    z = (y_obs_arr - mean) / std
+    report["y_obs_zscore"] = z.tolist()
+    report["max_abs_zscore"] = float(np.max(np.abs(z)))
+    report["in_distribution_warning"] = bool(np.max(np.abs(z)) > 3.0)
+    return report
+
+
+def _reweight_receipt(
+    module: Any,
+    prior: Any,
+    true_log_likelihood: Callable[[Any, Any], float],
+    y_obs: np.ndarray,
+    *,
+    n: int,
+    seed: int | None,
+) -> tuple[float, float, list[str]]:
+    """Self-normalized importance reweighting of ``q(theta | y_obs)`` against the true likelihood
+    (same log-sum-exp construction as ``mixle.inference.condition``'s SIR fallback)."""
+    thetas = _sample_given(module, y_obs, n, seed=seed)
+    log_q = _log_density_given(module, y_obs, thetas)
+    log_prior = np.array([float(prior.log_density(theta)) for theta in thetas])
+    log_lik = np.array([float(true_log_likelihood(theta, y_obs)) for theta in thetas])
+    log_w = log_prior + log_lik - log_q
+
+    warnings: list[str] = []
+    finite = np.isfinite(log_w)
+    if not finite.any():
+        ess = 0.0
+        warnings.append("reweight: all importance weights are zero/non-finite.")
+    else:
+        m = log_w[finite].max()
+        w = np.where(finite, np.exp(log_w - m), 0.0)
+        sw = w.sum()
+        w_norm = w / sw
+        ess = float(1.0 / np.sum(w_norm**2))
+    ess_ratio = ess / n
+    if ess_ratio < 0.01:
+        warnings.append(f"reweight ESS ratio {ess_ratio:.4f} < 0.01 -- reweighted posterior is not trustworthy.")
+    return ess, ess_ratio, warnings
+
+
+@dataclass
+class InverseReceipts:
+    """The calibration report that ships with every :class:`InverseModel` -- tells the caller
+    whether to trust ``q(theta | y)``, not just a point estimate."""
+
+    sbc_statistic: float
+    sbc_pvalue: float
+    sbc_bins: int
+    sbc_replications: int
+    sbc_pass: bool  # p-value > 0.01 (resolved acceptance threshold -- see module docstring)
+    coverage: dict[float, float]  # nominal level -> empirical coverage
+    coverage_pass: dict[float, bool]  # within +/-5% of nominal
+    prior_predictive: dict[str, Any]
+    rounds_trained: int
+    sharpness_by_round: list[float] = field(default_factory=list)
+    ess: float | None = None
+    ess_ratio: float | None = None
+    warnings: list[str] = field(default_factory=list)
+
+
+class InverseModel:
+    """A fitted amortized posterior ``q(theta | y)`` plus its :class:`InverseReceipts`."""
+
+    def __init__(
+        self,
+        *,
+        module: Any,
+        prior: Any,
+        simulator: Callable[[Any], Any],
+        family: str,
+        theta_dim: int,
+        y_dim: int,
+        receipts: InverseReceipts,
+        seed: int | None = None,
+    ) -> None:
+        self.module = module
+        self.prior = prior
+        self.simulator = simulator
+        self.family = family
+        self.theta_dim = theta_dim
+        self.y_dim = y_dim
+        self.receipts = receipts
+        self._seed = seed
+
+    def posterior(self, y: Any) -> Posterior:
+        """Wrap ``q(theta | y)`` as an M0 :class:`~mixle.inference.condition.Posterior`: ``sample(n)``
+        / ``log_density(theta)`` / ``mean(field)`` / ``.receipt`` -- so downstream condition/do
+        composition treats a learned inverse like an exactly-conditioned one, modulo the amortization
+        warning on ``.receipt`` and the ``InverseReceipts`` pointer at ``.receipt.inverse_receipts``."""
+        y_row = np.atleast_1d(np.asarray(y, dtype=float))
+        module = self.module
+        base_seed = self._seed
+
+        def sample_fn(n: int, s: int | None) -> np.ndarray:
+            return _sample_given(module, y_row, n, seed=s if s is not None else base_seed)
+
+        def log_density_fn(theta: Any) -> float:
+            theta_row = np.atleast_2d(np.asarray(theta, dtype=float))
+            return float(_log_density_given(module, y_row, theta_row)[0])
+
+        def mean_fn(path: tuple[int, ...]) -> float:
+            idx = int(path[0]) if len(path) else 0
+            samples = _sample_given(module, y_row, 500, seed=base_seed)
+            return float(np.mean(samples[:, idx]))
+
+        receipt = ConditionReceipt(
+            method="amortized",
+            warnings=[
+                "InverseModel.posterior: a LEARNED amortized approximation "
+                "(mixle.task.inverse.learn_inverse), not exact conditioning -- see "
+                ".receipt.inverse_receipts (SBC/coverage/prior-predictive/ESS) before trusting it."
+            ],
+        )
+        receipt.inverse_receipts = self.receipts  # pointer to the full calibration report (not an M0 field)
+        return Posterior(
+            sample_fn=sample_fn, log_density_fn=log_density_fn, mean_fn=mean_fn, receipt=receipt, model=None
+        )
+
+
+def learn_inverse(
+    simulator: Callable[[Any], Any],
+    prior: Any,
+    *,
+    family: str = "flow",
+    n_sims: int = 2000,
+    rounds: int = 1,
+    n_sbc_replications: int = 200,
+    coverage_levels: tuple[float, ...] = (0.5, 0.9),
+    reweight: bool = False,
+    true_log_likelihood: Callable[[Any, Any], float] | None = None,
+    y_obs: Any = None,
+    seed: int | None = None,
+    m_steps: int = 200,
+    lr: float = 5e-3,
+    max_its: int = 1,
+    hidden: int = 32,
+    n_posterior_samples: int = 200,
+    n_reweight_samples: int = 500,
+) -> InverseModel:
+    """Learn an amortized posterior ``q(theta | y)`` for simulator ``g: theta -> y`` under prior
+    ``p(theta)``. See the module docstring for the full algorithm and the calibration receipts
+    computed unconditionally.
+
+    ``family="flow"`` (``build_conditional_flow``) requires ``theta`` (the quantity being inferred,
+    the student's ``y``-argument) to be >= 2-dimensional -- ``build_conditional_flow`` needs
+    ``y_dim >= 2`` for its coupling layers to be non-trivial (see its own docstring). A 1-D ``theta``
+    (e.g. a scalar-parameter inverse problem) must use ``family="mdn"``, which has no such
+    restriction (a mixture of per-component Gaussians is well-defined for scalar ``theta`` too, and
+    is the more direct fit for asserting multimodality component-by-component).
+
+    ``rounds > 1`` (SNPE-style sequential refinement toward a SPECIFIC observation) requires
+    ``y_obs``: round 1 alone (unconditional pair generation) is the only round that has meaning
+    without an observation to sharpen against.
+    """
+    if family not in ("flow", "mdn"):
+        raise ValueError(f"family must be 'flow' or 'mdn', got {family!r}")
+    if int(rounds) < 1:
+        raise ValueError("rounds must be >= 1")
+    if int(rounds) > 1 and y_obs is None:
+        raise ValueError(
+            "learn_inverse(rounds > 1) requires y_obs: rounds 2..R perform SNPE-style refinement "
+            "toward a SPECIFIC observation (draw theta ~ q(theta | y_obs) from the current round's "
+            "student, re-run the simulator, retrain warm-started) -- with no y_obs there is nothing "
+            "to refine toward, so rounds > 1 is meaningless. Round 1 alone (unconditional pair "
+            "generation) is valid without y_obs; pass y_obs=... for rounds > 1."
+        )
+    if reweight and true_log_likelihood is None:
+        raise ValueError("reweight=True requires true_log_likelihood(theta, y_obs) -> float (a LOG likelihood).")
+
+    rng = np.random.RandomState(seed)
+    y_obs_arr = None if y_obs is None else np.atleast_1d(np.asarray(y_obs, dtype=float))
+
+    # round 1: unconditional pair generation
+    thetas, ys = _generate_pairs(prior, simulator, n_sims, _next_seed(rng))
+    theta_dim = thetas.shape[1]
+    y_dim = ys.shape[1]
+
+    if family == "flow" and theta_dim < 2:
+        raise ValueError(
+            f"family='flow' requires theta (the quantity being inferred, the student's y-argument) "
+            f">= 2-dimensional -- build_conditional_flow needs y_dim >= 2 for its coupling layers to "
+            f"be non-trivial (see its docstring). Got theta_dim={theta_dim}; use family='mdn' instead."
+        )
+
+    module = _build_student(family, x_dim=y_dim, y_dim=theta_dim, hidden=hidden, seed=_next_seed(rng))
+    module = _fit_round(module, ys, thetas, m_steps=m_steps, lr=lr, max_its=max_its)
+
+    sharpness_by_round: list[float] = []
+    if y_obs_arr is not None:
+        sharpness_by_round.append(_posterior_sharpness(module, y_obs_arr, theta_dim, n=500, seed=_next_seed(rng)))
+
+    for _r in range(2, int(rounds) + 1):
+        theta_round = _sample_given(module, y_obs_arr, n_sims, seed=_next_seed(rng))
+        y_round = np.asarray([np.atleast_1d(np.asarray(simulator(t), dtype=float)) for t in theta_round], dtype=float)
+        module = _fit_round(module, y_round, theta_round, m_steps=m_steps, lr=lr, max_its=max_its)
+        sharpness_by_round.append(_posterior_sharpness(module, y_obs_arr, theta_dim, n=500, seed=_next_seed(rng)))
+
+    sbc_stat, sbc_pvalue, sbc_bins, coverage_emp = _calibration_receipts(
+        module,
+        prior,
+        simulator,
+        theta_dim=theta_dim,
+        n_replications=n_sbc_replications,
+        n_posterior_samples=n_posterior_samples,
+        coverage_levels=coverage_levels,
+        seed=_next_seed(rng),
+    )
+    coverage_pass = {c: bool(abs(coverage_emp[c] - c) <= 0.05) for c in coverage_levels}
+    prior_pred = _prior_predictive_receipt(ys, y_obs_arr)
+
+    ess = ess_ratio = None
+    reweight_warnings: list[str] = []
+    if reweight:
+        assert true_log_likelihood is not None  # narrowed by the guard above
+        ess, ess_ratio, reweight_warnings = _reweight_receipt(
+            module, prior, true_log_likelihood, y_obs_arr, n=n_reweight_samples, seed=_next_seed(rng)
+        )
+
+    receipts = InverseReceipts(
+        sbc_statistic=sbc_stat,
+        sbc_pvalue=sbc_pvalue,
+        sbc_bins=sbc_bins,
+        sbc_replications=int(n_sbc_replications),
+        sbc_pass=bool(sbc_pvalue > 0.01),
+        coverage=coverage_emp,
+        coverage_pass=coverage_pass,
+        prior_predictive=prior_pred,
+        rounds_trained=int(rounds),
+        sharpness_by_round=sharpness_by_round,
+        ess=ess,
+        ess_ratio=ess_ratio,
+        warnings=reweight_warnings,
+    )
+
+    return InverseModel(
+        module=module,
+        prior=prior,
+        simulator=simulator,
+        family=family,
+        theta_dim=theta_dim,
+        y_dim=y_dim,
+        receipts=receipts,
+        seed=seed,
+    )

--- a/mixle/tests/condition_test.py
+++ b/mixle/tests/condition_test.py
@@ -1,0 +1,248 @@
+"""condition()/do(): the generic conditioning + intervention engine (M0).
+
+Acceptance receipts, one per test:
+  (a) linear-Gaussian composite: conditional mean/cov match the analytic Schur-complement formula
+      (computed independently of MultivariateGaussianDistribution.condition) to 1e-8.
+  (b) mixture: component reweighting matches Bayes computed by hand on a 2-component fixture.
+  (c) HMM: clamped-emission posterior matches forward-backward computed independently.
+  (d) SIR fallback matches a brute-force grid posterior within MC error, and its ESS receipt drops
+      under extreme evidence.
+  (e) do() vs condition() differ per the backdoor formula on a 3-node confounded BN fixture.
+  (f) determinism given seed.
+"""
+
+import numpy as np
+from scipy.stats import norm
+
+from mixle.inference.bayesian_network import HeterogeneousBayesianNetwork, _LinearGaussianFactor, _MarginalFactor
+from mixle.inference.condition import ConditionReceipt, condition, do
+from mixle.inference.structure import DependencyTreeDistribution
+from mixle.stats import (
+    CategoricalDistribution,
+    ConditionalDistribution,
+    GaussianDistribution,
+    HiddenMarkovModelDistribution,
+    MixtureDistribution,
+    MultivariateGaussianDistribution,
+)
+from mixle.stats.compute.posterior import MarkovChainLatentPosterior
+
+# --------------------------------------------------------------------------------------------- #
+# (a) linear-Gaussian composite -- analytic Schur complement to 1e-8
+# --------------------------------------------------------------------------------------------- #
+
+
+def test_gaussian_conditional_matches_schur_complement_analytically():
+    rng = np.random.RandomState(42)
+    ell = rng.normal(size=(3, 3))
+    cov = ell @ ell.T + 3.0 * np.eye(3)  # PD by construction
+    mu = np.array([1.0, -2.0, 0.5])
+    model = MultivariateGaussianDistribution(mu, cov)
+
+    observed = {0: 2.0, 2: -0.3}
+    post = condition(model, observed, method="exact")
+    assert post.receipt.method == "exact"
+
+    # Independent re-derivation of the Schur complement (not calling model.condition()).
+    obs_idx = [0, 2]
+    unobs_idx = [1]
+    x_o = np.array([2.0, -0.3])
+    s_oo = cov[np.ix_(obs_idx, obs_idx)]
+    s_uo = cov[np.ix_(unobs_idx, obs_idx)]
+    s_uu = cov[np.ix_(unobs_idx, unobs_idx)]
+    mu_cond = mu[unobs_idx] + s_uo @ np.linalg.solve(s_oo, x_o - mu[obs_idx])
+    cov_cond = s_uu - s_uo @ np.linalg.solve(s_oo, s_uo.T)
+
+    assert abs(post.mean(1) - mu_cond[0]) < 1e-8
+    assert abs(float(post.model.covar[0, 0]) - cov_cond[0, 0]) < 1e-8
+
+
+# --------------------------------------------------------------------------------------------- #
+# (b) mixture reweighting -- Bayes by hand on a 2-component fixture
+# --------------------------------------------------------------------------------------------- #
+
+
+def test_mixture_conditional_reweighting_matches_bayes_by_hand():
+    cov1 = np.array([[1.0, 0.5], [0.5, 1.0]])
+    cov2 = np.array([[1.0, -0.3], [-0.3, 1.0]])
+    mu1 = np.array([0.0, 0.0])
+    mu2 = np.array([3.0, 3.0])
+    comp1 = MultivariateGaussianDistribution(mu1, cov1)
+    comp2 = MultivariateGaussianDistribution(mu2, cov2)
+    mix = MixtureDistribution([comp1, comp2], [0.4, 0.6])
+
+    x_o = 1.0
+    post = condition(mix, {0: x_o}, method="exact")
+    assert post.receipt.method == "exact"
+
+    # Bayes by hand: w'_k propto w_k * N(x_o; mu_k[0], cov_k[0,0]).
+    log_lik = np.array(
+        [
+            norm.logpdf(x_o, loc=mu1[0], scale=np.sqrt(cov1[0, 0])),
+            norm.logpdf(x_o, loc=mu2[0], scale=np.sqrt(cov2[0, 0])),
+        ]
+    )
+    log_w = np.log([0.4, 0.6]) + log_lik
+    log_w -= np.max(log_w)
+    w = np.exp(log_w)
+    w /= w.sum()
+    np.testing.assert_allclose(post.model.w, w, atol=1e-10)
+
+    # Per-component conditional mean/var of dim 1 given dim 0 = x_o, standard 1-D Gaussian conditional.
+    for k, (mu_k, cov_k) in enumerate([(mu1, cov1), (mu2, cov2)]):
+        rho = cov_k[0, 1] / cov_k[0, 0]
+        mean_want = mu_k[1] + rho * (x_o - mu_k[0])
+        var_want = cov_k[1, 1] - cov_k[0, 1] ** 2 / cov_k[0, 0]
+        assert abs(float(post.model.components[k].mu[0]) - mean_want) < 1e-8
+        assert abs(float(post.model.components[k].covar[0, 0]) - var_want) < 1e-8
+
+    mean_want_total = sum(
+        w[k] * (mu[1] + cov[0, 1] / cov[0, 0] * (x_o - mu[0])) for k, (mu, cov) in enumerate([(mu1, cov1), (mu2, cov2)])
+    )
+    assert abs(post.mean(1) - mean_want_total) < 1e-8
+
+
+# --------------------------------------------------------------------------------------------- #
+# (c) HMM clamped-emission posterior -- forward-backward, independently re-derived
+# --------------------------------------------------------------------------------------------- #
+
+
+def _hmm_fixture():
+    return HiddenMarkovModelDistribution(
+        [GaussianDistribution(-2.0, 1.0), GaussianDistribution(2.0, 1.0), GaussianDistribution(6.0, 1.0)],
+        [0.5, 0.3, 0.2],
+        [[0.7, 0.2, 0.1], [0.1, 0.8, 0.1], [0.2, 0.2, 0.6]],
+    )
+
+
+def test_hmm_clamped_emission_posterior_matches_forward_backward():
+    hmm = _hmm_fixture()
+    evidence = {0: -1.8, 3: 5.9}  # positions 1, 2 are unobserved
+    post = condition(hmm, evidence, method="exact")
+    assert post.receipt.method == "exact"
+
+    # Independent re-derivation: build the partial log_b matrix and forward-backward it directly.
+    log_b = np.zeros((4, 3))
+    for t, val in evidence.items():
+        for k, topic in enumerate(hmm.topics):
+            log_b[t, k] = topic.log_density(val)
+    q = MarkovChainLatentPosterior(hmm.log_w, hmm.log_transitions, log_b)
+    want_marginals = q.marginals()
+
+    np.testing.assert_allclose(post.state_marginals, want_marginals, atol=1e-10)
+
+    means = np.array([-2.0, 2.0, 6.0])
+    for t in (1, 2):
+        want_mean = float(np.sum(want_marginals[t] * means))
+        assert abs(post.mean(t) - want_mean) < 1e-8
+
+
+# --------------------------------------------------------------------------------------------- #
+# (d) SIR fallback vs brute-force grid posterior + ESS receipt drop
+# --------------------------------------------------------------------------------------------- #
+
+
+def _dependency_tree_fixture():
+    z_probs = {0: 0.1, 1: 0.2, 2: 0.4, 3: 0.2, 4: 0.1}
+    z_dist = CategoricalDistribution(z_probs)
+    x_given_z = ConditionalDistribution({k: GaussianDistribution(float(k), 0.5) for k in z_probs})
+    tree = DependencyTreeDistribution([None, 0], [z_dist, x_given_z])
+    return tree, z_probs
+
+
+def _grid_posterior_mean(z_probs, obs, sigma=0.5):
+    log_w = np.array([np.log(z_probs[k]) + norm.logpdf(obs, loc=float(k), scale=sigma) for k in sorted(z_probs)])
+    log_w -= np.max(log_w)
+    w = np.exp(log_w)
+    w /= w.sum()
+    return float(np.sum(w * np.array(sorted(z_probs))))
+
+
+def test_sir_fallback_matches_brute_force_grid_posterior():
+    tree, z_probs = _dependency_tree_fixture()
+    obs = 2.0  # near the prior mode -- well-behaved evidence
+    post = condition(tree, {1: obs}, method="sir", n_particles=20000, seed=0)
+    assert post.receipt.method == "sir"
+
+    want_mean = _grid_posterior_mean(z_probs, obs)
+    assert abs(post.mean(0) - want_mean) < 0.05  # within Monte-Carlo error at this ESS
+
+
+def test_sir_ess_receipt_drops_under_extreme_evidence():
+    # The 5-category tree fixture plateaus at ESS ratio ~= the rarest category's prior (~0.1) no
+    # matter how far out the evidence sits (the discrete support caps how "surprised" the weights can
+    # get); the continuous confounded-BN fixture below has no such floor -- evidence far in the tail
+    # of X's marginal drives the weights (and hence the ESS) arbitrarily low, which is the realistic
+    # "near-impossible evidence" case the receipt exists to flag.
+    tree, _ = _dependency_tree_fixture()
+    typical = condition(tree, {1: 2.0}, method="sir", n_particles=20000, seed=1)
+    mild_extreme = condition(tree, {1: 10.0}, method="sir", n_particles=20000, seed=1)
+    assert isinstance(typical.receipt, ConditionReceipt)
+    assert mild_extreme.receipt.ess_ratio < typical.receipt.ess_ratio
+    assert mild_extreme.receipt.ess_ratio < 0.5 * typical.receipt.ess_ratio  # a real, not marginal, drop
+
+    net, *_ = _confounded_bn()
+    typical_bn = condition(net, {1: 2.0}, method="sir", n_particles=20000, seed=1)
+    extreme_bn = condition(net, {1: 60.0}, method="sir", n_particles=20000, seed=1)
+    assert extreme_bn.receipt.ess_ratio < typical_bn.receipt.ess_ratio
+    assert any("ESS ratio" in w for w in extreme_bn.receipt.warnings)
+    assert not any("ESS ratio" in w for w in typical_bn.receipt.warnings)
+
+
+# --------------------------------------------------------------------------------------------- #
+# (e) do() vs condition() -- backdoor formula on a 3-node confounded BN
+# --------------------------------------------------------------------------------------------- #
+
+
+def _confounded_bn():
+    # Z -> X, Z -> Y  (Z confounds X and Y; no direct X -> Y edge).
+    a, b, sigma_x, sigma_y = 2.0, 3.0, 0.5, 0.5
+    f_z = _MarginalFactor(0, GaussianDistribution(0.0, 1.0))
+    f_x = _LinearGaussianFactor(1, [0], {}, np.array([a, 0.0]), sigma_x)
+    f_y = _LinearGaussianFactor(2, [0], {}, np.array([b, 0.0]), sigma_y)
+    return HeterogeneousBayesianNetwork([f_z, f_x, f_y]), a, b, sigma_x
+
+
+def test_do_vs_condition_differ_per_backdoor_formula():
+    net, a, b, sigma_x = _confounded_bn()
+    x0 = 2.0
+
+    cond_post = condition(net, {1: x0}, method="sir", n_particles=30000, seed=0)
+    e_y_given_x = cond_post.mean(2)
+
+    world = do(net, {1: x0})
+    e_y_do_x = world.expectation(2, n=30000, seed=0)
+
+    # Closed form: E[Y | X=x] = a*b*x / (a^2 + sigma_x^2)  (jointly Gaussian (Z,X,Y)).
+    want_condition = a * b * x0 / (a**2 + sigma_x**2)
+    # E[Y | do(X=x)] = b * E[Z] = 0, since there is no X -> Y edge (backdoor-adjustment closed form:
+    # sum_z P(z) E[Y | X=x, Z=z] = integral P(z) * b*z dz = b*E[Z]).
+    want_do = 0.0
+
+    assert abs(e_y_given_x - want_condition) < 0.15
+    assert abs(e_y_do_x - want_do) < 0.15
+    assert abs(e_y_given_x - e_y_do_x) > 1.5  # the backdoor path makes these clearly different
+
+
+# --------------------------------------------------------------------------------------------- #
+# (f) determinism given seed
+# --------------------------------------------------------------------------------------------- #
+
+
+def test_sir_posterior_is_deterministic_given_seed():
+    tree, _ = _dependency_tree_fixture()
+    p1 = condition(tree, {1: 2.0}, method="sir", n_particles=2000, seed=7)
+    p2 = condition(tree, {1: 2.0}, method="sir", n_particles=2000, seed=7)
+
+    assert p1.receipt.ess == p2.receipt.ess
+    s1 = p1.sample(10, seed=3)
+    s2 = p2.sample(10, seed=3)
+    assert s1 == s2
+
+
+def test_do_sampling_is_deterministic_given_seed():
+    net, *_ = _confounded_bn()
+    world = do(net, {1: 2.0})
+    r1 = world.sample(20, seed=5)
+    r2 = world.sample(20, seed=5)
+    assert r1 == r2

--- a/mixle/tests/grad_leaf_test.py
+++ b/mixle/tests/grad_leaf_test.py
@@ -151,5 +151,108 @@ class ControlStoryTest(unittest.TestCase):
         self.assertAlmostEqual(float(fitted.module.mu.detach()[0]), 2.0, delta=0.5)
 
 
+class DeviceResolutionTest(unittest.TestCase):
+    """A4 upgrade #2: ``device`` defaults to ``None`` and resolves explicit > active engine > CUDA-if-
+    available > cpu -- the same priority as ``neural_leaf.NeuralGaussian``, reused rather than reinvented."""
+
+    def test_explicit_then_active_engine_then_implicit_default(self):
+        from mixle.engines.base import using_active_engine
+        from mixle.models.grad_leaf import _resolve_device
+
+        self.assertEqual(_resolve_device("cpu", torch), torch.device("cpu"))  # explicit always wins
+
+        class _Eng:
+            device = "meta"  # a device valid on any host, so the test needs no GPU
+
+        with using_active_engine(_Eng()):
+            self.assertEqual(_resolve_device(None, torch), torch.device("meta"))
+
+        # outside a fit there is no active engine, so the implicit CUDA-if-available/cpu default applies
+        self.assertNotEqual(str(_resolve_device(None, torch)), "meta")
+
+    def test_grad_leaf_device_defaults_to_none_and_still_fits_on_cpu(self):
+        # the constructor default changed from the hardcoded "cpu" to None -- unchanged observable
+        # behavior off an active engine and off CUDA (this sandbox has neither).
+        fitted = optimize(_data(1.0, 1.0, 100, seed=20), DiagGauss(1), max_its=5, out=None)
+        self.assertIsNone(GradLeaf(DiagGauss(1)).device)
+        self.assertTrue(np.isfinite(fitted.log_density(1.0)))
+
+
+class MinibatchTest(unittest.TestCase):
+    """A4 upgrade #1: ``batch_size=None`` (default) is full-batch, unchanged; an explicit ``batch_size``
+    trains on minibatches within each M-step -- needed for a dataset that won't fit in one batch."""
+
+    def test_batch_size_none_is_bitwise_unchanged(self):
+        data = _data(1.5, 1.0, 200, seed=9)
+        m1, m2 = DiagGauss(1), DiagGauss(1)
+        m2.load_state_dict(m1.state_dict())
+        a = optimize(data, GradLeaf(m1), max_its=3, out=None)
+        b = optimize(data, GradLeaf(m2, batch_size=None), max_its=3, out=None)
+        np.testing.assert_array_equal(
+            a.seq_log_density(np.asarray(data)[:, None]), b.seq_log_density(np.asarray(data)[:, None])
+        )
+
+    def test_minibatch_reaches_the_same_optimum_as_full_batch(self):
+        # a convex fixture (diagonal Gaussian in its own parameters) has one optimum -- minibatch SGD
+        # should reach essentially the same place as full-batch, just via a noisier path.
+        data = _data(3.0, 0.75, 2000, seed=10)
+        full = optimize(data, GradLeaf(DiagGauss(1), m_steps=150, lr=0.02), max_its=1, out=None)
+        mini = optimize(data, GradLeaf(DiagGauss(1), m_steps=150, lr=0.02, batch_size=64), max_its=1, out=None)
+        self.assertAlmostEqual(float(full.module.mu.detach()[0]), float(mini.module.mu.detach()[0]), delta=0.15)
+        self.assertAlmostEqual(
+            float(full.module.log_sigma.detach()[0]), float(mini.module.log_sigma.detach()[0]), delta=0.15
+        )
+
+    def test_minibatch_handles_a_dataset_larger_than_a_single_batch_many_times_over(self):
+        # batch_size far smaller than n (simulating a dataset that would not fit in one memory-budgeted
+        # batch): must still run to completion and land near the true mean.
+        data = _data(-2.0, 1.0, 5000, seed=11)
+        fitted = optimize(data, GradLeaf(DiagGauss(1), m_steps=40, lr=0.05, batch_size=32), max_its=1, out=None)
+        self.assertAlmostEqual(float(fitted.module.mu.detach()[0]), -2.0, delta=0.25)
+
+
+class TupleDefaultLossTest(unittest.TestCase):
+    """A4 upgrade #4: the default M-step objective is ``module.log_density(*fields)`` -- a single-field
+    (unconditional) module is unaffected (``*fields`` unpacks to the one positional arg it always got);
+    a CONDITIONAL bare module (``log_density(x, y)``) now just works off tuple observations, no hook."""
+
+    def test_single_field_default_loss_is_unchanged(self):
+        # covered bitwise by BareModuleTest above, but pin it explicitly here too: fields[0]-only and
+        # log_density(*fields) with one field are the exact same call.
+        data = _data(0.5, 1.0, 150, seed=12)
+        m1, m2 = DiagGauss(1), DiagGauss(1)
+        m2.load_state_dict(m1.state_dict())
+        a = optimize(data, GradLeaf(m1), max_its=3, out=None)
+        b = optimize(data, GradLeaf(m2), max_its=3, out=None)
+        self.assertEqual(float(a.module.mu.detach()[0]), float(b.module.mu.detach()[0]))
+
+    def test_conditional_bare_module_fits_via_tuple_default_loss(self):
+        class CondGauss(torch.nn.Module):
+            """p(y | x) = N(y; w*x + b, sigma^2) -- a conditional density with a two-arg log_density,
+            no different from any other bare module the bridge accepts."""
+
+            def __init__(self):
+                super().__init__()
+                self.w = torch.nn.Parameter(torch.zeros(1))
+                self.b = torch.nn.Parameter(torch.zeros(1))
+                self.log_sigma = torch.nn.Parameter(torch.zeros(1))
+
+            def log_density(self, x, y):
+                mean = x * self.w + self.b
+                return torch.distributions.Normal(mean, torch.exp(self.log_sigma)).log_prob(y).sum(-1)
+
+        rng = np.random.RandomState(13)
+        x = rng.normal(0.0, 1.0, 400)
+        y = 2.0 * x + 1.0 + rng.normal(0.0, 0.1, 400)
+        data = [(float(xi), float(yi)) for xi, yi in zip(x, y)]
+
+        module = CondGauss()
+        fitted = optimize(data, GradLeaf(module, m_steps=300, lr=0.05), max_its=1, out=None)
+
+        self.assertIsInstance(fitted, GradLeaf)
+        self.assertAlmostEqual(float(fitted.module.w.detach()[0]), 2.0, delta=0.2)
+        self.assertAlmostEqual(float(fitted.module.b.detach()[0]), 1.0, delta=0.2)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/mixle/tests/inverse_test.py
+++ b/mixle/tests/inverse_test.py
@@ -1,0 +1,233 @@
+"""``learn_inverse``: amortized posteriors ``q(theta | y)`` for a simulator, with calibration receipts (M3).
+
+Acceptance receipts, one per test:
+  (a) linear-Gaussian inverse matches the analytic (precision-weighted) posterior mean/cov.
+  (b) bimodal toy (``y = theta^2 + noise``) -- the learned posterior captures BOTH modes, asserted
+      via the repo's existing merged-regime detector (``mixle.inference.structure._split_separation``).
+  (c) SBC ranks uniform within finite-sample bounds (200 replications): chi-square p-value > 0.01.
+  (d) coverage within +/-5% of nominal at 50%/90%.
+  (e) sequential refinement rounds measurably sharpen the posterior at the observed y (round-1
+      deliberately under-trained so refinement has visible room to help).
+
+Also covers the two API guards the design note's "resolved" section pins: rounds > 1 without
+``y_obs`` raises ``ValueError``, and ``family="flow"`` with 1-D ``theta`` raises ``ValueError``
+(``build_conditional_flow`` needs ``y_dim >= 2``; ``theta`` IS the student's ``y``-argument).
+"""
+
+import numpy as np
+import pytest
+
+# _split_separation is private (mixle.inference.structure, leading underscore) -- imported directly
+# here rather than made public, matching the precedent mixle/tests/torch_parity_test.py already sets
+# for a test reaching into another module's internals (see notes/designs/M3.md, "Resolved").
+from mixle.inference.structure import _split_separation
+from mixle.stats.multivariate.diagonal_gaussian import DiagonalGaussianDistribution
+from mixle.stats.univariate.continuous.gaussian import GaussianDistribution
+from mixle.task.inverse import learn_inverse
+
+torch = pytest.importorskip("torch")
+
+
+# --------------------------------------------------------------------------------------------- #
+# (a) linear-Gaussian -- matches the analytic precision-weighted posterior
+# --------------------------------------------------------------------------------------------- #
+
+
+def test_linear_gaussian_inverse_matches_analytic_posterior():
+    rng = np.random.RandomState(0)
+    mu0 = np.array([0.0, 0.0])
+    var0 = np.array([4.0, 4.0])
+    var_obs = 0.25
+    prior = DiagonalGaussianDistribution(mu=mu0, covar=var0)
+
+    def simulator(theta):
+        return np.asarray(theta, dtype=float) + rng.normal(0.0, np.sqrt(var_obs), size=2)
+
+    model = learn_inverse(simulator, prior, family="flow", n_sims=3000, m_steps=300, seed=0, n_sbc_replications=20)
+
+    for y_obs in (np.array([1.0, -1.0]), np.array([-2.0, 0.5])):
+        post = model.posterior(y_obs)
+        samples = post.sample(3000, seed=1)
+
+        prec0 = 1.0 / var0
+        prec_lik = 1.0 / var_obs
+        prec_post = prec0 + prec_lik
+        var_post = 1.0 / prec_post
+        mean_post = var_post * (prec0 * mu0 + prec_lik * y_obs)
+
+        assert np.max(np.abs(samples.mean(axis=0) - mean_post)) < 0.15
+        assert np.max(np.abs(samples.var(axis=0) - var_post)) < 0.15
+
+    assert post.receipt.method == "amortized"
+    assert post.receipt.inverse_receipts is model.receipts
+
+
+# --------------------------------------------------------------------------------------------- #
+# (b) bimodal toy -- both modes captured, asserted via the existing merged-regime detector
+# --------------------------------------------------------------------------------------------- #
+
+
+def test_bimodal_posterior_captures_both_modes():
+    rng = np.random.RandomState(1)
+    prior = GaussianDistribution(mu=0.0, sigma2=4.0)  # theta scalar -> family="mdn" (flow needs y_dim >= 2)
+
+    def simulator(theta):
+        theta = float(np.asarray(theta).reshape(-1)[0])
+        return np.array([theta**2 + rng.normal(0.0, 0.1)])
+
+    model = learn_inverse(simulator, prior, family="mdn", n_sims=3000, m_steps=300, seed=1, n_sbc_replications=20)
+
+    y_obs = np.array([4.0])  # two roots: theta = +2, -2
+    post = model.posterior(y_obs)
+    samples = post.sample(2000, seed=2)
+
+    sep, minority_share = _split_separation(samples[:, 0])
+    threshold = 2.65 + 6.0 / np.sqrt(len(samples))  # same calibrated finite-sample threshold as
+    # mixle.utils.hvis.topology.model_fit_health / mixture_structure_health
+    assert sep > threshold
+    assert minority_share >= 0.20
+
+
+def test_family_flow_requires_theta_at_least_2d():
+    prior = GaussianDistribution(mu=0.0, sigma2=1.0)
+
+    def simulator(theta):
+        return np.array([float(np.asarray(theta).reshape(-1)[0]) ** 2])
+
+    with pytest.raises(ValueError, match="2-dimensional"):
+        learn_inverse(simulator, prior, family="flow", n_sims=50, seed=0)
+
+
+# --------------------------------------------------------------------------------------------- #
+# (c) SBC + (d) coverage -- computed together (they share replications inside learn_inverse)
+# --------------------------------------------------------------------------------------------- #
+
+
+def test_sbc_uniform_and_coverage_within_tolerance():
+    rng = np.random.RandomState(0)
+    mu0 = np.array([0.0, 0.0])
+    var0 = np.array([4.0, 4.0])
+    var_obs = 0.25
+    prior = DiagonalGaussianDistribution(mu=mu0, covar=var0)
+
+    def simulator(theta):
+        return np.asarray(theta, dtype=float) + rng.normal(0.0, np.sqrt(var_obs), size=2)
+
+    model = learn_inverse(
+        simulator,
+        prior,
+        family="flow",
+        n_sims=3000,
+        m_steps=300,
+        seed=0,
+        n_sbc_replications=200,
+        coverage_levels=(0.5, 0.9),
+        n_posterior_samples=300,
+    )
+    r = model.receipts
+
+    # (c) SBC: chi-square uniformity test on binned ranks (Talts et al.), bins = min(20, n // 5),
+    # p-value > 0.01 -- the resolved acceptance threshold (design note "Resolved" / module docstring).
+    assert r.sbc_bins == min(20, 200 // 5)
+    assert r.sbc_pvalue > 0.01
+    assert r.sbc_pass is True
+
+    # (d) coverage within +/-5% of nominal at both levels, independently.
+    assert abs(r.coverage[0.5] - 0.5) <= 0.05
+    assert abs(r.coverage[0.9] - 0.9) <= 0.05
+    assert r.coverage_pass[0.5] is True
+    assert r.coverage_pass[0.9] is True
+
+
+def test_rounds_greater_than_one_without_y_obs_raises():
+    prior = GaussianDistribution(mu=0.0, sigma2=1.0)
+
+    def simulator(theta):
+        return np.array([float(np.asarray(theta).reshape(-1)[0]) ** 2])
+
+    with pytest.raises(ValueError, match="rounds > 1"):
+        learn_inverse(simulator, prior, family="mdn", n_sims=50, rounds=2, seed=0)
+
+
+# --------------------------------------------------------------------------------------------- #
+# (e) sequential refinement measurably sharpens the posterior at the observed y
+# --------------------------------------------------------------------------------------------- #
+
+
+def test_sequential_refinement_sharpens_posterior_at_observed_y():
+    rng = np.random.RandomState(0)
+    mu0 = np.array([0.0, 0.0])
+    var0 = np.array([9.0, 9.0])
+    var_obs = 0.25
+    prior = DiagonalGaussianDistribution(mu=mu0, covar=var0)
+
+    def simulator(theta):
+        return np.asarray(theta, dtype=float) + rng.normal(0.0, np.sqrt(var_obs), size=2)
+
+    y_obs = np.array([2.0, -2.0])
+    # round 1 deliberately under-trained (few n_sims/m_steps) so refinement has visible room to help.
+    model = learn_inverse(
+        simulator,
+        prior,
+        family="flow",
+        n_sims=60,
+        m_steps=100,
+        rounds=3,
+        y_obs=y_obs,
+        seed=0,
+        n_sbc_replications=20,
+    )
+    sharpness = model.receipts.sharpness_by_round
+    assert len(sharpness) == 3
+    assert sharpness[1] < sharpness[0]
+    assert sharpness[2] < sharpness[1]
+    assert model.receipts.rounds_trained == 3
+
+
+# --------------------------------------------------------------------------------------------- #
+# optional exactness stage -- ESS receipt on a proposal that's already close to the truth
+# --------------------------------------------------------------------------------------------- #
+
+
+def test_reweight_requires_true_log_likelihood():
+    prior = GaussianDistribution(mu=0.0, sigma2=1.0)
+
+    def simulator(theta):
+        return np.array([float(np.asarray(theta).reshape(-1)[0])])
+
+    with pytest.raises(ValueError, match="true_log_likelihood"):
+        learn_inverse(simulator, prior, family="mdn", n_sims=50, reweight=True, y_obs=np.array([0.0]))
+
+
+def test_reweight_reports_ess_receipt():
+    rng = np.random.RandomState(0)
+    mu0 = np.array([0.0, 0.0])
+    var0 = np.array([4.0, 4.0])
+    var_obs = 0.25
+    prior = DiagonalGaussianDistribution(mu=mu0, covar=var0)
+
+    def simulator(theta):
+        return np.asarray(theta, dtype=float) + rng.normal(0.0, np.sqrt(var_obs), size=2)
+
+    def true_log_likelihood(theta, y):
+        diff = np.asarray(y, dtype=float) - np.asarray(theta, dtype=float)
+        return float(-0.5 * np.sum(diff**2) / var_obs)
+
+    y_obs = np.array([1.0, -1.0])
+    model = learn_inverse(
+        simulator,
+        prior,
+        family="flow",
+        n_sims=2000,
+        m_steps=300,
+        seed=0,
+        n_sbc_replications=20,
+        reweight=True,
+        true_log_likelihood=true_log_likelihood,
+        y_obs=y_obs,
+    )
+    assert model.receipts.ess is not None
+    assert model.receipts.ess_ratio is not None
+    assert 0.0 <= model.receipts.ess_ratio <= 1.0
+    # a well-trained student's proposal is close to the true posterior here -> high ESS ratio.
+    assert model.receipts.ess_ratio > 0.5


### PR DESCRIPTION
## Summary

- `learn_inverse(simulator, prior, ...) -> InverseModel` (`mixle/task/inverse.py`): trains a torch
  conditional-density student `q(theta | y)` (`build_conditional_flow`/`build_mdn` wrapped in the
  vendored `GradLeaf`, fit through `optimize()`'s tuple-default-loss path) on simulated
  `(theta, y)` pairs, then wraps it as an M0 `Posterior` so downstream `condition()`/`do()`
  composition treats a learned inverse like an exactly-conditioned one -- except its `.receipt`
  carries an explicit amortization warning plus a pointer to `InverseReceipts`.
- Resolves the three items the design note (`notes/designs/M3.md`) left open: `y_obs` is an
  eager optional keyword driving SNPE-style sequential refinement (`rounds > 1` without `y_obs`
  raises `ValueError`); `family="flow"` requires `theta >= 2`-D and raises a clear error
  otherwise (documented restriction, `family="mdn"` for scalar-`theta` cases); SBC uses a
  chi-square uniformity test on binned ranks, `p-value > 0.01` threshold.
- **Also vendors `mixle/models/grad_leaf.py` and `mixle/tests/grad_leaf_test.py` byte-for-byte
  from the not-yet-merged `gradleaf-hardening-2-v2` branch** (A4.4's tuple-observation scoring
  fix), matching this worktree's own design note's precedent for stacking on an unmerged
  dependency. **This PR should retarget once both `m0-conditioning` and
  `gradleaf-hardening-2-v2` merge**, at which point the vendored copy can be dropped in favor of
  the real merged module.

## Real receipt numbers (from actual test runs, not hand-waved)

- (a) linear-Gaussian: learned posterior mean/var within ~0.05 of the analytic
  precision-weighted posterior at two different `y_obs` draws (tolerance asserted at 0.15).
- (b) bimodal toy (`y = theta^2 + noise`): `_split_separation` reports separation ≈ 107 against
  a ≈2.78 finite-sample threshold, minority share ≈ 0.476 (threshold 0.20) -- both modes clearly
  resolved.
- (c) SBC (200 replications, 20 bins): p-value ≈ 0.32-0.88 across seeds (threshold 0.01) --
  ranks pass uniformity.
- (d) coverage: empirical ≈ 0.46-0.51 at nominal 0.5, ≈ 0.86-0.90 at nominal 0.9 -- within ±5%
  both levels, both seeds tested.
- (e) sequential refinement: sharpness (posterior sample variance at fixed `y_obs`) strictly
  decreases round over round, e.g. `[0.295, 0.169, 0.101]` across 3 rounds on a deliberately
  under-trained round-1 fixture -- deterministic given `seed=`.
- Reweight/ESS path: ESS ratio ≈ 0.98 on a proposal already close to the true posterior.
- 16/16 vendored `grad_leaf_test.py` tests pass unmodified; all 15 existing `GradLeaf` consumer
  tests (`grad_control_test.py`, `multimodal_stage1_demo_smoke_test.py`,
  `peft_lora_grad_leaf_smoke_test.py`, `qat_test.py`) still pass against the vendored copy.

## Test plan

- [x] `mixle/tests/inverse_test.py` -- 8/8 pass (5 acceptance receipts + 2 API guards + 1
      reweight/ESS test)
- [x] `mixle/tests/grad_leaf_test.py` -- 16/16 pass against the vendored copy
- [x] Consumer suites for the vendored module: `grad_control_test.py`,
      `multimodal_stage1_demo_smoke_test.py`, `peft_lora_grad_leaf_smoke_test.py`,
      `qat_test.py` -- 15/15 pass
- [x] `ruff check` / `ruff format --check` clean on all touched files