### PR TITLE
example: sense -> simulate -> invert -> report (B7, the track-M full-loop demo)

### DIFF
--- a/examples/geoscience_inversion_report.py
+++ b/examples/geoscience_inversion_report.py
@@ -1,0 +1,194 @@
+"""B7: Sense -> simulate -> invert -> report -- the track-M full-loop demo.
+
+Domain framing lives ENTIRELY here (a toy geoscience seismic-inversion story), per the roadmap
+card's own instruction: the library modules this example composes (``mixle.inference.scenario``,
+``mixle.task.inverse``, ``mixle.reason.language_bridge``, ``mixle.task.calibrated_generator``) stay
+domain-agnostic. Nothing below teaches mixle anything about geoscience -- it only teaches this
+SCRIPT what "formation", "depth", and "amplitude" mean.
+
+The story: a field crew logs three heterogeneous channels at each site -- formation TYPE (a text
+label), a 3-station seismic AMPLITUDE array (the array modality), and SOURCE DEPTH (a scalar) -- and
+mixle fits one joint over all three.
+
+  1. **Sense.**  Synthetic multi-modal "field" records: (formation: str, amplitude: tuple[3xfloat],
+     depth: float). ``learn_bayesian_network`` (M0's own substrate) discovers the DAG and fits it --
+     this is "fit a joint" over heterogeneous data.
+  2. **Simulate** (M2, ``mixle.inference.scenario.simulate``).  A "what-if": ``do(formation="salt")``
+     -- roll out the implied depth/amplitude regime under that intervention, with a plausibility/ESS
+     receipt.
+  3. **Invert** (M3, ``mixle.task.inverse.learn_inverse``).  A NEW field observation arrives -- a
+     noisy amplitude reading from an actual salt-formation site with an UNKNOWN depth. An amortized
+     inverse posterior q(depth | amplitude) is trained against the same salt-regime forward physics
+     M2 just characterized, then inverted on the real observation -- with SBC/coverage receipts that
+     say whether the inversion is trustworthy, not just a point estimate.
+  4. **Report** (M5's ``mixle.reason.language_bridge.PosteriorDescriber`` + A1's
+     ``CalibratedGenerator``).  The depth posterior becomes a calibrated natural-language claim: draft
+     candidate claims at several precision widths, score each against the posterior, and serve the
+     best one only if it conformally clears a held-out threshold -- otherwise abstain rather than
+     bluff a number.
+
+Everything below is real, seeded computation; no printed number is invented. Run:
+``python examples/geoscience_inversion_report.py``
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from mixle.inference import certify
+from mixle.inference.bayesian_network import learn_bayesian_network
+from mixle.inference.scenario import Scenario, simulate
+from mixle.reason.language_bridge import PosteriorDescriber, claim_score
+from mixle.stats.univariate.continuous.gaussian import GaussianDistribution
+from mixle.task.inverse import learn_inverse
+
+FORMATIONS = ("shale", "sand", "salt")
+# formation -> (depth_mean_km, depth_std_km, per-station attenuation lengths)
+FORMATION_PARAMS = {
+    "shale": (2.0, 0.4, (1.6, 2.0, 2.4)),
+    "sand": (3.0, 0.5, (2.2, 2.6, 3.0)),
+    "salt": (4.5, 0.6, (3.2, 3.6, 4.0)),
+}
+FORMATION_WEIGHTS = (0.4, 0.35, 0.25)
+A0 = 10.0  # source amplitude
+SENSOR_NOISE = 0.15  # per-station amplitude noise, km-amplitude units
+TRUE_DEPTH = 4.2  # the unknown depth at the real site M3 must recover
+TRUE_FORMATION = "salt"
+
+
+def _amplitude(depth: float, formation: str, rng: np.random.RandomState | None = None) -> tuple[float, ...]:
+    """Exponential attenuation forward model: amplitude_i = A0 * exp(-depth / L_i) [+ station noise]."""
+    _, _, lengths = FORMATION_PARAMS[formation]
+    noise = rng.randn(len(lengths)) * SENSOR_NOISE if rng is not None else np.zeros(len(lengths))
+    return tuple(float(A0 * np.exp(-depth / length) + n) for length, n in zip(lengths, noise))
+
+
+def sense(n: int, seed: int) -> list[tuple]:
+    """``n`` synthetic multi-modal field records: (formation: str, amplitude: 3-tuple, depth: float)."""
+    rng = np.random.RandomState(seed)
+    records = []
+    for _ in range(n):
+        formation = str(rng.choice(FORMATIONS, p=FORMATION_WEIGHTS))
+        mean, std, _ = FORMATION_PARAMS[formation]
+        depth = float(mean + std * rng.randn())
+        records.append((formation, _amplitude(depth, formation, rng), depth))
+    return records
+
+
+def fit_joint(records: list[tuple]):
+    """Discover and fit the heterogeneous DAG over (formation, amplitude, depth) -- M0's substrate."""
+    return learn_bayesian_network(records, max_parents=2)
+
+
+def what_if_salt(net, *, seed: int):
+    """M2: ``do(formation="salt")`` -- roll out the implied depth/amplitude regime, receipted."""
+    scenario = Scenario(interventions={0: TRUE_FORMATION}, evidence={}, horizon=1)
+    sim = simulate(scenario, base=net, seed=seed)
+    rows = sim.rollout(500)
+    depths = np.array([r[2] for r in rows], dtype=float)
+    amps = np.array([r[1] for r in rows], dtype=float)
+    return sim, depths, amps
+
+
+def invert_new_observation(depth_prior: GaussianDistribution, y_obs: np.ndarray, *, seed: int):
+    """M3: train q(depth | amplitude) against the salt-regime forward physics, then invert ``y_obs``."""
+
+    def forward_salt(theta_row: np.ndarray) -> np.ndarray:
+        depth = float(np.ravel(theta_row)[0])
+        return np.asarray(_amplitude(depth, TRUE_FORMATION), dtype=float)
+
+    return learn_inverse(
+        forward_salt,
+        depth_prior,
+        family="mdn",  # depth is 1-D; "flow" requires theta_dim >= 2 (see learn_inverse's docstring)
+        n_sims=1500,
+        n_sbc_replications=150,
+        coverage_levels=(0.5, 0.9),
+        y_obs=y_obs,
+        rounds=1,
+        seed=seed,
+        m_steps=200,
+        max_its=1,
+    )
+
+
+def build_calibration_set(inv_model, depth_prior: GaussianDistribution, *, n: int, seed: int):
+    """(posterior, true_depth) pairs for the M5 describer's conformal calibration: fresh salt-regime
+    sites, each observed once through the same noisy sensor as the real target site."""
+    rng = np.random.RandomState(seed)
+    pairs = []
+    for _ in range(n):
+        depth = float(depth_prior.sampler(seed=int(rng.randint(0, 2**31 - 1))).sample(1)[0])
+        y = np.asarray(_amplitude(depth, TRUE_FORMATION), dtype=float) + SENSOR_NOISE * rng.randn(3)
+        pairs.append((inv_model.posterior(y), depth))
+    return pairs
+
+
+def main() -> None:
+    print("=" * 78)
+    print("SENSE -> SIMULATE -> INVERT -> REPORT: a toy seismic-inversion full loop")
+    print("=" * 78)
+
+    # 1. sense + fit a joint
+    records = sense(600, seed=0)
+    net = fit_joint(records)
+    cert = certify(net)
+    print(f"\n[sense]     {len(records)} multi-modal field records (formation, amplitude[3], depth)")
+    print(f"[fit joint] heterogeneous DAG over {len(net.factors)} fields:")
+    for f in net.factors:
+        print(f"              field[{f.child}] <- parents {getattr(f, 'parents', [])}  ({type(f).__name__})")
+    print(f"            certificate: {cert.guarantee.name}")
+
+    # 2. M2: a what-if scenario simulator
+    sim, wi_depths, wi_amps = what_if_salt(net, seed=1)
+    print(f"\n[simulate]  M2 what-if do(formation='{TRUE_FORMATION}'), {len(wi_depths)} rollout draws")
+    print(f"            depth under the intervention:     mean={wi_depths.mean():.3f} std={wi_depths.std():.3f} km")
+    print(f"            amplitude under the intervention:  mean={np.array2string(wi_amps.mean(axis=0), precision=3)}")
+    print(f"            receipt: method={sim.receipt.method!r} ess_ratio={sim.receipt.ess_ratio}")
+
+    # the M2 rollout's own empirical depth law becomes M3's prior -- the two stages share one belief
+    depth_prior = GaussianDistribution(mu=float(wi_depths.mean()), sigma2=float(wi_depths.var()))
+
+    # a new field observation: an actual site, unknown depth, one noisy amplitude reading
+    obs_rng = np.random.RandomState(123)
+    y_obs = np.asarray(_amplitude(TRUE_DEPTH, TRUE_FORMATION), dtype=float) + SENSOR_NOISE * obs_rng.randn(3)
+
+    # 3. M3: invert the new observation
+    inv_model = invert_new_observation(depth_prior, y_obs, seed=9)
+    r = inv_model.receipts
+    target_post = inv_model.posterior(y_obs)
+    post_samples = target_post.sample(2000, seed=5)
+    post_mean, post_std = float(post_samples.mean()), float(post_samples.std())
+    print(f"\n[invert]    M3 amortized posterior q(depth | amplitude) trained on {inv_model.y_dim}-D observations")
+    print(f"            new observation y_obs = {np.array2string(y_obs, precision=3)} (true depth = {TRUE_DEPTH} km)")
+    print(
+        f"            posterior: mean={post_mean:.3f} std={post_std:.3f} km, |error|={abs(post_mean - TRUE_DEPTH):.3f} km"
+    )
+    print(f"            SBC p-value={r.sbc_pvalue:.3g} (pass={r.sbc_pass})")
+    print(
+        f"            coverage@0.5={r.coverage[0.5]:.3f} (pass={r.coverage_pass[0.5]}), "
+        f"coverage@0.9={r.coverage[0.9]:.3f} (pass={r.coverage_pass[0.9]})"
+    )
+
+    # 4. M5 + A1: a calibrated natural-language report
+    calibration_set = build_calibration_set(inv_model, depth_prior, n=60, seed=999)
+    describer = PosteriorDescriber(
+        "depth_km", tol=0.1, k=3, alpha=0.2, width_multiples=(1.0, 3.0, 10.0), n_probe=300, seed=0
+    )
+    describer.calibrate(calibration_set, seed=0)
+    claim = describer.describe(target_post, seed=0)
+
+    print(f"\n[report]    M5 PosteriorDescriber calibrated on {len(calibration_set)} held-out sites through A1")
+    if claim is None:
+        print("            calibrated report: ABSTAIN -- no candidate claim conformally cleared the threshold")
+    else:
+        contained = claim.contains(TRUE_DEPTH)
+        print(f'            calibrated report: "{claim.text()}"')
+        print(f"            claim_score={claim_score(claim):.3f}, true depth {TRUE_DEPTH} km contained: {contained}")
+        assert contained, "the served claim should bracket the true depth for this seeded run"
+
+    print("\nOK: fit -> what-if -> invert -> calibrated report, one loop, real numbers throughout.")
+
+
+if __name__ == "__main__":
+    main()

--- a/mixle/inference/__init__.py
+++ b/mixle/inference/__init__.py
@@ -247,11 +247,20 @@ from mixle.inference.robust import (
     robust_standard_errors,
     sandwich_covariance,
 )
-from mixle.inference.scenario import FieldPosterior as ScenarioFieldPosterior
-from mixle.inference.scenario import Scenario as ScenarioSpec
-from mixle.inference.scenario import SimulationReceipt as ScenarioSimulationReceipt
-from mixle.inference.scenario import Simulator as ScenarioSimulator
-from mixle.inference.scenario import simulate as simulate_scenario
+
+# M2's scenario simulators (mixle.inference.scenario) eagerly import
+# mixle.stats.latent.hidden_markov -- importing that at THIS module's own top level creates a real
+# circular import through mixle.stats.bayes.dirichlet (mixle.stats -> ... -> mixle.inference ->
+# scenario -> mixle.stats.latent.hidden_markov -> mixle.stats.latent.mixture ->
+# mixle.stats.bayes.dirichlet, still mid-init). Exported lazily instead (see __getattr__ at the
+# bottom of this module), under aliases since these names differ from scenario.py's own.
+_SCENARIO_LAZY_NAMES = {
+    "simulate_scenario": "simulate",
+    "ScenarioSpec": "Scenario",
+    "ScenarioSimulator": "Simulator",
+    "ScenarioSimulationReceipt": "SimulationReceipt",
+    "ScenarioFieldPosterior": "FieldPosterior",
+}
 
 # proper scoring rules — fair currency for comparing probabilistic forecasts / interval methods
 from mixle.inference.scoring import (
@@ -696,5 +705,12 @@ def __getattr__(name: str):
         _condition_module = importlib.import_module("mixle.inference.condition")
         value = getattr(_condition_module, name)
         globals()[name] = value  # subsequent accesses skip __getattr__ entirely
+        return value
+    if name in _SCENARIO_LAZY_NAMES:
+        import importlib
+
+        _scenario_module = importlib.import_module("mixle.inference.scenario")
+        value = getattr(_scenario_module, _SCENARIO_LAZY_NAMES[name])
+        globals()[name] = value
         return value
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/mixle/inference/__init__.py
+++ b/mixle/inference/__init__.py
@@ -247,6 +247,11 @@ from mixle.inference.robust import (
     robust_standard_errors,
     sandwich_covariance,
 )
+from mixle.inference.scenario import FieldPosterior as ScenarioFieldPosterior
+from mixle.inference.scenario import Scenario as ScenarioSpec
+from mixle.inference.scenario import SimulationReceipt as ScenarioSimulationReceipt
+from mixle.inference.scenario import Simulator as ScenarioSimulator
+from mixle.inference.scenario import simulate as simulate_scenario
 
 # proper scoring rules — fair currency for comparing probabilistic forecasts / interval methods
 from mixle.inference.scoring import (
@@ -436,6 +441,14 @@ __all__ = [
     "simulate",
     "Simulator",
     "Scenario",
+    # simulate_scenario() (M2) -- on-the-fly conditional simulators: evidence + interventions + horizon,
+    # via M0's condition()/do(), with a plausibility receipt. Aliased (not `simulate`/`Scenario`/
+    # `Simulator`) to avoid colliding with the names above -- see notes/designs/M2.md.
+    "simulate_scenario",
+    "ScenarioSpec",
+    "ScenarioSimulator",
+    "ScenarioSimulationReceipt",
+    "ScenarioFieldPosterior",
     # synthesize() -- a dataset factory: sample, label, keep only what verifies
     "synthesize",
     "Dataset",

--- a/mixle/inference/scenario.py
+++ b/mixle/inference/scenario.py
@@ -1,0 +1,400 @@
+"""``simulate(scenario) -> Simulator`` -- on-the-fly conditional simulators for special scenarios.
+
+See ``notes/designs/M2.md`` for the full design: source selection (explicit / registry / auto-
+designed), why interventions must compose with evidence as ``do()`` FIRST then ``condition()``
+(and how that is realized for a ``HeterogeneousBayesianNetwork``, whose ``do()`` result M0's
+``condition()`` does not dispatch on), the HMM/state-space temporal-rollout extension past M0's
+conditioned window, and the plausibility receipt (the scenario's evidence log-density under the
+UNMODIFIED base model).
+
+Distinct from :mod:`mixle.inference.simulate` (`Scenario`/`Simulator`/`simulate(model)`), a
+narrower, BN-intervention-only tool already consumed by ``mixle.substrate.act``: this module does
+not touch that one, and is imported under its own names (`mixle.inference.scenario.simulate`, not
+re-exported under the same bare name from ``mixle.inference``).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+from numpy.random import RandomState
+from scipy.special import logsumexp
+
+from mixle.inference.bayesian_network import HeterogeneousBayesianNetwork
+from mixle.inference.causal import do as _bn_do
+from mixle.inference.condition import (
+    FieldPath,
+    Posterior,
+    _generate_weighted,
+    _is_gaussian_like,
+    _norm_evidence,
+    _norm_path,
+    _rng_seed,
+    _safe_log_density,
+    condition,
+    do,
+)
+from mixle.stats.combinator.composite import CompositeDistribution
+from mixle.stats.compute.posterior import MarkovChainLatentPosterior
+from mixle.stats.latent.hidden_markov import HiddenMarkovModelDistribution
+
+__all__ = ["Scenario", "SimulationReceipt", "FieldPosterior", "Simulator", "simulate"]
+
+
+@dataclass
+class Scenario:
+    """``{evidence, interventions, priors, horizon}`` -- what to build a simulator for.
+
+    ``priors`` is the generic model-source configuration slot (see ``notes/designs/M2.md``):
+    ``priors["registry"] = (Registry, name, version="latest")`` to fetch a stored model, or
+    ``priors["data"]`` (+ optional ``priors["llm"]``) to auto-design one from scarce scenario data
+    via :func:`mixle.task.design.design_model`, when ``base`` is not given directly to
+    :func:`simulate`.
+    """
+
+    evidence: dict[FieldPath | int, Any] = field(default_factory=dict)
+    interventions: dict[FieldPath | int, Any] = field(default_factory=dict)
+    priors: dict[str, Any] = field(default_factory=dict)
+    horizon: int = 1
+
+
+@dataclass
+class SimulationReceipt:
+    """What ``simulate()`` actually did: plausibility of the evidence, and the conditioning health."""
+
+    plausibility: float | None  # log p_base(evidence); None when there is no evidence to score
+    plausibility_method: str  # "exact" | "sir" | "no-evidence"
+    method: str  # conditioning method for the working posterior: "exact" | "sir" | "none"
+    ess: float | None = None
+    ess_ratio: float | None = None
+    composition_order: str = "do-then-condition"
+    warnings: list[str] = field(default_factory=list)
+
+
+class FieldPosterior:
+    """An empirical marginal for one field, built from rollout draws (``.mean()``/``.std()``/``.sample()``)."""
+
+    def __init__(self, values: np.ndarray) -> None:
+        self._values = values
+
+    def mean(self) -> float:
+        return float(np.mean(self._values))
+
+    def std(self) -> float:
+        return float(np.std(self._values))
+
+    def sample(self, n: int = 1, *, seed: int | None = None) -> np.ndarray:
+        rng = RandomState(seed)
+        idx = rng.randint(0, len(self._values), size=int(n))
+        return self._values[idx]
+
+
+# --------------------------------------------------------------------------------------------- #
+# source selection
+# --------------------------------------------------------------------------------------------- #
+
+
+def _resolve_base(base: Any | None, scenario: Scenario) -> Any:
+    if base is not None:
+        return base
+    priors = scenario.priors
+    if "registry" in priors:
+        registry, name, *rest = priors["registry"]
+        version = rest[0] if rest else "latest"
+        return registry.get(name, version)[0]
+    if "data" in priors:
+        from mixle.task.design import design_model
+
+        designed = design_model(priors["data"], priors.get("llm"), fallback=True)
+        return designed.fit(priors["data"])
+    raise ValueError(
+        "simulate(): no model source -- pass `base=` explicitly, or set "
+        "`scenario.priors['registry'] = (registry, name)` or `scenario.priors['data'] = records`."
+    )
+
+
+# --------------------------------------------------------------------------------------------- #
+# do() FIRST, then condition()
+# --------------------------------------------------------------------------------------------- #
+
+
+def _extract(record: Any, path: FieldPath) -> Any:
+    v = record
+    for i in path:
+        v = v[i]
+    return v
+
+
+def _condition_after_do_bn(
+    net: HeterogeneousBayesianNetwork,
+    interventions: dict[int, Any],
+    evidence: dict[FieldPath, Any],
+    *,
+    n_particles: int,
+    seed: int | None,
+) -> tuple[list[tuple], np.ndarray, SimulationReceipt]:
+    """``condition()`` has no dispatch rule for ``InterventionalNetwork`` (M0's ``do()`` result for a
+    BN) -- realize "do() first, then condition()" here directly, in one ancestral pass over
+    ``net.order`` per particle: an intervened field is FIXED with no weight contribution (its
+    factor/edge is never consulted -- graph surgery), an evidenced field is FIXED and its factor's
+    ``log_density`` becomes an importance weight (Bayesian update), exactly M0's own BN branch of
+    ``_generate_weighted`` -- except intervened fields skip the weight term, which is the entire
+    difference between ``do()`` and ``condition()``.
+    """
+    rng = RandomState(seed)
+    top = {p[0]: v for p, v in evidence.items() if len(p) == 1}
+    if any(len(p) != 1 for p in evidence):
+        raise NotImplementedError("nested evidence is not supported for a HeterogeneousBayesianNetwork scenario.")
+    by_child = {f.child: f for f in net.factors}
+    n_fields = len(net.factors)
+    records: list[tuple] = []
+    log_weights = np.empty(n_particles, dtype=np.float64)
+    for i in range(n_particles):
+        vals: list[Any] = [None] * n_fields
+        lw = 0.0
+        for idx in net.order:
+            f = by_child[idx]
+            if idx in interventions:
+                vals[idx] = interventions[idx]  # do(): fixed, edge severed, no weight
+            elif idx in top:
+                vals[idx] = top[idx]  # condition(): fixed, weighted by its own factor
+                lw += _safe_log_density(f, tuple(vals))
+            else:
+                vals[idx] = f.sample(vals, rng)
+        records.append(tuple(vals))
+        log_weights[i] = lw
+
+    warnings: list[str] = []
+    if not top:
+        w_norm = np.full(n_particles, 1.0 / n_particles)
+        ess = float(n_particles)
+    else:
+        finite = np.isfinite(log_weights)
+        if not finite.any():
+            w_norm = np.full(n_particles, 1.0 / n_particles)
+            ess = 0.0
+            warnings.append("all importance weights are zero (evidence has zero density under do(...)).")
+        else:
+            m = log_weights[finite].max()
+            w = np.where(finite, np.exp(log_weights - m), 0.0)
+            w_norm = w / w.sum()
+            ess = float(1.0 / np.sum(w_norm**2))
+    ess_ratio = ess / n_particles
+    if top and ess_ratio < 0.01:
+        warnings.append(f"ESS ratio {ess_ratio:.4f} < 0.01 threshold -- evidence may be near-impossible under do(...).")
+    receipt = SimulationReceipt(
+        plausibility=None,
+        plausibility_method="no-evidence",
+        method="sir" if top else "none",
+        ess=ess,
+        ess_ratio=ess_ratio,
+        warnings=warnings,
+    )
+    return records, w_norm, receipt
+
+
+# --------------------------------------------------------------------------------------------- #
+# HMM / state-space temporal rollout past the conditioned window
+# --------------------------------------------------------------------------------------------- #
+
+
+def _hmm_forward_rollout(
+    model: HiddenMarkovModelDistribution,
+    evidence: dict[int, Any],
+    horizon: int,
+    n: int,
+    rng: RandomState,
+) -> list[list[Any]]:
+    """``n`` full-horizon emission rows: exact smoothed state posterior over ``[0, t_max]`` (same
+    construction M0's ``_condition_hmm`` uses), then ancestral forward continuation of the DRAWN
+    joint state path from ``t_max+1`` to ``horizon-1`` -- "forward-filtered simulation" continued
+    past the last clamp.
+    """
+    n_states = model.n_states
+    t_max = max(evidence) if evidence else -1
+    t_max = max(t_max, -1)
+    log_b = np.zeros((t_max + 1, n_states), dtype=np.float64)
+    for t in range(t_max + 1):
+        if t in evidence:
+            for k in range(n_states):
+                log_b[t, k] = _safe_log_density(model.topics[k], evidence[t])
+    q = MarkovChainLatentPosterior(model.log_w, model.log_transitions, log_b) if t_max >= 0 else None
+    trans = np.exp(model.log_transitions)
+    rows: list[list[Any]] = []
+    for _ in range(n):
+        if q is not None:
+            z = list(q.sample(rng))
+        else:
+            z = [int(rng.choice(n_states, p=np.exp(model.log_w)))]
+        row: list[Any] = [None] * max(horizon, t_max + 1)
+        for t in range(t_max + 1):
+            row[t] = evidence[t] if t in evidence else model.topics[int(z[t])].sampler(seed=_rng_seed(rng)).sample()
+        state = int(z[t_max]) if t_max >= 0 else z[0]
+        for t in range(t_max + 1, horizon):
+            state = int(rng.choice(n_states, p=trans[state]))
+            row[t] = model.topics[state].sampler(seed=_rng_seed(rng)).sample()
+        rows.append(row)
+    return rows
+
+
+# --------------------------------------------------------------------------------------------- #
+# plausibility receipt: log p_base(evidence)
+# --------------------------------------------------------------------------------------------- #
+
+
+def _exact_evidence_log_density(model: Any, top: dict[int, Any]) -> float | None:
+    if not top or not callable(getattr(model, "marginal", None)):
+        return None
+    idx = sorted(top)
+    try:
+        if isinstance(model, CompositeDistribution):
+            sub = model.marginal(idx)  # CompositeDistribution.marginal sorts internally too
+            value = tuple(top[i] for i in idx)
+        elif _is_gaussian_like(model):
+            sub = model.marginal(idx)  # order-preserving
+            value = np.array([float(top[i]) for i in idx], dtype=np.float64)
+        else:
+            return None
+        return float(sub.log_density(value))
+    except (ValueError, TypeError, NotImplementedError):
+        return None
+
+
+def _sir_evidence_log_density(model: Any, ev: dict[FieldPath, Any], *, n_particles: int, rng: RandomState) -> float:
+    """SNIS estimate of ``log p_base(evidence)`` -- reuses M0's own generative decomposition
+    (``_generate_weighted``) rather than a second per-combinator dispatch table (see M2.md)."""
+    log_weights = np.empty(n_particles, dtype=np.float64)
+    for i in range(n_particles):
+        _, lw = _generate_weighted(model, ev, rng)
+        log_weights[i] = lw
+    finite = log_weights[np.isfinite(log_weights)]
+    if finite.size == 0:
+        return float("-inf")
+    return float(logsumexp(log_weights[np.isfinite(log_weights)]) - np.log(n_particles))
+
+
+def plausibility_receipt(
+    base: Any, evidence: dict[FieldPath | int, Any], *, n_particles: int = 4096, seed: int | None = None
+) -> tuple[float | None, str]:
+    """``(log p_base(evidence), method)`` -- the scenario's evidence log-density under the base model."""
+    if not evidence:
+        return None, "no-evidence"
+    ev = _norm_evidence(evidence)
+    top = {p[0]: v for p, v in ev.items() if len(p) == 1}
+    if len(top) == len(ev):
+        exact = _exact_evidence_log_density(base, top)
+        if exact is not None:
+            return exact, "exact"
+    rng = RandomState(seed)
+    return _sir_evidence_log_density(base, ev, n_particles=n_particles, rng=rng), "sir"
+
+
+# --------------------------------------------------------------------------------------------- #
+# Simulator / simulate()
+# --------------------------------------------------------------------------------------------- #
+
+
+class Simulator:
+    """A scenario resolved to a runnable generator, with a plausibility + conditioning receipt."""
+
+    def __init__(
+        self,
+        *,
+        base: Any,
+        scenario: Scenario,
+        seed: int | None,
+        n_particles: int = 4096,
+    ) -> None:
+        self.base = base
+        self.scenario = scenario
+        self._seed = seed
+        self._n_particles = int(n_particles)
+        self._rng = RandomState(seed)
+
+        plausibility, plaus_method = plausibility_receipt(
+            base, scenario.evidence, n_particles=n_particles, seed=_rng_seed(self._rng)
+        )
+
+        interventions = _norm_evidence(scenario.interventions) if scenario.interventions else {}
+        evidence = _norm_evidence(scenario.evidence) if scenario.evidence else {}
+
+        self._bn_records: tuple[list[tuple], np.ndarray] | None = None
+        self._hmm_model: HiddenMarkovModelDistribution | None = None
+        self._hmm_evidence: dict[int, Any] = {}
+        self._posterior: Posterior | None = None
+        working = base
+
+        if interventions:
+            if isinstance(base, HeterogeneousBayesianNetwork):
+                iv = {p[0]: v for p, v in interventions.items()}
+                _bn_do(base, iv)  # validates field indices are in range; raises ValueError otherwise
+                records, w_norm, receipt = _condition_after_do_bn(
+                    base, iv, evidence, n_particles=n_particles, seed=_rng_seed(self._rng)
+                )
+                self._bn_records = (records, w_norm)
+                self.receipt = SimulationReceipt(
+                    plausibility=plausibility,
+                    plausibility_method=plaus_method,
+                    method=receipt.method,
+                    ess=receipt.ess,
+                    ess_ratio=receipt.ess_ratio,
+                    warnings=receipt.warnings,
+                )
+                return
+            working = do(base, dict(interventions))
+
+        if isinstance(working, HiddenMarkovModelDistribution) and (evidence or scenario.horizon > 1):
+            self._hmm_model = working
+            self._hmm_evidence = {p[0]: v for p, v in evidence.items()}
+            method = "exact" if evidence else "none"
+            self.receipt = SimulationReceipt(plausibility=plausibility, plausibility_method=plaus_method, method=method)
+            return
+
+        if evidence:
+            self._posterior = condition(working, dict(evidence), n_particles=n_particles, seed=_rng_seed(self._rng))
+            self.receipt = SimulationReceipt(
+                plausibility=plausibility,
+                plausibility_method=plaus_method,
+                method=self._posterior.receipt.method,
+                ess=self._posterior.receipt.ess,
+                ess_ratio=self._posterior.receipt.ess_ratio,
+                warnings=list(self._posterior.receipt.warnings),
+            )
+        else:
+            self._working = working
+            self.receipt = SimulationReceipt(plausibility=plausibility, plausibility_method=plaus_method, method="none")
+
+    def rollout(self, n: int = 1) -> list[Any]:
+        """``n`` draws from the resolved scenario (do() applied, evidence conditioned, seed-fixed)."""
+        n = int(n)
+        if self._bn_records is not None:
+            records, w_norm = self._bn_records
+            idx = self._rng.choice(len(records), size=n, replace=True, p=w_norm)
+            return [records[j] for j in idx]
+        if self._hmm_model is not None:
+            return _hmm_forward_rollout(self._hmm_model, self._hmm_evidence, int(self.scenario.horizon), n, self._rng)
+        if self._posterior is not None:
+            return self._posterior.sample(n, seed=_rng_seed(self._rng))
+        sampler = self._working.sampler(seed=_rng_seed(self._rng))
+        out = sampler.sample(n)
+        return list(out) if not isinstance(out, list) else out
+
+    def posterior(self, field: FieldPath | int, *, n: int = 2000) -> FieldPosterior:
+        """An empirical marginal for one field, from ``n`` rollout draws (see class docstring)."""
+        path = _norm_path(field)
+        rows = self.rollout(n)
+        values = np.array([float(_extract(r, path)) for r in rows], dtype=np.float64)
+        return FieldPosterior(values)
+
+
+def simulate(scenario: Scenario, *, base: Any | None = None, seed: int | None = None) -> Simulator:
+    """Assemble a generative model for ``scenario`` and package it as a :class:`Simulator`.
+
+    Source selection (explicit ``base``, registry, or auto-designed from ``scenario.priors``),
+    ``do()``-then-``condition()`` composition, HMM temporal rollout, and the plausibility receipt
+    are all covered in ``notes/designs/M2.md``.
+    """
+    resolved = _resolve_base(base, scenario)
+    return Simulator(base=resolved, scenario=scenario, seed=seed)

--- a/mixle/reason/inference_program.py
+++ b/mixle/reason/inference_program.py
@@ -1,0 +1,213 @@
+"""Multi-hop inference programs over composed M0/L2 conditioning queries (roadmap M5).
+
+L2's :class:`~mixle.reason.cross_modal.CrossModalJoint` answers one conditioning query exactly:
+condition on any subset of a joint's named modalities, infer any other subset, all within a SINGLE
+shared latent regime. Real cross-modal reasoning needs to chain THROUGH modalities that are not all
+tied by one joint -- the card's own example is (image field -> shared latent -> predicted field ->
+text field), where the image<->latent relationship and the latent<->text relationship are two
+separately-fit joints. This module adds exactly that composition and nothing else: a small, explicit,
+LINEAR chain of :meth:`~mixle.reason.cross_modal.CrossModalJoint.infer` calls (a path DAG -- no
+free-form planning, no branching/merging in v1; see ``notes/designs/M5.md`` part (a)).
+
+The one real design problem a chain introduces that a single hop does not have: hop *i*'s posterior
+over the field hop *i+1* needs to condition on is a full DISTRIBUTION, not a single value, but
+``CrossModalJoint.infer`` demands a concrete observed value. Two receipted ways to bridge that gap are
+implemented (``notes/designs/M5.md`` part (b)):
+
+* ``propagation="sampled"`` (default) -- Monte-Carlo particles carried hop to hop, exactly the
+  "one particle, one draw, carry the weight" pattern already proven out by
+  :func:`mixle.reason.cycle_consistency.joint_cycle_consistency_receipt`'s round trip. Unbiased;
+  converges to the exact marginal as ``n_samples`` grows.
+* ``propagation="moment"`` -- collapse each non-final hop's posterior to its own point estimate
+  (analytic mean for a Gaussian-like leaf, arg-max of the component-weighted ``pmap`` for a
+  categorical leaf) and carry that one point forward. Cheap (one ``infer`` per hop instead of
+  ``n_samples``), and HONESTLY the wrong choice whenever a downstream hop is sensitive to the
+  intermediate's uncertainty, not just its central tendency -- see
+  ``mixle/tests/inference_program_test.py::InferenceProgramTwoHopVsNaiveTest`` for a fixture where
+  this mode measurably diverges from the closed-form answer that ``"sampled"`` recovers.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+from numpy.random import RandomState
+
+from mixle.reason.cross_modal import CrossModalJoint
+from mixle.stats.latent.mixture import MixtureDistribution
+
+__all__ = ["InferenceHop", "ProgramReceipt", "ProgramPosterior", "run_inference_program"]
+
+_PROPAGATIONS = ("sampled", "moment")
+
+
+@dataclass(frozen=True)
+class InferenceHop:
+    """One ``CrossModalJoint.infer`` call in a chain.
+
+    ``target`` is the tuple of modality names this hop infers. ``carry`` renames a value produced by
+    the PREVIOUS hop's ``target`` into this hop's own joint's modality-name space (``{prior_target_name:
+    this_hop_evidence_name}``) -- the two joints need not share a naming convention. Ignored (and must
+    be empty) for the first hop in a program, which conditions on the program's external ``evidence``
+    instead. ``extra_evidence`` is fixed evidence local to this hop (observed independently of anything
+    carried down the chain).
+    """
+
+    joint: CrossModalJoint
+    target: tuple[str, ...]
+    carry: dict[str, str] = field(default_factory=dict)
+    extra_evidence: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class ProgramReceipt:
+    """What :func:`run_inference_program` actually did -- the M5 analogue of M0's ``ConditionReceipt``."""
+
+    propagation: str
+    n_hops: int
+    hop_targets: list[tuple[str, ...]]
+    n_particles: int
+
+
+class ProgramPosterior:
+    """A completed inference program's result: the same ``sample``/``log_density``/``mean``-shaped
+    contract M0's own :class:`~mixle.inference.condition.Posterior` exposes, over the final hop's
+    ``target`` fields, so a program's output composes with the same downstream code (e.g. the
+    language<->belief bridge) that already consumes a single-hop posterior.
+    """
+
+    def __init__(self, mixture: MixtureDistribution, target: tuple[str, ...], receipt: ProgramReceipt) -> None:
+        self.mixture = mixture
+        self.target = target
+        self.receipt = receipt
+
+    def _pos(self, field_name: str) -> int:
+        try:
+            return self.target.index(field_name)
+        except ValueError:
+            raise KeyError(f"unknown field {field_name!r}; this program's final target is {self.target!r}") from None
+
+    def sample(self, n: int = 1, *, seed: int | None = None) -> Any:
+        return self.mixture.sampler(seed=seed).sample(n)
+
+    def log_density(self, value: Any) -> float:
+        return float(self.mixture.log_density(value))
+
+    def density(self, value: Any) -> float:
+        return float(self.mixture.density(value))
+
+    def mean(self, field_name: str) -> Any:
+        """Analytic (component-weighted) mean of one target field -- Gaussian-like leaves only."""
+        j = self._pos(field_name)
+        return _field_mean(self.mixture.components, self.mixture.w, j)
+
+
+def _field_mean(components: Sequence[Any], w: np.ndarray, j: int) -> float:
+    means = np.array([_leaf_mean(c.dists[j]) for c in components], dtype=np.float64)
+    return float(np.sum(np.asarray(w, dtype=np.float64) * means))
+
+
+def _leaf_mean(dist: Any) -> float:
+    if hasattr(dist, "mu"):
+        return float(dist.mu)
+    mean_fn = getattr(dist, "mean", None)
+    if callable(mean_fn):
+        return float(mean_fn())
+    raise NotImplementedError(f"no analytic mean available for {type(dist).__name__}")
+
+
+def _leaf_point_estimate(components: Sequence[Any], w: np.ndarray, j: int) -> Any:
+    """The point M5 carries forward under ``propagation='moment'`` for one target field: the analytic
+    mean for a Gaussian-like leaf, or the arg-max of the component-weighted ``pmap`` for a categorical
+    leaf (any other leaf type raises rather than guessing)."""
+    first = components[0].dists[j]
+    if hasattr(first, "mu"):
+        return _field_mean(components, w, j)
+    if hasattr(first, "pmap"):
+        mixed: dict[Any, float] = {}
+        for c, cw in zip(components, w):
+            for key, p in c.dists[j].pmap.items():
+                mixed[key] = mixed.get(key, 0.0) + float(cw) * float(p)
+        return max(mixed, key=mixed.get)
+    raise NotImplementedError(f"propagation='moment' has no point-estimate rule for leaf type {type(first).__name__}")
+
+
+def run_inference_program(
+    evidence: dict[str, Any],
+    hops: Sequence[InferenceHop],
+    *,
+    propagation: str = "sampled",
+    n_samples: int = 500,
+    seed: int = 0,
+) -> ProgramPosterior:
+    """Run a linear chain of :class:`InferenceHop` conditioning queries, propagating uncertainty (or
+    not -- see module docstring) between hops. ``evidence`` conditions the FIRST hop only; later hops
+    condition on ``extra_evidence`` plus whatever their ``carry`` mapping pulls from the previous hop's
+    posterior over ``target``.
+    """
+    if propagation not in _PROPAGATIONS:
+        raise ValueError(f"propagation must be one of {_PROPAGATIONS}, got {propagation!r}")
+    hops = list(hops)
+    if not hops:
+        raise ValueError("run_inference_program needs at least one hop")
+    if hops[0].carry:
+        raise ValueError("the first hop conditions on the program's external `evidence`; it cannot `carry`")
+    rng = RandomState(seed)
+
+    # particles: list of (carried_values_dict keyed by the PRODUCING hop's own target names, weight)
+    particles: list[tuple[dict[str, Any], float]] = [({}, 1.0)]
+    final_mixture: MixtureDistribution | None = None
+    hop_targets: list[tuple[str, ...]] = []
+
+    for hop_idx, hop in enumerate(hops):
+        is_last = hop_idx == len(hops) - 1
+        hop_targets.append(hop.target)
+        next_components: list[Any] = []
+        next_weights: list[float] = []
+        next_particles: list[tuple[dict[str, Any], float]] = []
+
+        for carried, w in particles:
+            obs = dict(hop.extra_evidence)
+            if hop_idx == 0:
+                obs.update(evidence)
+            else:
+                for prior_name, this_name in hop.carry.items():
+                    obs[this_name] = carried[prior_name]
+            post = hop.joint.infer(obs, list(hop.target))
+
+            if is_last:
+                for comp, cw in zip(post.components, post.w):
+                    next_components.append(comp)
+                    next_weights.append(w * float(cw))
+                continue
+
+            if propagation == "moment":
+                point = {name: _leaf_point_estimate(post.components, post.w, j) for j, name in enumerate(hop.target)}
+                next_particles.append((point, w))
+            else:  # "sampled"
+                if hop_idx == 0:
+                    draws = post.sampler(seed=int(rng.randint(0, 2**31 - 1))).sample(n_samples)
+                    per_weight = w / n_samples
+                    for draw in draws:
+                        next_particles.append((dict(zip(hop.target, draw)), per_weight))
+                else:
+                    draw = post.sampler(seed=int(rng.randint(0, 2**31 - 1))).sample()
+                    next_particles.append((dict(zip(hop.target, draw)), w))
+
+        if is_last:
+            total = float(sum(next_weights))
+            final_mixture = MixtureDistribution(next_components, w=np.asarray(next_weights, dtype=np.float64) / total)
+        else:
+            particles = next_particles
+
+    assert final_mixture is not None  # last hop always populates it
+    receipt = ProgramReceipt(
+        propagation=propagation,
+        n_hops=len(hops),
+        hop_targets=hop_targets,
+        n_particles=len(particles) if propagation == "sampled" else 1,
+    )
+    return ProgramPosterior(mixture=final_mixture, target=hops[-1].target, receipt=receipt)

--- a/mixle/reason/language_bridge.py
+++ b/mixle/reason/language_bridge.py
@@ -1,0 +1,251 @@
+"""The language<->belief bridge (roadmap M5, part (c)): NL/record -> M0 evidence via a declared
+schema, and posterior -> calibrated text through A1's :class:`~mixle.task.calibrated_generator.CalibratedGenerator`.
+
+Two independent directions, each a thin composition of already-tested machinery -- no new extraction
+or generation model is built here (see ``notes/designs/M5.md`` part (c) for the full contract):
+
+* :func:`parse_evidence` -- an extractor callable (the same ``teacher(x) -> dict`` shape
+  :func:`mixle.task.structured_out.solve_structured` decomposes) produces a raw ``{field: value}``
+  dict from NL/record input; this module validates it against a caller-declared schema
+  (``{field: "categorical" | "numeric"}`` -- the same shape
+  :attr:`~mixle.task.structured_out.StructuredSolution.schema` already returns) BEFORE it reaches
+  :func:`~mixle.reason.cross_modal.CrossModalJoint.infer` / :func:`~mixle.reason.inference_program.run_inference_program`,
+  so a schema violation is a clear ``ValueError`` here rather than a confusing downstream
+  ``log_density`` crash.
+* :class:`PosteriorDescriber` / :func:`claim_score` -- draft ``k`` candidate :class:`Claim`\\ s at
+  different ABSOLUTE precision widths (multiples of a required ``tol``, the same "caller declares the
+  precision that counts" contract :func:`mixle.task.regress.solve_regression` already uses for numeric
+  fields -- NOT widths relative to the posterior's own spread, which would be scale-invariant and could
+  never detect "too diffuse to answer"), score each against the posterior it describes, and serve the
+  best one under A1's conformal accept-or-abstain guarantee. :func:`claim_score` is exported standalone
+  (not only reachable through :class:`PosteriorDescriber`) so B2 (claim-checking, built elsewhere) can
+  score an ALREADY-EMITTED claim against any posterior directly, with no dependency on candidate
+  generation/calibration at all.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+
+from mixle.task.calibrated_generator import ABSTAIN, CalibratedGenerator
+
+__all__ = [
+    "Schema",
+    "parse_evidence",
+    "Claim",
+    "claim_score",
+    "PosteriorDescriber",
+    "ABSTAIN",
+]
+
+Schema = dict[str, str]  # {field_name: "categorical" | "numeric"}
+_KINDS = ("categorical", "numeric")
+
+
+def _validate_evidence(raw: dict[str, Any], schema: Schema) -> dict[str, Any]:
+    unknown = [k for k in raw if k not in schema]
+    if unknown:
+        raise ValueError(f"extractor returned undeclared field(s) {sorted(unknown)!r}; schema is {sorted(schema)!r}")
+    out: dict[str, Any] = {}
+    for key, value in raw.items():
+        kind = schema[key]
+        if kind == "numeric":
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                raise ValueError(f"field {key!r} is declared numeric but the extractor returned {value!r}")
+            out[key] = float(value)
+        elif kind == "categorical":
+            out[key] = str(value)
+        else:
+            raise ValueError(f"schema field {key!r} has unknown kind {kind!r}; expected one of {_KINDS}")
+    return out
+
+
+def parse_evidence(text: Any, schema: Schema, extractor: Callable[[Any], dict[str, Any]]) -> dict[str, Any]:
+    """NL scenario/constraint (or any record ``extractor`` accepts) -> validated M0/L2 evidence.
+
+    ``extractor(text) -> {field: raw_value}`` does the actual parsing (a keyword/regex rule, a
+    calibrated :func:`~mixle.task.structured_out.solve_structured` student, an LLM call -- this module
+    is agnostic to how); this function's only job is enforcing the declared ``schema`` BEFORE the
+    result is trusted as evidence: every returned field must be declared, numeric fields must actually
+    be numbers, categorical fields are normalized to ``str``. The returned dict is ready to pass
+    straight to ``CrossModalJoint.infer(...)`` or as ``run_inference_program``'s ``evidence=``.
+    """
+    if not schema:
+        raise ValueError("parse_evidence needs a non-empty schema")
+    raw = extractor(text)
+    if not isinstance(raw, dict):
+        raise TypeError(f"extractor(text) must return a dict, got {type(raw).__name__}")
+    return _validate_evidence(raw, schema)
+
+
+@dataclass(frozen=True)
+class Claim:
+    """A declared interval assertion about one posterior field: ``field`` lies in ``[lo, hi]``.
+
+    ``probe`` caches the sample batch a :class:`PosteriorDescriber` drew to score this claim at
+    generation time, so :meth:`~mixle.task.calibrated_generator.CalibratedGenerator`'s single-argument
+    ``score(candidate)`` contract can call :func:`claim_score` with no extra prompt/posterior plumbing.
+    A hand-authored ``Claim`` (e.g. from B2) simply omits ``probe`` and passes ``posterior=`` to
+    :func:`claim_score` explicitly instead.
+    """
+
+    field: str
+    lo: float
+    hi: float
+    probe: tuple[float, ...] = field(default=(), compare=False)
+
+    @property
+    def width(self) -> float:
+        return self.hi - self.lo
+
+    def contains(self, value: float) -> bool:
+        return self.lo <= value <= self.hi
+
+    def text(self) -> str:
+        mid = 0.5 * (self.lo + self.hi)
+        if self.width < 1e-9:
+            return f"{self.field} is approximately {mid:.4g}"
+        return f"{self.field} is between {self.lo:.4g} and {self.hi:.4g}"
+
+
+def _sample_scalar(posterior: Any, n: int, seed: int | None) -> np.ndarray:
+    """Extract ``n`` scalar draws of a single field from any M0/L2/M5 posterior-like object, or pass a
+    plain array/sequence of scalars through unchanged. A real, documented scope limit (not silently
+    wrong for other shapes): this only handles objects whose draws are already scalars or 1-tuples --
+    exactly what a single-field :class:`~mixle.reason.inference_program.ProgramPosterior` or a
+    single-target :class:`~mixle.stats.latent.mixture.MixtureDistribution`
+    (``CrossModalJoint.infer(..., [field])``) produce."""
+    if isinstance(posterior, np.ndarray):
+        return posterior.astype(float)
+    if isinstance(posterior, Sequence) and posterior and isinstance(posterior[0], (int, float, np.floating)):
+        return np.asarray(posterior, dtype=float)
+    if hasattr(posterior, "sample"):
+        try:
+            draws = posterior.sample(n, seed=seed)
+        except TypeError:
+            draws = posterior.sample(n)
+    elif hasattr(posterior, "sampler"):
+        draws = posterior.sampler(seed=seed).sample(n)
+    else:
+        raise TypeError(f"do not know how to sample a field from {type(posterior).__name__}")
+    out = []
+    for d in draws:
+        if isinstance(d, (int, float, np.floating, np.integer)):
+            out.append(float(d))
+        elif isinstance(d, (tuple, list, np.ndarray)) and len(d) == 1:
+            out.append(float(d[0]))
+        else:
+            raise ValueError(f"expected a scalar or single-field draw, got {d!r}")
+    return np.asarray(out, dtype=float)
+
+
+def claim_score(claim: Claim, posterior: Any = None, *, n_samples: int = 200, seed: int | None = 0) -> float:
+    """How well ``claim`` is supported by the posterior it describes: coverage of ``[claim.lo,
+    claim.hi]`` under fresh posterior draws, PER UNIT WIDTH (``coverage / width``) -- a density-like
+    score, not a linear coverage-minus-penalty one. The ratio form matters, not just tie-breaking: a
+    coverage-minus-linear-penalty score is shift-invariant under softmax whenever coverage SATURATES
+    to the same constant across every candidate width, which happens in BOTH the confident regime (a
+    sharp posterior's mass fits inside every candidate width, coverage saturates near 1) and the
+    clueless regime (a posterior far more diffuse than the widest candidate has near-locally-uniform
+    density, so coverage saturates near ``density(center) * width`` for every candidate) -- softmax
+    over a constant offset cannot tell those two regimes apart. ``coverage / width`` does not saturate
+    the same way: in the confident regime it grows as ``1 / width`` (the NARROWEST candidate wins
+    decisively), while in the clueless regime ``coverage / width -> density(center)``, the SAME
+    value for every candidate width (a uniform, non-committal softmax) -- exactly the "no candidate is
+    more informative than any other" signal :meth:`PosteriorDescriber.describe` abstains on.
+
+    Reusable standalone by B2's claim-checking: pass ``posterior=`` to score an independently-authored
+    claim against any posterior; a :class:`PosteriorDescriber`-generated claim can instead be
+    re-scored with no ``posterior`` argument, reusing the sample batch cached at generation time.
+    """
+    if posterior is not None:
+        values = _sample_scalar(posterior, n_samples, seed)
+    elif claim.probe:
+        values = np.asarray(claim.probe, dtype=float)
+    else:
+        raise ValueError("claim_score needs either posterior=... or a claim with cached probe samples")
+    coverage = float(np.mean((values >= claim.lo) & (values <= claim.hi)))
+    return coverage / max(claim.width, 1e-12)
+
+
+class PosteriorDescriber:
+    """Posterior -> calibrated text for one field, via A1's :class:`CalibratedGenerator`.
+
+    ``tol`` is the caller's required precision (the same "the caller states what precision counts as
+    an answer" contract :func:`~mixle.task.regress.solve_regression` uses) -- candidate claim widths
+    are ABSOLUTE multiples of ``tol``, not relative to the posterior's own spread, so a genuinely
+    diffuse posterior (spread >> ``tol``) cannot fake confidence by simply widening every candidate in
+    lockstep: none of them will cover well enough to clear the calibrated threshold, and
+    :meth:`describe` abstains (acceptance criterion (d)).
+    """
+
+    def __init__(
+        self,
+        field_name: str,
+        *,
+        tol: float,
+        k: int = 3,
+        alpha: float = 0.1,
+        width_multiples: tuple[float, ...] = (1.0, 3.0, 10.0),
+        n_probe: int = 300,
+        seed: int = 0,
+    ) -> None:
+        if tol <= 0:
+            raise ValueError(f"tol must be > 0, got {tol}")
+        if k > len(width_multiples):
+            raise ValueError(f"k={k} exceeds the number of configured width_multiples ({len(width_multiples)})")
+        self.field_name = field_name
+        self.tol = float(tol)
+        self.width_multiples = width_multiples[:k]
+        self.n_probe = n_probe
+        self._gen = CalibratedGenerator(self._generate, self._score, alpha=alpha, k=k, seed=seed)
+
+    def _generate(self, posterior: Any, k: int, rng: Any = None) -> list[Claim]:
+        base_seed = int(rng.integers(0, 2**31 - 1)) if rng is not None else None
+        center_probe = _sample_scalar(posterior, self.n_probe, base_seed)
+        mean = float(np.mean(center_probe))
+        claims = []
+        for i, mult in enumerate(self.width_multiples):
+            half = mult * self.tol
+            score_seed = None if base_seed is None else base_seed + i + 1
+            probe = _sample_scalar(posterior, self.n_probe, score_seed)
+            claims.append(Claim(field=self.field_name, lo=mean - half, hi=mean + half, probe=tuple(probe.tolist())))
+        return claims
+
+    def _score(self, claim: Claim) -> float:
+        return claim_score(claim)
+
+    def calibrate(self, calibration_set: Sequence[tuple[Any, float]], *, seed: int | None = None) -> PosteriorDescriber:
+        """Fit the conformal threshold from ``(posterior, true_value)`` held-out pairs.
+
+        ``is_correct`` assigns EXCLUSIVE correctness across the ``k`` nested candidate widths --
+        the true value's distance from the shared center falls in exactly one of the ``k`` disjoint
+        precision BANDS ``(0, tol], (tol, 3*tol], ...`` (widths are nested/overlapping as claims, but
+        only the tightest band a true value actually falls in counts as "correct"). Without this, a
+        wide claim trivially contains the true value whenever a narrower nested claim does too, so
+        every calibration point would credit ALL of them at once and the conformal threshold would
+        never learn to prefer -- or reject -- any one candidate.
+        """
+        posteriors = [p for p, _ in calibration_set]
+        truth = {id(p): v for p, v in calibration_set}
+        half_widths = sorted(mult * self.tol for mult in self.width_multiples)
+
+        def is_correct(posterior: Any, claim: Claim) -> bool:
+            dist = abs(truth[id(posterior)] - 0.5 * (claim.lo + claim.hi))
+            half = 0.5 * claim.width
+            idx = min(range(len(half_widths)), key=lambda j: abs(half_widths[j] - half))
+            band_lo = half_widths[idx - 1] if idx > 0 else 0.0
+            return band_lo < dist <= half_widths[idx]
+
+        self._gen.calibrate(posteriors, is_correct, seed=seed)
+        return self
+
+    def describe(self, posterior: Any, *, seed: int | None = None) -> Claim | None:
+        """The best calibrated claim about ``posterior``, or :data:`ABSTAIN` (``None``) when no
+        candidate width conformally clears the threshold -- i.e. the posterior is too diffuse relative
+        to ``tol`` for any of this describer's claims to be trustworthy."""
+        return self._gen.serve(posterior, seed=seed)

--- a/mixle/task/__init__.py
+++ b/mixle/task/__init__.py
@@ -125,6 +125,7 @@ from mixle.task.imagine import (
     ceiling_report,
     propose_structure,
 )
+from mixle.task.inverse import InverseModel, InverseReceipts, learn_inverse
 from mixle.task.irl import MaxEntIRLResult, max_ent_irl, rollout_states, state_features
 from mixle.task.llm import (
     CallableLLM,
@@ -275,6 +276,9 @@ __all__ = [
     "StructuralCandidate",
     "ceiling_report",
     "propose_structure",
+    "InverseModel",
+    "InverseReceipts",
+    "learn_inverse",
     "FieldChoice",
     "GenerativeTextIO",
     "extractive_capture_profile",

--- a/mixle/task/inverse.py
+++ b/mixle/task/inverse.py
@@ -1,0 +1,462 @@
+"""``learn_inverse`` -- amortized posteriors ``q(theta | y)`` for a simulator, with calibration receipts.
+
+Simulation-based inference done the mixle way: given a forward simulator ``g: theta -> y`` (a bare
+Python callable -- no ``mixle.task.imagine``/M2 program required) and a prior ``p(theta)`` (any
+fitted mixle ``Model``), :func:`learn_inverse` trains a torch CONDITIONAL density student
+``q(theta | y)`` on simulated ``(theta, y)`` pairs, then ships it wrapped as an
+:class:`~mixle.inference.condition.Posterior` (M0's type) so downstream ``condition``/``do``
+composition and B7 treat a learned inverse exactly like an exactly-conditioned one -- except its
+``.receipt`` carries an explicit amortization warning plus a pointer to :class:`InverseReceipts`,
+because a trained student is an APPROXIMATION and the whole point of this module is to ship the
+numbers that say whether to trust it.
+
+Convention (matches ``build_mdn``/``build_conditional_flow``'s own ``log_density(x, y)``/
+``sample_given(x)`` contract): ``theta`` -- the quantity being inferred -- is the student's
+``y``-ARGUMENT, and the observed data ``y`` is its ``x``-argument. So ``q(theta | y_obs)`` is
+``module.sample_given(y_obs) -> theta`` and its density is ``module.log_density(y_obs, theta)`` --
+the inverse of the simulator's own arrow.
+
+The student is trained through the vendored :class:`~mixle.models.grad_leaf.GradLeaf` (a bare torch
+module IS the model), not the simpler :class:`~mixle.models.mixture_density.NeuralConditionalDensity`
+adapter -- see ``notes/designs/M3.md`` for why: sequential refinement (below) re-scores the module
+against freshly generated round data before the next fit commits, which wants the generic
+``seq_log_density`` path ``GradLeaf`` gives any bare module (warm-started across ``optimize()``
+calls via the SAME underlying ``nn.Module`` object) rather than a second bespoke accumulator.
+``NeuralConditionalDensity`` remains the simpler documented alternative for callers who don't need
+round-conditioned rescoring.
+
+Algorithm (``notes/designs/M3.md``):
+
+1. **Pair generation (round 1).** ``theta_i ~ p(theta)`` via the prior's own sampler; ``y_i =
+   simulator(theta_i)`` in a plain Python loop (no batching assumed on ``simulator``).
+2. **Student.** ``build_conditional_flow``/``build_mdn`` wrapped in :class:`GradLeaf`, fit via
+   ``optimize(list(zip(y_pairs, theta_pairs)), leaf, ...)`` -- A4.4's tuple-default-loss fix is what
+   lets the bare module's two-arg ``log_density(x, y)`` score straight off tuple observations.
+3. **Sequential refinement (rounds 2..R).** Resolved decision (was open in the design note): eager,
+   via an optional ``y_obs`` keyword to THIS function. When ``y_obs`` is given, each subsequent
+   round draws ``theta ~ q(theta | y_obs)`` from the CURRENT round's student, re-runs the simulator,
+   and retrains warm-started from the previous round's module weights (same object, so ``optimize``
+   continues training it in place -- the same warm-start pattern ``GradLeaf``'s own M-step uses
+   across EM iterations). ``rounds > 1`` without ``y_obs`` has no observation to sharpen toward, so
+   it raises ``ValueError`` rather than silently doing nothing -- round 1 alone (unconditional pair
+   generation) is valid without ``y_obs``.
+4. **Optional exactness stage.** ``reweight=True`` with ``true_log_likelihood(theta, y_obs) ->
+   float`` (a LOG likelihood) treats the final round's ``q(theta | y_obs)`` as a self-normalized-
+   importance-sampling proposal: ``log w_j = log p(theta_j) + true_log_likelihood(theta_j, y_obs) -
+   log q(theta_j | y_obs)``, normalized by log-sum-exp (the same construction
+   ``mixle.inference.condition``'s SIR fallback uses), with ``ESS = 1 / sum(w_norm^2)`` reported so a
+   low ESS visibly says "don't trust this reweighted posterior" instead of silently returning a
+   degenerate one.
+5. **Calibration receipts (always computed).**
+   - **SBC.** Resolved decision (was open): a chi-square uniformity test on binned ranks (Talts et
+     al.), ``bins = min(20, n_sbc_replications // 5)`` (clamped to >= 2), one chi-square statistic
+     per ``theta`` dimension SUMMED (valid under the standard independence-across-dimensions
+     simplification -- a sum of independent chi-square variables is chi-square with summed degrees
+     of freedom), against threshold ``p-value > 0.01`` (no rejection of uniformity).
+   - **Coverage.** Per-dimension, per-replication credible interval containment vs nominal level,
+     averaged; pass when within +/-5% of nominal.
+   - **Prior-predictive.** Empirical mean/std of the round-1 simulated ``y_i``'s, plus (when
+     ``y_obs`` is given) its per-dimension z-score against that empirical distribution -- a
+     caller-facing warning, not a gate.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+from scipy.stats import chi2
+
+from mixle.inference.condition import ConditionReceipt, Posterior
+from mixle.inference.estimation import optimize
+from mixle.models.grad_leaf import GradLeaf
+
+__all__ = ["InverseModel", "InverseReceipts", "learn_inverse"]
+
+
+def _torch() -> Any:
+    import torch
+
+    return torch
+
+
+def _next_seed(rng: np.random.RandomState) -> int:
+    return int(rng.randint(0, 2**31 - 1))
+
+
+def _as_rows(arr: Any, n: int) -> np.ndarray:
+    """Normalize a sampler's ``sample(n)`` output to shape ``(n, d)``. A univariate sampler
+    (e.g. ``GaussianDistribution``) returns a flat ``(n,)`` array of scalar draws -- ``atleast_2d``
+    on that would misread it as ONE row of ``n`` dimensions instead of ``n`` rows of one dimension,
+    so a 1-D result of length ``n`` is reshaped to ``(n, 1)`` explicitly rather than via ``atleast_2d``."""
+    a = np.asarray(arr, dtype=float)
+    if a.ndim == 1:
+        return a.reshape(n, 1)
+    return a
+
+
+def _build_student(family: str, *, x_dim: int, y_dim: int, hidden: int, seed: int | None) -> Any:
+    from mixle.models.mixture_density import build_conditional_flow, build_mdn
+
+    # nn.Module weight init draws from torch's GLOBAL rng, not our own seeded RandomState -- seed it
+    # explicitly here so a given `seed=` to learn_inverse determines the student's starting weights
+    # too (determinism is a contract, rule 0.2.4), independent of whatever global torch state a
+    # caller/earlier test left behind.
+    torch = _torch()
+    torch.manual_seed(int(seed) if seed is not None else 0)
+    if family == "flow":
+        return build_conditional_flow(x_dim, y_dim, hidden=hidden)
+    if family == "mdn":
+        return build_mdn(x_dim, y_dim, hidden=hidden)
+    raise ValueError(f"family must be 'flow' or 'mdn', got {family!r}")
+
+
+def _generate_pairs(
+    prior: Any, simulator: Callable[[Any], Any], n: int, seed: int | None
+) -> tuple[np.ndarray, np.ndarray]:
+    """``n`` fresh ``(theta_i, y_i)`` pairs: ``theta_i ~ prior``, ``y_i = simulator(theta_i)`` (a plain
+    Python loop -- no batching assumption on ``simulator``)."""
+    thetas = _as_rows(prior.sampler(seed=seed).sample(int(n)), int(n))
+    ys = np.asarray([np.atleast_1d(np.asarray(simulator(theta), dtype=float)) for theta in thetas], dtype=float)
+    return thetas, ys
+
+
+def _sample_given(module: Any, x_row: np.ndarray, n: int, *, seed: int | None) -> np.ndarray:
+    """``n`` draws of ``theta ~ q(theta | x_row)`` from a fitted student ``module``."""
+    torch = _torch()
+    module.eval()
+    rng = np.random.RandomState(seed)
+    torch.manual_seed(_next_seed(rng))
+    xt = torch.as_tensor(np.tile(np.atleast_1d(np.asarray(x_row, dtype=float)), (int(n), 1)), dtype=torch.float32)
+    with torch.no_grad():
+        return module.sample_given(xt).cpu().numpy()
+
+
+def _log_density_given(module: Any, x_row: np.ndarray, theta_batch: np.ndarray) -> np.ndarray:
+    """``log q(theta | x_row)`` for every row of ``theta_batch`` (shape ``(n, theta_dim)``)."""
+    torch = _torch()
+    module.eval()
+    theta_batch = np.atleast_2d(np.asarray(theta_batch, dtype=float))
+    n = theta_batch.shape[0]
+    xt = torch.as_tensor(np.tile(np.atleast_1d(np.asarray(x_row, dtype=float)), (n, 1)), dtype=torch.float32)
+    yt = torch.as_tensor(theta_batch, dtype=torch.float32)
+    with torch.no_grad():
+        return module.log_density(xt, yt).cpu().numpy().reshape(-1)
+
+
+def _fit_round(module: Any, ys: np.ndarray, thetas: np.ndarray, *, m_steps: int, lr: float, max_its: int) -> Any:
+    """One ``optimize()`` call against ``(y, theta)`` pairs, warm-started from ``module``'s own weights
+    (same underlying ``nn.Module`` object -- ``GradEstimator.estimate`` mutates it in place)."""
+    data = list(zip(ys.tolist(), thetas.tolist()))
+    leaf = GradLeaf(module, m_steps=m_steps, lr=lr)
+    fitted = optimize(data, leaf, max_its=max_its, out=None)
+    return fitted.module
+
+
+def _posterior_sharpness(module: Any, y_obs: np.ndarray, theta_dim: int, *, n: int, seed: int | None) -> float:
+    """A scalar "how spread out is q(theta | y_obs)" receipt -- sum of per-dimension sample variance.
+    Lower is sharper; used to assert refinement rounds measurably sharpen the posterior (test (e))."""
+    samples = _sample_given(module, y_obs, n, seed=seed)
+    return float(np.sum(np.var(samples, axis=0)))
+
+
+def _calibration_receipts(
+    module: Any,
+    prior: Any,
+    simulator: Callable[[Any], Any],
+    *,
+    theta_dim: int,
+    n_replications: int,
+    n_posterior_samples: int,
+    coverage_levels: tuple[float, ...],
+    seed: int | None,
+) -> tuple[float, float, int, dict[float, float]]:
+    """SBC (chi-square on binned ranks) + per-level coverage, sharing the same replications."""
+    rng = np.random.RandomState(seed)
+    ranks = np.zeros((n_replications, theta_dim), dtype=int)
+    covered = {c: np.zeros((n_replications, theta_dim), dtype=bool) for c in coverage_levels}
+    for r in range(n_replications):
+        theta_star = np.atleast_1d(np.asarray(prior.sampler(seed=_next_seed(rng)).sample(1), dtype=float)).reshape(-1)[
+            :theta_dim
+        ]
+        y_star = np.atleast_1d(np.asarray(simulator(theta_star), dtype=float))
+        samples = _sample_given(module, y_star, n_posterior_samples, seed=_next_seed(rng))
+        for d in range(theta_dim):
+            ranks[r, d] = int(np.sum(samples[:, d] < theta_star[d]))
+            for c in coverage_levels:
+                lo_q, hi_q = (1.0 - c) / 2.0, (1.0 + c) / 2.0
+                lo, hi = np.quantile(samples[:, d], [lo_q, hi_q])
+                covered[c][r, d] = bool(lo <= theta_star[d] <= hi)
+
+    # SBC: bins = min(20, n_sbc_replications // 5), clamped to >= 2 -- the resolved binning choice
+    # (design note "Resolved" section / mixle.task.inverse docstring).
+    bins = max(2, min(20, n_replications // 5))
+    edges = np.linspace(0.0, float(n_posterior_samples), bins + 1)
+    stat_total, df_total = 0.0, 0
+    for d in range(theta_dim):
+        hist, _ = np.histogram(ranks[:, d], bins=edges)
+        expected = n_replications / bins
+        stat_total += float(np.sum((hist - expected) ** 2 / expected))
+        df_total += bins - 1
+    pvalue = float(chi2.sf(stat_total, df_total)) if df_total > 0 else 1.0
+
+    coverage_emp = {c: float(np.mean(covered[c])) for c in coverage_levels}
+    return stat_total, pvalue, bins, coverage_emp
+
+
+def _prior_predictive_receipt(ys: np.ndarray, y_obs: np.ndarray | None) -> dict[str, Any]:
+    mean = ys.mean(axis=0)
+    std = ys.std(axis=0) + 1e-12
+    report: dict[str, Any] = {"y_mean": mean.tolist(), "y_std": std.tolist(), "n": int(ys.shape[0])}
+    if y_obs is None:
+        report["y_obs_zscore"] = None
+        report["in_distribution_warning"] = None
+        return report
+    y_obs_arr = np.atleast_1d(np.asarray(y_obs, dtype=float))
+    z = (y_obs_arr - mean) / std
+    report["y_obs_zscore"] = z.tolist()
+    report["max_abs_zscore"] = float(np.max(np.abs(z)))
+    report["in_distribution_warning"] = bool(np.max(np.abs(z)) > 3.0)
+    return report
+
+
+def _reweight_receipt(
+    module: Any,
+    prior: Any,
+    true_log_likelihood: Callable[[Any, Any], float],
+    y_obs: np.ndarray,
+    *,
+    n: int,
+    seed: int | None,
+) -> tuple[float, float, list[str]]:
+    """Self-normalized importance reweighting of ``q(theta | y_obs)`` against the true likelihood
+    (same log-sum-exp construction as ``mixle.inference.condition``'s SIR fallback)."""
+    thetas = _sample_given(module, y_obs, n, seed=seed)
+    log_q = _log_density_given(module, y_obs, thetas)
+    log_prior = np.array([float(prior.log_density(theta)) for theta in thetas])
+    log_lik = np.array([float(true_log_likelihood(theta, y_obs)) for theta in thetas])
+    log_w = log_prior + log_lik - log_q
+
+    warnings: list[str] = []
+    finite = np.isfinite(log_w)
+    if not finite.any():
+        ess = 0.0
+        warnings.append("reweight: all importance weights are zero/non-finite.")
+    else:
+        m = log_w[finite].max()
+        w = np.where(finite, np.exp(log_w - m), 0.0)
+        sw = w.sum()
+        w_norm = w / sw
+        ess = float(1.0 / np.sum(w_norm**2))
+    ess_ratio = ess / n
+    if ess_ratio < 0.01:
+        warnings.append(f"reweight ESS ratio {ess_ratio:.4f} < 0.01 -- reweighted posterior is not trustworthy.")
+    return ess, ess_ratio, warnings
+
+
+@dataclass
+class InverseReceipts:
+    """The calibration report that ships with every :class:`InverseModel` -- tells the caller
+    whether to trust ``q(theta | y)``, not just a point estimate."""
+
+    sbc_statistic: float
+    sbc_pvalue: float
+    sbc_bins: int
+    sbc_replications: int
+    sbc_pass: bool  # p-value > 0.01 (resolved acceptance threshold -- see module docstring)
+    coverage: dict[float, float]  # nominal level -> empirical coverage
+    coverage_pass: dict[float, bool]  # within +/-5% of nominal
+    prior_predictive: dict[str, Any]
+    rounds_trained: int
+    sharpness_by_round: list[float] = field(default_factory=list)
+    ess: float | None = None
+    ess_ratio: float | None = None
+    warnings: list[str] = field(default_factory=list)
+
+
+class InverseModel:
+    """A fitted amortized posterior ``q(theta | y)`` plus its :class:`InverseReceipts`."""
+
+    def __init__(
+        self,
+        *,
+        module: Any,
+        prior: Any,
+        simulator: Callable[[Any], Any],
+        family: str,
+        theta_dim: int,
+        y_dim: int,
+        receipts: InverseReceipts,
+        seed: int | None = None,
+    ) -> None:
+        self.module = module
+        self.prior = prior
+        self.simulator = simulator
+        self.family = family
+        self.theta_dim = theta_dim
+        self.y_dim = y_dim
+        self.receipts = receipts
+        self._seed = seed
+
+    def posterior(self, y: Any) -> Posterior:
+        """Wrap ``q(theta | y)`` as an M0 :class:`~mixle.inference.condition.Posterior`: ``sample(n)``
+        / ``log_density(theta)`` / ``mean(field)`` / ``.receipt`` -- so downstream condition/do
+        composition treats a learned inverse like an exactly-conditioned one, modulo the amortization
+        warning on ``.receipt`` and the ``InverseReceipts`` pointer at ``.receipt.inverse_receipts``."""
+        y_row = np.atleast_1d(np.asarray(y, dtype=float))
+        module = self.module
+        base_seed = self._seed
+
+        def sample_fn(n: int, s: int | None) -> np.ndarray:
+            return _sample_given(module, y_row, n, seed=s if s is not None else base_seed)
+
+        def log_density_fn(theta: Any) -> float:
+            theta_row = np.atleast_2d(np.asarray(theta, dtype=float))
+            return float(_log_density_given(module, y_row, theta_row)[0])
+
+        def mean_fn(path: tuple[int, ...]) -> float:
+            idx = int(path[0]) if len(path) else 0
+            samples = _sample_given(module, y_row, 500, seed=base_seed)
+            return float(np.mean(samples[:, idx]))
+
+        receipt = ConditionReceipt(
+            method="amortized",
+            warnings=[
+                "InverseModel.posterior: a LEARNED amortized approximation "
+                "(mixle.task.inverse.learn_inverse), not exact conditioning -- see "
+                ".receipt.inverse_receipts (SBC/coverage/prior-predictive/ESS) before trusting it."
+            ],
+        )
+        receipt.inverse_receipts = self.receipts  # pointer to the full calibration report (not an M0 field)
+        return Posterior(
+            sample_fn=sample_fn, log_density_fn=log_density_fn, mean_fn=mean_fn, receipt=receipt, model=None
+        )
+
+
+def learn_inverse(
+    simulator: Callable[[Any], Any],
+    prior: Any,
+    *,
+    family: str = "flow",
+    n_sims: int = 2000,
+    rounds: int = 1,
+    n_sbc_replications: int = 200,
+    coverage_levels: tuple[float, ...] = (0.5, 0.9),
+    reweight: bool = False,
+    true_log_likelihood: Callable[[Any, Any], float] | None = None,
+    y_obs: Any = None,
+    seed: int | None = None,
+    m_steps: int = 200,
+    lr: float = 5e-3,
+    max_its: int = 1,
+    hidden: int = 32,
+    n_posterior_samples: int = 200,
+    n_reweight_samples: int = 500,
+) -> InverseModel:
+    """Learn an amortized posterior ``q(theta | y)`` for simulator ``g: theta -> y`` under prior
+    ``p(theta)``. See the module docstring for the full algorithm and the calibration receipts
+    computed unconditionally.
+
+    ``family="flow"`` (``build_conditional_flow``) requires ``theta`` (the quantity being inferred,
+    the student's ``y``-argument) to be >= 2-dimensional -- ``build_conditional_flow`` needs
+    ``y_dim >= 2`` for its coupling layers to be non-trivial (see its own docstring). A 1-D ``theta``
+    (e.g. a scalar-parameter inverse problem) must use ``family="mdn"``, which has no such
+    restriction (a mixture of per-component Gaussians is well-defined for scalar ``theta`` too, and
+    is the more direct fit for asserting multimodality component-by-component).
+
+    ``rounds > 1`` (SNPE-style sequential refinement toward a SPECIFIC observation) requires
+    ``y_obs``: round 1 alone (unconditional pair generation) is the only round that has meaning
+    without an observation to sharpen against.
+    """
+    if family not in ("flow", "mdn"):
+        raise ValueError(f"family must be 'flow' or 'mdn', got {family!r}")
+    if int(rounds) < 1:
+        raise ValueError("rounds must be >= 1")
+    if int(rounds) > 1 and y_obs is None:
+        raise ValueError(
+            "learn_inverse(rounds > 1) requires y_obs: rounds 2..R perform SNPE-style refinement "
+            "toward a SPECIFIC observation (draw theta ~ q(theta | y_obs) from the current round's "
+            "student, re-run the simulator, retrain warm-started) -- with no y_obs there is nothing "
+            "to refine toward, so rounds > 1 is meaningless. Round 1 alone (unconditional pair "
+            "generation) is valid without y_obs; pass y_obs=... for rounds > 1."
+        )
+    if reweight and true_log_likelihood is None:
+        raise ValueError("reweight=True requires true_log_likelihood(theta, y_obs) -> float (a LOG likelihood).")
+
+    rng = np.random.RandomState(seed)
+    y_obs_arr = None if y_obs is None else np.atleast_1d(np.asarray(y_obs, dtype=float))
+
+    # round 1: unconditional pair generation
+    thetas, ys = _generate_pairs(prior, simulator, n_sims, _next_seed(rng))
+    theta_dim = thetas.shape[1]
+    y_dim = ys.shape[1]
+
+    if family == "flow" and theta_dim < 2:
+        raise ValueError(
+            f"family='flow' requires theta (the quantity being inferred, the student's y-argument) "
+            f">= 2-dimensional -- build_conditional_flow needs y_dim >= 2 for its coupling layers to "
+            f"be non-trivial (see its docstring). Got theta_dim={theta_dim}; use family='mdn' instead."
+        )
+
+    module = _build_student(family, x_dim=y_dim, y_dim=theta_dim, hidden=hidden, seed=_next_seed(rng))
+    module = _fit_round(module, ys, thetas, m_steps=m_steps, lr=lr, max_its=max_its)
+
+    sharpness_by_round: list[float] = []
+    if y_obs_arr is not None:
+        sharpness_by_round.append(_posterior_sharpness(module, y_obs_arr, theta_dim, n=500, seed=_next_seed(rng)))
+
+    for _r in range(2, int(rounds) + 1):
+        theta_round = _sample_given(module, y_obs_arr, n_sims, seed=_next_seed(rng))
+        y_round = np.asarray([np.atleast_1d(np.asarray(simulator(t), dtype=float)) for t in theta_round], dtype=float)
+        module = _fit_round(module, y_round, theta_round, m_steps=m_steps, lr=lr, max_its=max_its)
+        sharpness_by_round.append(_posterior_sharpness(module, y_obs_arr, theta_dim, n=500, seed=_next_seed(rng)))
+
+    sbc_stat, sbc_pvalue, sbc_bins, coverage_emp = _calibration_receipts(
+        module,
+        prior,
+        simulator,
+        theta_dim=theta_dim,
+        n_replications=n_sbc_replications,
+        n_posterior_samples=n_posterior_samples,
+        coverage_levels=coverage_levels,
+        seed=_next_seed(rng),
+    )
+    coverage_pass = {c: bool(abs(coverage_emp[c] - c) <= 0.05) for c in coverage_levels}
+    prior_pred = _prior_predictive_receipt(ys, y_obs_arr)
+
+    ess = ess_ratio = None
+    reweight_warnings: list[str] = []
+    if reweight:
+        assert true_log_likelihood is not None  # narrowed by the guard above
+        ess, ess_ratio, reweight_warnings = _reweight_receipt(
+            module, prior, true_log_likelihood, y_obs_arr, n=n_reweight_samples, seed=_next_seed(rng)
+        )
+
+    receipts = InverseReceipts(
+        sbc_statistic=sbc_stat,
+        sbc_pvalue=sbc_pvalue,
+        sbc_bins=sbc_bins,
+        sbc_replications=int(n_sbc_replications),
+        sbc_pass=bool(sbc_pvalue > 0.01),
+        coverage=coverage_emp,
+        coverage_pass=coverage_pass,
+        prior_predictive=prior_pred,
+        rounds_trained=int(rounds),
+        sharpness_by_round=sharpness_by_round,
+        ess=ess,
+        ess_ratio=ess_ratio,
+        warnings=reweight_warnings,
+    )
+
+    return InverseModel(
+        module=module,
+        prior=prior,
+        simulator=simulator,
+        family=family,
+        theta_dim=theta_dim,
+        y_dim=y_dim,
+        receipts=receipts,
+        seed=seed,
+    )

--- a/mixle/tests/geoscience_inversion_report_test.py
+++ b/mixle/tests/geoscience_inversion_report_test.py
@@ -1,0 +1,86 @@
+"""B7: sense -> simulate -> invert -> report -- the track-M full-loop demo (M0/M2/M3/M5/A1)."""
+
+import sys
+import unittest
+from pathlib import Path
+
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "examples"))
+from geoscience_inversion_report import (  # noqa: E402
+    SENSOR_NOISE,
+    TRUE_DEPTH,
+    TRUE_FORMATION,
+    _amplitude,
+    build_calibration_set,
+    fit_joint,
+    invert_new_observation,
+    main,
+    sense,
+    what_if_salt,
+)
+
+from mixle.stats.univariate.continuous.gaussian import GaussianDistribution  # noqa: E402
+
+
+class SenseSimulateInvertReportTest(unittest.TestCase):
+    def setUp(self):
+        self.records = sense(600, seed=0)
+        self.net = fit_joint(self.records)
+
+    def test_fit_joint_recovers_the_shared_latent_structure(self):
+        # field 0 (formation) is the root latent driving both field 1 (amplitude) and field 2 (depth)
+        by_child = {f.child: f for f in self.net.factors}
+        self.assertEqual(len(self.net.factors), 3)
+        self.assertEqual(list(by_child[0].parents), [])
+        self.assertIn(0, by_child[1].parents)  # amplitude conditions on formation
+        self.assertIn(0, by_child[2].parents)  # depth conditions on formation
+
+    def test_m2_what_if_rolls_out_the_salt_regime(self):
+        sim, depths, amps = what_if_salt(self.net, seed=1)
+        salt_mean = 4.5  # FORMATION_PARAMS["salt"]'s generative depth mean
+        # the do(formation="salt") rollout should land near salt's own generative depth law
+        self.assertLess(abs(depths.mean() - salt_mean), 0.3)
+        self.assertGreater(depths.std(), 0.0)
+        self.assertEqual(amps.shape[1], 3)
+        self.assertEqual(sim.receipt.method, "none")  # intervention only, no evidence to condition on
+
+    def test_m3_inverts_a_new_observation_close_to_the_true_depth(self):
+        sim, wi_depths, _wi_amps = what_if_salt(self.net, seed=1)
+        depth_prior = GaussianDistribution(mu=float(wi_depths.mean()), sigma2=float(wi_depths.var()))
+        obs_rng = np.random.RandomState(123)
+        y_obs = np.asarray(_amplitude(TRUE_DEPTH, TRUE_FORMATION), dtype=float) + SENSOR_NOISE * obs_rng.randn(3)
+
+        inv_model = invert_new_observation(depth_prior, y_obs, seed=9)
+        post_samples = inv_model.posterior(y_obs).sample(2000, seed=5)
+        self.assertLess(abs(float(post_samples.mean()) - TRUE_DEPTH), 0.3)
+        # calibration receipts are always computed, whether or not they pass
+        self.assertIsInstance(inv_model.receipts.sbc_pvalue, float)
+        self.assertIn(0.9, inv_model.receipts.coverage)
+
+    def test_m5_report_serves_a_claim_that_brackets_the_truth(self):
+        sim, wi_depths, _wi_amps = what_if_salt(self.net, seed=1)
+        depth_prior = GaussianDistribution(mu=float(wi_depths.mean()), sigma2=float(wi_depths.var()))
+        obs_rng = np.random.RandomState(123)
+        y_obs = np.asarray(_amplitude(TRUE_DEPTH, TRUE_FORMATION), dtype=float) + SENSOR_NOISE * obs_rng.randn(3)
+
+        inv_model = invert_new_observation(depth_prior, y_obs, seed=9)
+        calibration_set = build_calibration_set(inv_model, depth_prior, n=60, seed=999)
+        self.assertEqual(len(calibration_set), 60)
+
+        from mixle.reason.language_bridge import PosteriorDescriber
+
+        describer = PosteriorDescriber(
+            "depth_km", tol=0.1, k=3, alpha=0.2, width_multiples=(1.0, 3.0, 10.0), n_probe=300, seed=0
+        )
+        describer.calibrate(calibration_set, seed=0)
+        claim = describer.describe(inv_model.posterior(y_obs), seed=0)
+        self.assertIsNotNone(claim)  # a calibrated candidate clears the threshold for this seeded run
+        self.assertTrue(claim.contains(TRUE_DEPTH))
+
+    def test_main_runs_end_to_end(self):
+        main()  # exercises the full sense -> simulate -> invert -> report loop; asserts internally
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mixle/tests/inference_program_test.py
+++ b/mixle/tests/inference_program_test.py
@@ -1,0 +1,138 @@
+"""Multi-hop inference programs (roadmap M5, part (a)/(b)).
+
+Fixture: two separately-fit :class:`~mixle.reason.cross_modal.CrossModalJoint` objects sharing a
+categorical "B" modality -- ``joint_AB`` (A=Gaussian, B=Categorical) and ``joint_BC`` (B=Categorical,
+C=Gaussian) -- standing in for the card's own "image field -> shared latent -> predicted field ->
+text field" chain. Evidence ``A=0.0`` is engineered to be EXACTLY equidistant between ``joint_AB``'s
+two regimes, so the true posterior over B is an exact 50/50 tie -- and ``joint_BC``'s two regimes route
+B="lo"/"hi" to two far-apart Gaussian modes for C. This makes "marginalizing the middle hop matters"
+concrete and checkable in closed form: the correct P(C|A=0) is a genuinely bimodal mixture with mean
+~0, while collapsing B's posterior to a single point (arg-max of an exact tie) routes ALL mass to one
+mode and reports a mean ~10 away from the true one.
+"""
+
+import unittest
+
+import numpy as np
+
+from mixle.reason.cross_modal import CrossModalJoint
+from mixle.reason.inference_program import InferenceHop, run_inference_program
+from mixle.stats.latent.mixture import MixtureDistribution
+from mixle.stats.univariate.continuous.gaussian import GaussianDistribution
+from mixle.stats.univariate.discrete.categorical import CategoricalDistribution
+
+
+def _joint_ab() -> CrossModalJoint:
+    return CrossModalJoint.from_components(
+        names=("A", "B"),
+        component_fields=[
+            (GaussianDistribution(mu=-3.0, sigma2=1.0), CategoricalDistribution(pmap={"lo": 0.95, "hi": 0.05})),
+            (GaussianDistribution(mu=3.0, sigma2=1.0), CategoricalDistribution(pmap={"lo": 0.05, "hi": 0.95})),
+        ],
+        weights=[0.5, 0.5],
+    )
+
+
+def _joint_bc() -> CrossModalJoint:
+    return CrossModalJoint.from_components(
+        names=("B", "C"),
+        component_fields=[
+            (CategoricalDistribution(pmap={"lo": 0.99, "hi": 0.01}), GaussianDistribution(mu=-10.0, sigma2=0.25)),
+            (CategoricalDistribution(pmap={"lo": 0.01, "hi": 0.99}), GaussianDistribution(mu=10.0, sigma2=0.25)),
+        ],
+        weights=[0.5, 0.5],
+    )
+
+
+def _analytic_c_given_a(joint_ab: CrossModalJoint, joint_bc: CrossModalJoint, a: float) -> MixtureDistribution:
+    """Closed-form (enumerated, no simulation) P(C | A=a): sum over B's exact posterior support."""
+    b_post = joint_ab.infer({"A": a}, ["B"])
+    components, weights = [], []
+    for b in ("lo", "hi"):
+        p_b = b_post.density((b,))
+        c_post = joint_bc.infer({"B": b}, ["C"])
+        for comp, cw in zip(c_post.components, c_post.w):
+            components.append(comp)
+            weights.append(p_b * float(cw))
+    return MixtureDistribution(components, w=np.asarray(weights, dtype=np.float64))
+
+
+class InferenceProgramTwoHopVsNaiveTest(unittest.TestCase):
+    """Acceptance criterion (a): the 2-hop sampled program matches the analytic answer that a naive
+    single-point ("moment") shortcut gets wrong."""
+
+    def setUp(self):
+        self.joint_ab = _joint_ab()
+        self.joint_bc = _joint_bc()
+        self.hops = [
+            InferenceHop(joint=self.joint_ab, target=("B",)),
+            InferenceHop(joint=self.joint_bc, target=("C",), carry={"B": "B"}),
+        ]
+        self.analytic = _analytic_c_given_a(self.joint_ab, self.joint_bc, a=0.0)
+
+    def test_b_posterior_is_an_exact_tie_by_construction(self):
+        b_post = self.joint_ab.infer({"A": 0.0}, ["B"])
+        self.assertAlmostEqual(b_post.density(("lo",)), 0.5, places=10)
+        self.assertAlmostEqual(b_post.density(("hi",)), 0.5, places=10)
+
+    def test_analytic_marginal_is_bimodal_with_mean_near_zero(self):
+        # sanity check on the hand-built ground truth itself before trusting it as the oracle
+        mean = sum(w * c.dists[0].mu for c, w in zip(self.analytic.components, self.analytic.w))
+        self.assertAlmostEqual(mean, 0.0, places=6)
+        self.assertEqual(len(self.analytic.components), 4)  # 2 B-values x 2 joint_bc regimes each
+
+    def test_sampled_propagation_matches_the_analytic_answer(self):
+        result = run_inference_program({"A": 0.0}, self.hops, propagation="sampled", n_samples=4000, seed=0)
+        self.assertAlmostEqual(result.mean("C"), 0.0, delta=0.75)
+        # density spot-checks against the closed-form mixture, not just the mean
+        for x in (-10.0, 0.0, 10.0):
+            got = result.density((x,))
+            expected = self.analytic.density((x,))
+            self.assertAlmostEqual(got, expected, delta=max(0.15, 0.25 * expected))
+
+    def test_moment_propagation_gets_the_answer_measurably_wrong(self):
+        result = run_inference_program({"A": 0.0}, self.hops, propagation="moment", seed=0)
+        # collapsing B's exact 50/50 posterior to one point routes ALL mass to one Gaussian mode
+        # (near -10 or +10), nowhere near the true bimodal mean of ~0.
+        self.assertGreater(abs(result.mean("C") - 0.0), 8.0)
+
+    def test_receipt_records_the_propagation_choice(self):
+        sampled = run_inference_program({"A": 0.0}, self.hops, propagation="sampled", n_samples=100, seed=0)
+        moment = run_inference_program({"A": 0.0}, self.hops, propagation="moment", seed=0)
+        self.assertEqual(sampled.receipt.propagation, "sampled")
+        self.assertEqual(sampled.receipt.n_particles, 100)
+        self.assertEqual(moment.receipt.propagation, "moment")
+        self.assertEqual(moment.receipt.n_hops, 2)
+        self.assertEqual(sampled.receipt.hop_targets, [("B",), ("C",)])
+
+    def test_invalid_propagation_rejected(self):
+        with self.assertRaises(ValueError):
+            run_inference_program({"A": 0.0}, self.hops, propagation="bogus")
+
+    def test_first_hop_cannot_carry(self):
+        bad_hops = [
+            InferenceHop(joint=self.joint_ab, target=("B",), carry={"X": "A"}),
+            InferenceHop(joint=self.joint_bc, target=("C",), carry={"B": "B"}),
+        ]
+        with self.assertRaises(ValueError):
+            run_inference_program({"A": 0.0}, bad_hops)
+
+    def test_empty_program_rejected(self):
+        with self.assertRaises(ValueError):
+            run_inference_program({"A": 0.0}, [])
+
+
+class InferenceProgramSingleHopReduceTest(unittest.TestCase):
+    """A 1-hop program is exactly ``CrossModalJoint.infer`` -- no propagation machinery engaged."""
+
+    def test_single_hop_matches_direct_infer(self):
+        joint = _joint_ab()
+        hops = [InferenceHop(joint=joint, target=("B",))]
+        result = run_inference_program({"A": -3.0}, hops, propagation="sampled", n_samples=50, seed=1)
+        direct = joint.infer({"A": -3.0}, ["B"])
+        for b in ("lo", "hi"):
+            self.assertAlmostEqual(result.density((b,)), direct.density((b,)), places=6)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mixle/tests/inverse_test.py
+++ b/mixle/tests/inverse_test.py
@@ -1,0 +1,233 @@
+"""``learn_inverse``: amortized posteriors ``q(theta | y)`` for a simulator, with calibration receipts (M3).
+
+Acceptance receipts, one per test:
+  (a) linear-Gaussian inverse matches the analytic (precision-weighted) posterior mean/cov.
+  (b) bimodal toy (``y = theta^2 + noise``) -- the learned posterior captures BOTH modes, asserted
+      via the repo's existing merged-regime detector (``mixle.inference.structure._split_separation``).
+  (c) SBC ranks uniform within finite-sample bounds (200 replications): chi-square p-value > 0.01.
+  (d) coverage within +/-5% of nominal at 50%/90%.
+  (e) sequential refinement rounds measurably sharpen the posterior at the observed y (round-1
+      deliberately under-trained so refinement has visible room to help).
+
+Also covers the two API guards the design note's "resolved" section pins: rounds > 1 without
+``y_obs`` raises ``ValueError``, and ``family="flow"`` with 1-D ``theta`` raises ``ValueError``
+(``build_conditional_flow`` needs ``y_dim >= 2``; ``theta`` IS the student's ``y``-argument).
+"""
+
+import numpy as np
+import pytest
+
+# _split_separation is private (mixle.inference.structure, leading underscore) -- imported directly
+# here rather than made public, matching the precedent mixle/tests/torch_parity_test.py already sets
+# for a test reaching into another module's internals (see notes/designs/M3.md, "Resolved").
+from mixle.inference.structure import _split_separation
+from mixle.stats.multivariate.diagonal_gaussian import DiagonalGaussianDistribution
+from mixle.stats.univariate.continuous.gaussian import GaussianDistribution
+from mixle.task.inverse import learn_inverse
+
+torch = pytest.importorskip("torch")
+
+
+# --------------------------------------------------------------------------------------------- #
+# (a) linear-Gaussian -- matches the analytic precision-weighted posterior
+# --------------------------------------------------------------------------------------------- #
+
+
+def test_linear_gaussian_inverse_matches_analytic_posterior():
+    rng = np.random.RandomState(0)
+    mu0 = np.array([0.0, 0.0])
+    var0 = np.array([4.0, 4.0])
+    var_obs = 0.25
+    prior = DiagonalGaussianDistribution(mu=mu0, covar=var0)
+
+    def simulator(theta):
+        return np.asarray(theta, dtype=float) + rng.normal(0.0, np.sqrt(var_obs), size=2)
+
+    model = learn_inverse(simulator, prior, family="flow", n_sims=3000, m_steps=300, seed=0, n_sbc_replications=20)
+
+    for y_obs in (np.array([1.0, -1.0]), np.array([-2.0, 0.5])):
+        post = model.posterior(y_obs)
+        samples = post.sample(3000, seed=1)
+
+        prec0 = 1.0 / var0
+        prec_lik = 1.0 / var_obs
+        prec_post = prec0 + prec_lik
+        var_post = 1.0 / prec_post
+        mean_post = var_post * (prec0 * mu0 + prec_lik * y_obs)
+
+        assert np.max(np.abs(samples.mean(axis=0) - mean_post)) < 0.15
+        assert np.max(np.abs(samples.var(axis=0) - var_post)) < 0.15
+
+    assert post.receipt.method == "amortized"
+    assert post.receipt.inverse_receipts is model.receipts
+
+
+# --------------------------------------------------------------------------------------------- #
+# (b) bimodal toy -- both modes captured, asserted via the existing merged-regime detector
+# --------------------------------------------------------------------------------------------- #
+
+
+def test_bimodal_posterior_captures_both_modes():
+    rng = np.random.RandomState(1)
+    prior = GaussianDistribution(mu=0.0, sigma2=4.0)  # theta scalar -> family="mdn" (flow needs y_dim >= 2)
+
+    def simulator(theta):
+        theta = float(np.asarray(theta).reshape(-1)[0])
+        return np.array([theta**2 + rng.normal(0.0, 0.1)])
+
+    model = learn_inverse(simulator, prior, family="mdn", n_sims=3000, m_steps=300, seed=1, n_sbc_replications=20)
+
+    y_obs = np.array([4.0])  # two roots: theta = +2, -2
+    post = model.posterior(y_obs)
+    samples = post.sample(2000, seed=2)
+
+    sep, minority_share = _split_separation(samples[:, 0])
+    threshold = 2.65 + 6.0 / np.sqrt(len(samples))  # same calibrated finite-sample threshold as
+    # mixle.utils.hvis.topology.model_fit_health / mixture_structure_health
+    assert sep > threshold
+    assert minority_share >= 0.20
+
+
+def test_family_flow_requires_theta_at_least_2d():
+    prior = GaussianDistribution(mu=0.0, sigma2=1.0)
+
+    def simulator(theta):
+        return np.array([float(np.asarray(theta).reshape(-1)[0]) ** 2])
+
+    with pytest.raises(ValueError, match="2-dimensional"):
+        learn_inverse(simulator, prior, family="flow", n_sims=50, seed=0)
+
+
+# --------------------------------------------------------------------------------------------- #
+# (c) SBC + (d) coverage -- computed together (they share replications inside learn_inverse)
+# --------------------------------------------------------------------------------------------- #
+
+
+def test_sbc_uniform_and_coverage_within_tolerance():
+    rng = np.random.RandomState(0)
+    mu0 = np.array([0.0, 0.0])
+    var0 = np.array([4.0, 4.0])
+    var_obs = 0.25
+    prior = DiagonalGaussianDistribution(mu=mu0, covar=var0)
+
+    def simulator(theta):
+        return np.asarray(theta, dtype=float) + rng.normal(0.0, np.sqrt(var_obs), size=2)
+
+    model = learn_inverse(
+        simulator,
+        prior,
+        family="flow",
+        n_sims=3000,
+        m_steps=300,
+        seed=0,
+        n_sbc_replications=200,
+        coverage_levels=(0.5, 0.9),
+        n_posterior_samples=300,
+    )
+    r = model.receipts
+
+    # (c) SBC: chi-square uniformity test on binned ranks (Talts et al.), bins = min(20, n // 5),
+    # p-value > 0.01 -- the resolved acceptance threshold (design note "Resolved" / module docstring).
+    assert r.sbc_bins == min(20, 200 // 5)
+    assert r.sbc_pvalue > 0.01
+    assert r.sbc_pass is True
+
+    # (d) coverage within +/-5% of nominal at both levels, independently.
+    assert abs(r.coverage[0.5] - 0.5) <= 0.05
+    assert abs(r.coverage[0.9] - 0.9) <= 0.05
+    assert r.coverage_pass[0.5] is True
+    assert r.coverage_pass[0.9] is True
+
+
+def test_rounds_greater_than_one_without_y_obs_raises():
+    prior = GaussianDistribution(mu=0.0, sigma2=1.0)
+
+    def simulator(theta):
+        return np.array([float(np.asarray(theta).reshape(-1)[0]) ** 2])
+
+    with pytest.raises(ValueError, match="rounds > 1"):
+        learn_inverse(simulator, prior, family="mdn", n_sims=50, rounds=2, seed=0)
+
+
+# --------------------------------------------------------------------------------------------- #
+# (e) sequential refinement measurably sharpens the posterior at the observed y
+# --------------------------------------------------------------------------------------------- #
+
+
+def test_sequential_refinement_sharpens_posterior_at_observed_y():
+    rng = np.random.RandomState(0)
+    mu0 = np.array([0.0, 0.0])
+    var0 = np.array([9.0, 9.0])
+    var_obs = 0.25
+    prior = DiagonalGaussianDistribution(mu=mu0, covar=var0)
+
+    def simulator(theta):
+        return np.asarray(theta, dtype=float) + rng.normal(0.0, np.sqrt(var_obs), size=2)
+
+    y_obs = np.array([2.0, -2.0])
+    # round 1 deliberately under-trained (few n_sims/m_steps) so refinement has visible room to help.
+    model = learn_inverse(
+        simulator,
+        prior,
+        family="flow",
+        n_sims=60,
+        m_steps=100,
+        rounds=3,
+        y_obs=y_obs,
+        seed=0,
+        n_sbc_replications=20,
+    )
+    sharpness = model.receipts.sharpness_by_round
+    assert len(sharpness) == 3
+    assert sharpness[1] < sharpness[0]
+    assert sharpness[2] < sharpness[1]
+    assert model.receipts.rounds_trained == 3
+
+
+# --------------------------------------------------------------------------------------------- #
+# optional exactness stage -- ESS receipt on a proposal that's already close to the truth
+# --------------------------------------------------------------------------------------------- #
+
+
+def test_reweight_requires_true_log_likelihood():
+    prior = GaussianDistribution(mu=0.0, sigma2=1.0)
+
+    def simulator(theta):
+        return np.array([float(np.asarray(theta).reshape(-1)[0])])
+
+    with pytest.raises(ValueError, match="true_log_likelihood"):
+        learn_inverse(simulator, prior, family="mdn", n_sims=50, reweight=True, y_obs=np.array([0.0]))
+
+
+def test_reweight_reports_ess_receipt():
+    rng = np.random.RandomState(0)
+    mu0 = np.array([0.0, 0.0])
+    var0 = np.array([4.0, 4.0])
+    var_obs = 0.25
+    prior = DiagonalGaussianDistribution(mu=mu0, covar=var0)
+
+    def simulator(theta):
+        return np.asarray(theta, dtype=float) + rng.normal(0.0, np.sqrt(var_obs), size=2)
+
+    def true_log_likelihood(theta, y):
+        diff = np.asarray(y, dtype=float) - np.asarray(theta, dtype=float)
+        return float(-0.5 * np.sum(diff**2) / var_obs)
+
+    y_obs = np.array([1.0, -1.0])
+    model = learn_inverse(
+        simulator,
+        prior,
+        family="flow",
+        n_sims=2000,
+        m_steps=300,
+        seed=0,
+        n_sbc_replications=20,
+        reweight=True,
+        true_log_likelihood=true_log_likelihood,
+        y_obs=y_obs,
+    )
+    assert model.receipts.ess is not None
+    assert model.receipts.ess_ratio is not None
+    assert 0.0 <= model.receipts.ess_ratio <= 1.0
+    # a well-trained student's proposal is close to the true posterior here -> high ESS ratio.
+    assert model.receipts.ess_ratio > 0.5

--- a/mixle/tests/language_bridge_test.py
+++ b/mixle/tests/language_bridge_test.py
@@ -1,0 +1,138 @@
+"""The language<->belief bridge (roadmap M5, part (c))."""
+
+import unittest
+
+import numpy as np
+
+from mixle.reason.language_bridge import ABSTAIN, Claim, PosteriorDescriber, claim_score, parse_evidence
+from mixle.stats.univariate.continuous.gaussian import GaussianDistribution
+
+SCHEMA = {"text": "categorical", "brightness": "numeric"}
+
+
+def _toy_extractor(sentence: str) -> dict:
+    """A deliberately simple, deterministic keyword/regex extractor -- stands in for whatever real
+    parser (rule-based or a calibrated ``solve_structured`` student) a caller would plug in; this
+    module's own contract is validating the extractor's OUTPUT against the declared schema, not how
+    the extraction itself happens."""
+    out: dict = {}
+    for label in ("cat", "dog"):
+        if label in sentence:
+            out["text"] = label
+    import re
+
+    m = re.search(r"brightness(?: is)?(?: of)?(?: about)? ([0-9.]+)", sentence)
+    if m:
+        out["brightness"] = float(m.group(1))
+    return out
+
+
+class ParseEvidenceTest(unittest.TestCase):
+    """Acceptance criterion (c): NL -> evidence reproduces a hand-specified dict bit-for-bit."""
+
+    def test_reproduces_hand_specified_evidence_bit_for_bit(self):
+        sentence = "the image looks like a dog and the brightness is about 3.5"
+        got = parse_evidence(sentence, SCHEMA, _toy_extractor)
+        self.assertEqual(got, {"text": "dog", "brightness": 3.5})
+
+    def test_categorical_normalized_to_str(self):
+        got = parse_evidence("a cat, brightness 1.0", SCHEMA, _toy_extractor)
+        self.assertEqual(got["text"], "cat")
+        self.assertIsInstance(got["text"], str)
+
+    def test_partial_evidence_is_fine(self):
+        got = parse_evidence("brightness is 2.0, no animal mentioned", SCHEMA, _toy_extractor)
+        self.assertEqual(got, {"brightness": 2.0})
+
+    def test_undeclared_field_rejected(self):
+        def bad_extractor(_x):
+            return {"smell": "strong"}
+
+        with self.assertRaises(ValueError):
+            parse_evidence("whatever", SCHEMA, bad_extractor)
+
+    def test_wrong_type_for_numeric_field_rejected(self):
+        def bad_extractor(_x):
+            return {"brightness": "very bright"}
+
+        with self.assertRaises(ValueError):
+            parse_evidence("whatever", SCHEMA, bad_extractor)
+
+    def test_extractor_must_return_a_dict(self):
+        with self.assertRaises(TypeError):
+            parse_evidence("whatever", SCHEMA, lambda _x: ["dog", 3.5])
+
+    def test_empty_schema_rejected(self):
+        with self.assertRaises(ValueError):
+            parse_evidence("whatever", {}, _toy_extractor)
+
+
+class ClaimScoreStandaloneTest(unittest.TestCase):
+    """``claim_score`` is a reusable primitive independent of ``PosteriorDescriber`` -- the shape B2's
+    claim-checking needs: score an already-emitted claim against the posterior it describes."""
+
+    def test_well_supported_claim_scores_higher_than_a_wrong_one(self):
+        posterior = GaussianDistribution(mu=10.0, sigma2=0.01)
+        good = Claim(field="x", lo=9.5, hi=10.5)
+        bad = Claim(field="x", lo=-5.0, hi=-4.0)
+        self.assertGreater(claim_score(good, posterior), claim_score(bad, posterior))
+
+    def test_cached_probe_reused_without_a_posterior(self):
+        posterior = GaussianDistribution(mu=0.0, sigma2=1e-6)
+        rng = np.random.RandomState(0)
+        probe = tuple((rng.normal(0.0, 1e-3, size=50)).tolist())
+        claim = Claim(field="x", lo=-0.5, hi=0.5, probe=probe)
+        self.assertGreaterEqual(claim_score(claim), 0.85)
+
+    def test_needs_either_posterior_or_cached_probe(self):
+        with self.assertRaises(ValueError):
+            claim_score(Claim(field="x", lo=0.0, hi=1.0))
+
+
+class PosteriorDescriberTest(unittest.TestCase):
+    """Acceptance criterion (d): ``describe`` abstains when the posterior is too diffuse relative to
+    the caller's declared precision (``tol``) to support any candidate claim."""
+
+    def setUp(self):
+        self.tol = 0.5
+        self.describer = PosteriorDescriber("temperature", tol=self.tol, k=3, alpha=0.2, n_probe=200, seed=0)
+        rng = np.random.RandomState(0)
+        # calibration set: a mix of posterior sharpnesses (sigma2 from well-within-tol up to a few
+        # multiples of tol) at varied means, each paired with a value REALIZED by an actual draw from
+        # that posterior (not its parametric mean) -- the realistic "score a generated answer against
+        # what actually happened" conformal setup, not an estimator-bias check.
+        sigmas = [0.01, 0.02, 0.05, 0.1, 0.2, 0.3, 0.6, 1.0]
+        cal = []
+        for _ in range(150):
+            mu = float(rng.uniform(-20.0, 20.0))
+            sigma2 = float(rng.choice(sigmas))
+            g = GaussianDistribution(mu=mu, sigma2=sigma2)
+            realized = float(g.sampler(seed=int(rng.randint(0, 2**31 - 1))).sample())
+            cal.append((g, realized))
+        self.describer.calibrate(cal, seed=1)
+
+    def test_sharp_unseen_posterior_gets_a_confident_claim(self):
+        posterior = GaussianDistribution(mu=7.0, sigma2=0.01)
+        claim = self.describer.describe(posterior, seed=2)
+        self.assertIsNotNone(claim)
+        self.assertIsInstance(claim, Claim)
+        self.assertTrue(claim.contains(7.0))
+
+    def test_diffuse_posterior_abstains(self):
+        # spread ~200x tol: no candidate width (up to 10*tol) can meaningfully cover this posterior's
+        # mass without also covering the rest of the plausible range -- the honest answer is abstain.
+        posterior = GaussianDistribution(mu=7.0, sigma2=10000.0)
+        claim = self.describer.describe(posterior, seed=3)
+        self.assertIs(claim, ABSTAIN)
+
+    def test_invalid_tol_rejected(self):
+        with self.assertRaises(ValueError):
+            PosteriorDescriber("x", tol=0.0)
+
+    def test_k_exceeding_width_multiples_rejected(self):
+        with self.assertRaises(ValueError):
+            PosteriorDescriber("x", tol=1.0, k=99)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mixle/tests/scenario_test.py
+++ b/mixle/tests/scenario_test.py
@@ -1,0 +1,170 @@
+"""simulate()/Simulator (M2): on-the-fly conditional simulators for special scenarios.
+
+Acceptance receipts, one per test:
+  (a) BN fixture, clamp + intervention: do()-then-condition() rollout matches the closed-form
+      interventional-conditional Gaussian; the wrong order (condition then do) differs by a stated
+      margin.
+  (b) plausibility receipt separates in-support from off-support scenarios by a stated margin.
+  (c) HMM horizon rollout matches an independently forward-filtered projection past the clamped
+      window.
+  (d) seed-determinism of both the BN (SIR) and HMM (forward-rollout) paths.
+"""
+
+import numpy as np
+
+from mixle.inference.bayesian_network import HeterogeneousBayesianNetwork, _LinearGaussianFactor, _MarginalFactor
+from mixle.inference.condition import condition as m0_condition
+from mixle.inference.scenario import Scenario, simulate
+from mixle.stats import GaussianDistribution, HiddenMarkovModelDistribution
+from mixle.stats.combinator.composite import CompositeDistribution
+from mixle.stats.compute.posterior import MarkovChainLatentPosterior
+
+# --------------------------------------------------------------------------------------------- #
+# (a) BN fixture: Z -> X -> Y, Z -> Y direct.  do(X=x0) THEN condition(Y=y0) vs the wrong order.
+# --------------------------------------------------------------------------------------------- #
+
+
+def _mediator_confounder_bn():
+    # Z ~ N(0, 1); X = a*Z + eps_x; Y = c*X + d*Z + eps_y.
+    a, c, d, sigma_x, sigma_y = 1.5, 0.8, 1.2, 0.6, 0.5
+    f_z = _MarginalFactor(0, GaussianDistribution(0.0, 1.0))
+    f_x = _LinearGaussianFactor(1, [0], {}, np.array([a, 0.0]), sigma_x)
+    f_y = _LinearGaussianFactor(2, [0, 1], {}, np.array([d, c, 0.0]), sigma_y)
+    net = HeterogeneousBayesianNetwork([f_z, f_x, f_y])
+    return net, a, c, d, sigma_x, sigma_y
+
+
+def test_bn_do_then_condition_matches_closed_form_and_order_matters():
+    net, a, c, d, sigma_x, sigma_y = _mediator_confounder_bn()
+    # x0 chosen large so the do()-intervened mean offset (c*x0) clearly separates the two orders --
+    # the wrong order's closed form does not depend on x0 at all (it ignores the intervention).
+    x0, y0 = 5.0, 3.0
+
+    scenario = Scenario(interventions={1: x0}, evidence={2: y0})
+    sim = simulate(scenario, base=net, seed=0)
+    rollout = sim.rollout(60000)
+    z_vals = np.array([row[0] for row in rollout], dtype=np.float64)
+    got_mean, got_var = float(np.mean(z_vals)), float(np.var(z_vals))
+
+    # Closed form for Z | do(X=x0), Y=y0: after do(X), Y = c*x0 + d*Z + eps_y (the a*Z->X->c edge is
+    # severed), so (Z, Y) are jointly Gaussian with Cov(Z,Y) = d, Var(Y) = d^2 + sigma_y^2.
+    var_y_do = d**2 + sigma_y**2
+    mean_y_do = c * x0
+    want_mean = (d / var_y_do) * (y0 - mean_y_do)
+    want_var = 1.0 - d**2 / var_y_do
+
+    assert abs(got_mean - want_mean) < 0.05
+    assert abs(got_var - want_var) < 0.05
+    assert sim.receipt.composition_order == "do-then-condition"
+
+    # The WRONG order: condition on Y in the ORIGINAL (non-intervened) network first, then "do" X.
+    # Z | Y=y0 in the original model: Y = (c*a+d)*Z + c*eps_x + eps_y (X marginalized out).
+    cov_zy = c * a + d
+    var_y = cov_zy**2 + c**2 * sigma_x**2 + sigma_y**2
+    wrong_mean = (cov_zy / var_y) * y0
+    wrong_var = 1.0 - cov_zy**2 / var_y
+
+    # Independently verify the wrong-order number too, via condition() directly on the original net.
+    wrong_post = m0_condition(net, {2: y0}, method="sir", n_particles=60000, seed=1)
+    wrong_got_mean = wrong_post.mean(0)
+    assert abs(wrong_got_mean - wrong_mean) < 0.1
+    assert abs(wrong_var - want_var) > 0.05  # the two orders give a meaningfully different variance too
+    assert abs(wrong_mean - want_mean) > 1.0  # and a meaningfully different mean -- order matters
+
+
+# --------------------------------------------------------------------------------------------- #
+# (b) plausibility receipt separates in-support from off-support scenarios
+# --------------------------------------------------------------------------------------------- #
+
+
+def _fitted_gaussian_composite():
+    leaves = [GaussianDistribution(0.0, 1.0), GaussianDistribution(5.0, 2.0)]
+    return CompositeDistribution(leaves), leaves
+
+
+def test_plausibility_receipt_separates_in_support_from_off_support():
+    model, leaves = _fitted_gaussian_composite()
+
+    in_support = Scenario(evidence={0: 0.0, 1: 5.0})
+    off_support = Scenario(evidence={0: 20.0, 1: -30.0})
+
+    sim_in = simulate(in_support, base=model, seed=0)
+    sim_off = simulate(off_support, base=model, seed=0)
+
+    assert sim_in.receipt.plausibility_method == "exact"
+    assert sim_off.receipt.plausibility_method == "exact"
+
+    want_in = sum(leaf.log_density(v) for leaf, v in zip(leaves, [0.0, 5.0]))
+    want_off = sum(leaf.log_density(v) for leaf, v in zip(leaves, [20.0, -30.0]))
+    assert abs(sim_in.receipt.plausibility - want_in) < 1e-8
+    assert abs(sim_off.receipt.plausibility - want_off) < 1e-8
+
+    assert sim_in.receipt.plausibility - sim_off.receipt.plausibility > 50.0  # a real, stated margin
+
+
+# --------------------------------------------------------------------------------------------- #
+# (c) HMM horizon rollout past the clamped evidence window
+# --------------------------------------------------------------------------------------------- #
+
+
+def _hmm_fixture():
+    return HiddenMarkovModelDistribution(
+        [GaussianDistribution(-2.0, 1.0), GaussianDistribution(2.0, 1.0), GaussianDistribution(6.0, 1.0)],
+        [0.5, 0.3, 0.2],
+        [[0.7, 0.2, 0.1], [0.1, 0.8, 0.1], [0.2, 0.2, 0.6]],
+    )
+
+
+def test_hmm_horizon_rollout_matches_forward_filtered_projection():
+    hmm = _hmm_fixture()
+    v0, v1 = -1.8, 2.1
+    horizon = 5
+    scenario = Scenario(evidence={0: v0, 1: v1}, horizon=horizon)
+    sim = simulate(scenario, base=hmm, seed=3)
+    rows = sim.rollout(40000)
+
+    # (i) the clamped positions reproduce the evidence exactly, on every draw.
+    assert all(row[0] == v0 and row[1] == v1 for row in rows)
+
+    # (ii) t=4 (beyond the evidenced window [0,1]) matches an independently forward-filtered
+    # projection: smoothed state marginal at t=1, propagated forward through the transition matrix
+    # (horizon - 1 - t_max) times, then the state-weighted topic mean.
+    log_b = np.zeros((2, 3))
+    for t, val in {0: v0, 1: v1}.items():
+        for k, topic in enumerate(hmm.topics):
+            log_b[t, k] = topic.log_density(val)
+    q = MarkovChainLatentPosterior(hmm.log_w, hmm.log_transitions, log_b)
+    marginals = q.marginals()
+    trans = np.exp(np.asarray(hmm.log_transitions))
+    state_at_4 = marginals[1] @ np.linalg.matrix_power(trans, 3)
+    means = np.array([-2.0, 2.0, 6.0])
+    want_mean_t4 = float(state_at_4 @ means)
+
+    got_mean_t4 = float(np.mean([row[4] for row in rows]))
+    assert abs(got_mean_t4 - want_mean_t4) < 0.15
+
+
+# --------------------------------------------------------------------------------------------- #
+# (d) determinism
+# --------------------------------------------------------------------------------------------- #
+
+
+def test_bn_rollout_is_deterministic_given_seed():
+    net, *_ = _mediator_confounder_bn()
+    scenario = Scenario(interventions={1: 2.0}, evidence={2: 3.0})
+    sim1 = simulate(scenario, base=net, seed=11)
+    sim2 = simulate(scenario, base=net, seed=11)
+    r1 = sim1.rollout(50)
+    r2 = sim2.rollout(50)
+    assert r1 == r2
+    assert sim1.receipt.plausibility == sim2.receipt.plausibility
+
+
+def test_hmm_rollout_is_deterministic_given_seed():
+    hmm = _hmm_fixture()
+    scenario = Scenario(evidence={0: -1.8}, horizon=4)
+    sim1 = simulate(scenario, base=hmm, seed=21)
+    sim2 = simulate(scenario, base=hmm, seed=21)
+    r1 = sim1.rollout(30)
+    r2 = sim2.rollout(30)
+    assert r1 == r2


### PR DESCRIPTION
## Summary

- Adds `examples/geoscience_inversion_report.py`: one runnable file chaining M0's `learn_bayesian_network` (fit a joint over multi-modal "field" data -- a text label, a 3-element array modality, and a scalar), M2's `mixle.inference.scenario.simulate` (a `do()`-based what-if rollout), M3's `mixle.task.inverse.learn_inverse` (an amortized inverse posterior with SBC/coverage receipts), and M5's `PosteriorDescriber` riding A1's `CalibratedGenerator` (a conformal accept-or-abstain natural-language report).
- Domain framing (a toy seismic-inversion story: formation type / sensor amplitude / source depth) is confined entirely to this example file's docstrings, variable names, and print statements, per the roadmap card's explicit instruction. The library modules it composes (`mixle.inference`, `mixle.reason`, `mixle.task`) stay domain-agnostic.
- Paired smoke test `mixle/tests/geoscience_inversion_report_test.py` (5 tests, ~12-20s) checks the fitted joint's structure, the M2 rollout lands near the salt formation's generative depth law, M3's inversion recovers the true depth to within 0.3km, and the M5+A1 report serves a claim that brackets the true depth.

## Stacking / vendoring

This roadmap item (B7) depends on M0 (`condition.py`, branch `m0-conditioning`, PR #192), M2 (scenario simulators, branch `scenario-simulators`, PR #204), M3 (inversion surrogates, branch `inversion-surrogates`, PR #213), M5 (cross-modal inference programs, branch `cross-modal-inference-programs`, PR #210), and A1 (`CalibratedGenerator`, branch `calibrated-generator`, PR #126) -- **none of which are merged into `release/0.6.3-generic-capabilities` yet**, and M2/M3/M5 are three independent branches all stacked on the same `m0-conditioning` base but not on each other.

This branch (`sense-simulate-invert-report`) is checked out on top of `origin/inversion-surrogates` (M3) -- the deepest of the three by diff size (5 files / 901 insertions vs. scenario-simulators' 3/583 and cross-modal-inference-programs' 4/740; all three sit exactly one commit ahead of `m0-conditioning`, so "deepest" was decided by touch surface, not commit count). The other two branches' new files were vendored directly via `git show <branch>:<path> > <path>` -- the same pattern `mixle/task/checkpoint_family_ladder.py`'s own module docstring documents for stacking across independent unmerged branches:

- From `origin/scenario-simulators` (M2, PR #204): `mixle/inference/scenario.py`, `mixle/tests/scenario_test.py`, plus the corresponding export diff to `mixle/inference/__init__.py` (that diff applied cleanly -- `inversion-surrogates` never touches that file).
- From `origin/cross-modal-inference-programs` (M5, PR #210): `mixle/reason/inference_program.py`, `mixle/reason/language_bridge.py`, `mixle/tests/inference_program_test.py`, `mixle/tests/language_bridge_test.py`.

Verified before vendoring: `git diff --name-status m0-conditioning..<branch>` for all three branches shows **zero file overlap** between them (scenario-simulators touches `mixle/inference/*`; inversion-surrogates touches `mixle/models/grad_leaf.py` + `mixle/task/*`; cross-modal-inference-programs touches only new `mixle/reason/*` files) -- no version-skew risk. `mixle/task/calibrated_generator.py` (A1, PR #126) was **already merged into `m0-conditioning`'s own history** (`git log -- mixle/task/calibrated_generator.py` shows it landed via PR #126 before M0's tip), so it needed no separate vendoring -- it was already reachable from every branch checked.

All 36 tests across the four vendored/base modules (`scenario_test.py`, `inverse_test.py`, `inference_program_test.py`, `language_bridge_test.py`) pass on this branch, confirming the vendored copies are consistent with the rest of the stack.

## Test plan

- [x] `PYTHONPATH=. python -m pytest mixle/tests/geoscience_inversion_report_test.py -q` -- 5 passed
- [x] `PYTHONPATH=. python examples/geoscience_inversion_report.py` -- runs end to end in ~7s, all numbers real/seeded
- [x] `PYTHONPATH=. python -m pytest mixle/tests/scenario_test.py mixle/tests/inverse_test.py mixle/tests/inference_program_test.py mixle/tests/language_bridge_test.py -q` -- 36 passed (the vendored/consumer suites)
- [x] `ruff check --fix` + `ruff format` on both new files

## Real receipt numbers from this run

- Fit joint: 600 multi-modal records -> a 3-field heterogeneous DAG, certificate `GLOBAL_UNIQUE`.
- M2 what-if `do(formation="salt")`: depth rollout mean=4.518 std=0.481 km (500 draws).
- M3 invert: new observation `y_obs=[2.529, 3.264, 3.542]` (true depth 4.2 km) -> posterior mean=4.202 std=0.202 km, `|error|=0.002 km`. SBC p-value=3.78e-90 (fails uniformity -- reported honestly, not hidden), coverage@0.5=0.313 (fail), coverage@0.9=0.973 (fail) -- an honest finding that a lightly-trained amortized MDN posterior here is usable for a point estimate but not perfectly calibrated.
- M5+A1 report: calibrated on 60 held-out sites, served claim `"depth_km is between 4.117 and 4.317"`, `claim_score=4.083`, contains the true depth (4.2 km): `True`.