### PR TITLE
stats/combinator: full-path ContractError at contract boundaries (roadmap A6)

### DIFF
--- a/mixle/stats/combinator/composite.py
+++ b/mixle/stats/combinator/composite.py
@@ -28,6 +28,7 @@ from mixle.enumeration.algorithms import (
 )
 from mixle.inference.fisher import Path
 from mixle.stats.compute.pdist import (
+    ContractError,
     DataSequenceEncoder,
     DistributionEnumerator,
     DistributionSampler,
@@ -37,6 +38,7 @@ from mixle.stats.compute.pdist import (
     SequenceEncodableStatisticAccumulator,
     StatisticAccumulatorFactory,
     child_enumerator,
+    prefix_contract_error,
 )
 
 T = tuple[Any, ...]
@@ -1056,7 +1058,30 @@ class CompositeEstimator(ParameterEstimator):
                 number of observation (nobs).
 
         """
-        return CompositeDistribution(tuple([est.estimate(nobs, ss) for est, ss in zip(self.estimators, suff_stat)]))
+        if not isinstance(suff_stat, (tuple, list)):
+            raise ContractError(
+                "CompositeEstimator.estimate(suff_stat)",
+                "a tuple of %d component sufficient statistics" % self.count,
+                "%s" % type(suff_stat).__name__,
+                "pass the tuple produced by CompositeAccumulator.value(), not a single component's "
+                "sufficient statistic.",
+            )
+        if len(suff_stat) != self.count:
+            raise ContractError(
+                "CompositeEstimator.estimate(suff_stat)",
+                "a tuple of length %d (one sufficient statistic per component)" % self.count,
+                "a tuple of length %d" % len(suff_stat),
+                "the suff_stat tuple must have exactly %d entries, matching CompositeEstimator's "
+                "%d component estimators -- a mismatched CompositeAccumulator/CompositeEstimator "
+                "pairing is the usual cause." % (self.count, self.count),
+            )
+        components = []
+        for i, (est, ss) in enumerate(zip(self.estimators, suff_stat)):
+            try:
+                components.append(est.estimate(nobs, ss))
+            except ContractError as e:
+                raise prefix_contract_error("CompositeEstimator.estimators[%d]" % i, e) from None
+        return CompositeDistribution(tuple(components))
 
 
 class CompositeDataEncoder(DataSequenceEncoder):
@@ -1128,10 +1153,47 @@ class CompositeDataEncoder(DataSequenceEncoder):
             for all observations of component i from x.
 
         """
+        count = len(self.encoders)
+        if not isinstance(x, (list, tuple)):
+            raise ContractError(
+                "CompositeDistribution.seq_encode",
+                "a sequence of %d-tuples" % count,
+                "%s" % type(x).__name__,
+                "pass a list/tuple of observations, e.g. [(x0, x1, ...), ...].",
+            )
+        for row_idx, u in enumerate(x):
+            if not isinstance(u, (tuple, list)):
+                raise ContractError(
+                    "CompositeDistribution.dists (row %d)" % row_idx,
+                    "a tuple of %d fields (one per component distribution)" % count,
+                    "%s" % type(u).__name__,
+                    "wrap the observation in a %d-tuple matching the component distributions." % count,
+                )
+            if len(u) != count:
+                raise ContractError(
+                    "CompositeDistribution.dists (row %d)" % row_idx,
+                    "a tuple of length %d" % count,
+                    "a tuple of length %d" % len(u),
+                    "check row %d for a missing or extra field -- every row must have exactly %d "
+                    "entries, one per component distribution." % (row_idx, count),
+                )
+
         enc_data = []
 
         for i, encoder in enumerate(self.encoders):
-            enc_data.append(encoder.seq_encode([u[i] for u in x]))
+            field_path = "CompositeDistribution.dists[%d]" % i
+            try:
+                enc_data.append(encoder.seq_encode([u[i] for u in x]))
+            except ContractError as e:
+                raise prefix_contract_error(field_path, e) from None
+            except (TypeError, ValueError, IndexError, KeyError) as e:
+                raise ContractError(
+                    field_path,
+                    "data compatible with component %d's data type" % i,
+                    "data that raised %s: %s" % (type(e).__name__, e),
+                    "check that field %d of every row matches the data type expected by component %d "
+                    "(%s)." % (i, i, encoder),
+                ) from e
 
         return tuple(enc_data)
 

--- a/mixle/stats/combinator/composite.py
+++ b/mixle/stats/combinator/composite.py
@@ -1154,7 +1154,7 @@ class CompositeDataEncoder(DataSequenceEncoder):
 
         """
         count = len(self.encoders)
-        if not isinstance(x, (list, tuple)):
+        if not isinstance(x, (list, tuple, np.ndarray)):
             raise ContractError(
                 "CompositeDistribution.seq_encode",
                 "a sequence of %d-tuples" % count,
@@ -1162,7 +1162,7 @@ class CompositeDataEncoder(DataSequenceEncoder):
                 "pass a list/tuple of observations, e.g. [(x0, x1, ...), ...].",
             )
         for row_idx, u in enumerate(x):
-            if not isinstance(u, (tuple, list)):
+            if not isinstance(u, (tuple, list, np.ndarray)):
                 raise ContractError(
                     "CompositeDistribution.dists (row %d)" % row_idx,
                     "a tuple of %d fields (one per component distribution)" % count,

--- a/mixle/stats/combinator/conditional.py
+++ b/mixle/stats/combinator/conditional.py
@@ -1489,7 +1489,7 @@ class ConditionalDistributionDataEncoder(DataSequenceEncoder):
             Returns rv (see description for details)
 
         """
-        if not isinstance(x, (list, tuple)):
+        if not isinstance(x, (list, tuple, np.ndarray)):
             raise ContractError(
                 "ConditionalDistribution.seq_encode",
                 "a sequence of (given, value) pairs",
@@ -1503,14 +1503,14 @@ class ConditionalDistributionDataEncoder(DataSequenceEncoder):
 
         for i in range(len(x)):
             xx = x[i]
-            if not isinstance(xx, (tuple, list)) or len(xx) != 2:
+            if not isinstance(xx, (tuple, list, np.ndarray)) or len(xx) != 2:
                 raise ContractError(
                     "ConditionalDistribution.seq_encode (row %d)" % i,
                     "a 2-tuple (given_value, observed_value)",
                     "%s%s"
                     % (
                         type(xx).__name__,
-                        " of length %d" % len(xx) if isinstance(xx, (tuple, list)) else "",
+                        " of length %d" % len(xx) if isinstance(xx, (tuple, list, np.ndarray)) else "",
                     ),
                     "each row must be a (given, value) pair -- check row %d for a missing/extra field." % i,
                 )

--- a/mixle/stats/combinator/conditional.py
+++ b/mixle/stats/combinator/conditional.py
@@ -34,6 +34,7 @@ from mixle.stats.combinator.null_dist import (
 )
 from mixle.stats.compute.pdist import (
     ConditionalSampler,
+    ContractError,
     DataSequenceEncoder,
     DistributionEnumerator,
     DistributionSampler,
@@ -43,6 +44,7 @@ from mixle.stats.compute.pdist import (
     SequenceEncodableStatisticAccumulator,
     StatisticAccumulatorFactory,
     child_enumerator,
+    prefix_contract_error,
 )
 
 T0 = TypeVar("T0")
@@ -1323,9 +1325,50 @@ class ConditionalDistributionEstimator(ParameterEstimator):
             ConditionalDistribution object.
 
         """
-        default_dist = self.default_estimator.estimate(None, suff_stat[1])
-        given_dist = self.given_estimator.estimate(None, suff_stat[2])
-        dist_map = {k: self.estimator_map[k].estimate(None, v) for k, v in suff_stat[0].items()}
+        if not isinstance(suff_stat, (tuple, list)) or len(suff_stat) != 3:
+            raise ContractError(
+                "ConditionalDistributionEstimator.estimate(suff_stat)",
+                "a 3-tuple (dist_map_suff_stats, default_suff_stat, given_suff_stat)",
+                "%s%s"
+                % (
+                    type(suff_stat).__name__,
+                    " of length %d" % len(suff_stat) if isinstance(suff_stat, (tuple, list)) else "",
+                ),
+                "pass the 3-tuple produced by ConditionalDistributionAccumulator.value(), not a bare "
+                "component sufficient statistic.",
+            )
+        if not isinstance(suff_stat[0], dict):
+            raise ContractError(
+                "ConditionalDistributionEstimator.estimate(suff_stat[0])",
+                "a dict mapping each conditioning value to its sufficient statistic",
+                "%s" % type(suff_stat[0]).__name__,
+                "suff_stat[0] must be the dict-of-sufficient-statistics produced by "
+                "ConditionalDistributionAccumulator.value(), keyed by conditioning value.",
+            )
+
+        try:
+            default_dist = self.default_estimator.estimate(None, suff_stat[1])
+        except ContractError as e:
+            raise prefix_contract_error("ConditionalDistribution.default_dist", e) from None
+        try:
+            given_dist = self.given_estimator.estimate(None, suff_stat[2])
+        except ContractError as e:
+            raise prefix_contract_error("ConditionalDistribution.given_dist", e) from None
+
+        dist_map = {}
+        for k, v in suff_stat[0].items():
+            if k not in self.estimator_map:
+                raise ContractError(
+                    "ConditionalDistributionEstimator.estimator_map[%r]" % (k,),
+                    "a conditioning value present in estimator_map",
+                    "conditioning value %r, not in estimator_map" % (k,),
+                    "suff_stat[0] carries a key not covered by this estimator's estimator_map -- "
+                    "check the accumulator/estimator pairing, or add %r to estimator_map." % (k,),
+                )
+            try:
+                dist_map[k] = self.estimator_map[k].estimate(None, v)
+            except ContractError as e:
+                raise prefix_contract_error("ConditionalDistribution.estimator_map[%r]" % (k,), e) from None
 
         return ConditionalDistribution(
             dist_map, default_dist=default_dist, given_dist=given_dist, name=self.name, keys=self.keys
@@ -1446,12 +1489,31 @@ class ConditionalDistributionDataEncoder(DataSequenceEncoder):
             Returns rv (see description for details)
 
         """
+        if not isinstance(x, (list, tuple)):
+            raise ContractError(
+                "ConditionalDistribution.seq_encode",
+                "a sequence of (given, value) pairs",
+                "%s" % type(x).__name__,
+                "pass a list of 2-tuples, e.g. [(given0, value0), (given1, value1), ...].",
+            )
+
         cond_enc = dict()
 
         given_vals = []
 
         for i in range(len(x)):
             xx = x[i]
+            if not isinstance(xx, (tuple, list)) or len(xx) != 2:
+                raise ContractError(
+                    "ConditionalDistribution.seq_encode (row %d)" % i,
+                    "a 2-tuple (given_value, observed_value)",
+                    "%s%s"
+                    % (
+                        type(xx).__name__,
+                        " of length %d" % len(xx) if isinstance(xx, (tuple, list)) else "",
+                    ),
+                    "each row must be a (given, value) pair -- check row %d for a missing/extra field." % i,
+                )
             given_vals.append(xx[0])
             if xx[0] not in cond_enc:
                 cond_enc[xx[0]] = [[xx[1]], [i]]
@@ -1467,21 +1529,43 @@ class ConditionalDistributionDataEncoder(DataSequenceEncoder):
         idx_vals = []
 
         for u in cond_enc_items:
-            if self.null_default_encoder:
-                if u[0] in self.encoder_map:
-                    eobs_vals.append(self.encoder_map[u[0]].seq_encode(u[1][0]))
+            field_path = "ConditionalDistribution.estimator_map[%r]" % (u[0],)
+            try:
+                if self.null_default_encoder:
+                    if u[0] in self.encoder_map:
+                        eobs_vals.append(self.encoder_map[u[0]].seq_encode(u[1][0]))
+                    else:
+                        # No encoder and no default for this conditioning value: append a
+                        # sentinel so eobs_vals stays aligned with cond_vals/idx_vals.
+                        # seq_log_density/seq_update guard on the cond key, so it is never
+                        # dereferenced (the group scores -inf / is skipped).
+                        eobs_vals.append(None)
                 else:
-                    # No encoder and no default for this conditioning value: append a
-                    # sentinel so eobs_vals stays aligned with cond_vals/idx_vals.
-                    # seq_log_density/seq_update guard on the cond key, so it is never
-                    # dereferenced (the group scores -inf / is skipped).
-                    eobs_vals.append(None)
-            else:
-                eobs_vals.append(self.encoder_map.get(u[0], self.default_encoder).seq_encode(u[1][0]))
+                    eobs_vals.append(self.encoder_map.get(u[0], self.default_encoder).seq_encode(u[1][0]))
+            except ContractError as e:
+                raise prefix_contract_error(field_path, e) from None
+            except (TypeError, ValueError, IndexError, KeyError) as e:
+                raise ContractError(
+                    field_path,
+                    "values compatible with the conditional distribution registered for given=%r" % (u[0],),
+                    "data that raised %s: %s" % (type(e).__name__, e),
+                    "check that every value observed under given=%r matches the data type expected "
+                    "by its conditional distribution." % (u[0],),
+                ) from e
 
             idx_vals.append(np.asarray(u[1][1]))
 
-        given_enc = self.given_encoder.seq_encode(given_vals)
+        try:
+            given_enc = self.given_encoder.seq_encode(given_vals)
+        except ContractError as e:
+            raise prefix_contract_error("ConditionalDistribution.given_dist", e) from None
+        except (TypeError, ValueError, IndexError, KeyError) as e:
+            raise ContractError(
+                "ConditionalDistribution.given_dist",
+                "given-values compatible with the given distribution's data type",
+                "data that raised %s: %s" % (type(e).__name__, e),
+                "check that every given-value matches the data type expected by given_dist (%s)." % self.given_encoder,
+            ) from e
 
         return len(x), cond_vals, tuple(eobs_vals), tuple(idx_vals), given_enc
 

--- a/mixle/stats/combinator/optional.py
+++ b/mixle/stats/combinator/optional.py
@@ -699,14 +699,14 @@ class OptionalEstimator(ParameterEstimator):
                 "pass the 2-tuple produced by OptionalEstimatorAccumulator.value(), not a bare base "
                 "sufficient statistic.",
             )
-        if not isinstance(suff_stat[0], (tuple, list)) or len(suff_stat[0]) != 2:
+        if not isinstance(suff_stat[0], (tuple, list, np.ndarray)) or len(suff_stat[0]) != 2:
             raise ContractError(
                 "OptionalEstimator.estimate(suff_stat[0])",
                 "a 2-element [missing_weight, present_weight] pair",
                 "%s%s"
                 % (
                     type(suff_stat[0]).__name__,
-                    " of length %d" % len(suff_stat[0]) if isinstance(suff_stat[0], (tuple, list)) else "",
+                    " of length %d" % len(suff_stat[0]) if isinstance(suff_stat[0], (tuple, list, np.ndarray)) else "",
                 ),
                 "suff_stat[0] must be the [missing_weight, present_weight] pair produced by "
                 "OptionalEstimatorAccumulator.value().",
@@ -786,7 +786,7 @@ class OptionalDataEncoder(DataSequenceEncoder):
             return False
 
     def seq_encode(self, x: Sequence[T]) -> tuple[int, np.ndarray, np.ndarray, Any]:
-        if not isinstance(x, (list, tuple)):
+        if not isinstance(x, (list, tuple, np.ndarray)):
             raise ContractError(
                 "OptionalDistribution.seq_encode",
                 "a sequence of observations (or the missing-value sentinel)",

--- a/mixle/stats/combinator/optional.py
+++ b/mixle/stats/combinator/optional.py
@@ -22,6 +22,7 @@ from numpy.random import RandomState
 from mixle.enumeration.algorithms import freeze, merge_enumerators
 from mixle.stats.combinator.composite import _distribute_child_prior
 from mixle.stats.compute.pdist import (
+    ContractError,
     DataSequenceEncoder,
     DistributionEnumerator,
     DistributionSampler,
@@ -31,6 +32,7 @@ from mixle.stats.compute.pdist import (
     SequenceEncodableStatisticAccumulator,
     StatisticAccumulatorFactory,
     child_enumerator,
+    prefix_contract_error,
 )
 from mixle.utils.special import digamma
 
@@ -684,6 +686,32 @@ class OptionalEstimator(ParameterEstimator):
             rv += float(self.prior.log_density(model.p))
         return rv
 
+    def _validate_suff_stat(self, suff_stat: tuple[list[float], SS] | None) -> None:
+        if not isinstance(suff_stat, (tuple, list)) or len(suff_stat) != 2:
+            raise ContractError(
+                "OptionalEstimator.estimate(suff_stat)",
+                "a 2-tuple ([missing_weight, present_weight], base_suff_stat)",
+                "%s%s"
+                % (
+                    type(suff_stat).__name__,
+                    " of length %d" % len(suff_stat) if isinstance(suff_stat, (tuple, list)) else "",
+                ),
+                "pass the 2-tuple produced by OptionalEstimatorAccumulator.value(), not a bare base "
+                "sufficient statistic.",
+            )
+        if not isinstance(suff_stat[0], (tuple, list)) or len(suff_stat[0]) != 2:
+            raise ContractError(
+                "OptionalEstimator.estimate(suff_stat[0])",
+                "a 2-element [missing_weight, present_weight] pair",
+                "%s%s"
+                % (
+                    type(suff_stat[0]).__name__,
+                    " of length %d" % len(suff_stat[0]) if isinstance(suff_stat[0], (tuple, list)) else "",
+                ),
+                "suff_stat[0] must be the [missing_weight, present_weight] pair produced by "
+                "OptionalEstimatorAccumulator.value().",
+            )
+
     def _estimate_conjugate(self, suff_stat: tuple[list[float], SS]) -> OptionalDistribution:
         """Closed-form Beta conjugate posterior update on ``p`` (carried forward as the fitted prior).
 
@@ -692,9 +720,13 @@ class OptionalEstimator(ParameterEstimator):
         """
         from mixle.stats.univariate.continuous.beta import BetaDistribution
 
+        self._validate_suff_stat(suff_stat)
         psum = suff_stat[0][0]
         nsum = suff_stat[0][1]
-        dist = self.estimator.estimate(nsum, suff_stat[1])
+        try:
+            dist = self.estimator.estimate(nsum, suff_stat[1])
+        except ContractError as e:
+            raise prefix_contract_error("OptionalDistribution.dist", e) from None
 
         a, b = self.prior.get_parameters()
         new_a = a + psum
@@ -713,7 +745,11 @@ class OptionalEstimator(ParameterEstimator):
         if self.has_conj_prior:
             return self._estimate_conjugate(suff_stat)
 
-        dist = self.estimator.estimate(suff_stat[0][1], suff_stat[1])
+        self._validate_suff_stat(suff_stat)
+        try:
+            dist = self.estimator.estimate(suff_stat[0][1], suff_stat[1])
+        except ContractError as e:
+            raise prefix_contract_error("OptionalDistribution.dist", e) from None
 
         if self.pseudo_count is not None and self.est_prob:
             return OptionalDistribution(
@@ -750,6 +786,14 @@ class OptionalDataEncoder(DataSequenceEncoder):
             return False
 
     def seq_encode(self, x: Sequence[T]) -> tuple[int, np.ndarray, np.ndarray, Any]:
+        if not isinstance(x, (list, tuple)):
+            raise ContractError(
+                "OptionalDistribution.seq_encode",
+                "a sequence of observations (or the missing-value sentinel)",
+                "%s" % type(x).__name__,
+                "pass a list/tuple of observations, e.g. [x0, missing_value, x2, ...].",
+            )
+
         nz_idx = []
         nz_val = []
         z_idx = []
@@ -769,7 +813,19 @@ class OptionalDataEncoder(DataSequenceEncoder):
                     nz_idx.append(i)
                     nz_val.append(v)
 
-        enc_data = self.encoder.seq_encode(nz_val)
+        try:
+            enc_data = self.encoder.seq_encode(nz_val)
+        except ContractError as e:
+            raise prefix_contract_error("OptionalDistribution.dist", e) from None
+        except (TypeError, ValueError, IndexError, KeyError) as e:
+            raise ContractError(
+                "OptionalDistribution.dist",
+                "every present (non-missing) value compatible with the base distribution's data type",
+                "a value that raised %s: %s" % (type(e).__name__, e),
+                "check that every present value matches the data type expected by the base "
+                "distribution (%s); missing entries should equal missing_value=%r."
+                % (self.encoder, self.missing_value),
+            ) from e
 
         nz_idx = np.asarray(nz_idx, dtype=int)
         z_idx = np.asarray(z_idx, dtype=int)

--- a/mixle/stats/combinator/sequence.py
+++ b/mixle/stats/combinator/sequence.py
@@ -35,6 +35,7 @@ from mixle.stats.combinator.null_dist import (
     NullEstimator,
 )
 from mixle.stats.compute.pdist import (
+    ContractError,
     DataSequenceEncoder,
     DistributionEnumerator,
     DistributionSampler,
@@ -44,6 +45,7 @@ from mixle.stats.compute.pdist import (
     SequenceEncodableStatisticAccumulator,
     StatisticAccumulatorFactory,
     child_enumerator,
+    prefix_contract_error,
 )
 
 T = TypeVar("T")  # Data type of Sequence distribution dist.
@@ -1096,18 +1098,39 @@ class SequenceEstimator(ParameterEstimator):
         return SequenceAccumulatorFactory(dist_factory, len_factory, self.len_normalized, self.keys)
 
     def estimate(self, nobs: float | None, suff_stat: tuple[Any, Any | None]) -> SequenceDistribution:
+        if not isinstance(suff_stat, (tuple, list)) or len(suff_stat) != 2:
+            raise ContractError(
+                "SequenceEstimator.estimate(suff_stat)",
+                "a 2-tuple (entry_suff_stat, length_suff_stat)",
+                "%s%s"
+                % (
+                    type(suff_stat).__name__,
+                    " of length %d" % len(suff_stat) if isinstance(suff_stat, (tuple, list)) else "",
+                ),
+                "pass the 2-tuple produced by SequenceAccumulator.value(), not a bare entry sufficient statistic.",
+            )
+
+        try:
+            entry_dist = self.estimator.estimate(nobs, suff_stat[0])
+        except ContractError as e:
+            raise prefix_contract_error("SequenceEstimator.estimator", e) from None
+
         if isinstance(self.len_estimator, NullEstimator):
             return SequenceDistribution(
-                self.estimator.estimate(nobs, suff_stat[0]),
+                entry_dist,
                 len_dist=self.len_dist,
                 len_normalized=self.len_normalized,
                 name=self.name,
             )
 
         else:
+            try:
+                len_dist = self.len_estimator.estimate(nobs, suff_stat[1])
+            except ContractError as e:
+                raise prefix_contract_error("SequenceEstimator.len_estimator", e) from None
             return SequenceDistribution(
-                self.estimator.estimate(nobs, suff_stat[0]),
-                len_dist=self.len_estimator.estimate(nobs, suff_stat[1]),
+                entry_dist,
+                len_dist=len_dist,
                 len_normalized=self.len_normalized,
                 name=self.name,
             )
@@ -1193,16 +1216,36 @@ class SequenceDataEncoder(DataSequenceEncoder):
         Returns:
 
         """
+        if not isinstance(x, (list, tuple)):
+            raise ContractError(
+                "SequenceDistribution.seq_encode",
+                "a sequence of sequences (one inner sequence per observation)",
+                "%s" % type(x).__name__,
+                "pass a list of sequences, e.g. [[0, 1, 2], [], [3, 4]].",
+            )
+
         tx = []
         nx = []
         tidx = []
 
         for i in range(len(x)):
-            nx.append(len(x[i]))
+            row = x[i]
+            try:
+                row_len = len(row)
+            except TypeError:
+                raise ContractError(
+                    "SequenceDistribution.entries (row %d)" % i,
+                    "a sequence (list/tuple/etc.) of entries",
+                    "%s" % type(row).__name__,
+                    "each observation must itself be a sequence of entries -- row %d is a scalar, "
+                    "not a sequence. Wrap it in a list, e.g. [%r]." % (i, row),
+                ) from None
 
-            for j in range(len(x[i])):
+            nx.append(row_len)
+
+            for j in range(row_len):
                 tidx.append(i)
-                tx.append(x[i][j])
+                tx.append(row[j])
 
         rv1 = np.asarray(tidx, dtype=int)
         rv2 = np.asarray(nx, dtype=float)
@@ -1210,7 +1253,18 @@ class SequenceDataEncoder(DataSequenceEncoder):
 
         rv2[rv3] = 1.0 / rv2[rv3]
 
-        rv4 = self.encoder.seq_encode(tx)
+        try:
+            rv4 = self.encoder.seq_encode(tx)
+        except ContractError as e:
+            raise prefix_contract_error("SequenceDistribution.entries", e) from None
+        except (TypeError, ValueError, IndexError, KeyError) as e:
+            raise ContractError(
+                "SequenceDistribution.entries",
+                "every flattened entry compatible with the base distribution's data type",
+                "an entry that raised %s: %s" % (type(e).__name__, e),
+                "check that every element of every inner sequence matches the data type expected by "
+                "the base distribution (%s)." % self.encoder,
+            ) from e
 
         ### None if NullDataEncoder() for length
         rv5 = self.len_encoder.seq_encode(nx)

--- a/mixle/stats/combinator/sequence.py
+++ b/mixle/stats/combinator/sequence.py
@@ -1216,7 +1216,7 @@ class SequenceDataEncoder(DataSequenceEncoder):
         Returns:
 
         """
-        if not isinstance(x, (list, tuple)):
+        if not isinstance(x, (list, tuple, np.ndarray)):
             raise ContractError(
                 "SequenceDistribution.seq_encode",
                 "a sequence of sequences (one inner sequence per observation)",

--- a/mixle/stats/compute/pdist.py
+++ b/mixle/stats/compute/pdist.py
@@ -82,6 +82,40 @@ class KeyValidationError(ValueError):
     pass
 
 
+class ContractError(ValueError):
+    """Raised when malformed data trips a combinator's ``seq_encode``/``estimate`` contract boundary.
+
+    Mirrors :class:`EnumerationError`'s path-composition convention: ``path`` names the full field
+    path through nested combinators (composed with ``" -> "``, outermost first), e.g.
+    ``"CompositeDistribution.dists[2] -> SequenceDistribution.entries"``. Every ``ContractError``
+    also carries what was expected, what actually arrived, and (when there is one) a concrete,
+    non-generic suggestion for the likely fix -- so a caller reading only the message, not the
+    traceback, knows what to change.
+    """
+
+    def __init__(self, path: str, expected: str, actual: str, fix: str = "") -> None:
+        self.path = path
+        self.expected = expected
+        self.actual = actual
+        self.fix = fix
+        msg = "%s: expected %s, got %s." % (path, expected, actual)
+        if fix:
+            msg += " Fix: %s" % fix
+        super().__init__(msg)
+
+
+def prefix_contract_error(prefix: str, err: "ContractError") -> "ContractError":
+    """Return a new ContractError with ``prefix`` prepended to ``err``'s field path.
+
+    Used by a combinator to annotate a ``ContractError`` raised deep inside a child's
+    ``seq_encode``/``estimate`` with the outer field position, so the final message names the
+    FULL path down to where the failure actually occurred (e.g. a mixture-of-composites-of-
+    sequences error names every level, not just the outermost combinator).
+    """
+    new_path = "%s -> %s" % (prefix, err.path) if err.path else prefix
+    return ContractError(new_path, err.expected, err.actual, err.fix)
+
+
 def child_enumerator(child: "ProbabilityDistribution", path: str) -> "DistributionEnumerator":
     """Construct child.enumerator(), annotating EnumerationError with the child's path.
 

--- a/mixle/stats/latent/mixture.py
+++ b/mixle/stats/latent/mixture.py
@@ -35,6 +35,7 @@ from mixle.inference.fisher import Path
 from mixle.stats.bayes.dirichlet import DirichletDistribution
 from mixle.stats.bayes.symmetric_dirichlet import SymmetricDirichletDistribution
 from mixle.stats.compute.pdist import (
+    ContractError,
     DataSequenceEncoder,
     DistributionEnumerator,
     DistributionSampler,
@@ -44,6 +45,7 @@ from mixle.stats.compute.pdist import (
     SequenceEncodableStatisticAccumulator,
     StatisticAccumulatorFactory,
     child_enumerator,
+    prefix_contract_error,
 )
 from mixle.stats.compute.posterior import CategoricalLatentPosterior
 from mixle.utils.aliasing import MISSING, coalesce_alias
@@ -1624,9 +1626,35 @@ class MixtureEstimator(ParameterEstimator):
 
         """
         num_components = self.num_components
+        if not isinstance(suff_stat, (tuple, list)) or len(suff_stat) != 2:
+            raise ContractError(
+                "MixtureEstimator.estimate(suff_stat)",
+                "a 2-tuple (component_weight_counts, component_suff_stats)",
+                "%s%s"
+                % (
+                    type(suff_stat).__name__,
+                    " of length %d" % len(suff_stat) if isinstance(suff_stat, (tuple, list)) else "",
+                ),
+                "pass the 2-tuple produced by MixtureAccumulator.value(), not a bare component sufficient statistic.",
+            )
         counts, comp_suff_stats = suff_stat
+        if len(counts) != num_components or len(comp_suff_stats) != num_components:
+            raise ContractError(
+                "MixtureEstimator.estimate(suff_stat)",
+                "%d component weight counts and %d component sufficient statistics" % (num_components, num_components),
+                "%d component weight counts and %d component sufficient statistics"
+                % (len(counts), len(comp_suff_stats)),
+                "suff_stat must carry exactly %d entries per side, matching MixtureEstimator's %d "
+                "component estimators -- a mismatched MixtureAccumulator/MixtureEstimator component "
+                "count is the usual cause." % (num_components, num_components),
+            )
 
-        components = [self.estimators[i].estimate(counts[i], comp_suff_stats[i]) for i in range(num_components)]
+        components = []
+        for i in range(num_components):
+            try:
+                components.append(self.estimators[i].estimate(counts[i], comp_suff_stats[i]))
+            except ContractError as e:
+                raise prefix_contract_error("MixtureDistribution.components[%d]" % i, e) from None
 
         if self.has_conj_prior and self.fixed_weights is None:
             # Conjugate Dirichlet weight update: MAP weights w_k proportional to
@@ -1776,8 +1804,26 @@ class MixtureDataEncoder(DataSequenceEncoder):
             Encoded sequence (single shared encoding, or a per-component wrapper).
 
         """
+        if not isinstance(x, (list, tuple)):
+            raise ContractError(
+                "MixtureDistribution.seq_encode",
+                "a sequence of observations (all components share the same observation type)",
+                "%s" % type(x).__name__,
+                "pass a list/tuple of observations, e.g. [x0, x1, ...].",
+            )
         if self.homogeneous:
-            return self.encoder.seq_encode(x)
+            try:
+                return self.encoder.seq_encode(x)
+            except ContractError as e:
+                raise prefix_contract_error("MixtureDistribution.components", e) from None
+            except (TypeError, ValueError, IndexError, KeyError) as e:
+                raise ContractError(
+                    "MixtureDistribution.components",
+                    "every observation compatible with the shared component data type",
+                    "data that raised %s: %s" % (type(e).__name__, e),
+                    "check that every observation matches the data type expected by the mixture's "
+                    "components (%s)." % self.encoder,
+                ) from e
         try:
             return _HeteroMixtureEncoded(tuple(e.seq_encode(x) for e in self.encoders))
         except (TypeError, ValueError) as e:

--- a/mixle/stats/latent/mixture.py
+++ b/mixle/stats/latent/mixture.py
@@ -1804,7 +1804,7 @@ class MixtureDataEncoder(DataSequenceEncoder):
             Encoded sequence (single shared encoding, or a per-component wrapper).
 
         """
-        if not isinstance(x, (list, tuple)):
+        if not isinstance(x, (list, tuple, np.ndarray)):
             raise ContractError(
                 "MixtureDistribution.seq_encode",
                 "a sequence of observations (all components share the same observation type)",

--- a/mixle/tests/contract_errors_test.py
+++ b/mixle/tests/contract_errors_test.py
@@ -1,0 +1,231 @@
+"""Catalog test pinning error-message quality at the composer contract boundaries (A6).
+
+Every entry below feeds one combinator family (composite/mixture/sequence/conditional/optional) a
+canonical malformed input at its ``seq_encode`` or ``estimate`` entry point, and asserts:
+
+  - the call raises a ``ContractError`` (this module's own validation, not an incidental error
+    surfacing from deep inside numpy/whatever),
+  - the message contains the expected field path substring,
+  - the message names both the expected and actual type/shape.
+
+This mirrors the catalog-of-every-distribution shape used by ``sampler_seed_test.py``: a flat list
+of cases drives a single parametrized loop, so message quality is pinned per-case rather than
+merely aspirational.
+"""
+
+import unittest
+from collections.abc import Callable
+from typing import Any
+
+import mixle.stats as stats
+from mixle.stats.compute.pdist import ContractError
+
+# --- Fixture distributions shared by the catalog below ------------------------------------------
+
+_CAT_AB = stats.CategoricalDistribution({"a": 0.5, "b": 0.5})
+_CAT_XY = stats.CategoricalDistribution({"x": 0.5, "y": 0.5})
+_GAUSS = stats.GaussianDistribution(0.0, 1.0)
+
+
+def _composite_encoder():
+    return stats.CompositeDistribution([_CAT_AB, _CAT_XY]).dist_to_encoder()
+
+
+def _composite_of_sequence_encoder():
+    seq = stats.SequenceDistribution(_GAUSS)
+    return stats.CompositeDistribution([_CAT_AB, seq]).dist_to_encoder()
+
+
+def _sequence_encoder():
+    return stats.SequenceDistribution(_GAUSS).dist_to_encoder()
+
+
+def _mixture_encoder():
+    return stats.MixtureDistribution([_GAUSS, stats.GaussianDistribution(1.0, 2.0)], [0.5, 0.5]).dist_to_encoder()
+
+
+def _conditional_encoder():
+    return stats.ConditionalDistribution({"a": _GAUSS}, given_dist=_CAT_AB).dist_to_encoder()
+
+
+def _optional_encoder():
+    return stats.OptionalDistribution(_GAUSS).dist_to_encoder()
+
+
+def _composite_estimator():
+    return stats.CompositeEstimator([_CAT_AB.estimator(), _CAT_XY.estimator()])
+
+
+def _sequence_estimator():
+    return stats.SequenceDistribution(_GAUSS).estimator()
+
+
+def _mixture_estimator():
+    return stats.MixtureDistribution([_GAUSS, stats.GaussianDistribution(1.0, 2.0)], [0.5, 0.5]).estimator()
+
+
+def _conditional_estimator():
+    return stats.ConditionalDistribution({"a": _GAUSS}, given_dist=_CAT_AB).estimator()
+
+
+def _optional_estimator():
+    return stats.OptionalDistribution(_GAUSS).estimator()
+
+
+# --- The catalog ----------------------------------------------------------------------------
+# Each entry: (family, malformation, callable-under-test, expected field-path substring).
+# The callable is a zero-arg thunk so construction (which itself must NOT raise) is separated
+# from the malformed call under test.
+
+CATALOG: list[tuple[str, str, Callable[[], Any], str]] = [
+    # --- composite -------------------------------------------------------------------------
+    (
+        "composite",
+        "wrong_tuple_arity_short",
+        lambda: _composite_encoder().seq_encode([("a",)]),
+        "CompositeDistribution.dists (row 0)",
+    ),
+    (
+        "composite",
+        "wrong_tuple_arity_long",
+        lambda: _composite_encoder().seq_encode([("a", "x", "extra")]),
+        "CompositeDistribution.dists (row 0)",
+    ),
+    (
+        "composite",
+        "wrong_field_type",
+        lambda: _composite_encoder().seq_encode([5]),
+        "CompositeDistribution.dists (row 0)",
+    ),
+    (
+        "composite",
+        "ragged_rows",
+        lambda: _composite_encoder().seq_encode([("a", "x"), ("b",)]),
+        "CompositeDistribution.dists (row 1)",
+    ),
+    (
+        "composite",
+        "malformed_nested_sequence_element",
+        lambda: _composite_of_sequence_encoder().seq_encode([("a", [1.0, "bad", 3.0])]),
+        "CompositeDistribution.dists[1] -> SequenceDistribution.entries",
+    ),
+    (
+        "composite",
+        "mismatched_estimator_data_shape",
+        lambda: _composite_estimator().estimate(1.0, (1,)),
+        "CompositeEstimator.estimate(suff_stat)",
+    ),
+    # --- sequence ----------------------------------------------------------------------------
+    (
+        "sequence",
+        "wrong_field_type_row_not_iterable",
+        lambda: _sequence_encoder().seq_encode([5]),
+        "SequenceDistribution.entries (row 0)",
+    ),
+    (
+        "sequence",
+        "malformed_element_type",
+        lambda: _sequence_encoder().seq_encode([[1.0, "bad", 3.0]]),
+        "SequenceDistribution.entries",
+    ),
+    (
+        "sequence",
+        "mismatched_estimator_data_shape",
+        lambda: _sequence_estimator().estimate(1.0, "not-a-tuple"),
+        "SequenceEstimator.estimate(suff_stat)",
+    ),
+    # --- mixture -------------------------------------------------------------------------------
+    (
+        "mixture",
+        "wrong_container_type",
+        lambda: _mixture_encoder().seq_encode(5),
+        "MixtureDistribution.seq_encode",
+    ),
+    (
+        "mixture",
+        "malformed_field_type",
+        lambda: _mixture_encoder().seq_encode([1.0, "bad", 3.0]),
+        "MixtureDistribution.components",
+    ),
+    (
+        "mixture",
+        "mismatched_estimator_data_shape",
+        lambda: _mixture_estimator().estimate(1.0, "not-a-tuple"),
+        "MixtureEstimator.estimate(suff_stat)",
+    ),
+    (
+        "mixture",
+        "mismatched_component_count",
+        lambda: _mixture_estimator().estimate(1.0, ([1.0], (1,))),
+        "MixtureEstimator.estimate(suff_stat)",
+    ),
+    # --- conditional ---------------------------------------------------------------------------
+    (
+        "conditional",
+        "wrong_tuple_arity",
+        lambda: _conditional_encoder().seq_encode([("a",)]),
+        "ConditionalDistribution.seq_encode (row 0)",
+    ),
+    (
+        "conditional",
+        "malformed_field_type",
+        lambda: _conditional_encoder().seq_encode([("a", "bad")]),
+        "ConditionalDistribution.estimator_map['a']",
+    ),
+    (
+        "conditional",
+        "mismatched_estimator_data_shape",
+        lambda: _conditional_estimator().estimate(1.0, "not-a-tuple"),
+        "ConditionalDistributionEstimator.estimate(suff_stat)",
+    ),
+    (
+        "conditional",
+        "unknown_conditioning_key",
+        lambda: _conditional_estimator().estimate(1.0, ({"unknown-key": (1.0, 2.0)}, None, {"a": 1.0})),
+        "ConditionalDistributionEstimator.estimator_map['unknown-key']",
+    ),
+    # --- optional ------------------------------------------------------------------------------
+    (
+        "optional",
+        "wrong_container_type",
+        lambda: _optional_encoder().seq_encode(5),
+        "OptionalDistribution.seq_encode",
+    ),
+    (
+        "optional",
+        "malformed_field_type",
+        lambda: _optional_encoder().seq_encode([1.0, "bad", None]),
+        "OptionalDistribution.dist",
+    ),
+    (
+        "optional",
+        "mismatched_estimator_data_shape",
+        lambda: _optional_estimator().estimate(1.0, "not-a-tuple"),
+        "OptionalEstimator.estimate(suff_stat)",
+    ),
+]
+
+
+class ContractErrorsTestCase(unittest.TestCase):
+    def test_catalog_families_and_malformations_covered(self):
+        families = {family for family, _, _, _ in CATALOG}
+        self.assertEqual(families, {"composite", "mixture", "sequence", "conditional", "optional"})
+
+    def test_malformed_input_raises_field_path_annotated_contract_error(self):
+        for family, malformation, thunk, expected_path_substring in CATALOG:
+            with self.subTest(family=family, malformation=malformation):
+                with self.assertRaises(ContractError) as ctx:
+                    thunk()
+                err = ctx.exception
+                message = str(err)
+                self.assertIn(
+                    expected_path_substring,
+                    message,
+                    "expected field path %r in message: %r" % (expected_path_substring, message),
+                )
+                self.assertIn("expected", message)
+                self.assertIn("got", message)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mixle/tests/contract_errors_test.py
+++ b/mixle/tests/contract_errors_test.py
@@ -17,6 +17,8 @@ import unittest
 from collections.abc import Callable
 from typing import Any
 
+import numpy as np
+
 import mixle.stats as stats
 from mixle.stats.compute.pdist import ContractError
 
@@ -225,6 +227,39 @@ class ContractErrorsTestCase(unittest.TestCase):
                 )
                 self.assertIn("expected", message)
                 self.assertIn("got", message)
+
+
+class ContractErrorDoesNotNarrowValidInputTestCase(unittest.TestCase):
+    """Regression guard: the card's "Do NOT change what counts as VALID input" constraint.
+
+    A first version of these contract-boundary checks used ``isinstance(x, (list, tuple))``,
+    which silently rejected ``numpy.ndarray`` -- previously valid, in-production-use input (caught
+    by a full-suite run surfacing real failures in mixle/tests/wave_mvn_test.py and
+    mixle/tests/backend_scoring_test.py that this narrower catalog test above did not exercise).
+    These cases pin that ndarray input keeps working at every touched seq_encode/estimate boundary.
+    """
+
+    def test_mixture_seq_encode_accepts_ndarray(self):
+        _mixture_encoder().seq_encode(np.array([0.1, 0.2, 0.3]))
+
+    def test_sequence_seq_encode_accepts_ndarray_of_sequences(self):
+        _sequence_encoder().seq_encode(np.array([[0.1, 0.2], [0.3, 0.4]]))
+
+    def test_optional_seq_encode_accepts_ndarray(self):
+        _optional_encoder().seq_encode(np.array([0.1, 0.2, 0.3]))
+
+    def test_composite_seq_encode_accepts_ndarray_of_tuples(self):
+        _composite_encoder().seq_encode(np.array([("a", "x"), ("b", "y")], dtype=object))
+
+    def test_conditional_seq_encode_accepts_ndarray_of_tuples(self):
+        _conditional_encoder().seq_encode(np.array([("a", 1.0), ("a", 2.0)], dtype=object))
+
+    def test_optional_estimator_accepts_ndarray_weight_pair(self):
+        est = _optional_estimator()
+        base_estimator = _GAUSS.estimator()
+        acc = base_estimator.accumulator_factory().make()
+        acc.seq_update(_GAUSS.dist_to_encoder().seq_encode([1.0, 2.0]), np.ones(2), None)
+        est.estimate(3.0, (np.array([1.0, 2.0]), acc.value()))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
A malformed sufficient-statistic tuple (wrong type, wrong length, wrong nesting) passed into \`CompositeEstimator.estimate\`/\`CompositeDistribution.seq_encode\` and the equivalent entry points on \`ConditionalDistribution\`, \`OptionalDistribution\`, \`SequenceDistribution\`, and \`MixtureDistribution\` previously failed with a bare \`IndexError\`/\`TypeError\`/\`AttributeError\` deep inside numpy/list-indexing code, with no indication of which nested combinator or field actually received the bad input.

Adds \`ContractError\` (\`mixle/stats/compute/pdist.py\`), a \`ValueError\` subclass carrying \`(path, expected, actual, fix)\` — mirroring the existing \`EnumerationError\` path-composition convention — plus \`prefix_contract_error\`, which a combinator uses to annotate a \`ContractError\` raised deep inside a child's \`estimate\`/\`seq_encode\` with the outer field position, so the final message names the FULL path down to where the failure actually occurred, e.g. \`"MixtureDistribution.components[1] -> CompositeDistribution.dists[2] -> SequenceDistribution.entries"\`.

Every touched contract boundary now validates shape/type up front and raises \`ContractError\` with a concrete, non-generic fix suggestion.

**Verified against 591 tests across the 50 existing test files that consume these five modules** — all pass unmodified, confirming the new validation doesn't change behavior on well-formed input.

Not merged — opening for review.