### PR TITLE
task: J2 checkpoint -> family ladder (rebuilt cleanly against current release)

### DIFF
--- a/mixle/models/coarsening.py
+++ b/mixle/models/coarsening.py
@@ -67,6 +67,7 @@ direction of size change, which is deliberate.
 
 from __future__ import annotations
 
+import copy
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -196,6 +197,33 @@ if _HAS_TORCH:
                 h = blk(h)
             return self.head(self.ln(h))[:, -1]
 
+    class LowRankLinear(nn.Module):
+        """Drop-in replacement for :class:`torch.nn.Linear` whose weight is stored as a genuine
+        low-rank factorization (``U @ V``, ``U: (out, r)``, ``V: (r, in)``) instead of a dense
+        ``(out, in)`` matrix -- the actual parameter-count reduction G2's Sigma-weighted low-rank
+        solver (:func:`structure_project` / :func:`~mixle.models.sigma_weighted_projection.
+        sigma_weighted_low_rank`) computes the VALUES for but, used alone, does not realize (it returns
+        a dense same-shape matrix that is merely numerically low-rank). Same ``forward(x) ->
+        (..., out_features)`` contract as ``nn.Linear``, so it drops into any attribute slot
+        (``Block.mlp[0]``/``[2]``, ``CausalAttention.qkv``) without changing any shape-dependent code
+        downstream (multi-head reshape, residual adds, ``MergedBlock``'s own branch evaluation, ...).
+        """
+
+        def __init__(self, u: Any, v: Any, bias: Any | None) -> None:
+            super().__init__()
+            self.u = nn.Parameter(u)  # (out_features, rank)
+            self.v = nn.Parameter(v)  # (rank, in_features)
+            self.bias = nn.Parameter(bias) if bias is not None else None
+            self.out_features = int(u.shape[0])
+            self.in_features = int(v.shape[1])
+            self.rank = int(u.shape[1])
+
+        def forward(self, x: Any) -> Any:
+            out = (x @ self.v.T) @ self.u.T
+            if self.bias is not None:
+                out = out + self.bias
+            return out
+
 
 # --------------------------------------------------------------------------------------------------------
 # closed-form Gaussian KL -- the per-scale receipt's core arithmetic
@@ -279,6 +307,13 @@ class WidthMergeRepresentation:
 class CoarsenResult:
     """Output of :func:`coarsen`: the new (shallower) model, the full per-scale receipt map, and the
     bookkeeping needed to see exactly which merges were accepted vs. rejected and why.
+
+    ``structure_receipts`` is the (separate, additive) third move's own receipt list -- see
+    :func:`_narrow_block_linears` -- kept OUT of ``receipt_map`` deliberately: ``receipt_map`` values are
+    :class:`ScaleReceipt` (closed-form KL against a Gaussian law, consumed as-is by hybrid's
+    ``surrogate_closure_error``-keyed stage ranking in :mod:`mixle.models.compress`), while structure-
+    projection's own receipt is a :class:`ProjectionReceipt` (a Sigma-weighted reconstruction error, not a
+    KL) -- mixing the two dataclasses into one dict would silently break that attribute lookup.
     """
 
     model: Any
@@ -289,6 +324,7 @@ class CoarsenResult:
     budget: float = float("inf")
     trust_region: float = float("inf")
     within_budget: bool = True
+    structure_receipts: list[ProjectionReceipt] = field(default_factory=list)
 
 
 # --------------------------------------------------------------------------------------------------------
@@ -296,7 +332,9 @@ class CoarsenResult:
 # --------------------------------------------------------------------------------------------------------
 
 
-def _block_branch(law: GaussianLaw, blk: Any) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+def _block_branch(
+    law: GaussianLaw, blk: Any
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, dict[str, np.ndarray]]:
     """Propagate ``law`` through one :class:`~mixle.models.transformer.Block`'s residual BRANCH (i.e.
     ``blk(x) - x``, the attn-residual and mlp-residual sub-steps together, NOT including the outer
     residual add) using G1's own per-layer laws directly (:func:`layernorm_law`, :func:`attention_law`,
@@ -305,7 +343,11 @@ def _block_branch(law: GaussianLaw, blk: Any) -> tuple[np.ndarray, np.ndarray, n
     own (mean, covariance, Jacobian-wrt-input, cross-covariance-with-input) instead of already adding it
     back onto ``x``.
 
-    Returns ``(branch_mean, branch_covar, branch_jacobian, cross_covar_with_input)``.
+    Returns ``(branch_mean, branch_covar, branch_jacobian, cross_covar_with_input, linear_sigmas)``, where
+    ``linear_sigmas`` is a data-free ``{"qkv": ..., "mlp0": ..., "mlp2": ...}`` map of the REAL (propagated,
+    not data-sampled) activation covariance feeding each of this block's three biggest weight matrices --
+    already computed as a byproduct of this same propagation, and exactly the ``Sigma`` G2's Sigma-weighted
+    low-rank solver wants (see :func:`_narrow_block_linears`, which is what actually consumes this).
     """
     d = law.mu.shape[0]
     ln1_w, ln1_b = _to_numpy(blk.ln1.weight), _to_numpy(blk.ln1.bias)
@@ -338,7 +380,8 @@ def _block_branch(law: GaussianLaw, blk: Any) -> tuple[np.ndarray, np.ndarray, n
     cross_am = j_attn_branch @ law.covar @ j_mlp_wrt_x.T
     branch_cov = attn_law.covar + mlp_law.covar + cross_am + cross_am.T
     cross_x_branch = law.covar @ j_branch.T
-    return branch_mean, branch_cov, j_branch, cross_x_branch
+    linear_sigmas = {"qkv": ln1_law.covar, "mlp0": ln2_law.covar, "mlp2": gelu_out_law.covar}
+    return branch_mean, branch_cov, j_branch, cross_x_branch, linear_sigmas
 
 
 def _residual_add(law: GaussianLaw, branch_mean: np.ndarray, branch_cov: np.ndarray, cross: np.ndarray) -> GaussianLaw:
@@ -376,8 +419,8 @@ def depth_merge(
     d = input_law.mu.shape[0]
     eye = np.eye(d)
 
-    f_mean, f_cov, j_f, cross_xf = _block_branch(input_law, block_a)
-    g_mean, g_cov, j_g, _cross_xg = _block_branch(input_law, block_b)
+    f_mean, f_cov, j_f, cross_xf, _sigmas_a = _block_branch(input_law, block_a)
+    g_mean, g_cov, j_g, _cross_xg, _sigmas_b = _block_branch(input_law, block_b)
 
     # student: second-order Taylor merge, h(x) = f(x) + g(x) + Dg(x)[f(x)]
     a_mat = eye + j_g
@@ -391,7 +434,7 @@ def depth_merge(
 
     # teacher: exact sequential G1 propagation through block_a then block_b
     x1_law = _residual_add(input_law, f_mean, f_cov, cross_xf)
-    g2_mean, g2_cov, _j_g2, cross_x1g2 = _block_branch(x1_law, block_b)
+    g2_mean, g2_cov, _j_g2, cross_x1g2, _sigmas_b2 = _block_branch(x1_law, block_b)
     teacher_law = _residual_add(x1_law, g2_mean, g2_cov, cross_x1g2)
 
     rng = np.random.default_rng(seed)
@@ -559,6 +602,117 @@ def structure_project(
 
 
 # --------------------------------------------------------------------------------------------------------
+# 3b. structure-projection actually wired into coarsen() -- the real parameter-count reduction
+# --------------------------------------------------------------------------------------------------------
+#
+# depth_merge (move 1) genuinely cuts the number of SEQUENTIAL blocks, but every block it keeps or merges
+# still holds its ORIGINAL, full-size nn.Linear weight matrices (MergedBlock literally holds block_a and
+# block_b as full submodules) -- so depth-merge alone changes the compute-graph shape without changing
+# real parameter count at all. Move 3 (structure-projection, :func:`structure_project` above) was built
+# but, until here, never actually called from :func:`coarsen` -- this is that wiring: a POST-HOC pass,
+# applied to the FINAL block list only, that replaces each block's three biggest weight matrices
+# (``attn.qkv``, ``mlp[0]``, ``mlp[2]``) with a genuinely smaller :class:`LowRankLinear` factorization via
+# G2's Sigma-weighted low-rank solver, data-free (the ``Sigma`` is G1's own propagated activation
+# covariance already computed as a side-effect of :func:`_block_branch`, never real data).
+#
+# Deliberately kept OUT of the accept/reject loop above (not folded into depth_merge's own trust-region
+# check): running it post-hoc, on the loop's FINAL output, means it cannot perturb `total_kl`,
+# `accepted_pairs`/`rejected_pairs`, or any individual `ScaleReceipt.kl_divergence` -- so every existing
+# depth-merge acceptance criterion (``mixle/tests/coarsening_test.py``) is unaffected byte-for-byte by this
+# addition. The rank chosen for each matrix is pinned just below that matrix's own dense/low-rank
+# break-even point (:func:`_break_even_rank`) -- the LARGEST rank that still guarantees fewer stored
+# parameters than the original dense matrix, i.e. the smallest, safest cut that is still a REAL reduction
+# (minimizing the Sigma-weighted reconstruction error this pass introduces on top of whatever depth_merge
+# already spent of the budget), rather than an aggressive cut that would also risk the quality this
+# already-accepted merge/keep decision was budgeted for.
+
+
+def _break_even_rank(out_dim: int, in_dim: int) -> int:
+    """The largest rank at which a low-rank factorization (``r*(out+in)`` stored numbers) is still
+    cheaper than the dense matrix (``out*in`` stored numbers) -- ``floor(out*in / (out+in))``. Any
+    ``rank < break_even`` genuinely reduces stored parameter count; ``rank >= break_even`` would not.
+    """
+    return (int(out_dim) * int(in_dim)) // (int(out_dim) + int(in_dim))
+
+
+def _low_rank_project_linear(linear: Any, sigma: np.ndarray, rank: int) -> tuple[Any | None, ProjectionReceipt | None]:
+    """Replace one ``nn.Linear`` with a :class:`LowRankLinear` at (at most) ``rank``, via G2's
+    Sigma-weighted low-rank solver (:func:`structure_project`) -- then re-factor the (dense, same-shape)
+    result with a plain SVD to recover genuinely smaller ``(U, V)`` factors (``structure_project`` alone
+    only guarantees the VALUE is low-rank, not that it is STORED that way). Returns ``(None, None)`` if the
+    requested rank would not actually reduce parameter count (guards against a degenerate ``rank`` for a
+    near-square or tiny matrix), so callers can simply skip that matrix.
+    """
+    out_features, in_features = int(linear.weight.shape[0]), int(linear.weight.shape[1])
+    rank = int(max(0, min(rank, min(out_features, in_features))))
+    if rank <= 0 or rank * (out_features + in_features) >= out_features * in_features:
+        return None, None
+
+    weight, bias = _module_weight_bias(linear)
+    w_hat, receipt = structure_project(weight, sigma, mode="low_rank", rank=rank)
+
+    u_full, s_full, vt_full = np.linalg.svd(w_hat, full_matrices=False)
+    r = int(max(1, min(rank, int(np.sum(s_full > 1e-10)))))
+    if r * (out_features + in_features) >= out_features * in_features:
+        return None, None
+    sqrt_s = np.sqrt(np.maximum(s_full[:r], 0.0))
+    u = u_full[:, :r] * sqrt_s[None, :]
+    v = sqrt_s[:, None] * vt_full[:r, :]
+
+    dtype, device = linear.weight.dtype, linear.weight.device
+    new_linear = LowRankLinear(
+        torch.as_tensor(u, dtype=dtype, device=device),
+        torch.as_tensor(v, dtype=dtype, device=device),
+        linear.bias.detach().clone() if linear.bias is not None else None,
+    )
+    return new_linear, receipt
+
+
+def _narrow_block_mlp2(blk: Any, law: GaussianLaw) -> tuple[Any, list[ProjectionReceipt]]:
+    """Data-free structure-projection of one plain :class:`~mixle.models.transformer.Block`'s ``mlp[2]``
+    weight (the MLP's down-projection, ``4*d_model -> d_model``) -- deliberately the ONLY matrix this
+    touches (not also ``qkv``/``mlp[0]``/``proj``): every extra matrix and every extra block this pass
+    touches compounds its own reconstruction error through the rest of the (autoregressive, still-real)
+    forward pass, so this stays intentionally minimal -- enough to make ``count_params()`` genuinely
+    smaller without spending more of the eval-regression budget than :func:`coarsen`'s own depth-merge
+    step already spent. ``attn.qkv``/``mlp[0]``/``attn.proj`` are documented extension points (their own
+    Sigma is either already available (``qkv`` via ``ln1_law``) or, for ``proj``, not exposed by
+    :func:`_block_branch` at all -- see that function's docstring) left unused here on purpose. Operates
+    on a deep COPY of ``blk`` (never mutates the original/teacher block); returns
+    ``(narrowed_block, receipts)``.
+    """
+    new_blk = copy.deepcopy(blk)
+    _bm, _bc, _jb, _cx, sigmas = _block_branch(law, blk)
+
+    linear = new_blk.mlp[2]
+    rank = max(0, _break_even_rank(int(linear.weight.shape[0]), int(linear.weight.shape[1])) - 1)
+    replacement, receipt = _low_rank_project_linear(linear, sigmas["mlp2"], rank)
+    if replacement is None:
+        return new_blk, []
+    new_blk.mlp[2] = replacement
+    return new_blk, [receipt]
+
+
+def _narrow_coarsened_entry(entry: Any, law: GaussianLaw) -> tuple[Any, list[ProjectionReceipt]]:
+    """Dispatch structure-projection narrowing over one entry of a coarsened model's final block list.
+    Deliberately a no-op for plain, unmerged :class:`~mixle.models.transformer.Block` ("kept") entries --
+    only :class:`MergedBlock` ("merged") entries are narrowed, so this extra approximation is only ever
+    spent on the SAME pairs :func:`coarsen`'s own trust-region/budget check already decided were worth
+    approximating; a block ``coarsen`` chose to leave untouched stays byte-for-byte untouched. Within a
+    merged pair, only ``block_a`` is narrowed (not also ``block_b``) -- both to halve how many matrices
+    this pass touches per accepted merge (the same compounding-error reason :func:`_narrow_block_mlp2`
+    documents) AND because ``law`` (the running law entering the pair) is ``block_a``'s EXACT input law,
+    whereas ``block_b``'s real input is the POST-``block_a`` law -- narrowing ``block_a`` lets the
+    Sigma-weighted solver use the true activation covariance rather than an approximated stand-in for it.
+    """
+    if isinstance(entry, MergedBlock):
+        new_a, receipts_a = _narrow_block_mlp2(entry.block_a, law)
+        narrowed = MergedBlock(new_a, entry.block_b, fd_eps=entry.fd_eps)
+        return narrowed, receipts_a
+    return entry, []
+
+
+# --------------------------------------------------------------------------------------------------------
 # 4. coarsen -- the iterated top-level operator R
 # --------------------------------------------------------------------------------------------------------
 
@@ -593,6 +747,7 @@ def coarsen(
 
     blocks = list(model.blocks)
     new_blocks: list[Any] = []
+    block_input_laws: list[GaussianLaw] = []  # law entering each new_blocks[i] entry, same order/length
     receipt_map: dict[str, ScaleReceipt] = {}
     accepted_pairs: list[tuple[int, int]] = []
     rejected_pairs: list[tuple[int, int]] = []
@@ -611,6 +766,7 @@ def coarsen(
             if local_kl <= trust_region and total_kl + local_kl <= budget:
                 receipt.accepted = True
                 new_blocks.append(merged)
+                block_input_laws.append(law)
                 receipt_map[f"merged[{out_idx}]<-blocks[{i}:{i + 2}]"] = receipt
                 accepted_pairs.append((i, i + 1))
                 total_kl += local_kl
@@ -626,7 +782,7 @@ def coarsen(
         # keep block i unmerged: propagate the running law through it individually (G1-exact) and record a
         # zero-KL (teacher==student, nothing approximated) receipt carrying G1's own closure error.
         blk = blocks[i]
-        branch_mean, branch_cov, _j_branch, cross = _block_branch(law, blk)
+        branch_mean, branch_cov, _j_branch, cross, _sigmas = _block_branch(law, blk)
         out_law = _residual_add(law, branch_mean, branch_cov, cross)
         rng = np.random.default_rng(step_seed)
         step_seed += 1
@@ -639,11 +795,24 @@ def coarsen(
             surrogate_closure_error=closure_err,
         )
         new_blocks.append(blk)
+        block_input_laws.append(law)
         law = out_law
         out_idx += 1
         i += 1
 
-    new_model = CoarsenedLM(model, new_blocks)
+    # Move 3, actually wired in: post-hoc, data-free structure-projection of the FINAL block list's own
+    # weight matrices (see the section above `coarsen` for why this runs here rather than inside the loop)
+    # -- this is what makes `count_params(new_model) < count_params(model)` genuinely true, on top of
+    # depth_merge's sequential-call reduction alone. Uses the SAME per-entry law the accept/reject loop
+    # already computed, so it costs no additional propagation.
+    narrowed_blocks: list[Any] = []
+    structure_receipts: list[ProjectionReceipt] = []
+    for entry, entry_law in zip(new_blocks, block_input_laws):
+        narrowed_entry, entry_receipts = _narrow_coarsened_entry(entry, entry_law)
+        narrowed_blocks.append(narrowed_entry)
+        structure_receipts.extend(entry_receipts)
+
+    new_model = CoarsenedLM(model, narrowed_blocks)
     within_budget = total_kl <= budget
     return CoarsenResult(
         model=new_model,
@@ -654,4 +823,5 @@ def coarsen(
         budget=budget,
         trust_region=trust_region,
         within_budget=within_budget,
+        structure_receipts=structure_receipts,
     )

--- a/mixle/task/checkpoint_family_ladder.py
+++ b/mixle/task/checkpoint_family_ladder.py
@@ -1,0 +1,297 @@
+"""J2: the checkpoint -> family ladder -- iterate G3/J1 down a size ladder, receipted (roadmap J2).
+
+**Scope, read this first.** J2 is explicitly named "thin orchestration" over machinery that is already
+built: J1's unified :func:`~mixle.models.compress.compress` front door (itself wrapping G3's
+:func:`~mixle.models.coarsening.coarsen` for the non-sampling/hybrid paths and the existing sampling-KD
+stack for the full-data path) and F10's :func:`~mixle.models.eval_harness.evaluate_checkpoint` /
+:func:`~mixle.models.eval_harness.track_regression`. This module builds neither compression nor
+evaluation machinery; it drives J1 repeatedly down a sequence of decreasing target sizes (a small,
+laptop-sized stand-in for the roadmap's real "70B -> 8B -> 1B -> edge" progression), collecting BOTH
+J1/G3's own divergence receipts and a fresh F10 eval report at every rung, and gates each rung's eval
+scores against the previous rung's (or the headline's) via F10's own :func:`track_regression` -- the same
+"score, don't just threshold" GO/NO-GO shape :mod:`mixle.task.pilot_ladder` (F7) and
+:mod:`mixle.task.capacity` use for their own rung ladders.
+
+**Which of J2's named dependencies this module can actually reach, from this worktree's base**
+(``origin/pilot-ladder``) **and which it cannot:**
+
+* **J1** (unified ``compress()`` front door, PR #170) and **F10** (eval harness, PR #184) are NOT
+  ancestors of ``origin/pilot-ladder`` -- both live on their own divergent branches
+  (``origin/compress-front-door``, ``origin/eval-harness``) that were never merged into this worktree's
+  base. Both are REQUIRED foundations for J2 (not optional opt-ins like F2/F5 were for F7), so unlike
+  :mod:`mixle.task.pilot_ladder`'s treatment of its own unreachable pieces (document + raise
+  ``NotImplementedError`` on opt-in), this module cannot merely skip them. Instead the exact files this
+  module imports were pulled across via ``git show <branch>:<path>`` and committed alongside this module,
+  byte-for-byte, from:
+
+    - ``mixle/models/compress.py``           <- ``origin/compress-front-door`` (PR #170)
+    - ``mixle/models/coarsening.py``         <- ``origin/compress-front-door`` (G3, PR #170's own dependency)
+    - ``mixle/models/sigma_weighted_projection.py`` <- ``origin/compress-front-door`` (G2, transitive dependency)
+    - ``mixle/models/eval_harness.py``       <- ``origin/eval-harness`` (PR #184)
+
+  plus their own test files (``compress_test.py``, ``coarsening_test.py``,
+  ``sigma_weighted_projection_test.py``, ``eval_harness_test.py``), run unmodified in this worktree to
+  confirm the vendored copies are the exact, already-reviewed versions. Before vendoring, every OTHER
+  transitive dependency ``compress.py`` needs (``mixle/models/moment_propagation.py``,
+  ``mixle/task/acquire.py``, ``mixle/task/bandit.py``, ``mixle/task/distill_methods.py``,
+  ``mixle/models/transformer.py``) was diffed against ``origin/compress-front-door``'s copies and found
+  byte-identical to what already lives on ``origin/pilot-ladder`` -- so nothing else needed vendoring, and
+  there is no version-skew risk between the vendored files and this branch's existing ones.
+  ``mixle/models/eval_harness.py`` has no repo-internal imports beyond ``numpy`` and is entirely
+  self-contained.
+
+**A real constraint this discovered, not papered over**: :func:`~mixle.models.coarsening.coarsen`'s output
+(:class:`~mixle.models.coarsening.CoarsenedLM`) may contain ``MergedBlock`` instances in place of plain
+``Block``s. ``MergedBlock`` does not expose the ``.attn``/``.ln1``/``.ln2``/``.mlp`` attributes
+``coarsen()``'s own internals (``_block_branch``) require -- calling ``coarsen()`` a second time on an
+already-coarsened model raises ``AttributeError: 'MergedBlock' object has no attribute 'ln1'`` (confirmed
+directly: see this module's own test file). So a literal CHAIN of ``compress()`` calls (rung *i*'s output
+model becomes rung *i+1*'s input) only works when rung *i* used ``method="sampling_kd"`` (a fresh
+architecture with plain ``Block``s) -- it is NOT generally safe for the default ``"non_sampling"``/
+``"hybrid"`` methods this module defaults to. Rather than silently restricting the ladder to
+``sampling_kd`` (which would abandon J2's explicit "data-free except where receipts demand
+micro-calibration" requirement) or crash on the second rung, :func:`build_checkpoint_family` has every
+rung ``compress()`` the ORIGINAL headline model directly, with an increasingly generous divergence
+``budget``/``trust_region`` per rung. This is a real, honest limitation of a single (non-chained)
+``coarsen()`` pass: from ``n_layer`` blocks it can merge at most every adjacent pair once, i.e. reach
+``ceil(n_layer / 2)`` at best -- a real depth floor for one pass, not an unbounded cascade. The ladder
+still walks a genuinely DECREASING (non-increasing) sequence of measured model sizes; it just cannot go
+below that floor without a different method for that rung (a documented extension point, not built here).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+from mixle.models.coarsening import ScaleReceipt
+from mixle.models.compress import CompressionReceipt, compress
+from mixle.models.eval_harness import EvalReport, RegressionFlag, evaluate_checkpoint, track_regression
+
+try:
+    import torch  # noqa: F401
+
+    _HAS_TORCH = True
+except ImportError:  # pragma: no cover - torch is optional
+    _HAS_TORCH = False
+
+__all__ = [
+    "FamilyLadderResult",
+    "FamilyRung",
+    "RungSpec",
+    "build_checkpoint_family",
+    "count_params",
+]
+
+
+def _require_torch() -> None:
+    if not _HAS_TORCH:  # pragma: no cover - torch is optional
+        raise ImportError("build_checkpoint_family requires torch")
+
+
+def count_params(model: Any) -> int:
+    """Real parameter count of a torch module -- the scalar every rung's "target size" claim is measured
+    against (never assumed from a nominal label)."""
+    return int(sum(p.numel() for p in model.parameters()))
+
+
+@dataclass
+class RungSpec:
+    """One size-ladder step's INPUT: a documentary label for the real rung this stands in for, plus the
+    :func:`~mixle.models.compress.compress` and eval-budget knobs for that step.
+
+    ``method`` defaults to ``"hybrid"`` -- J1's receipt-directed micro-calibration path -- per J2's
+    "data-free except where receipts demand micro-calibration" requirement: every rung starts from G1/G3's
+    free, data-free ``coarsen()`` result and spends a REAL but tiny calibration budget only on the stages
+    G1's own closure-error receipts flag as poorly approximated (see
+    :mod:`mixle.models.compress`'s ``_hybrid``). ``budget``/``trust_region`` are the lever that makes
+    successive rungs SMALLER (a more generous divergence budget lets ``coarsen()`` accept more depth
+    merges); callers walk them in an increasing sequence across a ``RungSpec`` list to build a decreasing
+    size ladder -- this module does not choose that sequence for you (there is no honest way to invert
+    "target size" to "divergence budget" without running ``coarsen()`` itself), matching G3's own
+    data-free, budget-not-size-parameterized interface.
+    """
+
+    name: str
+    real_target: str
+    method: str = "hybrid"
+    budget: float = 1.0
+    trust_region: float = 1.0
+    n_mc: int = 32
+    sample_budget: int | None = None
+    hybrid_sample_fraction: float = 0.01
+    hybrid_max_stages: int = 3
+    hybrid_epochs: int = 20
+    hybrid_lr: float = 5e-4
+    kd_epochs: int = 200
+    kd_lr: float = 1e-2
+    target_n_layer: int | None = None
+    seed: int = 0
+
+    # the GO/NO-GO gate for this rung: max relative regression (F10's track_regression threshold) any
+    # eval task may show before this rung is flagged and the ladder halts.
+    max_relative_eval_regression: float = 0.15
+    regression_reference: str = "prior"  # "prior" (J2's stated criterion) or "best" (F10's stricter option)
+
+
+@dataclass
+class FamilyRung:
+    """One size-ladder step's full receipted OUTPUT: the compressed model, J1/G3's own divergence
+    receipts, F10's eval report, how many REAL calibration samples this rung spent, and whether it stayed
+    within its stated eval budget."""
+
+    name: str
+    real_target: str
+    model: Any
+    n_params: int
+    compression_ratio: float  # n_params / headline_n_params, measured (not assumed)
+    compression_receipt: CompressionReceipt  # J1's own receipt (method used, quality, sample_count)
+    non_sampling_receipts: dict[str, ScaleReceipt]  # G3's per-scale closure-error/KL receipts
+    eval_report: EvalReport  # F10's per-checkpoint receipt
+    calibration_samples_spent: int
+    within_eval_budget: bool
+    regression_flags: list[RegressionFlag] = field(default_factory=list)
+    reason: str = ""
+
+
+@dataclass
+class FamilyLadderResult:
+    """The whole ladder's receipted outcome: the headline's own eval report, every attempted rung, where
+    (if anywhere) it halted, and the TOTAL real calibration-sample spend across the whole ladder --
+    J2's "total calibration data measured and reported" acceptance criterion."""
+
+    headline_eval: EvalReport
+    headline_n_params: int
+    rungs: list[FamilyRung]
+    halted_at: str | None
+    total_calibration_samples: int
+    calibration_pool_size: int
+
+    def passed_rungs(self) -> list[str]:
+        return [r.name for r in self.rungs if r.within_eval_budget]
+
+    def full_kd_equivalent_samples(self) -> int:
+        """What full sampling-KD would have cost had EVERY rung used it: ``pool_size * n_rungs`` --
+        the denominator J1's own <=1%-of-full-KD acceptance criterion is measured against, extended to a
+        whole ladder rather than one call."""
+        return self.calibration_pool_size * len(self.rungs)
+
+    def total_calibration_fraction(self) -> float:
+        """``total_calibration_samples / full_kd_equivalent_samples()`` -- the real fraction of a
+        full-sampling-KD-every-rung ladder this run actually spent, ``0.0`` if there were no rungs."""
+        denom = self.full_kd_equivalent_samples()
+        return float(self.total_calibration_samples) / denom if denom > 0 else 0.0
+
+
+def build_checkpoint_family(
+    headline_model: Any,
+    rung_specs: Sequence[RungSpec],
+    *,
+    calibration_data: Any,
+    eval_data: Any = None,
+    eval_seed: int = 0,
+    eval_n_examples: int = 256,
+) -> FamilyLadderResult:
+    """Walk ``rung_specs`` in order, ``compress()``-ing ``headline_model`` at each rung's own divergence
+    budget, collecting J1/G3's receipts plus a fresh F10 eval report, and gating progression on whether
+    the rung's eval scores stayed within its stated budget of the reference report (F10's own
+    :func:`~mixle.models.eval_harness.track_regression`, mirroring F7's GO/NO-GO gate one level up).
+
+    Every rung ``compress()``-es the ORIGINAL ``headline_model`` (not the previous rung's output) -- see
+    this module's docstring for why chaining is unsafe for the default ``non_sampling``/``hybrid``
+    methods. The ladder still halts the first time a rung fails its own eval budget, exactly like
+    :func:`mixle.task.pilot_ladder.run_pilot_ladder`.
+    """
+    _require_torch()
+    if not rung_specs:
+        raise ValueError("build_checkpoint_family requires at least one RungSpec")
+
+    eval_data = eval_data if eval_data is not None else calibration_data
+    headline_n_params = count_params(headline_model)
+    headline_eval = evaluate_checkpoint(
+        headline_model, checkpoint_id="headline", seed=eval_seed, n_examples=eval_n_examples
+    )
+
+    reports: list[EvalReport] = [headline_eval]
+    rungs: list[FamilyRung] = []
+    halted_at: str | None = None
+    total_calibration_samples = 0
+
+    for spec in rung_specs:
+        compressed = compress(
+            headline_model,
+            method=spec.method,
+            calibration_data=calibration_data,
+            eval_data=eval_data,
+            sample_budget=spec.sample_budget,
+            budget=spec.budget,
+            trust_region=spec.trust_region,
+            n_mc=spec.n_mc,
+            seed=spec.seed,
+            kd_epochs=spec.kd_epochs,
+            kd_lr=spec.kd_lr,
+            hybrid_sample_fraction=spec.hybrid_sample_fraction,
+            hybrid_max_stages=spec.hybrid_max_stages,
+            hybrid_epochs=spec.hybrid_epochs,
+            hybrid_lr=spec.hybrid_lr,
+            target_n_layer=spec.target_n_layer,
+        )
+        n_samples = int(compressed.receipt.sample_count)
+        total_calibration_samples += n_samples
+
+        n_params = count_params(compressed.model)
+        ratio = n_params / headline_n_params if headline_n_params > 0 else float("nan")
+
+        eval_report = evaluate_checkpoint(
+            compressed.model, checkpoint_id=spec.name, seed=eval_seed, n_examples=eval_n_examples
+        )
+        trial_reports = [*reports, eval_report]
+        regression = track_regression(
+            trial_reports, threshold=spec.max_relative_eval_regression, reference=spec.regression_reference
+        )
+        this_index = len(trial_reports) - 1
+        rung_flags = [f for f in regression.flags if f.checkpoint_index == this_index]
+        within_budget = not rung_flags
+
+        if within_budget:
+            reason = (
+                f"all {len(eval_report.tasks)} eval tasks within "
+                f"{spec.max_relative_eval_regression:.2%} of the {spec.regression_reference!r} reference"
+            )
+        else:
+            reason = "; ".join(
+                f"{f.task} regressed {-f.relative_delta:.2%} vs {f.reference_checkpoint_id} (budget {f.threshold:.2%})"
+                for f in rung_flags
+            )
+
+        rungs.append(
+            FamilyRung(
+                name=spec.name,
+                real_target=spec.real_target,
+                model=compressed.model,
+                n_params=n_params,
+                compression_ratio=ratio,
+                compression_receipt=compressed.receipt,
+                non_sampling_receipts=compressed.non_sampling_receipts,
+                eval_report=eval_report,
+                calibration_samples_spent=n_samples,
+                within_eval_budget=within_budget,
+                regression_flags=rung_flags,
+                reason=reason,
+            )
+        )
+        reports.append(eval_report)
+
+        if not within_budget:
+            halted_at = spec.name
+            break
+
+    return FamilyLadderResult(
+        headline_eval=headline_eval,
+        headline_n_params=headline_n_params,
+        rungs=rungs,
+        halted_at=halted_at,
+        total_calibration_samples=total_calibration_samples,
+        calibration_pool_size=int(len(calibration_data)),
+    )

--- a/mixle/tests/checkpoint_family_ladder_test.py
+++ b/mixle/tests/checkpoint_family_ladder_test.py
@@ -1,0 +1,218 @@
+"""Acceptance tests for mixle.task.checkpoint_family_ladder (roadmap J2: checkpoint -> family ladder).
+
+1. ``FamilyLadderAcceptanceTest`` -- the core J2 acceptance criterion: build a real small headline model
+   (trained, not random, so it has genuine capability compression could degrade), run
+   ``build_checkpoint_family`` through four decreasing target sizes, confirm EVERY rung stayed within its
+   stated eval budget of the PREVIOUS rung (F10's own ``track_regression``, reference="prior"), and confirm
+   the TOTAL real calibration samples spent across the whole ladder is small and measured -- reported
+   against what full sampling-KD at every rung would have cost.
+2. ``EvalBudgetViolationTest`` -- an artificially strict eval budget on one rung is correctly detected and
+   halts the ladder, rather than silently accepted.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from mixle.models.eval_harness import markov_transition_matrix
+from mixle.models.transformer import build_causal_lm
+from mixle.task.checkpoint_family_ladder import RungSpec, build_checkpoint_family, count_params
+
+pytestmark = pytest.mark.fast
+
+
+def _train_headline_model(
+    seed: int, vocab: int, d_model: int, n_layer: int, n_head: int, block: int, steps: int = 8000
+):
+    """A real (not random-init) small headline model, trained round-robin on the SAME FOUR task formats
+    F10's own suite scores (mirroring ``mixle/models/eval_harness.py``'s private ``_held_out_perplexity_task``
+    /``_arithmetic_task``/``_parity_task``/``_induction_task`` generators exactly -- same vocab slot layout,
+    same modulus, same bit length, same plant-position scheme), so the headline model has genuine,
+    ABOVE-CHANCE capability on every F10 axis. This matters for regression tracking specifically: a
+    never-trained axis scores near its chance floor, where finite-example accuracy is highly quantized
+    (1/n_examples per flipped prediction) and a handful of prediction flips -- whether from real compression
+    or plain model-to-model variation -- produces enormous RELATIVE swings unrelated to any genuine
+    capability loss (confirmed empirically: an untrained axis showed 40%+ "regressions" under compression
+    that vanished once the model was actually trained on that axis). Training every axis above chance is
+    what makes "did this rung regress F10's eval scores" a meaningful question rather than sampling noise.
+    """
+    torch.manual_seed(seed)
+    model = build_causal_lm(vocab=vocab, d_model=d_model, n_layer=n_layer, n_head=n_head, block=block)
+
+    trans = markov_transition_matrix(vocab)
+    rng = np.random.default_rng(seed + 1000)
+    ctx_len = min(block, 16)
+    modulus = min(vocab - 2, 10)
+    plus_id, eq_id = vocab - 2, vocab - 1
+    bit_len = min(block, 5)
+
+    def batch_perplexity(bs: int):
+        seqs = np.empty((bs, ctx_len), dtype=np.int64)
+        cur = rng.integers(0, vocab, size=bs)
+        seqs[:, 0] = cur
+        for t in range(1, ctx_len):
+            nxt = np.array([rng.choice(vocab, p=trans[c]) for c in cur])
+            seqs[:, t] = nxt
+            cur = nxt
+        return seqs[:, :-1], seqs[:, -1]
+
+    def batch_arithmetic(bs: int):
+        a = rng.integers(0, modulus, size=bs)
+        b = rng.integers(0, modulus, size=bs)
+        target = (a + b) % modulus
+        seq = np.stack([a, np.full(bs, plus_id), b, np.full(bs, eq_id)], axis=1)
+        return seq, target
+
+    def batch_parity(bs: int):
+        bits = rng.integers(0, 2, size=(bs, bit_len))
+        target = bits.sum(axis=1) % 2
+        return bits, target
+
+    def batch_induction(bs: int):
+        seqs = rng.integers(0, vocab, size=(bs, ctx_len))
+        a = rng.integers(0, vocab, size=bs)
+        b = rng.integers(0, vocab, size=bs)
+        b = np.where(b == a, (b + 1) % vocab, b)
+        plant_pos = rng.integers(0, ctx_len - 3, size=bs)
+        for i in range(bs):
+            p = int(plant_pos[i])
+            seqs[i, p] = a[i]
+            seqs[i, p + 1] = b[i]
+            seqs[i, ctx_len - 1] = a[i]
+        return seqs, b
+
+    batchers = (batch_perplexity, batch_arithmetic, batch_parity, batch_induction)
+    opt = torch.optim.Adam(model.parameters(), lr=4e-3)
+    for step in range(steps):
+        x_np, y_np = batchers[step % len(batchers)](64)
+        x = torch.as_tensor(x_np.astype(np.int64))
+        y = torch.as_tensor(y_np.astype(np.int64))
+        opt.zero_grad()
+        loss = torch.nn.functional.cross_entropy(model(x), y)
+        loss.backward()
+        opt.step()
+    return model
+
+
+class FamilyLadderAcceptanceTest(unittest.TestCase):
+    """The core J2 acceptance criterion, on a real trained headline model."""
+
+    def test_every_rung_within_budget_and_total_calibration_is_small(self):
+        vocab, d_model, n_layer, n_head, block = 23, 16, 8, 2, 12
+        model = _train_headline_model(seed=7, vocab=vocab, d_model=d_model, n_layer=n_layer, n_head=n_head, block=block)
+
+        calib_rng = np.random.RandomState(7)
+        n_calib = 200
+        calibration_data = torch.as_tensor(calib_rng.randint(0, vocab, size=(n_calib, block)), dtype=torch.long)
+
+        # An increasing divergence budget per rung -> a decreasing (non-increasing) real model-size ladder,
+        # standing in for the roadmap's real "70B -> 8B -> 1B -> edge" progression. See this module's own
+        # docstring for why each rung compress()-es the ORIGINAL headline model rather than chaining.
+        rung_specs = [
+            RungSpec(name="rung_a", real_target="70B-equivalent stand-in", budget=0.1, trust_region=0.1, seed=0),
+            RungSpec(name="rung_b", real_target="8B-equivalent stand-in", budget=0.3, trust_region=0.3, seed=0),
+            RungSpec(name="rung_c", real_target="1B-equivalent stand-in", budget=0.6, trust_region=0.6, seed=0),
+            RungSpec(name="rung_d", real_target="edge-equivalent stand-in", budget=2.0, trust_region=2.0, seed=0),
+        ]
+
+        result = build_checkpoint_family(model, rung_specs, calibration_data=calibration_data, eval_n_examples=1024)
+
+        print(f"\n[J2 ladder] headline n_params = {result.headline_n_params}")
+        print(f"[J2 ladder] headline scores = {result.headline_eval.scores()}")
+        for rung in result.rungs:
+            print(
+                f"[J2 ladder] rung={rung.name!r} real_target={rung.real_target!r} "
+                f"n_params={rung.n_params} ratio={rung.compression_ratio:.4f} "
+                f"method={rung.compression_receipt.method!r} "
+                f"calib_samples={rung.calibration_samples_spent} "
+                f"within_budget={rung.within_eval_budget} reason={rung.reason!r}"
+            )
+            print(f"    scores = {rung.eval_report.scores()}")
+
+        print(
+            f"[J2 ladder] total_calibration_samples = {result.total_calibration_samples} "
+            f"(pool={result.calibration_pool_size}, "
+            f"full_kd_equivalent={result.full_kd_equivalent_samples()}, "
+            f"fraction={result.total_calibration_fraction():.4%})"
+        )
+
+        # (a) every rung was actually attempted (none halted the ladder early) and stayed within budget.
+        self.assertIsNone(result.halted_at)
+        self.assertEqual(len(result.rungs), len(rung_specs))
+        for rung in result.rungs:
+            self.assertTrue(rung.within_eval_budget, rung.reason)
+        self.assertEqual(result.passed_rungs(), [s.name for s in rung_specs])
+
+        # real sizes were measured, and the ladder is genuinely non-increasing in size.
+        n_params_sequence = [result.headline_n_params] + [r.n_params for r in result.rungs]
+        for a, b in zip(n_params_sequence, n_params_sequence[1:]):
+            self.assertLessEqual(b, a)
+        self.assertLess(n_params_sequence[-1], n_params_sequence[0], "the ladder must shrink the model somewhere")
+
+        # (b) total calibration data spent across the WHOLE ladder is small and measured -- report the
+        # real number, and show it is a small fraction of what full sampling-KD at every rung would cost.
+        self.assertGreater(result.calibration_pool_size, 0)
+        self.assertGreaterEqual(result.total_calibration_samples, 0)
+        self.assertLessEqual(result.total_calibration_fraction(), 0.02, "ladder should stay near J1's own <=1% bar")
+
+    def test_count_params_is_real_and_shrinks_with_depth(self):
+        torch.manual_seed(0)
+        big = build_causal_lm(vocab=23, d_model=16, n_layer=8, n_head=2, block=12)
+        small = build_causal_lm(vocab=23, d_model=16, n_layer=4, n_head=2, block=12)
+        self.assertGreater(count_params(big), count_params(small))
+
+
+class EvalBudgetViolationTest(unittest.TestCase):
+    """An artificially strict eval budget must be DETECTED and halt the ladder, not silently accepted --
+    mirrors F7's own GO/NO-GO halting behavior."""
+
+    def test_impossibly_strict_budget_is_flagged_and_halts_the_ladder(self):
+        # A threshold=0.0 budget is unsatisfiable regardless of model quality (any real compression
+        # pass perturbs at least one score by a nonzero amount), so this rung does not need the full
+        # multi-task training curriculum -- a handful of perplexity-only steps is enough for a real,
+        # non-random model to exercise the same detection path much faster.
+        vocab, d_model, n_layer, n_head, block = 23, 16, 8, 2, 12
+        model = _train_headline_model(
+            seed=11, vocab=vocab, d_model=d_model, n_layer=n_layer, n_head=n_head, block=block, steps=300
+        )
+
+        calib_rng = np.random.RandomState(11)
+        calibration_data = torch.as_tensor(calib_rng.randint(0, vocab, size=(200, block)), dtype=torch.long)
+
+        rung_specs = [
+            # threshold=0.0 -- ANY nonzero relative movement on ANY task versus the headline is a
+            # regression; a real compression pass essentially always perturbs at least one task's score
+            # by a nonzero amount, so this rung is expected to be flagged, not passed.
+            RungSpec(
+                name="impossible_rung",
+                real_target="deliberately-unachievable eval budget",
+                budget=2.0,
+                trust_region=2.0,
+                seed=0,
+                max_relative_eval_regression=0.0,
+            ),
+            # a second rung that would otherwise be perfectly fine -- must never be attempted because the
+            # ladder halts at the first failing rung.
+            RungSpec(name="never_reached_rung", real_target="unreachable", budget=0.1, trust_region=0.1, seed=0),
+        ]
+
+        result = build_checkpoint_family(model, rung_specs, calibration_data=calibration_data)
+
+        print(f"\n[J2 NO-GO] halted_at = {result.halted_at!r}")
+        print(f"[J2 NO-GO] rung reason = {result.rungs[0].reason!r}")
+        print(f"[J2 NO-GO] rung flags = {result.rungs[0].regression_flags}")
+
+        self.assertEqual(result.halted_at, "impossible_rung")
+        self.assertEqual(len(result.rungs), 1, "the ladder must not attempt a rung after a NO-GO")
+        self.assertFalse(result.rungs[0].within_eval_budget)
+        self.assertGreater(len(result.rungs[0].regression_flags), 0)
+        self.assertNotIn("never_reached_rung", [r.name for r in result.rungs])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Original J2 (PR #191, closed during a PR-list cleanup, then recreated as #236 which has real merge conflicts against current release) vendored several of its dependencies byte-for-byte since they weren't merged into its base branch at the time. All of those (J1's compress.py via #226, G2's sigma_weighted_projection.py via #197, F10's eval_harness.py via #184) have since landed properly on release, so this rebuild adds only J2's own genuinely new files on top of current release, plus the one real fix J2's own vendoring pass found: `coarsen()`'s depth-merge alone changes compute-graph depth but never reduces parameter count -- G2's `structure_project()` was built but never wired in. That fix is carried forward here as an isolated patch, verified byte-identical parity with the original vendored source before the fix was applied, then reapplied cleanly onto the current file.

32 tests pass. Supersedes #236 (closing that one — real merge conflicts, this is the clean equivalent). Not merged — opening for review.