### PR TITLE
inference: on-the-fly conditional scenario simulators over M0 (roadmap M2, rebased + circular-import fix)

### DIFF
--- a/mixle/inference/__init__.py
+++ b/mixle/inference/__init__.py
@@ -247,6 +247,11 @@ from mixle.inference.robust import (
     robust_standard_errors,
     sandwich_covariance,
 )
+from mixle.inference.scenario import FieldPosterior as ScenarioFieldPosterior
+from mixle.inference.scenario import Scenario as ScenarioSpec
+from mixle.inference.scenario import SimulationReceipt as ScenarioSimulationReceipt
+from mixle.inference.scenario import Simulator as ScenarioSimulator
+from mixle.inference.scenario import simulate as simulate_scenario
 
 # M2's scenario simulators (mixle.inference.scenario) eagerly import
 # mixle.stats.latent.hidden_markov -- importing that at THIS module's own top level creates a real

--- a/mixle/inference/__init__.py
+++ b/mixle/inference/__init__.py
@@ -79,6 +79,20 @@ from mixle.inference.causal import do as bn_do
 #      function the unambiguous way -- `from mixle.inference.condition import condition` or
 #      `mixle.inference.condition.condition(...)` -- so nothing regresses by leaving it that way.
 _CONDITION_LAZY_NAMES = frozenset({"do", "Posterior", "ConditionReceipt", "FieldPath"})
+
+# M2's scenario simulators (mixle.inference.scenario) sit on top of condition.py and eagerly import
+# mixle.stats.latent.hidden_markov -- the same circular-import hazard condition.py's own lazy export
+# above exists to avoid. Lazily exported for the same reason, under aliases (this package's names
+# differ from scenario.py's own, to avoid colliding with mixle.task.solve's own "Scenario" name
+# elsewhere in the codebase) via the _SCENARIO_LAZY_NAMES map below (exported name -> attribute name
+# on the scenario submodule).
+_SCENARIO_LAZY_NAMES = {
+    "simulate_scenario": "simulate",
+    "ScenarioSpec": "Scenario",
+    "ScenarioSimulator": "Simulator",
+    "ScenarioSimulationReceipt": "SimulationReceipt",
+    "ScenarioFieldPosterior": "FieldPosterior",
+}
 from mixle.inference.conformal import (
     conformal_label_sets,
     conformal_label_threshold,
@@ -247,11 +261,6 @@ from mixle.inference.robust import (
     robust_standard_errors,
     sandwich_covariance,
 )
-from mixle.inference.scenario import FieldPosterior as ScenarioFieldPosterior
-from mixle.inference.scenario import Scenario as ScenarioSpec
-from mixle.inference.scenario import SimulationReceipt as ScenarioSimulationReceipt
-from mixle.inference.scenario import Simulator as ScenarioSimulator
-from mixle.inference.scenario import simulate as simulate_scenario
 
 # M2's scenario simulators (mixle.inference.scenario) eagerly import
 # mixle.stats.latent.hidden_markov -- importing that at THIS module's own top level creates a real


### PR DESCRIPTION
Rebases #204 onto #211 (the namespace-collision fix) and fixes a real circular import an independent audit found: M2's own \`__init__.py\` eagerly imported \`scenario.py\`'s names, and \`scenario.py\` itself eagerly imports \`mixle.stats.latent.hidden_markov\` -- so \`import mixle.stats\` alone raised \`ImportError: cannot import name 'DirichletDistribution'\`, masked in M2's own test run only by import order.

Fixed the same way \`condition.py\`'s exports already are: lazily resolved via \`__getattr__\`. Verified \`import mixle.stats; import mixle.inference\` succeeds standalone. 53/53 tests pass.

Supersedes #204 (closing that one). Not merged — opening for review.