### PR TITLE
task/router: batch the frontier tier's call, fix the C2 doc sample that exposed it

### DIFF
--- a/docs/bring_your_own_model.rst
+++ b/docs/bring_your_own_model.rst
@@ -158,23 +158,31 @@ external teacher only when the local model is unsure:
    cascade.report()        # realized $/request saved vs. teacher-only
    cascade.harvested()     # (texts, labels) the teacher answered -- feed back into distill()
 
-``Router`` generalizes this to several calibrated tiers (tiny -> small ->
-... -> the external checkpoint as the final, always-answering fallback):
+``Router`` generalizes this to several calibrated tiers (cheapest first,
+... -> the external checkpoint as the final, always-answering fallback).
+Build it from ``(name, model, cost)`` tuples -- any tier before the last
+just needs a ``decide(x)`` method, exactly what ``calibrated`` above
+already has:
 
 .. code-block:: python
 
    from mixle.task import Router
 
-   router = Router.from_solutions(
-       [tiny_solution, small_solution],
-       teacher=teacher,          # the wrapped external checkpoint, last and most expensive
-       costs=[0.0001, 0.001, 0.03],
-       names=["tiny", "small", "external-checkpoint"],
-   )
+   router = Router([
+       ("local-checkpoint", calibrated, 0.0001),  # the calibrated student from step 3, above
+       ("external-checkpoint", teacher, 0.03),    # the wrapped external checkpoint, last and most expensive
+   ])
 
-   router(request)
+   router("free prize inside!!!")
    router.report()      # per-tier traffic and realized cost
    router.harvested()   # requests only the external model answered -- re-distill to shrink escalation
+
+A deeper stack (tiny -> small -> ... -> external) is the same shape with
+more tuples; :func:`~mixle.task.router.Router.from_solutions` is a
+convenience constructor for the case where each tier is a full
+:class:`~mixle.task.solve.Solution` (from :func:`~mixle.task.solve.solve`)
+rather than a bare calibrated model -- it reads each ``Solution``'s
+``.cascade.model`` for you.
 
 In both cases the external, HF/TRL-trained model never needs to change: it
 is the fallback tier, called exactly the same way it was called in step 1.

--- a/mixle/task/router.py
+++ b/mixle/task/router.py
@@ -96,7 +96,11 @@ class Router:
                 self.stats.tiers[i].answered += 1
                 return label
         _, teacher, _ = self.tiers[-1]
-        label = teacher(x)
+        # The frontier/teacher is a BATCHED callable (`texts -> [label]`, e.g. llm_labeler's shape) --
+        # calling it with a bare `x` (a single string) would iterate over its characters instead of
+        # treating it as one request. Wrap-and-unwrap the same way Cascade._teacher_label already does.
+        out = teacher([x])
+        label = out[0] if isinstance(out, (list, tuple)) else out
         self.stats.tiers[-1].answered += 1
         self.stats.harvested_inputs.append(x)
         self.stats.harvested_labels.append(label)

--- a/mixle/tests/task_router_test.py
+++ b/mixle/tests/task_router_test.py
@@ -80,6 +80,31 @@ class RouterTest(unittest.TestCase):
         with self.assertRaises(TypeError):
             Router([("bad", object(), 0.001), ("frontier", lambda x: "a", 0.03)])
 
+    def test_final_tier_batches_a_single_request_to_the_teacher(self):
+        """Regression: the final/frontier tier must call a BATCHED teacher (`texts -> [label]`, the
+        shape mixle.task.llm_labeler and every mixle.task distillation entry point produces) with
+        `[x]`, not a bare `x` -- calling a batched callable with a single string silently iterates
+        over its CHARACTERS instead of treating it as one request (caught by an independent audit
+        running mixle's own docs/bring_your_own_model.rst sample end to end)."""
+        from mixle.task import Router
+
+        class DecideNeverConfident:
+            def decide(self, x):
+                from mixle.task.calibrate import ESCALATE
+
+                return ESCALATE  # always defer to the frontier tier
+
+        def batched_teacher(xs):
+            # A real batched-teacher shape: takes a LIST, returns a LIST of the same length. If the
+            # router ever calls this with a bare string again, `len(xs)` will be the string's
+            # character count instead of 1, and this assertion will fail loudly.
+            assert isinstance(xs, list), f"teacher must be called with a list, got {type(xs).__name__}"
+            return [f"label-for:{x}" for x in xs]
+
+        router = Router([("local", DecideNeverConfident(), 0.0001), ("frontier", batched_teacher, 0.03)])
+        result = router("a single multi-character request")
+        self.assertEqual(result, "label-for:a single multi-character request")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
An independent audit found \`docs/bring_your_own_model.rst\`'s Router example called \`Router.from_solutions()\` with undefined variables and the wrong object type — would raise \`AttributeError\` if actually executed.

Fixing the doc surfaced a second, real bug: \`Router.__call__\`'s frontier tier called \`teacher(x)\` with a bare single request, but every \`mixle.task\` distillation entry point produces a **batched** teacher (\`texts -> [label]\`) — calling one with a bare string silently iterates over its characters. \`Cascade\` already handles this correctly; \`Router\`'s final tier didn't. Fixed the same way, plus a regression test with a real batched-shape mock teacher.

Rewrote the doc example to build \`Router\` from \`(name, model, cost)\` tuples and executed the corrected sample end-to-end before committing — produces a real, correct decision now.

9/9 Router tests pass (8 existing + 1 new). Not merged — opening for review.