### PR TITLE
D4: revert the swap itself, not just the M-step, on a rejected hot-swap round

### DIFF
--- a/mixle/inference/leaf_hotswap.py
+++ b/mixle/inference/leaf_hotswap.py
@@ -27,9 +27,19 @@ receipt later shows the surrogate drifting away from the real held-out data (e.g
 regime shifts after the swap), :func:`swap_back` restores the exact retained object and gradient
 fitting resumes exactly where it left off -- "never truly forget", the same policy D2's freeze/
 roll-up commits to for frozen mixture components. F itself (the real Neal-Hinton free energy) is
-still the audit receipt: :func:`run_em_with_hotswap` gates every round's M-step (gradient OR
-closed-form) behind the same accept/reject monotone-F test D2/D3 already use, so a bad swap can
-cost speed (a rejected round, or a later swap-back) but never correctness.
+still the audit receipt: :func:`run_em_with_hotswap` gates every round's proposal -- the swap-in
+itself AND the following M-step (gradient OR closed-form), as one atomic unit -- behind the same
+accept/reject monotone-F test D2/D3 already use, so a bad swap can cost speed (a rejected-and-
+reverted round, or a later swap-back once already committed) but never correctness. This is the
+gate that actually makes the mechanism safe: :func:`moment_matched_surrogate` on its own is a
+plain Gaussian MLE fit with no guarantee of matching an arbitrary (e.g. multi-modal) gradient
+leaf's held-out density -- see that function's own docstring for a worked adversarial example and
+``mixle.tests.leaf_hotswap_test.MonotoneObjectiveGateCatchesBadSwapTestCase`` for the regression
+test proving the gate rejects and fully reverts (not merely skips the M-step of) exactly that
+case. Earlier revisions of this module applied a plateau-triggered swap to the working tree
+unconditionally, before the round's accept/reject check, and only skipped ``model = candidate`` on
+rejection -- so a rejected round still silently returned the corrupted surrogate; the gate now
+rolls the swap itself back too when a round is rejected.
 
 Scope: like D2/D3, this targets one gradient leaf embedded as a component of a
 :class:`~mixle.stats.latent.mixture.MixtureDistribution` (mixed freely with classical families,
@@ -204,6 +214,26 @@ def moment_matched_surrogate(
 
     ``gradient_leaf`` is accepted (rather than a bare module) purely as a type/documentation
     signal of intent -- see the module docstring's "why not G1" note -- it is not otherwise used.
+
+    IMPORTANT, honest limitation -- read before trusting this function's output alone: a single
+    Gaussian can only ever be as good an approximation as the true fitted density IS Gaussian.
+    Against a unimodal, roughly-Gaussian-shaped leaf (the common case for a single mixture
+    component pulling its own well-separated slice of responsibility-weighted data) this is an
+    excellent approximation. Against a leaf whose OWN fitted density is multi-modal, heavy-tailed,
+    or otherwise non-Gaussian, this function will silently produce a POOR approximation with no
+    warning -- e.g. on a genuinely bimodal ``GradLeaf`` (two well-separated modes,
+    ``mixle.tests.leaf_hotswap_test.BimodalGauss``) the moment-matched surrogate collapses both
+    modes into one wide Gaussian sitting between them, degrading held-out NLL by roughly 80%
+    relative to the original leaf (see
+    ``mixle.tests.leaf_hotswap_test.MonotoneObjectiveGateCatchesBadSwapTestCase``). This function
+    provides NO guarantee, on its own, that the surrogate's held-out density tracks the original
+    leaf's -- that guarantee, to the extent one exists, is earned entirely by
+    :func:`run_em_with_hotswap`'s per-round monotone-F accept/reject gate (see that function's own
+    docstring): a swap-plus-refit round that does not improve the real Neal-Hinton objective is
+    rejected and reverted, INCLUDING the swap itself, not merely the following M-step. Do not call
+    :func:`moment_matched_surrogate` outside that gated driver (or an equivalent one) and assume
+    the result is a safe stand-in for ``gradient_leaf`` -- verify with a real misfit receipt
+    (:func:`misfit_receipt`) against genuinely held-out data first.
     """
     if not isinstance(gradient_leaf, GradLeaf):
         raise TypeError("moment_matched_surrogate expects a GradLeaf (the D4 hot-swap target).")
@@ -347,6 +377,12 @@ class LeafHotswapStats:
     ``objective``), plus the D4-specific ``n_gradient_m_steps`` / ``n_closed_form_m_steps`` split
     that is literally what "faster to same F" is measured against: a swapped component's per-round
     M-step cost drops from D1's ``param_count * _GRADIENT_STEPS`` proxy to ``param_count``.
+
+    ``swapped_this_round`` is which components a plateau *proposed* a swap for this round -- it is
+    recorded even when ``accepted`` is False (a rejected round rolls the swap itself back out of
+    the returned model/``swap_records``, but the attempt still happened and is worth a receipt);
+    use ``n_swapped`` (or check ``idx in swap_records``) for which swaps are actually COMMITTED as
+    of this round.
     """
 
     round_index: int
@@ -490,6 +526,19 @@ def run_em_with_hotswap(
         if old_value is None:
             old_value = current_value
 
+        # ``pre_swap_model`` is the receipt of "the tree as it stood when ``current_value`` was
+        # measured" -- the ONLY state the round's accept/reject gate below is entitled to fall back
+        # to. A newly-triggered plateau swap is proposed into ``model`` below (so the very same
+        # round's closed-form M-step can immediately re-fit it against fresh responsibilities), but
+        # that proposal is provisional exactly like the M-step's own ``candidate``: if the round is
+        # rejected, EVERYTHING proposed this round -- the M-step AND the swap-in -- must roll back
+        # together, or a swap that measurably worsens the objective would silently survive into the
+        # returned model even though ``accepted`` reads False for that round (the bug this comment
+        # replaces: ``model`` used to be rebound in place by the swap loop below with no matching
+        # rollback path, so a rejected round still returned the swapped-in surrogate).
+        pre_swap_model = model
+        new_swap_ids: list[int] = []
+
         for idx in range(model.num_components):
             if idx in frozen_idx or idx in swapped_idx or model.zw[idx]:
                 continue
@@ -506,6 +555,7 @@ def run_em_with_hotswap(
             swap_records[idx] = record
             swapped_idx.add(idx)
             swapped_this_round.append(idx)
+            new_swap_ids.append(idx)
 
         candidate, n_grad, n_closed = _m_step_hotswap(enc_payload, estimator, model, gamma, frozen_idx, swapped_idx)
         candidate_frozen = detect_frozen(cache, candidate)
@@ -518,6 +568,18 @@ def run_em_with_hotswap(
             model = candidate
             round_value = candidate_value
         else:
+            # Roll back not just the M-step but this round's provisional swap-in(s) too: the gate
+            # rejected the round's objective, so the surrogate that produced it never earns a place
+            # in the returned model. The retained gradient leaf(s) go back into ``model`` exactly as
+            # :func:`swap_back` would restore them, the streak resets so the plateau monitor can
+            # retry cleanly next round, and any never-committed ``SwapRecord``/cache entry from this
+            # round's rejected proposal is discarded rather than left to look like a real swap.
+            model = pre_swap_model
+            for idx in new_swap_ids:
+                swapped_idx.discard(idx)
+                swap_records.pop(idx, None)
+                cache.invalidate(idx)
+                monitor.reset(idx)
             round_value = current_value
 
         history.append(

--- a/mixle/tests/leaf_hotswap_test.py
+++ b/mixle/tests/leaf_hotswap_test.py
@@ -58,9 +58,62 @@ class DiagGauss(torch.nn.Module):
         return self._dist().sample((n,))
 
 
+class BimodalGauss(torch.nn.Module):
+    """A genuinely bimodal density module (a learnable mixture-of-2-Gaussians): unlike
+    :class:`DiagGauss`, its architecture is NOT constrained to be Gaussian-shaped, so a
+    moment-matched Gaussian surrogate cannot trivially match it -- this is the adversarial fixture
+    the shipped acceptance test (criterion 1, "held-out density preserved") never actually
+    exercised, since :class:`DiagGauss` is itself Gaussian and a Gaussian surrogate matching a
+    Gaussian ground truth proves nothing about the general claim."""
+
+    def __init__(self, mu0=(-1.0, 1.0), log_sigma0: float = 0.0):
+        super().__init__()
+        self.mu = torch.nn.Parameter(torch.tensor(list(mu0), dtype=torch.float32))
+        self.log_sigma = torch.nn.Parameter(torch.full((2,), float(log_sigma0)))
+        self.logit_w = torch.nn.Parameter(torch.zeros(2))
+
+    def log_density(self, x):
+        x = x.reshape(-1, 1)
+        sigma = torch.exp(self.log_sigma)
+        comp_ll = torch.distributions.Normal(self.mu, sigma).log_prob(x)
+        log_w = torch.log_softmax(self.logit_w, dim=0)
+        return torch.logsumexp(comp_ll + log_w, dim=-1)
+
+    def sample(self, n: int):
+        w = torch.softmax(self.logit_w, dim=0)
+        comp = torch.multinomial(w, n, replacement=True)
+        sigma = torch.exp(self.log_sigma)
+        mu = self.mu[comp]
+        s = sigma[comp]
+        return (mu + s * torch.randn(n)).reshape(-1, 1)
+
+
 def _data(mu, sigma, n, seed):
     rng = np.random.RandomState(seed)
     return [float(v) for v in rng.normal(mu, sigma, n)]
+
+
+def _bimodal_data(n, seed, mu=(-3.0, 3.0), sigma=0.5):
+    """``n`` draws from an evenly-weighted N(``mu[0]``, ``sigma``) / N(``mu[1]``, ``sigma``) mixture
+    -- the adversarial "arbitrary complex leaf" ground truth for :class:`BimodalGauss`."""
+    rng = np.random.RandomState(seed)
+    n1 = n // 2
+    x = np.concatenate([rng.normal(mu[0], sigma, n1), rng.normal(mu[1], sigma, n - n1)])
+    rng.shuffle(x)
+    return [float(v) for v in x]
+
+
+def _fit_bimodal_near_convergence(data, seed, m_steps=400, max_its=60):
+    """Fit a :class:`BimodalGauss` ``GradLeaf`` close to its optimum on ``data``, mirroring
+    :func:`_fit_near_convergence`'s two-stage (EM-driven ``optimize`` then explicit extra gradient
+    rounds) convergence discipline."""
+    torch.manual_seed(seed)
+    fitted = optimize(data, BimodalGauss(mu0=(-1.0, 1.0)), max_its=max_its, out=None, prev_estimate=None)
+    estimator = GradEstimator(fitted.module, m_steps=m_steps, lr=5e-3)
+    acc = estimator.accumulator_factory().make()
+    enc = np.asarray(data)[:, None]
+    acc.seq_update(enc, np.ones(len(data)), None)
+    return estimator.estimate(float(len(data)), acc.value())
 
 
 def _fit_near_convergence(mu=3.0, sigma=1.0, n=600, seed=0, m_steps=200, max_its=40):
@@ -253,6 +306,105 @@ class SwapBackOnMisfitTestCase(unittest.TestCase):
         restored = swap_back(model, record, round_index=len(history))
         self.assertIs(restored.components[0], record.original)
         self.assertTrue(record.swapped_back)
+
+
+class MonotoneObjectiveGateCatchesBadSwapTestCase(unittest.TestCase):
+    """:func:`moment_matched_surrogate` is, by its own docstring, "a genuine fit... it reads no
+    attribute off ``gradient_leaf`` at all" -- a plain MLE Gaussian fit to the raw training data,
+    nothing more. On a genuinely bimodal leaf that is a BAD approximation (see
+    ``test_moment_matched_surrogate_collapses_a_bimodal_leaf_to_one_gaussian`` below), not merely a
+    coarse one. This class is what actually keeps :func:`run_em_with_hotswap` safe on such a leaf:
+    its per-round monotone-F accept/reject gate (the same construction D2/D3 already use) must
+    reject a swap-plus-refit round whose objective does not improve, and -- the specific bug fixed
+    alongside this test -- must roll the SWAP ITSELF back to the retained gradient leaf when it
+    does, not just skip the following M-step's parameter update. Before the fix, the swap was
+    applied to ``model`` unconditionally and eagerly (before the round's accept/reject check), and
+    the ``else`` branch of that check only skipped ``model = candidate`` -- it never undid the
+    swap, so a rejected round still silently returned the corrupted surrogate.
+    """
+
+    def test_moment_matched_surrogate_collapses_a_bimodal_leaf_to_one_gaussian(self):
+        """Reproduces the audit's adversarial finding directly against the primitive: a
+        ``BimodalGauss`` GradLeaf correctly learns two well-separated modes, but
+        ``moment_matched_surrogate`` -- which never looks at the leaf's own density, only at the
+        raw data -- collapses them into one wide Gaussian with a large held-out NLL penalty."""
+        train_data = _bimodal_data(2000, seed=1, mu=(-3.0, 3.0), sigma=0.5)
+        fitted = _fit_bimodal_near_convergence(train_data, seed=1)
+        holdout = np.asarray(_bimodal_data(1000, seed=99, mu=(-3.0, 3.0), sigma=0.5))[:, None]
+
+        learned_mu = sorted(fitted.module.mu.detach().numpy().tolist())
+        self.assertAlmostEqual(learned_mu[0], -3.0, delta=0.3)
+        self.assertAlmostEqual(learned_mu[1], 3.0, delta=0.3)
+
+        surrogate = moment_matched_surrogate(fitted, train_data)
+        grad_nll = float(-np.mean(fitted.seq_log_density(holdout)))
+        surrogate_nll = float(-np.mean(surrogate.seq_log_density(holdout)))
+        rel_degradation = (surrogate_nll - grad_nll) / grad_nll
+
+        print(
+            f"[D4 adversarial] bimodal leaf mu={learned_mu}, held-out NLL: gradient leaf={grad_nll:.4f} "
+            f"nats, surrogate={surrogate_nll:.4f} nats ({rel_degradation * 100:.1f}% relative degradation)"
+        )
+        # this is the module's documented, honest limitation: moment_matched_surrogate ALONE is a
+        # coarse, Gaussian-only fit whose quality is not guaranteed on a non-Gaussian leaf.
+        self.assertGreater(rel_degradation, 0.5, "a Gaussian surrogate should badly misfit a bimodal leaf")
+
+    def test_run_em_with_hotswap_rejects_and_reverts_a_bad_bimodal_swap(self):
+        """End to end: a mixture with a pre-plateaued, genuinely bimodal gradient leaf component
+        proposes a moment-matched swap exactly like the well-behaved (Gaussian-shaped) fixture
+        does, but here the surrogate is a bad approximation. The per-round monotone-F gate must (1)
+        reject that round (``accepted`` reads False), (2) leave NO record of a committed swap
+        (``swap_records`` empty -- the swap never survives to be returned), and (3) return a final
+        model whose component 0 is still the retained ``GradLeaf``, with held-out fit quality
+        essentially unaffected by the rejected swap attempt.
+        """
+        rng = np.random.RandomState(21)
+        comp0_data = _bimodal_data(1200, seed=22, mu=(-3.0, 3.0), sigma=0.5)
+        comp1_data = [float(v) for v in rng.normal(20.0, 1.0, 600)]
+        full_data = comp0_data + comp1_data
+        rng.shuffle(full_data)
+
+        pretrained = _fit_bimodal_near_convergence(comp0_data, seed=22)
+        comp0 = GradLeaf(pretrained.module, m_steps=30, lr=5e-3)
+        comp1 = GaussianDistribution(19.0, 1.5)
+        start = MixtureDistribution([comp0, comp1], [0.66, 0.34])
+        estimator = MixtureEstimator([GradEstimator(pretrained.module, m_steps=30, lr=5e-3), GaussianEstimator()])
+        enc = seq_encode(full_data, model=start)
+        holdout_for_comp0 = _bimodal_data(400, seed=23, mu=(-3.0, 3.0), sigma=0.5)
+
+        pre_swap_nll = float(-np.mean(pretrained.seq_log_density(np.asarray(holdout_for_comp0)[:, None])))
+
+        model, history, swap_records = run_em_with_hotswap(
+            enc,
+            estimator,
+            start,
+            max_its=10,
+            delta=1.0e-9,
+            plateau_patience=1,
+            holdout_data=holdout_for_comp0,
+            misfit_tol=0.15,
+        )
+
+        swap_attempted = any(h.swapped_this_round for h in history)
+        self.assertTrue(swap_attempted, "the plateaued bimodal leaf should still trigger a swap attempt")
+        rejected_rounds = [h for h in history if h.swapped_this_round and not h.accepted]
+        self.assertTrue(rejected_rounds, "the round proposing the bad swap should be rejected by the gate")
+
+        self.assertNotIn(0, swap_records, "a rejected swap must leave no committed SwapRecord for component 0")
+        self.assertIsInstance(
+            model.components[0], GradLeaf, "the retained gradient leaf must still be in place after rejection"
+        )
+
+        final_nll = float(-np.mean(model.components[0].seq_log_density(np.asarray(holdout_for_comp0)[:, None])))
+        print(
+            f"[D4 adversarial, end-to-end] pre-swap-attempt NLL={pre_swap_nll:.4f}, "
+            f"post-rejected-swap-attempt NLL={final_nll:.4f}"
+        )
+        self.assertLess(
+            abs(final_nll - pre_swap_nll),
+            0.2,
+            "a rejected bad swap must not measurably degrade the returned model's fit quality",
+        )
 
 
 class PlateauMonitorTestCase(unittest.TestCase):


### PR DESCRIPTION
## Summary

An audit of D4 (leaf hot-swap / analytic roll-up, `mixle/inference/leaf_hotswap.py`) flagged that
`moment_matched_surrogate` is a plain Gaussian MLE fit to raw training data -- its own docstring
already admitted it reads no attribute off `gradient_leaf` at all -- and that the shipped
acceptance test only exercised a Gaussian-shaped toy `GradLeaf`, so the "held-out density
preserved" claim was never checked against a leaf whose own fitted density is non-Gaussian.

**Reproduced first.** A genuinely bimodal `GradLeaf` (mixture-of-2-Gaussians torch module) trained
on `N(-3, .5)`/`N(3, .5)` data correctly recovers `mu=[-2.98, 3.01]`. `moment_matched_surrogate`
collapses both modes into one wide Gaussian (`mu~=0.02`, `sigma^2~=9.24`): held-out NLL 2.53 vs.
the gradient leaf's own 1.42 nats -- a 78% relative degradation, matching the audit's finding.

**Traced whether the mixture-level monotone-F accept/reject gate catches this before it corrupts a
real fit.** It did not, prior to this PR -- and the root cause is a real bug, not a documentation
gap. `run_em_with_hotswap` applied a plateau-triggered swap to the working `model` unconditionally,
*before* the round's accept/reject check; the reject branch only skipped `model = candidate`, it
never undid the swap. So a round the gate correctly flagged as non-improving (`accepted=False`)
still silently returned the corrupted surrogate as the final model. End-to-end repro against the
bimodal leaf confirmed this exactly: round 1 was rejected, yet component 0 ended up as the bad
surrogate (NLL 2.52) rather than the retained gradient leaf (NLL 1.42) -- despite the module's own
docstring claiming a bad swap "can cost speed... but never correctness."

## Fix

Capture the model as it stood when the round's `current_value` was measured (`pre_swap_model`),
and on rejection roll this round's proposed swap-in(s) back out along with the M-step -- resetting
`swapped_idx` / `swap_records` / the freeze-rollup cache / the plateau monitor for those indices so
the retained gradient leaf resumes fitting cleanly next round, exactly like a never-attempted swap.

Re-running the same adversarial bimodal scenario end to end after the fix: round 1 is now rejected
*and reverted* -- final component-0 held-out NLL is 1.3795, matching the pre-swap-attempt gradient
leaf's 1.3794. The bad surrogate never reaches the returned model.

## Tests

Added `MonotoneObjectiveGateCatchesBadSwapTestCase` to `mixle/tests/leaf_hotswap_test.py`:
a `BimodalGauss` fixture (non-Gaussian-shaped, unlike the existing `DiagGauss` fixture) plus two
tests -- the primitive-level surrogate collapse (asserts >50% relative NLL degradation) and the
end-to-end reject-and-revert (asserts the rejected round leaves no committed `SwapRecord`, the
final model still holds the real `GradLeaf`, and held-out fit quality is essentially unaffected).

Also tightened `moment_matched_surrogate`'s and the module's docstrings: the surrogate alone has no
held-out quality guarantee against a non-Gaussian leaf -- the per-round monotone-F gate is what
actually makes the hot-swap mechanism safe, not the surrogate's own approximation quality.

## Test plan

- [x] `pytest mixle/tests/leaf_hotswap_test.py mixle/tests/block_em_test.py` -- 16 passed (10 prior + 2 new adversarial + 4 D3 block-em consumer tests unaffected)
- [x] `ruff check` / `ruff format --check` clean on both touched files
- [x] Adversarial bimodal repro re-run before and after the fix with real, printed NLL numbers (see summary)