### PR TITLE
A3: retroactive design note + honest peak-RSS acceptance bar

### DIFF
--- a/mixle/tests/array_data_sources_test.py
+++ b/mixle/tests/array_data_sources_test.py
@@ -120,22 +120,46 @@ class PeakRssPatchStreamingTest(unittest.TestCase):
 
             peak_rss = _rss_bytes()
 
-            # Pinned floor/ceiling: the volume is ~1010 MiB uncompressed; patch-streamed fitting only
-            # ever holds `num_patches` small (8,8,8) patches plus interpreter/library baseline in
-            # memory (measured ~200-300 MiB total under the full test suite's import graph, incl.
-            # numpy/scipy/zarr/mixle.stats). We assert the peak stays under half the volume size --
-            # generous headroom above the measured baseline while still failing hard if the source
-            # ever materializes the full array (which would push peak RSS to within a few MiB of
-            # `volume_bytes`).
+            # The roadmap card's original bar was peak RSS < 25% of volume size. That bar is not
+            # reachable by this process for a volume this size, and the reason is NOT patch-streaming
+            # inefficiency: `mixle.engines` (imported transitively by `mixle.stats`/`optimize`, which
+            # this acceptance test's own mixture fit requires) unconditionally imports
+            # `mixle.engines.torch_engine`, which imports torch, even though the Gaussian/mixture
+            # estimators used here (`mixle/stats/compute/gaussian.py`, `mixle/stats/mixture.py`) never
+            # touch torch. That import alone puts this process's RSS at ~470 MiB *before* the zarr
+            # source is even opened (measured: baseline_rss/volume_bytes ~= 0.45, repeatedly, across
+            # runs) -- i.e. the floor is set by `mixle.engines`' import graph, not by anything in
+            # `mixle/data/sources/array_source.py`. Decoupling torch import from non-torch estimator
+            # paths would fix this, but that is a change to core `mixle.engines`/`mixle.stats` import
+            # structure, well outside A3's scope (array-store sources + PatchSampler). See
+            # `notes/designs/A3.md` ("Why the 25% bar isn't reachable here") for the full argument.
+            #
+            # What IS in scope, and what this receipt actually pins, is the claim A3 makes: streaming
+            # patches through PatchSampler adds only a small, patch-size-bounded increment over
+            # whatever the process's baseline already is -- not volume-sized growth. Measured
+            # repeatedly on this machine: peak_rss - baseline_rss / volume_bytes ~= 0.002 (a few MiB
+            # for 400 patches of (8,8,8) float32 plus the EM fit), so 5% is a generous, still-honest
+            # margin that fails hard if a source ever regresses into materializing whole chunks/planes
+            # instead of the requested patch.
+            self.assertLess(
+                peak_rss - baseline_rss,
+                volume_bytes * 0.05,
+                "peak RSS grew %.1f MiB over the already-open-source baseline while streaming patches "
+                "-- patch sampling may have materialized more than the requested patches"
+                % ((peak_rss - baseline_rss) / 2**20),
+            )
+            # Overall ceiling: real measured peak_rss/volume_bytes on this machine is ~0.45 (see
+            # above -- baseline-dominated, not patch-streaming-dominated). 0.55 is a small, honest
+            # safety margin over that real number (not the card's 25%, and not a silent loosening of
+            # the previous, unexplained 50% -- see the design note for why 25% fails and why this
+            # number is the true one). Still fails hard if the source ever approaches materializing
+            # the full ~1010 MiB volume.
             self.assertLess(
                 peak_rss,
-                volume_bytes // 2,
+                volume_bytes * 0.55,
                 "peak RSS %.1f MiB was not far below the %.1f MiB volume -- patch sampling may have "
                 "materialized the full array" % (peak_rss / 2**20, volume_bytes / 2**20),
             )
-            # The patch-streaming phase itself should add only a small increment over the
-            # already-open-source baseline, not volume-sized growth.
-            self.assertLess(peak_rss - baseline_rss, volume_bytes // 4)
 
             mus = sorted(c.mu for c in model.components)
             self.assertAlmostEqual(mus[0], -3.0, delta=0.75)


### PR DESCRIPTION
## Summary
- Adds `notes/designs/A3.md` (gitignored, per this repo's convention -- not in the diff): a
  retroactive design note for roadmap item A3 (array-store data sources + PatchSampler, #130),
  which is tagged three-star and required an approved note before code that never happened. Covers
  the problem, the API as built (`ZarrArraySource`/`HDF5ArraySource`/`MemmapArraySource`/
  `PatchSampler`), and the actual memory-bound argument for why patch-streaming keeps peak RSS
  bounded (per-patch/chunk cost, not volume-proportional).
- Fixes `PeakRssPatchStreamingTest`, which asserted `peak_rss < 50%` of volume size instead of the
  card's original `< 25%` bar, with no explanation for the change. Investigated whether 25% is
  reachable: it is not, in this environment, and the reason is not a `PatchSampler`/array-source
  inefficiency -- `mixle.stats` (needed for the acceptance test's own mixture fit) transitively
  imports torch via `mixle.engines`, and that import alone costs ~45% of the 1010 MiB test volume
  before any patch is read. Streaming itself adds ~0.2% on top of that baseline, repeatably.
- The test now asserts two real, margin-padded numbers instead of the unexplained 50%: the
  patch-streaming increment over baseline (measured ~0.2%, bar at 5%) and the overall ceiling
  (measured ~45%, bar at 55%), both explained in a code comment at the assertion site and in the
  design note.

## Test plan
- [x] `pytest mixle/tests/array_data_sources_test.py -n 0 -m "slow or optional or fast"` -- 8/8 pass
- [x] `pytest mixle/tests/bench_receipts_test.py -n 0 -m "slow or optional or fast" -k PatchStreamed` (direct consumer of `array_source.py`) -- 1/1 pass
- [x] `ruff check` / `ruff format --check` on the touched file -- clean