### PR TITLE
tests: strengthen A5's entropy top-k acceptance test to the card's real bar

### DIFF
--- a/mixle/tests/task_acquire_test.py
+++ b/mixle/tests/task_acquire_test.py
@@ -224,6 +224,31 @@ class DisagreementAndEntropySanityTest(unittest.TestCase):
         far_points = {-2.9, -2.0, 2.0, 2.9}
         self.assertLess(len(far_points & set(top)), 3)
 
+    def test_entropy_top_k_overlaps_the_true_boundary_set(self) -> None:
+        """Per the roadmap card: 'entropy top-k overlaps the true boundary set > 0.7' -- a real
+        overlap-fraction check against the actual points nearest THETA_TRUE, not just the weaker
+        'not every pick is a confident-extreme point' sanity check above. An independent audit found
+        that weaker check was the only entropy assertion actually shipped; this is the real bar.
+
+        The tiny 9-point pool above doesn't reliably clear 0.7 (measured ~0.33 with only 9 candidates
+        and a 12-member ensemble bootstrapped from 20 points -- too little signal for a clean top-k
+        boundary set at that scale). Verified directly, not guessed: the larger, already-established
+        150-point pool from ThresholdTaskTest below (same synthetic task, same THETA_TRUE) DOES clear
+        the bar at k=10 (measured overlap=0.8, k=15 also 0.8) -- the card's claim holds, it just needs
+        enough pool signal to be meaningful, which this test now provides honestly rather than
+        asserting it on a fixture too small to demonstrate it."""
+        rng = np.random.RandomState(0)
+        pool_x = list(rng.uniform(-3, 3, size=150))
+        pool_y = [_teacher(x, rng) for x in pool_x]
+        ensemble = _fit_ensemble(np.array(pool_x), np.array(pool_y), np.random.RandomState(11), n_members=20)
+
+        k = 10
+        true_boundary = set(sorted(pool_x, key=lambda x: abs(x - THETA_TRUE))[:k])
+        top = acquire(pool_x, ensemble, k=k, strategy="entropy")
+        self.assertEqual(len(top), k)
+        overlap = len(set(top) & true_boundary) / k
+        self.assertGreater(overlap, 0.7, f"entropy top-{k} overlap with the true boundary set was only {overlap:.3f}")
+
     def test_entropy_works_on_single_non_ensemble_model(self) -> None:
         member = self.ensemble.members[0]
         top = acquire(self.pool, member, k=len(self.pool), strategy="entropy")


### PR DESCRIPTION
An independent audit found the only shipped entropy-strategy assertion (`test_entropy_runs_and_ranks_boundary_high`) was much weaker than the roadmap card's stated acceptance criterion ("entropy top-k overlaps the true boundary set > 0.7") — it only checked that not all 3 picks were confident-extreme points, which could pass even with a weak overlap.

Added `test_entropy_top_k_overlaps_the_true_boundary_set`, a real overlap-fraction check against the actual k points nearest the true decision threshold.

Verified directly before writing this test:
- The original test's tiny 9-point pool / 12-member bootstrapped ensemble does NOT reliably clear 0.7 — measured overlap ≈ 0.33 (too little signal for a clean top-k boundary set at that scale).
- The file's own larger, pre-existing 150-point pool fixture (`ThresholdTaskTest`, same synthetic task, same `THETA_TRUE`) DOES clear the bar — measured overlap = 0.8 at both k=10 and k=15 (drops at k=20/30, as expected for a fixed-size boundary set).

The card's claim holds; it just needed a fixture with enough real signal to demonstrate it, which this test now provides. Original weaker test kept in place, unchanged.

11/11 tests pass.