### PR TITLE
task: F11 deployment of the family -- I-quantized artifacts + J4 edge tier, serve receipt

### DIFF
--- a/mixle/task/deploy_family.py
+++ b/mixle/task/deploy_family.py
@@ -1,0 +1,262 @@
+"""F11: deployment of the family -- the trained checkpoint family served through the existing stack.
+
+**Scope, read this first.** F11 is, per the roadmap, thin composition over machinery that already
+exists and is already receipted:
+
+* **J2** (:mod:`mixle.task.checkpoint_family_ladder`) builds the family itself: a headline causal LM
+  plus a ladder of decreasing-size rungs, each with its own real eval report.
+* **I1** (:mod:`mixle.models.unified_quantizer`) turns a torch model's real parameter tensors into
+  "I-quantized artifacts" -- per-tensor auto-picked quantization with a measured bytes/error receipt.
+* **J4** (:mod:`mixle.task.frontier_to_native`) builds the edge tier: a frontier-distilled, LNS-compressed,
+  calibrated student served behind a :class:`~mixle.task.cascade.Cascade`, with its own cost/quality receipt.
+* **Economics** (:mod:`mixle.task.economics`) supplies :class:`~mixle.task.economics.CostModel`, the unit
+  costs a per-request dollar figure is built from.
+
+This module does not re-derive compression, quantization, distillation, calibration, or cost
+arithmetic; it takes J2's family, I1-quantizes every rung (plus the headline) into a real measured
+artifact, and reports a cost/quality **frontier** across those artifacts -- the roadmap's "end-to-end
+serve receipt (cost/quality frontier plot)" acceptance criterion -- next to J4's own served-cascade
+receipt for the edge tier.
+
+**A real constraint this discovered, not glossed over: two receipted "quality" axes don't share
+units, so this module does not force them onto one line.** J2's family rungs are causal LMs scored by
+F10's synthetic eval suite (:mod:`mixle.models.eval_harness`) -- perplexity plus three accuracy-style
+tasks. J4's edge student is a distilled classifier scored by held-out label accuracy on whatever task
+it was trained for. Both are real, receipted quality numbers, but they measure different capabilities
+on different tasks; averaging them into one scalar would manufacture a false equivalence the
+underlying receipts do not support. So :func:`deploy_family` reports two things side by side instead:
+a same-axis cost/quality **frontier across the J2 family + headline** (comparable, because every point
+is the SAME eval suite on the SAME task), and J4's own :class:`~mixle.task.frontier_to_native.CascadeReceipt`
+as the edge tier's cost/quality trade on ITS task, unmerged. ``ServeReceipt.summary()`` prints both.
+
+**Why this does not build a full :class:`~mixle.task.router.Router` across the whole family.**
+``Router`` requires every non-final tier to expose ``decide(x)`` (a :class:`~mixle.task.calibrate.CalibratedTaskModel`
+shape returning a label or ``ESCALATE``); J2's family rungs are plain causal LMs with no calibrated
+decision boundary, and building one would mean inventing an eval-suite-specific classifier wrapper
+this task does not ask for. J4's own 2-tier :class:`~mixle.task.cascade.Cascade` (student, calibrated;
+frontier, a callable) already IS the calibrated-routing piece this module reuses unmodified via
+:func:`~mixle.task.frontier_to_native.build_served_cascade` -- what's genuinely new here is turning
+J2's *causal-LM* family into comparable priced artifacts, which is a quantization/costing question,
+not a routing one.
+
+**Cost model.** Every artifact's per-request cost is priced off ONE :class:`~mixle.task.economics.CostModel`,
+scaled by real measured artifact bytes relative to the most expensive (headline/frontier) artifact:
+``cost_per_request = cost.c_frontier * (artifact_bytes / headline_artifact_bytes)``. This is an honest,
+declared proxy (inference cost tracks model size, not size-independent) rather than a literal cloud
+price list -- the real number in the receipt is ``artifact_bytes`` (I1's measured quantized footprint);
+the dollar figure is a transparent, reproducible scaling of it through the SAME :class:`CostModel` the
+rest of the stack (J4's cascade) already uses for its own tier's cost.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+
+from mixle.models.unified_quantizer import quantize_tensor
+from mixle.task.checkpoint_family_ladder import FamilyLadderResult
+from mixle.task.economics import CostModel
+from mixle.task.frontier_to_native import CascadeReceipt
+
+__all__ = [
+    "ArtifactReceipt",
+    "FrontierPoint",
+    "ServeReceipt",
+    "quantize_family_artifacts",
+    "deploy_family",
+]
+
+# The three F10 eval tasks that are accuracy-style (higher_is_better=True, bounded roughly in [0, 1]);
+# held_out_perplexity is excluded (lower_is_better, unbounded) so the frontier's quality axis is a
+# single consistent direction ("higher = better") without needing to invert/rescale perplexity.
+_QUALITY_TASKS = ("modular_arithmetic", "parity_reasoning", "in_context_induction")
+
+
+def _quality_score(eval_report: Any) -> float:
+    """Mean accuracy across :data:`_QUALITY_TASKS` -- F10's real per-task scores, not a re-derived metric."""
+    scores = eval_report.scores()
+    vals = [scores[t] for t in _QUALITY_TASKS if t in scores]
+    if not vals:
+        raise ValueError(f"eval_report for {eval_report.checkpoint_id!r} has none of {_QUALITY_TASKS}")
+    return float(np.mean(vals))
+
+
+@dataclass(frozen=True)
+class ArtifactReceipt:
+    """One model's I1-quantized deployment artifact: real measured bytes/error rolled up over every
+    parameter tensor -- I1's own :class:`~mixle.models.unified_quantizer.QuantizationReceipt` per tensor,
+    summed/averaged here, not re-derived."""
+
+    name: str
+    n_tensors: int
+    dense_bytes: int
+    quantized_bytes: int
+    compression_ratio: float
+    mean_reconstruction_error: float
+    method_counts: dict[str, int]
+
+    def summary(self) -> str:
+        methods = ", ".join(f"{m}={n}" for m, n in sorted(self.method_counts.items()))
+        return (
+            f"{self.name}: {self.n_tensors} tensors, {self.dense_bytes}B dense -> {self.quantized_bytes}B "
+            f"quantized ({self.compression_ratio:.2f}x), mean_recon_error={self.mean_reconstruction_error:.4g} "
+            f"[{methods}]"
+        )
+
+
+def quantize_family_artifacts(model: Any, *, name: str, bits: int = 8, seed: int = 0) -> ArtifactReceipt:
+    """I1: ``quantize_tensor(method="auto")`` over every real, non-empty parameter tensor of ``model``.
+
+    Rolls I1's per-tensor receipts (chosen method, measured bytes, measured reconstruction error) into
+    one per-model :class:`ArtifactReceipt` -- real totals over real per-tensor measurements, never a
+    single assumed bits-per-parameter constant. ``seed`` is offset per tensor (``seed + i``) so the
+    auto-pick bandit's tie-breaking is deterministic but not identical across tensors of the same shape.
+    """
+    dense_bytes = 0
+    quantized_bytes = 0
+    errors: list[float] = []
+    method_counts: dict[str, int] = {}
+    n_tensors = 0
+    for i, p in enumerate(model.parameters()):
+        arr = p.detach().cpu().numpy()
+        if arr.size == 0:
+            continue
+        qt = quantize_tensor(arr, method="auto", bits=bits, seed=seed + i)
+        n_tensors += 1
+        dense_bytes += arr.size * 4
+        quantized_bytes += qt.receipt.nbytes
+        errors.append(qt.receipt.reconstruction_error)
+        method_counts[qt.method] = method_counts.get(qt.method, 0) + 1
+    if n_tensors == 0:
+        raise ValueError(f"model {name!r} has no non-empty parameter tensors to quantize")
+    return ArtifactReceipt(
+        name=name,
+        n_tensors=n_tensors,
+        dense_bytes=dense_bytes,
+        quantized_bytes=quantized_bytes,
+        compression_ratio=(dense_bytes / quantized_bytes) if quantized_bytes else float("inf"),
+        mean_reconstruction_error=float(np.mean(errors)),
+        method_counts=method_counts,
+    )
+
+
+@dataclass(frozen=True)
+class FrontierPoint:
+    """One priced, quality-scored point on the family's cost/quality frontier."""
+
+    name: str
+    real_target: str
+    artifact: ArtifactReceipt
+    cost_per_request: float
+    quality: float
+
+
+@dataclass(frozen=True)
+class ServeReceipt:
+    """F11's end-to-end serve receipt: the J2-family cost/quality frontier, plus J4's own edge-tier
+    served-cascade receipt reported alongside it (see the module docstring for why the two axes are
+    kept separate rather than merged)."""
+
+    points: list[FrontierPoint]
+    edge_cascade: CascadeReceipt | None = field(default=None)
+
+    def frontier_sorted_by_cost(self) -> list[FrontierPoint]:
+        return sorted(self.points, key=lambda p: p.cost_per_request)
+
+    def is_monotone_frontier(self, *, tol: float = 1e-9) -> bool:
+        """Real, checkable claim: walking the family points cheapest-first, quality never DROPS below
+        tolerance -- i.e. paying more for a bigger rung is never strictly worse on the eval suite."""
+        ordered = self.frontier_sorted_by_cost()
+        return all(b.quality >= a.quality - tol for a, b in zip(ordered, ordered[1:]))
+
+    def frontier_plot(self, *, width: int = 40) -> str:
+        """A deterministic, dependency-free ASCII cost/quality scatter (no matplotlib in this repo's
+        dependency set) -- x = cost_per_request (log-scaled across the family's real span), y = quality.
+        This is a real, reproducible rendering of the receipted numbers below, not decoration."""
+        ordered = self.frontier_sorted_by_cost()
+        costs = [p.cost_per_request for p in ordered]
+        c_lo, c_hi = min(costs), max(costs)
+        log_lo = np.log10(c_lo) if c_lo > 0 else 0.0
+        log_hi = np.log10(c_hi) if c_hi > 0 else 0.0
+        span = (log_hi - log_lo) or 1.0
+
+        rows = []
+        for p in ordered:
+            log_c = np.log10(p.cost_per_request) if p.cost_per_request > 0 else log_lo
+            col = int(round((log_c - log_lo) / span * (width - 1)))
+            bar = [" "] * width
+            bar[col] = "*"
+            rows.append(f"  {''.join(bar)}  {p.name:12s} cost=${p.cost_per_request:.6f}  quality={p.quality:.3f}")
+        header = f"  cost/quality frontier (x: log cost, ${c_lo:.6f}..${c_hi:.6f}; * = one family point)"
+        return "\n".join([header, *rows])
+
+    def summary(self) -> str:
+        lines = ["F11 served family -- J2 family cost/quality frontier:"]
+        for p in self.frontier_sorted_by_cost():
+            lines.append(
+                f"  {p.name:12s} ({p.real_target}): cost=${p.cost_per_request:.6f}/req quality={p.quality:.3f} "
+                f"| {p.artifact.summary()}"
+            )
+        lines.append(f"  monotone (quality non-decreasing in cost): {self.is_monotone_frontier()}")
+        lines.append("")
+        lines.append(self.frontier_plot())
+        if self.edge_cascade is not None:
+            lines.append("")
+            lines.append("J4 edge-tier served-cascade receipt (own task, own quality axis):")
+            lines.append(self.edge_cascade.summary())
+        return "\n".join(lines)
+
+
+def deploy_family(
+    family: FamilyLadderResult,
+    headline_model: Any,
+    *,
+    edge_cascade_receipt: CascadeReceipt | None = None,
+    cost: CostModel | None = None,
+    bits: int = 8,
+    seed: int = 0,
+) -> ServeReceipt:
+    """Build F11's end-to-end serve receipt from a J2 :class:`FamilyLadderResult` plus its own
+    ``headline_model``.
+
+    Every rung (and the headline) is I1-quantized into a real measured :class:`ArtifactReceipt`
+    (:func:`quantize_family_artifacts`); each artifact's per-request cost is priced off ``cost``
+    (a :class:`~mixle.task.economics.CostModel`, ``CostModel(c_frontier=1.0)`` by default) scaled by
+    real measured bytes relative to the headline's own artifact (see module docstring); quality is
+    J2's own real :class:`~mixle.models.eval_harness.EvalReport` for that rung/headline, reduced to
+    :func:`_quality_score`. ``edge_cascade_receipt`` (optional) is J4's own
+    :class:`~mixle.task.frontier_to_native.CascadeReceipt` for the edge tier, carried through
+    unmodified and reported alongside the family frontier rather than merged into it.
+    """
+    cost = cost if cost is not None else CostModel(c_frontier=1.0)
+
+    headline_artifact = quantize_family_artifacts(headline_model, name="headline", bits=bits, seed=seed)
+    headline_bytes = headline_artifact.quantized_bytes
+    if headline_bytes <= 0:
+        raise ValueError("headline artifact has zero quantized bytes; cannot price the family relative to it")
+
+    points = [
+        FrontierPoint(
+            name="headline",
+            real_target="headline",
+            artifact=headline_artifact,
+            cost_per_request=cost.c_frontier,
+            quality=_quality_score(family.headline_eval),
+        )
+    ]
+    for i, rung in enumerate(family.rungs):
+        artifact = quantize_family_artifacts(rung.model, name=rung.name, bits=bits, seed=seed + 1000 * (i + 1))
+        rel_cost = cost.c_frontier * (artifact.quantized_bytes / headline_bytes)
+        points.append(
+            FrontierPoint(
+                name=rung.name,
+                real_target=rung.real_target,
+                artifact=artifact,
+                cost_per_request=rel_cost,
+                quality=_quality_score(rung.eval_report),
+            )
+        )
+
+    return ServeReceipt(points=points, edge_cascade=edge_cascade_receipt)

--- a/mixle/tests/deploy_family_test.py
+++ b/mixle/tests/deploy_family_test.py
@@ -1,0 +1,259 @@
+"""Acceptance tests for mixle.task.deploy_family (roadmap F11: deployment of the family).
+
+Builds a real J2 checkpoint family (small trained headline + two rungs, reusing
+``checkpoint_family_ladder_test``'s training curriculum at reduced steps) and a real J4 served
+edge cascade (reusing ``frontier_to_native_test``'s frontier/student setup), then exercises F11's
+own acceptance criterion: an end-to-end serve receipt carrying a real cost/quality frontier across
+the family, plus the edge tier's own real cost/quality receipt reported alongside it.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from mixle.models.eval_harness import markov_transition_matrix  # noqa: E402
+from mixle.models.transformer import build_causal_lm  # noqa: E402
+from mixle.task.checkpoint_family_ladder import RungSpec, build_checkpoint_family  # noqa: E402
+from mixle.task.deploy_family import (  # noqa: E402
+    ArtifactReceipt,
+    deploy_family,
+    quantize_family_artifacts,
+)
+from mixle.task.distill import distill_records_from_labels  # noqa: E402
+from mixle.task.economics import CostModel  # noqa: E402
+from mixle.task.edge import footprint  # noqa: E402
+from mixle.task.frontier_to_native import (  # noqa: E402
+    build_served_cascade,
+    distill_to_lns_student,
+    measure_cascade_receipt,
+)
+
+pytestmark = pytest.mark.fast
+
+
+# --- a small real (not random-init) headline causal LM, trained on F10's own four eval axes at
+# reduced steps -- enough to be measurably above chance without J2's own full 8000-step budget. -----
+
+
+def _train_small_headline(seed: int, vocab: int, d_model: int, n_layer: int, n_head: int, block: int, steps: int):
+    torch.manual_seed(seed)
+    model = build_causal_lm(vocab=vocab, d_model=d_model, n_layer=n_layer, n_head=n_head, block=block)
+
+    trans = markov_transition_matrix(vocab)
+    rng = np.random.default_rng(seed + 1000)
+    ctx_len = min(block, 16)
+    modulus = min(vocab - 2, 10)
+    plus_id, eq_id = vocab - 2, vocab - 1
+    bit_len = min(block, 5)
+
+    def batch_perplexity(bs):
+        seqs = np.empty((bs, ctx_len), dtype=np.int64)
+        cur = rng.integers(0, vocab, size=bs)
+        seqs[:, 0] = cur
+        for t in range(1, ctx_len):
+            nxt = np.array([rng.choice(vocab, p=trans[c]) for c in cur])
+            seqs[:, t] = nxt
+            cur = nxt
+        return seqs[:, :-1], seqs[:, -1]
+
+    def batch_arithmetic(bs):
+        a = rng.integers(0, modulus, size=bs)
+        b = rng.integers(0, modulus, size=bs)
+        target = (a + b) % modulus
+        seq = np.stack([a, np.full(bs, plus_id), b, np.full(bs, eq_id)], axis=1)
+        return seq, target
+
+    def batch_parity(bs):
+        bits = rng.integers(0, 2, size=(bs, bit_len))
+        target = bits.sum(axis=1) % 2
+        return bits, target
+
+    def batch_induction(bs):
+        seqs = rng.integers(0, vocab, size=(bs, ctx_len))
+        a = rng.integers(0, vocab, size=bs)
+        b = rng.integers(0, vocab, size=bs)
+        b = np.where(b == a, (b + 1) % vocab, b)
+        plant_pos = rng.integers(0, ctx_len - 3, size=bs)
+        for i in range(bs):
+            p = int(plant_pos[i])
+            seqs[i, p] = a[i]
+            seqs[i, p + 1] = b[i]
+            seqs[i, ctx_len - 1] = a[i]
+        return seqs, b
+
+    batchers = (batch_perplexity, batch_arithmetic, batch_parity, batch_induction)
+    opt = torch.optim.Adam(model.parameters(), lr=4e-3)
+    for step in range(steps):
+        x_np, y_np = batchers[step % len(batchers)](64)
+        x = torch.as_tensor(x_np.astype(np.int64))
+        y = torch.as_tensor(y_np.astype(np.int64))
+        opt.zero_grad()
+        loss = torch.nn.functional.cross_entropy(model(x), y)
+        loss.backward()
+        opt.step()
+    return model
+
+
+# --- a small J4 frontier/student pair, straight from frontier_to_native_test's own setup. -----------
+
+
+def _truth(records):
+    out = []
+    for r in records:
+        score = (1.5 if r["region"] == "west" else -0.5) + 0.4 * r["spend"] + 0.3 * r["visits"]
+        out.append("churn" if score < 1.0 else "retain")
+    return out
+
+
+def _gen(n, seed):
+    rng = np.random.RandomState(seed)
+    return [
+        {
+            "region": rng.choice(["west", "east"]),
+            "spend": float(rng.normal(2.0, 1.5)),
+            "visits": int(rng.poisson(3)),
+        }
+        for _ in range(n)
+    ]
+
+
+class _Teacher:
+    def __init__(self, frontier):
+        self.frontier = frontier
+
+    def __call__(self, records):
+        return self.frontier.batch(list(records))
+
+
+def _build_edge_cascade_receipt():
+    records = _gen(1200, 0)
+    labels = _truth(records)
+    frontier = distill_records_from_labels(
+        records, labels, dim=512, hidden=[128], epochs=120, lr=1e-2, seed=0, task="frontier"
+    )
+    teacher = _Teacher(frontier)
+    teacher_bytes = footprint(frontier).bytes
+
+    train = _gen(500, 1)
+    lns_student = distill_to_lns_student(teacher, train, min_gain=1.0, seed=0, task="lns_edge_student")
+
+    cal = _gen(150, 2)
+    cost = CostModel(c_frontier=1.0, c_local=0.001)
+    cascade = build_served_cascade(lns_student, teacher, cal, alpha=0.1, cost=cost)
+
+    test_records = _gen(250, 3)
+    truth = _truth(test_records)
+    return measure_cascade_receipt(cascade, test_records, truth, teacher_bytes=teacher_bytes)
+
+
+class QuantizeFamilyArtifactsTest(unittest.TestCase):
+    """I1 rolled up over a real torch model: real measured bytes/error, never assumed."""
+
+    def test_artifact_receipt_is_real_and_smaller_than_dense(self):
+        torch.manual_seed(0)
+        model = build_causal_lm(vocab=23, d_model=16, n_layer=3, n_head=2, block=12)
+        artifact = quantize_family_artifacts(model, name="probe", seed=0)
+
+        self.assertIsInstance(artifact, ArtifactReceipt)
+        self.assertGreater(artifact.n_tensors, 0)
+        self.assertGreater(artifact.dense_bytes, 0)
+        self.assertGreater(artifact.quantized_bytes, 0)
+        # int8/int4/lns/sorted_profile: every method should beat fp32 dense storage on a real model.
+        self.assertLess(artifact.quantized_bytes, artifact.dense_bytes)
+        self.assertGreater(artifact.compression_ratio, 1.0)
+        self.assertGreaterEqual(artifact.mean_reconstruction_error, 0.0)
+        self.assertEqual(sum(artifact.method_counts.values()), artifact.n_tensors)
+
+    def test_empty_model_raises(self):
+        class _Empty(torch.nn.Module):
+            pass
+
+        with self.assertRaises(ValueError):
+            quantize_family_artifacts(_Empty(), name="empty")
+
+
+class DeployFamilyEndToEndTest(unittest.TestCase):
+    """The F11 acceptance criterion: a real end-to-end serve receipt (cost/quality frontier) built
+    from a real J2 family, I1-quantized, priced with a real CostModel, next to a real J4 edge-tier
+    served-cascade receipt."""
+
+    @classmethod
+    def setUpClass(cls):
+        vocab, d_model, n_layer, n_head, block = 23, 16, 6, 2, 12
+        cls.headline = _train_small_headline(
+            seed=7, vocab=vocab, d_model=d_model, n_layer=n_layer, n_head=n_head, block=block, steps=1500
+        )
+
+        calib_rng = np.random.RandomState(7)
+        calibration_data = torch.as_tensor(calib_rng.randint(0, vocab, size=(150, block)), dtype=torch.long)
+
+        rung_specs = [
+            RungSpec(name="rung_mid", real_target="1B-equivalent stand-in", budget=0.4, trust_region=0.4, seed=0),
+            RungSpec(name="rung_edge", real_target="edge-equivalent stand-in", budget=1.5, trust_region=1.5, seed=0),
+        ]
+        cls.family = build_checkpoint_family(
+            cls.headline, rung_specs, calibration_data=calibration_data, eval_n_examples=256
+        )
+
+        cls.edge_receipt = _build_edge_cascade_receipt()
+
+        cls.serve_receipt = deploy_family(
+            cls.family,
+            cls.headline,
+            edge_cascade_receipt=cls.edge_receipt,
+            cost=CostModel(c_frontier=1.0),
+            seed=0,
+        )
+
+    def test_family_actually_shrank(self):
+        # sanity on the fixture itself: the ladder did produce a real, non-increasing size sequence.
+        self.assertGreaterEqual(len(self.family.rungs), 1)
+        n_params = [self.family.headline_n_params] + [r.n_params for r in self.family.rungs]
+        for a, b in zip(n_params, n_params[1:]):
+            self.assertLessEqual(b, a)
+
+    def test_serve_receipt_has_one_point_per_family_member(self):
+        print("\n" + self.serve_receipt.summary())
+        # headline + every attempted rung, each with a real quantized artifact.
+        self.assertEqual(len(self.serve_receipt.points), 1 + len(self.family.rungs))
+        names = {p.name for p in self.serve_receipt.points}
+        self.assertIn("headline", names)
+        for rung in self.family.rungs:
+            self.assertIn(rung.name, names)
+
+    def test_cost_tracks_real_measured_artifact_bytes(self):
+        headline_point = next(p for p in self.serve_receipt.points if p.name == "headline")
+        # headline is priced at exactly CostModel.c_frontier (the pricing anchor).
+        self.assertAlmostEqual(headline_point.cost_per_request, 1.0, places=9)
+        for p in self.serve_receipt.points:
+            self.assertGreater(p.cost_per_request, 0.0)
+            self.assertGreater(p.artifact.quantized_bytes, 0)
+            # the cost/bytes ratio is identical across every point (same linear scaling by construction) --
+            # a real, checkable relationship between the priced number and the measured one.
+            ratio = p.cost_per_request / p.artifact.quantized_bytes
+            headline_ratio = headline_point.cost_per_request / headline_point.artifact.quantized_bytes
+            self.assertAlmostEqual(ratio, headline_ratio, places=9)
+
+    def test_quality_scores_are_real_and_bounded(self):
+        for p in self.serve_receipt.points:
+            self.assertGreaterEqual(p.quality, 0.0)
+            self.assertLessEqual(p.quality, 1.0)
+
+    def test_frontier_plot_renders_every_point(self):
+        plot = self.serve_receipt.frontier_plot()
+        for p in self.serve_receipt.points:
+            self.assertIn(p.name, plot)
+
+    def test_edge_cascade_receipt_is_carried_through_unmodified(self):
+        self.assertIs(self.serve_receipt.edge_cascade, self.edge_receipt)
+        self.assertTrue(self.edge_receipt.earns_its_complexity())
+        self.assertIn("served", self.serve_receipt.summary())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Original PR #201 was based on a stale pre-rebuild branch (`checkpoint-family-ladder`, the old J2 attempt superseded by the clean rebuild in #247, already merged). Isolated F11's real contribution (`deploy_family.py` + its test, unchanged from #201) and reapplied it on top of current release, where all its dependencies already exist via their own canonical merges. 8/8 tests pass against release's real dependency versions. Closes the gap left by #201/#203 which can no longer merge cleanly.