### PR TITLE
release-checklists: a tracked, public release-gate checklist per version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to mixle are documented here. The format follows
 Workstream: generic AI-capability platform pieces on top of the core estimation engine (task
 decomposition, cross-modal reasoning, self-improvement loops, a system facade), plus a hardening
 pass across the automatic-inference and design-of-experiments subsystems. This section is finalized
-at release time per the version release checklist in `notes/mixle-development-agent-rules.md`.
+at release time per [`release-checklists/0.6.3.md`](release-checklists/0.6.3.md).
 
 ### Added
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,8 +47,8 @@ commit.
   changed.
 - Include a test plan: what you ran, what passed, what you narrowed the test selection to and why.
 - Target `main` unless you're told otherwise; release branches (`release/X.Y.Z-*`) are used for
-  large in-flight bodies of work and merged back per
-  `notes/mixle-development-agent-rules.md`'s release checklist.
+  large in-flight bodies of work and merged back per the checklist in
+  [`release-checklists/`](release-checklists/README.md).
 - Update `CHANGELOG.md`'s `[Unreleased]` section for any user-visible change (new public API, fixed
   bug, behavior change). Purely internal refactors with no visible effect don't need an entry.
 - CI must be green (lint, fast, full) before merge; the `optional` and `security` jobs are informative

--- a/release-checklists/0.6.3.md
+++ b/release-checklists/0.6.3.md
@@ -1,0 +1,95 @@
+# mixle 0.6.3 release checklist
+
+**Status: not ready to release.**
+
+- Release branch: `release/0.6.3-generic-capabilities`
+- Checklist opened: 2026-07-09
+- Tracking commit as of this update: `de38ba5642d703f101d9573f33dbb7c1c5d21233` ("examples:
+  frontier-family showcase notebook (B6) (#269)")
+
+See [`README.md`](README.md) for the status legend and evidence discipline this file follows.
+
+## 1. Branch and CI state
+
+| Gate | Status | Evidence |
+| --- | --- | --- |
+| No open PRs against the release branch | `TODO` | 1 open: [#270](https://github.com/gmboquet/mixle/pull/270) "docs: comprehensive docstring and documentation pass" — merge or close before proceeding. Checked 2026-07-09 via `gh pr list --state open --base release/0.6.3-generic-capabilities`. |
+| `main` is not ahead of the release branch | `DONE` | `git rev-list --count origin/release/0.6.3-generic-capabilities..origin/main` → `0`, checked 2026-07-09. |
+| `v0.6.3` tag does not already exist | `DONE` | `git tag -l` and `git ls-remote --tags origin` both empty for `0.6.3`, checked 2026-07-09. |
+| CI is green on the exact current tip | `PARTIAL` | Last confirmed green run was against `f67d20ca` — 90 commits behind the current tip (`git rev-list --count f67d20ca..de38ba56` → `90`). A fresh run was triggered 2026-07-09 against `de38ba56` (`gh workflow run Tests --ref release/0.6.3-generic-capabilities`, run id `29000947923`) — not yet complete as of this writing. **Do not treat this gate as satisfied until that run (or a newer one against the then-current tip) is green.** |
+
+## 2. Version and metadata
+
+| Gate | Status | Evidence |
+| --- | --- | --- |
+| `pyproject.toml` version equals the release version | `TODO` — **blocker** | `version = "0.6.2"` on the release branch as of `de38ba56` (`grep -n '^version' pyproject.toml`). Must be bumped to `0.6.3` before build/tag. |
+| `__version__` matches package metadata | `TODO` | Re-check after the bump above; `mixle/__init__.py` derives it from installed package metadata (`importlib.metadata.version("mixle")`), so it will follow automatically once `pyproject.toml` is correct and the package is reinstalled — verify with `python -c "import mixle; print(mixle.__version__)"` after a fresh install. |
+| Bump is the correct semver level | `TODO` | This release is additive (new modules/APIs; no removed/renamed public symbol identified so far) — tentatively a minor bump (`0.6.2` → `0.6.3`), consistent with the branch name. Re-confirm against the final CHANGELOG once frozen. |
+| `requires-python` and classifiers are current | `DONE` | `requires-python = ">=3.10"`, matches the CI matrix (3.10/3.11/3.12). Checked 2026-07-09. |
+| `CHANGELOG.md` has a dated, complete `0.6.3` entry | `PARTIAL` | `## [Unreleased] — 0.6.3` section exists with Added/Fixed content. Needs: a final pass against everything merged since it was last updated (90+ commits, including anything #270 adds), and a real date replacing "Unreleased" at cut time. |
+| Migration notes for any breaking change | `TODO` | No breaking/removed public API identified yet in this pass — confirm with a deliberate sweep before cutting, not just "nothing came to mind." |
+
+## 3. Build and install clean
+
+Not yet run this pass — do not skip on the assumption the dev tree looks fine.
+
+| Gate | Status | Evidence |
+| --- | --- | --- |
+| `python -m build` produces sdist + wheel with zero errors | `TODO` | |
+| `twine check dist/*` | `TODO` | |
+| Fresh, isolated venv install (not editable, not `PYTHONPATH`) | `TODO` | `python -m venv /tmp/relcheck && /tmp/relcheck/bin/pip install dist/mixle-0.6.3-*.whl` |
+| Import smoke from that install | `TODO` | `/tmp/relcheck/bin/python -c "import mixle; print(mixle.__version__)"` |
+| Full public-module import sweep | `TODO` | `python -c "import importlib,pkgutil,mixle; [importlib.import_module(m.name) for m in pkgutil.walk_packages(mixle.__path__,'mixle.') if '.tests' not in m.name and not m.name.endswith('_test')]"` — fail on anything that isn't a documented optional-dependency guard. |
+| Non-`.py` package data present in the wheel | `TODO` | `unzip -l dist/*.whl` |
+
+## 4. Dependency correctness
+
+| Gate | Status | Evidence |
+| --- | --- | --- |
+| Declared deps match imports (both directions) | `TODO` | |
+| Dependency graph resolves clean | `TODO` | `pip install --dry-run '.[all]'` in a clean env |
+| Version bounds are real, not just present | `TODO` | Spot-check the ones known to be version-sensitive (`networkx`, `numpy`, `scipy`, `torch`) against the actual API surface used. |
+| Optional deps stay truly optional | `PARTIAL` | The `fast` CI lane installs only `.[test]` (no torch/numba/spark/...) and has been green historically, which is real evidence the base import path doesn't hard-require them — but re-verify against the current tip once CI (§1) is green. |
+
+## 5. Test rigor
+
+| Gate | Status | Evidence |
+| --- | --- | --- |
+| `lint` (ruff format --check + ruff check; mypy advisory) | `PARTIAL` | Green as of `f67d20ca`; not yet re-run against `de38ba56` — covered by the CI run in flight (§1). |
+| `fast` × py3.10/3.11/3.12 | `PARTIAL` | Same as above. |
+| `full` (non-optional suite, py3.12) | `PARTIAL` | Same as above. |
+| `optional` (torch/numba/jax extras) | `TODO` | Only runs on `workflow_dispatch`/schedule, not on every push — confirm it has been run recently against a commit close to the current tip, or trigger it explicitly before cutting. |
+| `security` / `pip-audit` (base install) | `TODO` | Advisory-only job (`continue-on-error: true`); check its latest output for anything that should block release even though CI won't fail on it. |
+| No known flaky tests in the gate | `TODO` | No systematic flake sweep run this pass. Several BLAS/platform-dependent threshold flakes were fixed earlier in 0.6.3 (t-SNE separation pins, copula seed-catalog gaps) — no new ones identified, but this hasn't been re-verified by deliberately looping the suite. |
+
+## 6. Hygiene scan
+
+| Gate | Status | Evidence |
+| --- | --- | --- |
+| No secrets in code/tests/docs | `TODO` | Not scanned this pass. |
+| No debug leftovers (`breakpoint()`, stray `print()`, `pdb`) | `TODO` | Not scanned this pass. |
+| No AI-assistant mention in commit authorship/history reachable from the release | `DONE`, with a noted residual | `git log --all --format='%H' --grep='Co-Authored-By: Claude' -i` finds 40 commits across this local clone's full ref set, but `comm -12` against `git rev-list origin/release/0.6.3-generic-capabilities` and against `git rev-list origin/main` both return **zero** — none of the 40 are reachable from the release branch or `main`. Checked 2026-07-09. **Residual, accepted risk:** those 40 commits belonged to since-closed PRs; GitHub retains closed-PR diffs even after the branch is deleted, so the mention is still visible to someone browsing that specific closed PR's history on GitHub, even though it will never appear in a built release artifact or in `git log` on a clone of the release branch/tag. This does not block release; re-run this exact check against the final tag commit before cutting, since new commits land constantly. |
+| Author/committer identities are acceptable | `DONE` | `git log --all --format='%an <%ae>'` on refs reachable from release/main shows only `Grant Boquet <grant.boquet@gmail.com>`, plus pre-existing historical contributors (`Adam Walder`, `Walder, Adam Randall`) unrelated to this release's work. Checked 2026-07-09. |
+
+## 7. Documentation
+
+| Gate | Status | Evidence |
+| --- | --- | --- |
+| `CONTRIBUTING.md`, `SECURITY.md`, `CHANGELOG.md` present and current | `PARTIAL` | All three exist; `CONTRIBUTING.md`'s release-checklist link needs to point here (this PR fixes that) rather than the old, now-gone `notes/mixle-development-agent-rules.md` reference. |
+| Sphinx docs build strict (`-W --keep-going`) | `TODO` | `make -C docs html SPHINXOPTS="-W --keep-going"` not run this pass. |
+| Generated `docs/api/*.rst` current | `TODO` | Re-run `make -C docs apidoc` and diff — several modules landed in the last 90 commits. |
+| README reflects current version/capabilities | `TODO` | Not reviewed against the full 0.6.3 diff this pass. |
+
+## 8. Examples and notebooks
+
+| Gate | Status | Evidence |
+| --- | --- | --- |
+| Every shipped example executes from a clean install | `TODO` | Not run this pass. |
+| Every shipped notebook executes top-to-bottom on a clean kernel | `TODO` | The current tip's own last commit adds a new notebook (`examples: frontier-family showcase notebook (B6) (#269)`) — this needs to be in the execution sweep, not assumed working because it's new. |
+
+## Known concrete blockers (as of 2026-07-09)
+
+1. `pyproject.toml` still declares `0.6.2` — needs the version bump (§2).
+2. [#270](https://github.com/gmboquet/mixle/pull/270) is open against the release branch — needs merge or close (§1).
+3. CI has not been confirmed green against the current tip — run `29000947923` is in flight; re-check it, and re-run if anything else lands before it finishes (§1, §5).
+4. Sections 3, 4, 6 (secrets/debug), 7, and 8 have not been executed at all this pass — they are not "probably fine," they are unverified.

--- a/release-checklists/README.md
+++ b/release-checklists/README.md
@@ -1,0 +1,64 @@
+# Release checklists
+
+This folder is the tracked, public record of what has to be true before a `mixle` version ships.
+One file per release: `0.6.3.md`, `0.6.4.md`, and so on. The file is created when release
+preparation begins and updated in place — with evidence — as gates are actually verified. It stays
+in git history after the release ships, so anyone can see exactly what was checked, how, and when.
+
+This is a checklist of **gates**, not a task list. An unchecked item means the release is not
+ready, full stop — there is no "ship now, verify later" for anything marked here.
+
+## Scope
+
+This tracks the `mixle` package itself: the code in this repository, its own CI, its own version.
+`mixle` ships alongside sibling packages (`mixle-knowledge`, `mixle-agent`, `mixle-mlops`,
+`mixle-pde`, and others) as part of a coordinated release, but cross-package coordination —
+lockstep versions, family co-install, publication order — is the release owner's responsibility and
+tracked outside this repo. Where a family-level decision constrains something checked here (a
+sibling's minimum required `mixle` version, for example), this checklist links to it rather than
+duplicating it.
+
+## Status legend
+
+| Status | Meaning |
+| --- | --- |
+| `TODO` | Required, no evidence yet. |
+| `PARTIAL` | Some evidence exists but doesn't cover the exact release commit, or is otherwise incomplete. |
+| `DONE` | Verified against the exact commit that will be (or was) released, with evidence recorded inline. |
+| `EXCLUDED` | Explicitly out of scope for this release, with a one-line reason. Silence is not the same as excluded. |
+
+## Evidence discipline
+
+A gate is `DONE` only when the entry names, at minimum:
+
+- the command run;
+- the commit SHA it was run against;
+- the result (pass/fail, with the actual number — "4,890 passed" not "tests passed");
+- the date.
+
+"It passed in CI on some earlier commit" does not satisfy a gate for the current tip. A release
+branch that gained commits since the last green run needs a fresh run — CI status against an old
+SHA is not evidence about the current one.
+
+## What's checked here
+
+The gate categories are: branch/CI state, version and package metadata, a clean build-and-install
+(not just "tests pass in the dev tree" — a fresh venv installing the built wheel), dependency
+correctness, the full test gate (not just the fast default), a hygiene scan (secrets, debug
+leftovers, and — specific to how this codebase is developed — no AI-assistant attribution in
+authorship or commit history), documentation, and example/notebook execution. Each release's file
+spells these out with the exact commands for that release's CI configuration, since the gates
+themselves can change between releases (a new CI job, a new supported Python version, a new
+optional extra).
+
+## Using this for a new release
+
+1. Copy the most recent release's file as a starting template — the shape doesn't change much
+   release to release, but re-verify every gate; don't carry over old evidence.
+2. Update the version-specific specifics (target version, changelog section, any new gates).
+3. Work through it in roughly top-to-bottom order — branch/CI state and version metadata gate
+   everything after them.
+4. Commit progress as you go, in the open, so the file's git history shows how the release
+   actually got verified, not just a final "all green" snapshot.
+5. See [`CONTRIBUTING.md`](../CONTRIBUTING.md) for the day-to-day PR/test/lint conventions this
+   checklist assumes.


### PR DESCRIPTION
Adds `release-checklists/`, a git-tracked folder holding one checklist file per release, kept in history so the release process is auditable rather than asserted after the fact.

- `README.md` — the process: one file per release, status legend (`TODO`/`PARTIAL`/`DONE`/`EXCLUDED`), and the evidence discipline a `DONE` gate requires (exact command + commit SHA + result; CI green on an old SHA does not satisfy a gate for the current tip).
- `0.6.3.md` — populated with real, verified-today status, not a blank template:
  - 1 open PR against the release branch ([#270](https://github.com/gmboquet/mixle/pull/270))
  - `main` confirmed not ahead of release
  - no `v0.6.3` tag exists yet
  - **version bump not done** — `pyproject.toml` still says `0.6.2` on the release branch (a concrete blocker)
  - a completed no-Claude-mention sweep: 40 commits with a `Co-Authored-By: Claude` trailer exist somewhere in this clone's full ref set, but **zero** are reachable from `origin/release/0.6.3-generic-capabilities` or `origin/main` (verified via `git rev-list` + `comm`) — with the residual (those commits' closed PRs are still browsable on GitHub) noted honestly rather than hidden
  - CI was 90 commits stale against the last confirmed-green run — triggered a fresh run against the current tip as part of this pass

Also fixes `CONTRIBUTING.md`'s and `CHANGELOG.md`'s release-checklist references, which pointed at `notes/mixle-development-agent-rules.md` — a path in a private, unpublished sibling repo, never part of this package and not reachable by anyone who clones it.