### PR TITLE
release-checklists: add lessons-learned loop + complete the 0.6.3 gate set

### DIFF
--- a/release-checklists/0.6.3.md
+++ b/release-checklists/0.6.3.md
@@ -60,7 +60,8 @@ Not yet run this pass — do not skip on the assumption the dev tree looks fine.
 | `full` (non-optional suite, py3.12) | `PARTIAL` | Same as above. |
 | `optional` (torch/numba/jax extras) | `TODO` | Only runs on `workflow_dispatch`/schedule, not on every push — confirm it has been run recently against a commit close to the current tip, or trigger it explicitly before cutting. |
 | `security` / `pip-audit` (base install) | `TODO` | Advisory-only job (`continue-on-error: true`); check its latest output for anything that should block release even though CI won't fail on it. |
-| No known flaky tests in the gate | `TODO` | No systematic flake sweep run this pass. Several BLAS/platform-dependent threshold flakes were fixed earlier in 0.6.3 (t-SNE separation pins, copula seed-catalog gaps) — no new ones identified, but this hasn't been re-verified by deliberately looping the suite. |
+| No known flaky tests in the gate | `TODO` | No systematic flake sweep run this pass. Several BLAS/platform-dependent threshold flakes were fixed earlier in 0.6.3 (t-SNE separation pins, copula seed-catalog gaps) — no new ones identified, but this hasn't been re-verified by deliberately looping the suite. See [`lessons-learned.md`](lessons-learned.md) L-0.6.3-7 / L-0.6.3-8. |
+| Supported OS matrix is stated and covered | `PARTIAL` | CI runs Linux x86_64 only. macOS arm64 is the dev platform (tests are run there ad hoc, not in CI); Windows is neither claimed nor tested. Decision needed before cut: either add a macOS CI leg, or explicitly declare Linux as the only *tested* platform with macOS/Windows best-effort — and say so in the README/classifiers. Do not leave it silent. |
 
 ## 6. Hygiene scan
 
@@ -79,6 +80,7 @@ Not yet run this pass — do not skip on the assumption the dev tree looks fine.
 | Sphinx docs build strict (`-W --keep-going`) | `TODO` | `make -C docs html SPHINXOPTS="-W --keep-going"` not run this pass. |
 | Generated `docs/api/*.rst` current | `TODO` | Re-run `make -C docs apidoc` and diff — several modules landed in the last 90 commits. |
 | README reflects current version/capabilities | `TODO` | Not reviewed against the full 0.6.3 diff this pass. |
+| Process references resolve within this repo | `DONE` | `CONTRIBUTING.md` and `CHANGELOG.md` no longer point at `notes/mixle-development-agent-rules.md` (a path in a private sibling repo, unreachable by a cloner); both now point into `release-checklists/`. Fixed 2026-07-09. See [`lessons-learned.md`](lessons-learned.md) L-0.6.3-12. |
 
 ## 8. Examples and notebooks
 
@@ -87,9 +89,61 @@ Not yet run this pass — do not skip on the assumption the dev tree looks fine.
 | Every shipped example executes from a clean install | `TODO` | Not run this pass. |
 | Every shipped notebook executes top-to-bottom on a clean kernel | `TODO` | The current tip's own last commit adds a new notebook (`examples: frontier-family showcase notebook (B6) (#269)`) — this needs to be in the execution sweep, not assumed working because it's new. |
 
+## 9. Post-merge and final re-verification
+
+Passing on each contributing branch is not the same as passing on the merged tip — a merge is where
+cross-branch interactions surface (see [`lessons-learned.md`](lessons-learned.md) L-0.6.3-6). Re-run
+the confidence gates against the exact commit that will be tagged.
+
+| Gate | Status | Evidence |
+| --- | --- | --- |
+| Full suite green against the exact tag commit (not just per-branch CI) | `TODO` | Rerun §3–§5 against the frozen tip after the last merge. |
+| Re-run after every commit that lands during verification | `TODO` | If anything merges while §3–§8 are in progress, the evidence for the earlier gates is stale — re-verify or re-freeze. |
+
+## 10. Reproducibility
+
+A published version must stay installable and runnable years later; that depends on bounded deps plus
+a captured resolution (see [`lessons-learned.md`](lessons-learned.md) L-0.6.3-9).
+
+| Gate | Status | Evidence |
+| --- | --- | --- |
+| Resolved dependency set captured for this release | `TODO` | `pip freeze` (or `uv pip compile`) from the clean install of §3, stored/linked so the exact environment can be reconstructed. |
+| The *previous* release still installs and smoke-runs | `TODO` | In a clean env, `pip install mixle==0.6.2` and run its smoke import. A prior pinned release that no longer resolves means a dependency bound has drifted — fix it in *this* release's bounds. |
+
+## 11. Publication
+
+Do not start until §1–§10 are `DONE` or explicitly `EXCLUDED`. Publish in dependency order — as part
+of a coordinated family release, `mixle` (core) publishes before any sibling that depends on it;
+that cross-package ordering is tracked by the release owner outside this repo (see the Scope note in
+[`README.md`](README.md)). The steps below are `mixle`'s own.
+
+| Step | Status | Evidence |
+| --- | --- | --- |
+| Build from the frozen commit: `python -m build`; `twine check dist/*` | `TODO` | Same artifacts verified in §3 — do not rebuild from a different tree. |
+| TestPyPI dry run: `twine upload --repository testpypi dist/*`, then install back from TestPyPI in a clean env and smoke-run | `TODO` | Catches metadata/index/resolution problems *before* the irreversible PyPI upload. |
+| PyPI publish: `twine upload dist/*` | `TODO` | |
+| Tag the exact published commit: `git tag -a v0.6.3 -m "mixle v0.6.3"` && `git push origin v0.6.3` (never `--force`) | `TODO` | Tag only the commit that was built and published — the tag is the immutable record. |
+| Post-publish verification from the real index | `TODO` | Fresh venv(s), `pip install mixle==0.6.3`, import + smoke. A failure here is broken-in-the-wild — treat it as an incident (§12), not a warning. |
+| Docs / changelog / website updated to the published version | `TODO` | |
+
+## 12. Rollback / incident readiness
+
+A published version is immutable — you never fix a bad release in place.
+
+| Gate | Status | Evidence |
+| --- | --- | --- |
+| The rollback path is understood before publishing | `TODO` | A broken `0.6.3` is fixed by publishing `0.6.3.1`/`0.6.4`, not by re-uploading `0.6.3` (PyPI forbids it). *Yank* only for a security/critical defect — a yank leaves it installable by exact pin so existing lockfiles keep working; it is not a delete. Confirm the owner knows which applies before cutting. |
+
+## 13. Sign-off
+
+| Gate | Status | Evidence |
+| --- | --- | --- |
+| Release owner sign-off | `TODO` | Name + date, recorded here, only after every gate above is `DONE` or `EXCLUDED`. This line is the release decision. |
+
 ## Known concrete blockers (as of 2026-07-09)
 
 1. `pyproject.toml` still declares `0.6.2` — needs the version bump (§2).
 2. [#270](https://github.com/gmboquet/mixle/pull/270) is open against the release branch — needs merge or close (§1).
 3. CI has not been confirmed green against the current tip — run `29000947923` is in flight; re-check it, and re-run if anything else lands before it finishes (§1, §5).
-4. Sections 3, 4, 6 (secrets/debug), 7, and 8 have not been executed at all this pass — they are not "probably fine," they are unverified.
+4. The supported-OS decision is open — CI is Linux-only; either add a macOS leg or explicitly declare the tested-platform scope (§5).
+5. Sections 3, 4, 6 (secrets/debug), 7, 8, 9, 10, 11, 12, and 13 have not been executed at all this pass — they are not "probably fine," they are unverified.

--- a/release-checklists/README.md
+++ b/release-checklists/README.md
@@ -1,9 +1,13 @@
 # Release checklists
 
 This folder is the tracked, public record of what has to be true before a `mixle` version ships.
-One file per release: `0.6.3.md`, `0.6.4.md`, and so on. The file is created when release
-preparation begins and updated in place — with evidence — as gates are actually verified. It stays
-in git history after the release ships, so anyone can see exactly what was checked, how, and when.
+
+- **`<version>.md`** (`0.6.3.md`, `0.6.4.md`, …) — one checklist per release, created when
+  preparation begins and updated in place *with evidence* as gates are verified. It stays in git
+  history after the release ships, so anyone can see exactly what was checked, how, and when.
+- **`lessons-learned.md`** — a cumulative, cross-release record of what went wrong (or nearly did),
+  where each lesson is tied to the checklist gate that now catches it. This is what keeps the
+  checklist from being a static wish-list: it grows from real failures.
 
 This is a checklist of **gates**, not a task list. An unchecked item means the release is not
 ready, full stop — there is no "ship now, verify later" for anything marked here.
@@ -42,23 +46,53 @@ SHA is not evidence about the current one.
 
 ## What's checked here
 
-The gate categories are: branch/CI state, version and package metadata, a clean build-and-install
-(not just "tests pass in the dev tree" — a fresh venv installing the built wheel), dependency
-correctness, the full test gate (not just the fast default), a hygiene scan (secrets, debug
-leftovers, and — specific to how this codebase is developed — no AI-assistant attribution in
-authorship or commit history), documentation, and example/notebook execution. Each release's file
-spells these out with the exact commands for that release's CI configuration, since the gates
-themselves can change between releases (a new CI job, a new supported Python version, a new
-optional extra).
+The gate categories run pre-flight → verify → publish → post-publish:
+
+- **Branch / CI state** — no open PRs, `main` not ahead, no pre-existing tag, CI green *on the exact
+  tip*.
+- **Version and metadata** — the version string is actually bumped, semver is right, changelog and
+  migration notes are current.
+- **Build and install clean** — a fresh venv installing the *built wheel* (not the dev tree, not
+  `PYTHONPATH`), an import smoke, and a full public-module import sweep.
+- **Dependency correctness** — declared deps match imports both ways, bounds are real and tested,
+  optional deps stay optional.
+- **Test rigor** — the *full* suite (not the fast default), across the supported Python/OS matrix,
+  run against the clean install, with no known flakes.
+- **Hygiene** — secrets, debug leftovers, and — specific to how this codebase is developed — no
+  AI-assistant attribution anywhere in authorship, commit trailers, or PR history.
+- **Documentation and examples** — docs build strict, process references resolve *within the repo*,
+  every shipped example/notebook actually executes.
+- **Post-merge re-verification** — the confidence gates re-run against the exact tag commit, because
+  green-per-branch isn't green-on-the-merge.
+- **Reproducibility** — the resolved dependency set is captured, and the *previous* release still
+  installs.
+- **Publication and rollback** — build → TestPyPI dry run → PyPI → tag → post-publish verify, in
+  dependency order, with the rollback path (patch, or yank-not-delete) understood first.
+- **Sign-off** — a named, dated release decision, only after everything above is `DONE` or
+  `EXCLUDED`.
+
+Each release's file spells these out with the exact commands for that release's CI configuration,
+since the gates themselves change between releases (a new CI job, a new supported Python version, a
+new optional extra) — and each new gate should trace back to a lesson in `lessons-learned.md`.
 
 ## Using this for a new release
 
 1. Copy the most recent release's file as a starting template — the shape doesn't change much
    release to release, but re-verify every gate; don't carry over old evidence.
-2. Update the version-specific specifics (target version, changelog section, any new gates).
-3. Work through it in roughly top-to-bottom order — branch/CI state and version metadata gate
+2. Fold in every open lesson from `lessons-learned.md`: each one should already correspond to a gate
+   in the template. If a past lesson has no gate yet, add it before you start.
+3. Update the version-specific specifics (target version, changelog section, any new gates).
+4. Work through it in roughly top-to-bottom order — branch/CI state and version metadata gate
    everything after them.
-4. Commit progress as you go, in the open, so the file's git history shows how the release
+5. Commit progress as you go, in the open, so the file's git history shows how the release
    actually got verified, not just a final "all green" snapshot.
-5. See [`CONTRIBUTING.md`](../CONTRIBUTING.md) for the day-to-day PR/test/lint conventions this
-   checklist assumes.
+
+## Closing the loop after a release
+
+The checklist only gets better if failures feed back into it. After each release — or each release
+*attempt* that got blocked — run a short retrospective (`lessons-learned.md` describes the steps):
+write up what went wrong or nearly did, and for each item, add or strengthen the gate that would
+have caught it, in the same change. A lesson that doesn't change the checklist is just a story.
+
+See [`CONTRIBUTING.md`](../CONTRIBUTING.md) for the day-to-day PR/test/lint conventions this
+checklist assumes.

--- a/release-checklists/lessons-learned.md
+++ b/release-checklists/lessons-learned.md
@@ -1,0 +1,210 @@
+# Release lessons learned
+
+A cumulative, cross-release record of things that went wrong — or nearly did — while releasing
+`mixle`, so the same mistake is caught by process next time instead of by luck.
+
+## The rule that keeps this useful
+
+A lessons-learned log that is only a list of war stories rots into something nobody reads. This one
+has one rule: **every lesson must terminate in a checklist gate.** Each entry ends with either
+
+- **→ Gate:** the checklist item (existing or newly added) that now catches this class of failure; or
+- **→ No gate:** an explicit, dated decision that a gate isn't worth it, and why.
+
+If a lesson can't be turned into a gate or a deliberate no-gate decision, it isn't done being
+understood yet. When you add a lesson here, you add or strengthen the gate in the current release
+checklist in the *same* change — that is the whole point of writing it down.
+
+## How to run a release retrospective
+
+After each release (or after a release *attempt* that got blocked), before the memory fades:
+
+1. Walk the release checklist and this session's history. For every gate that was `TODO`/`PARTIAL`
+   at the end, every fire drill, and every "we almost shipped X" — write it up below under that
+   release's heading.
+2. For each, find the gate that would have caught it. If the gate exists, note that it worked (or
+   why it didn't fire). If it doesn't exist, add it to the checklist template and reference it here.
+3. Keep entries concrete: the actual symptom, the actual root cause, the actual command that now
+   catches it. "Be more careful" is not a lesson.
+
+---
+
+## 0.6.3
+
+The 0.6.3 cycle was a large, fast, multi-agent build (~160 commits merged in a few days), which is
+exactly the condition under which release discipline earns its keep. Most of these were caught
+during the build or a pre-release review, not in the wild — but each is a real thing that happened.
+
+### L-0.6.3-1 — Shipped a release branch with the previous version string
+
+**What happened.** `release/0.6.3-generic-capabilities` carried `version = "0.6.2"` in
+`pyproject.toml` the entire time — the branch name said 0.6.3, the metadata said 0.6.2. Left
+unchecked, the build would have produced a `mixle-0.6.2` wheel from the 0.6.3 branch.
+
+**Root cause.** The version bump was treated as a "do it at the end" step with nothing enforcing it,
+and a branch name is not metadata.
+
+**→ Gate:** §2, *`pyproject.toml` version equals the release version* — verified with
+`grep -nE '^version' pyproject.toml` and a `git tag` check that the target tag doesn't already exist,
+as a hard blocker before any build.
+
+### L-0.6.3-2 — `PYTHONPATH`/editable runs hid a real packaging failure
+
+**What happened.** A persistence test spawned a subprocess that failed with
+`No module named 'mixle.task'` — but *only* under a `PYTHONPATH`/editable-install run. It passed the
+moment the actual built wheel was installed. The "failure" was a harness artifact, and only a clean
+install could prove that.
+
+**Root cause.** A warm dev tree (editable install, `PYTHONPATH` on the path) resolves imports that a
+real installed wheel would not. Tests run against the working tree do not validate the artifact.
+
+**→ Gate:** §3, *fresh, isolated venv install from the built wheel* (never editable, never
+`PYTHONPATH`) + import smoke + running the suite against that install.
+
+### L-0.6.3-3 — The default test command silently ran a subset
+
+**What happened.** The repo's default `pytest` is `-m fast`. On this codebase that selected ~4,440
+tests and *silently deselected ~849* slower ones. A developer running `pytest` and seeing green had
+not run the suite a release needs.
+
+**Root cause.** A fast per-commit gate and a release gate are different things, and pytest deselects
+quietly (exit 0, no warning).
+
+**→ Gate:** §5, run the *full* non-optional suite (`pytest -m "not optional and not benchmark"`),
+and the `optional` extras suite — the checklist names the exact selection so "I ran the tests" can't
+mean the fast subset.
+
+### L-0.6.3-4 — Missing optional-backend guards broke the no-torch CI lane, repeatedly
+
+**What happened.** New test files (`eval_harness_test`, `scaling_laws_test`, `training_health_test`,
+`doe_amplify_test`, and others) imported torch — or called a torch-only path like
+`GaussianProcessRegressor` — with no skip guard. On the torch-free `fast`/`full` CI lanes these
+*errored during collection* instead of skipping, reddening CI. This recurred several times across the
+batch merges.
+
+**Root cause.** The base install is deliberately torch-free (torch is an optional extra), but a
+test that needs an optional backend must declare that with `pytest.importorskip(...)` or
+`@unittest.skipUnless(_HAS_TORCH, ...)`. It's an easy omission and nothing at authoring time forces
+it.
+
+**→ Gate:** §4 *optional deps stay truly optional* + §5 running the full suite on the torch-free
+install, which is exactly the lane that surfaces an unguarded import. Recurring-pattern note in the
+checklist: a new test touching an optional backend must guard.
+
+### L-0.6.3-5 — A public family added without registering it in its enforcing catalog
+
+**What happened.** New copula distributions were exported from `mixle.stats` but not added to the
+seed-repeatability catalog that `sampler_seed_test` checks — twice (first Frank/Clayton/StudentT,
+then Gumbel/CVine/DVine/RVine). Each broke the release-branch test suite and, through it, every open
+PR's CI.
+
+**Root cause.** A public export and its enforcement catalog must move in lockstep, and the coupling
+isn't obvious from either file alone. (The good news: the catalog test *is* the enforcement — it
+failed loudly rather than letting an unverified sampler ship.)
+
+**→ Gate:** the catalog test itself is the standing gate, exercised by §5's full suite; plus a
+`CONTRIBUTING`-level note that adding a public distribution means updating its catalog test in the
+same change.
+
+### L-0.6.3-6 — A boundary violation landed because the full suite wasn't run on the merged tip
+
+**What happened.** Copula-selection logic was added *inside* `mixle/inference/estimation.py`,
+importing concrete `mixle.stats` distributions (even function-locally) — a violation of a boundary
+rule enforced by an AST-scanning test (`estimation.py` is a high-level compute utility that must
+never import concrete distributions). Each contributing branch's own CI was green; the violation only
+appeared once several branches were merged and the full suite ran against the combined tree.
+
+**Root cause.** Green-on-each-branch is not green-on-the-merge. A rule enforced by a test only helps
+if that test actually runs against the state you're shipping.
+
+**→ Gate:** §9 (new), *re-verify the full suite against the post-merge / current tip*, not just
+per-branch CI — the merge is where cross-branch interactions surface.
+
+### L-0.6.3-7 — Cross-platform numeric flakiness (passes on dev, reds on CI)
+
+**What happened.** Seeded exact-t-SNE trajectories and a couple of correlation/separation thresholds
+landed at different values across numpy/BLAS builds — e.g. separation 1.414 locally (macOS) vs 1.2491
+on the Linux CI py3.12 wheels, a hair under a 1.25 pin. Green locally, red on CI.
+
+**Root cause.** A seed does not make floating-point BLAS deterministic across platforms; a threshold
+pinned to the dev machine's exact value is a platform-specific assertion in disguise.
+
+**→ Gate:** §5 *no known flaky tests* + the evidence rule that CI (the real target OS), not the dev
+machine, is the source of truth. Platform-sensitive thresholds are pinned with margin below every
+observed trajectory, asserting the qualitative claim, not a knife-edge number.
+
+### L-0.6.3-8 — A stochastic test passed alone but reddened in the full run
+
+**What happened.** `structure_learning::test_responsibilities_recover_clusters` passed 3/3 in
+isolation but went red once in the full suite — a stochastic EM-recovery test sensitive to RNG/order
+pollution from other tests.
+
+**Root cause.** A test that depends on global RNG state (rather than its own in-test seed) is order-
+dependent, so "passes when I run it" and "passes in the gate" diverge.
+
+**→ Gate:** §5 *no known flaky tests* — detect by looping a suspect test and by varying order; fix by
+seeding the test's own RNG. A gate that reds at random destroys the confidence a release exists to
+build.
+
+### L-0.6.3-9 — A dependency API used beyond its declared lower bound
+
+**What happened.** The grammar serializer called `networkx.node_link_data(edges=...)`, which exists
+only in networkx ≥ 3.4, and raised `TypeError` on an environment's networkx 3.0. The dependency was
+declared, but the *bound* didn't reflect the API the code actually used.
+
+**Root cause.** "The dependency is declared" and "the declared range actually works" are different
+claims; the second needs a version-bounds review against the real API surface.
+
+**→ Gate:** §4 *version bounds are real, not just present* — spot-check version-sensitive deps
+(`networkx`, `numpy`, `scipy`, `torch`) against the API used, and pin the lower bound to it.
+
+### L-0.6.3-10 — CI drifted far behind the tip while everyone assumed "it's green"
+
+**What happened.** The last *confirmed*-green CI run was ~90 commits behind the current release tip.
+"CI is green" was true about a commit nobody was about to ship.
+
+**Root cause.** CI status is about a specific SHA, and a fast-moving branch outruns its last full
+run. "Green" with no SHA attached is not a fact about the tip.
+
+**→ Gate:** §1 *CI is green on the exact current tip*, plus the README evidence rule: green-on-an-
+old-SHA does not satisfy a gate for the current one; a branch that gained commits needs a fresh run.
+
+### L-0.6.3-11 — Reading a stale local branch instead of `origin/*`
+
+**What happened.** During the review a local checkout trailed `origin` by dozens of commits, which
+produced wrong conclusions about branch state until the reads were switched to `origin/*` refs.
+
+**Root cause.** A local branch is a cache, not the truth; release decisions made from it can be
+decisions about a state that no longer exists.
+
+**→ Gate:** §1 phrasing — every branch/tip/ahead-behind check reads `origin/*` refs (or does a fresh
+`git fetch` first), never a possibly-stale local ref.
+
+### L-0.6.3-12 — The release process pointed at a doc nobody releasing could reach
+
+**What happened.** `CONTRIBUTING.md` and `CHANGELOG.md` referenced the release checklist as living in
+`notes/mixle-development-agent-rules.md` — a path in a *separate, private, unpublished* sibling repo.
+Anyone who cloned `mixle` and followed the process hit a dead reference.
+
+**Root cause.** The process that governs a repo has to live *in* that repo. A pointer to a
+private/inaccessible location is the same as no process for an outside contributor. (This is why
+`release-checklists/` exists as a tracked, in-repo folder — this file included.)
+
+**→ Gate:** §7 *docs/process references resolve within the repo* — the checklist, and any process doc
+it links, live in `mixle` itself, not in a sibling repo.
+
+### L-0.6.3-13 — AI-assistant attribution can hide where a plain commit-message grep won't find it
+
+**What happened.** A sweep for AI-assistant attribution found 40 commits carrying a
+`Co-Authored-By: Claude …` *trailer* — which a `git log --grep` over commit *subjects* misses, and
+which can also live in PR bodies/comments that never touch `git log` at all. (In this case all 40
+were on since-closed PR branches, unreachable from `release`/`main` — but the point is the search has
+to be wide enough to know that.)
+
+**Root cause.** Attribution hides in commit trailers, author/committer identity fields, and the
+GitHub PR layer — not just the visible commit message — so a narrow grep gives false confidence.
+
+**→ Gate:** §6 *no AI-assistant mention* — the check spans author/committer identity, full commit
+bodies/trailers (`--grep` over `%B`, not just `%s`), and PR titles/bodies/comments via the GitHub
+API, evaluated against refs actually reachable from the release, with any residual (e.g. closed-PR
+pages) stated rather than hidden.


### PR DESCRIPTION
Follow-up to the initial `release-checklists/` PR, addressing two gaps: the checklist wasn't complete, and there was no mechanism to keep it from going stale.

## `lessons-learned.md` (new)
A cumulative, cross-release record of what went wrong or nearly did — with one governing rule that keeps it from becoming a write-only graveyard: **every lesson must terminate in a checklist gate** (or an explicit, dated no-gate decision). A lesson that doesn't change the process is just a story.

Seeded with **13 concrete lessons from the 0.6.3 build/review**, each mapped to the gate that now catches it — e.g. shipped-branch-said-0.6.2, `PYTHONPATH` hiding a packaging failure, `-m fast` silently deselecting ~849 tests, unguarded torch imports reddening the no-torch lane (repeatedly), a boundary violation that only surfaced on the merged tip, cross-platform BLAS flakiness, CI drifting 90 commits behind "green", and AI-attribution hiding in commit trailers/PR bodies where a subject-line grep misses it.

## `0.6.3.md` — completed the back half
The initial file was a solid *pre-flight verification tracker* but stopped before the release itself. Added:
- **§9 Post-merge re-verification** — green-per-branch ≠ green-on-the-merge.
- **§10 Reproducibility** — capture the resolved dep set; prove `mixle==0.6.2` still installs.
- **§11 Publication** — build → TestPyPI dry run → PyPI → tag → post-publish verify, in dependency order.
- **§12 Rollback / incident** — patch or yank-not-delete; never re-upload a version.
- **§13 Sign-off** — a named, dated release decision.
- **OS-matrix gate** (CI is Linux-only — decision needed, not silence) and an **in-repo-process-references** gate.

`README.md` updated to document the full pre-flight → verify → publish → post-publish gate set and the retrospective loop.

Structurally checked: §1–§13 in order, 13 lessons, all cross-references resolve.