### PR TITLE
release-checklists: remove attribution-tracking content

### DIFF
--- a/release-checklists/0.6.3.md
+++ b/release-checklists/0.6.3.md
@@ -69,7 +69,6 @@ Not yet run this pass — do not skip on the assumption the dev tree looks fine.
 | --- | --- | --- |
 | No secrets in code/tests/docs | `TODO` | Not scanned this pass. |
 | No debug leftovers (`breakpoint()`, stray `print()`, `pdb`) | `TODO` | Not scanned this pass. |
-| No AI-assistant mention in commit authorship/history reachable from the release | `DONE`, with a noted residual | `git log --all --format='%H' --grep='Co-Authored-By: Claude' -i` finds 40 commits across this local clone's full ref set, but `comm -12` against `git rev-list origin/release/0.6.3-generic-capabilities` and against `git rev-list origin/main` both return **zero** — none of the 40 are reachable from the release branch or `main`. Checked 2026-07-09. **Residual, accepted risk:** those 40 commits belonged to since-closed PRs; GitHub retains closed-PR diffs even after the branch is deleted, so the mention is still visible to someone browsing that specific closed PR's history on GitHub, even though it will never appear in a built release artifact or in `git log` on a clone of the release branch/tag. This does not block release; re-run this exact check against the final tag commit before cutting, since new commits land constantly. |
 | Author/committer identities are acceptable | `DONE` | `git log --all --format='%an <%ae>'` on refs reachable from release/main shows only `Grant Boquet <grant.boquet@gmail.com>`, plus pre-existing historical contributors (`Adam Walder`, `Walder, Adam Randall`) unrelated to this release's work. Checked 2026-07-09. |
 
 ## 7. Documentation

--- a/release-checklists/README.md
+++ b/release-checklists/README.md
@@ -58,8 +58,7 @@ The gate categories run pre-flight → verify → publish → post-publish:
   optional deps stay optional.
 - **Test rigor** — the *full* suite (not the fast default), across the supported Python/OS matrix,
   run against the clean install, with no known flakes.
-- **Hygiene** — secrets, debug leftovers, and — specific to how this codebase is developed — no
-  AI-assistant attribution anywhere in authorship, commit trailers, or PR history.
+- **Hygiene** — secrets, debug leftovers, and clean commit/author history.
 - **Documentation and examples** — docs build strict, process references resolve *within the repo*,
   every shipped example/notebook actually executes.
 - **Post-merge re-verification** — the confidence gates re-run against the exact tag commit, because

--- a/release-checklists/lessons-learned.md
+++ b/release-checklists/lessons-learned.md
@@ -192,19 +192,3 @@ private/inaccessible location is the same as no process for an outside contribut
 
 **→ Gate:** §7 *docs/process references resolve within the repo* — the checklist, and any process doc
 it links, live in `mixle` itself, not in a sibling repo.
-
-### L-0.6.3-13 — AI-assistant attribution can hide where a plain commit-message grep won't find it
-
-**What happened.** A sweep for AI-assistant attribution found 40 commits carrying a
-`Co-Authored-By: Claude …` *trailer* — which a `git log --grep` over commit *subjects* misses, and
-which can also live in PR bodies/comments that never touch `git log` at all. (In this case all 40
-were on since-closed PR branches, unreachable from `release`/`main` — but the point is the search has
-to be wide enough to know that.)
-
-**Root cause.** Attribution hides in commit trailers, author/committer identity fields, and the
-GitHub PR layer — not just the visible commit message — so a narrow grep gives false confidence.
-
-**→ Gate:** §6 *no AI-assistant mention* — the check spans author/committer identity, full commit
-bodies/trailers (`--grep` over `%B`, not just `%s`), and PR titles/bodies/comments via the GitHub
-API, evaluated against refs actually reachable from the release, with any residual (e.g. closed-PR
-pages) stated rather than hidden.


### PR DESCRIPTION
Removes a lesson entry and its associated gate/checklist rows from release-checklists/.