### PR TITLE
release: 0.6.3 prep + fix critical import breakage in mixle.models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,11 @@ All notable changes to mixle are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and versions follow
 [Semantic Versioning](https://semver.org/).
 
-## [Unreleased] — 0.6.3
+## [0.6.3] — 2026-07-09
 
 Workstream: generic AI-capability platform pieces on top of the core estimation engine (task
 decomposition, cross-modal reasoning, self-improvement loops, a system facade), plus a hardening
-pass across the automatic-inference and design-of-experiments subsystems. This section is finalized
-at release time per [`release-checklists/0.6.3.md`](release-checklists/0.6.3.md).
+pass across the automatic-inference and design-of-experiments subsystems.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,21 @@ pass across the automatic-inference and design-of-experiments subsystems.
   `explain()`'s decision-margin ledger; a stale `capacity.py` embedding-head rung mismatch; CI
   flakiness in EM's log-likelihood computation and a de-flaked mixture-of-trees test; Python
   3.10-specific abstention timing in the oracle-timeout path.
+- Release-verification pass (found via a fresh, non-editable venv install of the built wheel --
+  never caught by the dev environment, which has every optional extra installed): `import mixle`
+  was completely broken (a missing-import `NameError` at class-definition time in
+  `mixle.models.dpo_leaf` cascaded through `mixle.models.__init__`'s eager import chain into nearly
+  every module), plus the same missing-import/stale-duplicate-method pattern recurring across 7
+  sibling model files and `pinn.py`; 8 further modules importing torch-gated names unconditionally
+  at module level (undermining their own already-correct optional-torch guards); a real
+  `DPOAccumulator.value()` bug (weights returned as a list, not an array); a data-shape bug in
+  `zero_shot_bootstrap`'s generic neural-density fallback (a 24-dim row was split into 24 scalar
+  fields instead of one vector field); a stale test fixture double-wrapping `Registry.tier_stack`'s
+  frontier callable; a layering violation (`mixle.experimental.long_context_eval` importing upward
+  from `mixle.ppl`); and 2 more test files with the same unguarded-torch-import bug. Also: `numba`'s
+  `tbb` dependency floor made `pip install mixle[numba]`/`mixle[all]` uninstallable on Apple Silicon
+  (no arm64 wheels) -- now platform-gated; `ray` and `lightning` were used by real, documented
+  optional backends with no corresponding `pip install mixle[...]` extra -- both added.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ Release-branch notes live in [CHANGELOG.md](CHANGELOG.md) and
 
 ## Installation
 
-Python 3.10+ (developed on 3.12). On PyPI as `mixle`; the import name is `mixle`.
+Python 3.10+ (developed on 3.12). On PyPI as `mixle`; the import name is `mixle`. CI tests Linux
+x86_64; macOS (incl. Apple Silicon) is the primary day-to-day dev platform and works in practice, but
+isn't CI-gated. Windows is untested and unclaimed.
 
 ```sh
 pip install mixle          # base (numpy, scipy, mpmath): every family, fit locally
@@ -64,8 +66,8 @@ The base install fits every distribution locally. Acceleration and scale-out are
 | -------------------------------------------------------- | ------------------------------------------------------------- |
 | `numba`                                                  | JIT-compiled hot paths (falls back to pure NumPy when absent) |
 | `torch`                                                  | GPU / autograd engine                                         |
-| `spark` · `dask` · `mpi`                                 | distributed estimation backends                               |
-| `pandas` · `arrow` · `sql` · `mongo` · `hadoop` · `data` | data-source connectors                                        |
+| `spark` · `dask` · `ray` · `lightning` · `mpi`           | distributed estimation backends                               |
+| `pandas` · `arrow` · `sql` · `mongo` · `hadoop` · `data` · `arrays` | data-source connectors                              |
 | `gmpy2`                                                  | GMP-FFT big-integer multiply for count-DP ranking             |
 | `umap`                                                   | model-based UMAP embeddings                                   |
 | `sympy` · `sage`                                         | symbolic / closed-form export                                 |

--- a/docs/api/mixle.data.rst
+++ b/docs/api/mixle.data.rst
@@ -26,5 +26,6 @@ Submodules
    mixle.data.partition
    mixle.data.schema
    mixle.data.stream_token_source
+   mixle.data.streaming_corpus
    mixle.data.structure
    mixle.data.validate

--- a/docs/api/mixle.data.sources.array_source.rst
+++ b/docs/api/mixle.data.sources.array_source.rst
@@ -1,0 +1,6 @@
+mixle.data.sources.array\_source module
+=======================================
+
+.. automodule:: mixle.data.sources.array_source
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.data.sources.rst
+++ b/docs/api/mixle.data.sources.rst
@@ -11,6 +11,7 @@ Submodules
 .. toctree::
    :maxdepth: 4
 
+   mixle.data.sources.array_source
    mixle.data.sources.arrow_source
    mixle.data.sources.graph_source
    mixle.data.sources.hadoop_source

--- a/docs/api/mixle.data.streaming_corpus.rst
+++ b/docs/api/mixle.data.streaming_corpus.rst
@@ -1,0 +1,6 @@
+mixle.data.streaming\_corpus module
+===================================
+
+.. automodule:: mixle.data.streaming_corpus
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.epistemic.coherence.rst
+++ b/docs/api/mixle.epistemic.coherence.rst
@@ -1,0 +1,6 @@
+mixle.epistemic.coherence module
+================================
+
+.. automodule:: mixle.epistemic.coherence
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.epistemic.discrepancy.rst
+++ b/docs/api/mixle.epistemic.discrepancy.rst
@@ -1,0 +1,6 @@
+mixle.epistemic.discrepancy module
+==================================
+
+.. automodule:: mixle.epistemic.discrepancy
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.epistemic.journal.rst
+++ b/docs/api/mixle.epistemic.journal.rst
@@ -1,0 +1,6 @@
+mixle.epistemic.journal module
+==============================
+
+.. automodule:: mixle.epistemic.journal
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.epistemic.likelihood.rst
+++ b/docs/api/mixle.epistemic.likelihood.rst
@@ -1,0 +1,6 @@
+mixle.epistemic.likelihood module
+=================================
+
+.. automodule:: mixle.epistemic.likelihood
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.epistemic.loop.rst
+++ b/docs/api/mixle.epistemic.loop.rst
@@ -1,0 +1,6 @@
+mixle.epistemic.loop module
+===========================
+
+.. automodule:: mixle.epistemic.loop
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.epistemic.portfolio.rst
+++ b/docs/api/mixle.epistemic.portfolio.rst
@@ -1,0 +1,6 @@
+mixle.epistemic.portfolio module
+================================
+
+.. automodule:: mixle.epistemic.portfolio
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.epistemic.rst
+++ b/docs/api/mixle.epistemic.rst
@@ -1,0 +1,19 @@
+mixle.epistemic package
+=======================
+
+.. automodule:: mixle.epistemic
+   :members:
+   :show-inheritance:
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   mixle.epistemic.coherence
+   mixle.epistemic.discrepancy
+   mixle.epistemic.journal
+   mixle.epistemic.likelihood
+   mixle.epistemic.loop
+   mixle.epistemic.portfolio

--- a/docs/api/mixle.evolve.closed_loop.rst
+++ b/docs/api/mixle.evolve.closed_loop.rst
@@ -1,0 +1,6 @@
+mixle.evolve.closed\_loop module
+================================
+
+.. automodule:: mixle.evolve.closed_loop
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.evolve.concept_discovery.rst
+++ b/docs/api/mixle.evolve.concept_discovery.rst
@@ -1,0 +1,6 @@
+mixle.evolve.concept\_discovery module
+======================================
+
+.. automodule:: mixle.evolve.concept_discovery
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.evolve.rst
+++ b/docs/api/mixle.evolve.rst
@@ -11,6 +11,8 @@ Submodules
 .. toctree::
    :maxdepth: 4
 
+   mixle.evolve.closed_loop
+   mixle.evolve.concept_discovery
    mixle.evolve.improve
    mixle.evolve.ledger
    mixle.evolve.objective

--- a/docs/api/mixle.experimental.context_spine.rst
+++ b/docs/api/mixle.experimental.context_spine.rst
@@ -1,0 +1,6 @@
+mixle.experimental.context\_spine module
+========================================
+
+.. automodule:: mixle.experimental.context_spine
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.experimental.graduation.rst
+++ b/docs/api/mixle.experimental.graduation.rst
@@ -1,0 +1,6 @@
+mixle.experimental.graduation module
+====================================
+
+.. automodule:: mixle.experimental.graduation
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.experimental.growth_operators.rst
+++ b/docs/api/mixle.experimental.growth_operators.rst
@@ -1,0 +1,6 @@
+mixle.experimental.growth\_operators module
+===========================================
+
+.. automodule:: mixle.experimental.growth_operators
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.experimental.kv_cache_quant.rst
+++ b/docs/api/mixle.experimental.kv_cache_quant.rst
@@ -1,0 +1,6 @@
+mixle.experimental.kv\_cache\_quant module
+==========================================
+
+.. automodule:: mixle.experimental.kv_cache_quant
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.experimental.long_context_eval.rst
+++ b/docs/api/mixle.experimental.long_context_eval.rst
@@ -1,0 +1,6 @@
+mixle.experimental.long\_context\_eval module
+=============================================
+
+.. automodule:: mixle.experimental.long_context_eval
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.experimental.moment_closure_attention.rst
+++ b/docs/api/mixle.experimental.moment_closure_attention.rst
@@ -1,0 +1,6 @@
+mixle.experimental.moment\_closure\_attention module
+====================================================
+
+.. automodule:: mixle.experimental.moment_closure_attention
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.experimental.retrieval_memory_spine.rst
+++ b/docs/api/mixle.experimental.retrieval_memory_spine.rst
@@ -1,0 +1,6 @@
+mixle.experimental.retrieval\_memory\_spine module
+==================================================
+
+.. automodule:: mixle.experimental.retrieval_memory_spine
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.experimental.rst
+++ b/docs/api/mixle.experimental.rst
@@ -11,4 +11,17 @@ Submodules
 .. toctree::
    :maxdepth: 4
 
+   mixle.experimental.context_spine
+   mixle.experimental.graduation
+   mixle.experimental.growth_operators
+   mixle.experimental.kv_cache_quant
+   mixle.experimental.long_context_eval
+   mixle.experimental.moment_closure_attention
    mixle.experimental.program
+   mixle.experimental.retrieval_memory_spine
+   mixle.experimental.selective_scan
+   mixle.experimental.sketch_state_attention
+   mixle.experimental.ssm_hybrid
+   mixle.experimental.structure_edit_schedule
+   mixle.experimental.summary_tree
+   mixle.experimental.tying_discovery

--- a/docs/api/mixle.experimental.selective_scan.rst
+++ b/docs/api/mixle.experimental.selective_scan.rst
@@ -1,0 +1,6 @@
+mixle.experimental.selective\_scan module
+=========================================
+
+.. automodule:: mixle.experimental.selective_scan
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.experimental.sketch_state_attention.rst
+++ b/docs/api/mixle.experimental.sketch_state_attention.rst
@@ -1,0 +1,6 @@
+mixle.experimental.sketch\_state\_attention module
+==================================================
+
+.. automodule:: mixle.experimental.sketch_state_attention
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.experimental.ssm_hybrid.rst
+++ b/docs/api/mixle.experimental.ssm_hybrid.rst
@@ -1,0 +1,6 @@
+mixle.experimental.ssm\_hybrid module
+=====================================
+
+.. automodule:: mixle.experimental.ssm_hybrid
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.experimental.structure_edit_schedule.rst
+++ b/docs/api/mixle.experimental.structure_edit_schedule.rst
@@ -1,0 +1,6 @@
+mixle.experimental.structure\_edit\_schedule module
+===================================================
+
+.. automodule:: mixle.experimental.structure_edit_schedule
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.experimental.summary_tree.rst
+++ b/docs/api/mixle.experimental.summary_tree.rst
@@ -1,0 +1,6 @@
+mixle.experimental.summary\_tree module
+=======================================
+
+.. automodule:: mixle.experimental.summary_tree
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.experimental.tying_discovery.rst
+++ b/docs/api/mixle.experimental.tying_discovery.rst
@@ -1,0 +1,6 @@
+mixle.experimental.tying\_discovery module
+==========================================
+
+.. automodule:: mixle.experimental.tying_discovery
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.inference.backend_respecialization.rst
+++ b/docs/api/mixle.inference.backend_respecialization.rst
@@ -1,0 +1,6 @@
+mixle.inference.backend\_respecialization module
+================================================
+
+.. automodule:: mixle.inference.backend_respecialization
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.inference.block_em.rst
+++ b/docs/api/mixle.inference.block_em.rst
@@ -1,0 +1,6 @@
+mixle.inference.block\_em module
+================================
+
+.. automodule:: mixle.inference.block_em
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.inference.condition.rst
+++ b/docs/api/mixle.inference.condition.rst
@@ -1,0 +1,6 @@
+mixle.inference.condition module
+================================
+
+.. automodule:: mixle.inference.condition
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.inference.conditional_jit_controller.rst
+++ b/docs/api/mixle.inference.conditional_jit_controller.rst
@@ -1,0 +1,6 @@
+mixle.inference.conditional\_jit\_controller module
+===================================================
+
+.. automodule:: mixle.inference.conditional_jit_controller
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.inference.copula_structure.rst
+++ b/docs/api/mixle.inference.copula_structure.rst
@@ -1,0 +1,6 @@
+mixle.inference.copula\_structure module
+========================================
+
+.. automodule:: mixle.inference.copula_structure
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.inference.freeze_rollup.rst
+++ b/docs/api/mixle.inference.freeze_rollup.rst
@@ -1,0 +1,6 @@
+mixle.inference.freeze\_rollup module
+=====================================
+
+.. automodule:: mixle.inference.freeze_rollup
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.inference.leaf_hotswap.rst
+++ b/docs/api/mixle.inference.leaf_hotswap.rst
@@ -1,0 +1,6 @@
+mixle.inference.leaf\_hotswap module
+====================================
+
+.. automodule:: mixle.inference.leaf_hotswap
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.inference.node_precision_plan.rst
+++ b/docs/api/mixle.inference.node_precision_plan.rst
@@ -1,0 +1,6 @@
+mixle.inference.node\_precision\_plan module
+============================================
+
+.. automodule:: mixle.inference.node_precision_plan
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.inference.node_report.rst
+++ b/docs/api/mixle.inference.node_report.rst
@@ -1,0 +1,6 @@
+mixle.inference.node\_report module
+===================================
+
+.. automodule:: mixle.inference.node_report
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.inference.rst
+++ b/docs/api/mixle.inference.rst
@@ -21,15 +21,20 @@ Submodules
    :maxdepth: 4
 
    mixle.inference._advi
+   mixle.inference.backend_respecialization
    mixle.inference.backends
    mixle.inference.bayesian_network
    mixle.inference.belief
    mixle.inference.blackbox
+   mixle.inference.block_em
    mixle.inference.block_gibbs
    mixle.inference.calibrate_fit
    mixle.inference.calibration
    mixle.inference.causal
+   mixle.inference.condition
+   mixle.inference.conditional_jit_controller
    mixle.inference.conformal
+   mixle.inference.copula_structure
    mixle.inference.create
    mixle.inference.cross_validation
    mixle.inference.decision
@@ -41,14 +46,18 @@ Submodules
    mixle.inference.explain
    mixle.inference.fisher
    mixle.inference.forecast
+   mixle.inference.freeze_rollup
    mixle.inference.fusion_policy
    mixle.inference.glm
    mixle.inference.gradient_fit
    mixle.inference.heterogeneous_executor
    mixle.inference.jit
+   mixle.inference.leaf_hotswap
    mixle.inference.model_comparison
    mixle.inference.mpi_executor
    mixle.inference.multiple_testing
+   mixle.inference.node_precision_plan
+   mixle.inference.node_report
    mixle.inference.nonparametric
    mixle.inference.objectives
    mixle.inference.orchestration
@@ -64,6 +73,7 @@ Submodules
    mixle.inference.reproduce
    mixle.inference.resampling
    mixle.inference.robust
+   mixle.inference.scenario
    mixle.inference.scoring
    mixle.inference.select
    mixle.inference.simulate

--- a/docs/api/mixle.inference.scenario.rst
+++ b/docs/api/mixle.inference.scenario.rst
@@ -1,0 +1,6 @@
+mixle.inference.scenario module
+===============================
+
+.. automodule:: mixle.inference.scenario
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.models.coarsening.rst
+++ b/docs/api/mixle.models.coarsening.rst
@@ -1,0 +1,6 @@
+mixle.models.coarsening module
+==============================
+
+.. automodule:: mixle.models.coarsening
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.models.compress.rst
+++ b/docs/api/mixle.models.compress.rst
@@ -1,0 +1,6 @@
+mixle.models.compress module
+============================
+
+.. automodule:: mixle.models.compress
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.models.eval_harness.rst
+++ b/docs/api/mixle.models.eval_harness.rst
@@ -1,0 +1,6 @@
+mixle.models.eval\_harness module
+=================================
+
+.. automodule:: mixle.models.eval_harness
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.models.grad_leaf.rst
+++ b/docs/api/mixle.models.grad_leaf.rst
@@ -1,0 +1,6 @@
+mixle.models.grad\_leaf module
+==============================
+
+.. automodule:: mixle.models.grad_leaf
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.models.memory_efficient_training.rst
+++ b/docs/api/mixle.models.memory_efficient_training.rst
@@ -1,0 +1,6 @@
+mixle.models.memory\_efficient\_training module
+===============================================
+
+.. automodule:: mixle.models.memory_efficient_training
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.models.moe.rst
+++ b/docs/api/mixle.models.moe.rst
@@ -1,0 +1,6 @@
+mixle.models.moe module
+=======================
+
+.. automodule:: mixle.models.moe
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.models.moment_propagation.rst
+++ b/docs/api/mixle.models.moment_propagation.rst
@@ -1,0 +1,6 @@
+mixle.models.moment\_propagation module
+=======================================
+
+.. automodule:: mixle.models.moment_propagation
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.models.mup.rst
+++ b/docs/api/mixle.models.mup.rst
@@ -1,0 +1,6 @@
+mixle.models.mup module
+=======================
+
+.. automodule:: mixle.models.mup
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.models.qat.rst
+++ b/docs/api/mixle.models.qat.rst
@@ -1,0 +1,6 @@
+mixle.models.qat module
+=======================
+
+.. automodule:: mixle.models.qat
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.models.rst
+++ b/docs/api/mixle.models.rst
@@ -15,30 +15,44 @@ Submodules
    mixle.models._kernels
    mixle.models._neural_serial
    mixle.models._result
+   mixle.models.coarsening
+   mixle.models.compress
    mixle.models.continual
    mixle.models.dependence
    mixle.models.dirichlet_process_mixture
    mixle.models.dpo_leaf
    mixle.models.embedding
    mixle.models.energy
+   mixle.models.eval_harness
    mixle.models.feature_map
    mixle.models.gaussian_process
+   mixle.models.grad_leaf
    mixle.models.grammar
    mixle.models.hamiltonian
    mixle.models.knowledge_graph
    mixle.models.language_model
+   mixle.models.memory_efficient_training
    mixle.models.mixture_density
+   mixle.models.moe
+   mixle.models.moment_propagation
+   mixle.models.mup
    mixle.models.neural
    mixle.models.neural_density
    mixle.models.neural_families
    mixle.models.neural_leaf
    mixle.models.partially_observable_markov_decision_process
    mixle.models.pinn
+   mixle.models.qat
    mixle.models.quotient
    mixle.models.random_forest
    mixle.models.random_graph
+   mixle.models.self_distillation
+   mixle.models.sigma_weighted_projection
    mixle.models.softmax_leaf
+   mixle.models.sorted_profile_quantizer
    mixle.models.sparse_gaussian_process
+   mixle.models.sparsity_2_4
    mixle.models.streaming_transformer_leaf
    mixle.models.train_search
    mixle.models.transformer
+   mixle.models.unified_quantizer

--- a/docs/api/mixle.models.self_distillation.rst
+++ b/docs/api/mixle.models.self_distillation.rst
@@ -1,0 +1,6 @@
+mixle.models.self\_distillation module
+======================================
+
+.. automodule:: mixle.models.self_distillation
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.models.sigma_weighted_projection.rst
+++ b/docs/api/mixle.models.sigma_weighted_projection.rst
@@ -1,0 +1,6 @@
+mixle.models.sigma\_weighted\_projection module
+===============================================
+
+.. automodule:: mixle.models.sigma_weighted_projection
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.models.sorted_profile_quantizer.rst
+++ b/docs/api/mixle.models.sorted_profile_quantizer.rst
@@ -1,0 +1,6 @@
+mixle.models.sorted\_profile\_quantizer module
+==============================================
+
+.. automodule:: mixle.models.sorted_profile_quantizer
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.models.sparsity_2_4.rst
+++ b/docs/api/mixle.models.sparsity_2_4.rst
@@ -1,0 +1,6 @@
+mixle.models.sparsity\_2\_4 module
+==================================
+
+.. automodule:: mixle.models.sparsity_2_4
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.models.unified_quantizer.rst
+++ b/docs/api/mixle.models.unified_quantizer.rst
@@ -1,0 +1,6 @@
+mixle.models.unified\_quantizer module
+======================================
+
+.. automodule:: mixle.models.unified_quantizer
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.ppl.rst
+++ b/docs/api/mixle.ppl.rst
@@ -29,6 +29,7 @@ Submodules
    mixle.ppl.provenance
    mixle.ppl.regression
    mixle.ppl.rough_paths
+   mixle.ppl.scaling_laws
    mixle.ppl.statespace
    mixle.ppl.summarize
    mixle.ppl.survival

--- a/docs/api/mixle.ppl.scaling_laws.rst
+++ b/docs/api/mixle.ppl.scaling_laws.rst
@@ -1,0 +1,6 @@
+mixle.ppl.scaling\_laws module
+==============================
+
+.. automodule:: mixle.ppl.scaling_laws
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.reason.cross_modal.rst
+++ b/docs/api/mixle.reason.cross_modal.rst
@@ -1,0 +1,6 @@
+mixle.reason.cross\_modal module
+================================
+
+.. automodule:: mixle.reason.cross_modal
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.reason.inference_program.rst
+++ b/docs/api/mixle.reason.inference_program.rst
@@ -1,0 +1,6 @@
+mixle.reason.inference\_program module
+======================================
+
+.. automodule:: mixle.reason.inference_program
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.reason.language_bridge.rst
+++ b/docs/api/mixle.reason.language_bridge.rst
@@ -1,0 +1,6 @@
+mixle.reason.language\_bridge module
+====================================
+
+.. automodule:: mixle.reason.language_bridge
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.reason.rst
+++ b/docs/api/mixle.reason.rst
@@ -15,6 +15,7 @@ Submodules
    mixle.reason.anchor_harness
    mixle.reason.belief_walk
    mixle.reason.core
+   mixle.reason.cross_modal
    mixle.reason.cycle_consistency
    mixle.reason.design
    mixle.reason.discrete
@@ -22,6 +23,8 @@ Submodules
    mixle.reason.encoder
    mixle.reason.fusion
    mixle.reason.graph_llm
+   mixle.reason.inference_program
+   mixle.reason.language_bridge
    mixle.reason.llm
    mixle.reason.modality
    mixle.reason.model
@@ -29,3 +32,4 @@ Submodules
    mixle.reason.store
    mixle.reason.task_projection
    mixle.reason.transport_edge
+   mixle.reason.zero_shot_bootstrap

--- a/docs/api/mixle.reason.zero_shot_bootstrap.rst
+++ b/docs/api/mixle.reason.zero_shot_bootstrap.rst
@@ -1,0 +1,6 @@
+mixle.reason.zero\_shot\_bootstrap module
+=========================================
+
+.. automodule:: mixle.reason.zero_shot_bootstrap
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.rst
+++ b/docs/api/mixle.rst
@@ -16,12 +16,13 @@ Subpackages
    mixle.doe
    mixle.engines
    mixle.enumeration
+   mixle.epistemic
    mixle.evolve
    mixle.experimental
    mixle.inference
    mixle.models
-   mixle.ppl
    mixle.pool
+   mixle.ppl
    mixle.reason
    mixle.represent
    mixle.stats

--- a/docs/api/mixle.stats.compute.error_receipts.rst
+++ b/docs/api/mixle.stats.compute.error_receipts.rst
@@ -1,0 +1,6 @@
+mixle.stats.compute.error\_receipts module
+==========================================
+
+.. automodule:: mixle.stats.compute.error_receipts
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.stats.compute.rst
+++ b/docs/api/mixle.stats.compute.rst
@@ -17,6 +17,7 @@ Submodules
    mixle.stats.compute.declarations
    mixle.stats.compute.decomposition
    mixle.stats.compute.encoded
+   mixle.stats.compute.error_receipts
    mixle.stats.compute.exp_family
    mixle.stats.compute.fused_codegen
    mixle.stats.compute.fused_kernels

--- a/docs/api/mixle.stats.multivariate._copula_common.rst
+++ b/docs/api/mixle.stats.multivariate._copula_common.rst
@@ -1,0 +1,6 @@
+mixle.stats.multivariate.\_copula\_common module
+================================================
+
+.. automodule:: mixle.stats.multivariate._copula_common
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.stats.multivariate.clayton_copula.rst
+++ b/docs/api/mixle.stats.multivariate.clayton_copula.rst
@@ -1,0 +1,6 @@
+mixle.stats.multivariate.clayton\_copula module
+===============================================
+
+.. automodule:: mixle.stats.multivariate.clayton_copula
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.stats.multivariate.frank_copula.rst
+++ b/docs/api/mixle.stats.multivariate.frank_copula.rst
@@ -1,0 +1,6 @@
+mixle.stats.multivariate.frank\_copula module
+=============================================
+
+.. automodule:: mixle.stats.multivariate.frank_copula
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.stats.multivariate.gumbel_copula.rst
+++ b/docs/api/mixle.stats.multivariate.gumbel_copula.rst
@@ -1,0 +1,6 @@
+mixle.stats.multivariate.gumbel\_copula module
+==============================================
+
+.. automodule:: mixle.stats.multivariate.gumbel_copula
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.stats.multivariate.rst
+++ b/docs/api/mixle.stats.multivariate.rst
@@ -11,11 +11,18 @@ Submodules
 .. toctree::
    :maxdepth: 4
 
+   mixle.stats.multivariate._copula_common
    mixle.stats.multivariate.categorical_multinomial
+   mixle.stats.multivariate.clayton_copula
    mixle.stats.multivariate.composition
    mixle.stats.multivariate.diagonal_gaussian
    mixle.stats.multivariate.dirichlet_multinomial
+   mixle.stats.multivariate.frank_copula
    mixle.stats.multivariate.gaussian_copula
+   mixle.stats.multivariate.gumbel_copula
    mixle.stats.multivariate.integer_multinomial
    mixle.stats.multivariate.multivariate_gaussian
    mixle.stats.multivariate.multivariate_student_t
+   mixle.stats.multivariate.rvine_copula
+   mixle.stats.multivariate.student_t_copula
+   mixle.stats.multivariate.vine_copula

--- a/docs/api/mixle.stats.multivariate.rvine_copula.rst
+++ b/docs/api/mixle.stats.multivariate.rvine_copula.rst
@@ -1,0 +1,6 @@
+mixle.stats.multivariate.rvine\_copula module
+=============================================
+
+.. automodule:: mixle.stats.multivariate.rvine_copula
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.stats.multivariate.student_t_copula.rst
+++ b/docs/api/mixle.stats.multivariate.student_t_copula.rst
@@ -1,0 +1,6 @@
+mixle.stats.multivariate.student\_t\_copula module
+==================================================
+
+.. automodule:: mixle.stats.multivariate.student_t_copula
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.stats.multivariate.vine_copula.rst
+++ b/docs/api/mixle.stats.multivariate.vine_copula.rst
@@ -1,0 +1,6 @@
+mixle.stats.multivariate.vine\_copula module
+============================================
+
+.. automodule:: mixle.stats.multivariate.vine_copula
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.task.acquire.rst
+++ b/docs/api/mixle.task.acquire.rst
@@ -1,0 +1,6 @@
+mixle.task.acquire module
+=========================
+
+.. automodule:: mixle.task.acquire
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.task.bandit.rst
+++ b/docs/api/mixle.task.bandit.rst
@@ -1,0 +1,6 @@
+mixle.task.bandit module
+========================
+
+.. automodule:: mixle.task.bandit
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.task.calibrated_generator.rst
+++ b/docs/api/mixle.task.calibrated_generator.rst
@@ -1,0 +1,6 @@
+mixle.task.calibrated\_generator module
+=======================================
+
+.. automodule:: mixle.task.calibrated_generator
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.task.checkpoint_family_ladder.rst
+++ b/docs/api/mixle.task.checkpoint_family_ladder.rst
@@ -1,0 +1,6 @@
+mixle.task.checkpoint\_family\_ladder module
+============================================
+
+.. automodule:: mixle.task.checkpoint_family_ladder
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.task.data_mixture.rst
+++ b/docs/api/mixle.task.data_mixture.rst
@@ -1,0 +1,6 @@
+mixle.task.data\_mixture module
+===============================
+
+.. automodule:: mixle.task.data_mixture
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.task.deploy_family.rst
+++ b/docs/api/mixle.task.deploy_family.rst
@@ -1,0 +1,6 @@
+mixle.task.deploy\_family module
+================================
+
+.. automodule:: mixle.task.deploy_family
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.task.discrepancy_invention_loop.rst
+++ b/docs/api/mixle.task.discrepancy_invention_loop.rst
@@ -1,0 +1,6 @@
+mixle.task.discrepancy\_invention\_loop module
+==============================================
+
+.. automodule:: mixle.task.discrepancy_invention_loop
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.task.emulate.rst
+++ b/docs/api/mixle.task.emulate.rst
@@ -1,0 +1,6 @@
+mixle.task.emulate module
+=========================
+
+.. automodule:: mixle.task.emulate
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.task.environment.rst
+++ b/docs/api/mixle.task.environment.rst
@@ -1,0 +1,6 @@
+mixle.task.environment module
+=============================
+
+.. automodule:: mixle.task.environment
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.task.frontier_to_native.rst
+++ b/docs/api/mixle.task.frontier_to_native.rst
@@ -1,0 +1,6 @@
+mixle.task.frontier\_to\_native module
+======================================
+
+.. automodule:: mixle.task.frontier_to_native
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.task.inverse.rst
+++ b/docs/api/mixle.task.inverse.rst
@@ -1,0 +1,6 @@
+mixle.task.inverse module
+=========================
+
+.. automodule:: mixle.task.inverse
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.task.pilot_ladder.rst
+++ b/docs/api/mixle.task.pilot_ladder.rst
@@ -1,0 +1,6 @@
+mixle.task.pilot\_ladder module
+===============================
+
+.. automodule:: mixle.task.pilot_ladder
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.task.rst
+++ b/docs/api/mixle.task.rst
@@ -11,36 +11,48 @@ Submodules
 .. toctree::
    :maxdepth: 4
 
+   mixle.task.acquire
    mixle.task.active
    mixle.task.artifact
+   mixle.task.bandit
    mixle.task.calibrate
+   mixle.task.calibrated_generator
    mixle.task.capability
    mixle.task.capacity
    mixle.task.cascade
+   mixle.task.checkpoint_family_ladder
    mixle.task.collapse
    mixle.task.compose
    mixle.task.constrained
+   mixle.task.data_mixture
    mixle.task.density
+   mixle.task.deploy_family
    mixle.task.design
    mixle.task.design_prior
    mixle.task.disagreement
+   mixle.task.discrepancy_invention_loop
    mixle.task.distill
    mixle.task.distill_methods
    mixle.task.distill_soft
    mixle.task.economics
    mixle.task.edge
+   mixle.task.emulate
+   mixle.task.environment
    mixle.task.explore_world
    mixle.task.extract
+   mixle.task.frontier_to_native
    mixle.task.generative_capability
    mixle.task.generative_text
    mixle.task.harness
    mixle.task.imagine
+   mixle.task.inverse
    mixle.task.irl
    mixle.task.llm
    mixle.task.model
    mixle.task.multilabel
    mixle.task.orchestrate
    mixle.task.outcome_decomposer
+   mixle.task.pilot_ladder
    mixle.task.plan
    mixle.task.plan_model
    mixle.task.plan_refine
@@ -57,6 +69,8 @@ Submodules
    mixle.task.sft_plan
    mixle.task.solve
    mixle.task.structured_out
+   mixle.task.task_decomposition
    mixle.task.toolcall
    mixle.task.traces
    mixle.task.tune
+   mixle.task.vlm

--- a/docs/api/mixle.task.task_decomposition.rst
+++ b/docs/api/mixle.task.task_decomposition.rst
@@ -1,0 +1,6 @@
+mixle.task.task\_decomposition module
+=====================================
+
+.. automodule:: mixle.task.task_decomposition
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.task.vlm.rst
+++ b/docs/api/mixle.task.vlm.rst
@@ -1,0 +1,6 @@
+mixle.task.vlm module
+=====================
+
+.. automodule:: mixle.task.vlm
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.utils.automatic.detectors.beta_binomial.rst
+++ b/docs/api/mixle.utils.automatic.detectors.beta_binomial.rst
@@ -1,0 +1,6 @@
+mixle.utils.automatic.detectors.beta\_binomial module
+=====================================================
+
+.. automodule:: mixle.utils.automatic.detectors.beta_binomial
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.utils.automatic.detectors.binomial.rst
+++ b/docs/api/mixle.utils.automatic.detectors.binomial.rst
@@ -1,0 +1,6 @@
+mixle.utils.automatic.detectors.binomial module
+===============================================
+
+.. automodule:: mixle.utils.automatic.detectors.binomial
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.utils.automatic.detectors.geometric.rst
+++ b/docs/api/mixle.utils.automatic.detectors.geometric.rst
@@ -1,0 +1,6 @@
+mixle.utils.automatic.detectors.geometric module
+================================================
+
+.. automodule:: mixle.utils.automatic.detectors.geometric
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.utils.automatic.detectors.half_normal.rst
+++ b/docs/api/mixle.utils.automatic.detectors.half_normal.rst
@@ -1,0 +1,6 @@
+mixle.utils.automatic.detectors.half\_normal module
+===================================================
+
+.. automodule:: mixle.utils.automatic.detectors.half_normal
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.utils.automatic.detectors.inverse_gamma.rst
+++ b/docs/api/mixle.utils.automatic.detectors.inverse_gamma.rst
@@ -1,0 +1,6 @@
+mixle.utils.automatic.detectors.inverse\_gamma module
+=====================================================
+
+.. automodule:: mixle.utils.automatic.detectors.inverse_gamma
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.utils.automatic.detectors.rayleigh.rst
+++ b/docs/api/mixle.utils.automatic.detectors.rayleigh.rst
@@ -1,0 +1,6 @@
+mixle.utils.automatic.detectors.rayleigh module
+===============================================
+
+.. automodule:: mixle.utils.automatic.detectors.rayleigh
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.utils.automatic.detectors.rst
+++ b/docs/api/mixle.utils.automatic.detectors.rst
@@ -12,16 +12,22 @@ Submodules
    :maxdepth: 4
 
    mixle.utils.automatic.detectors.beta
+   mixle.utils.automatic.detectors.beta_binomial
+   mixle.utils.automatic.detectors.binomial
    mixle.utils.automatic.detectors.exgaussian
    mixle.utils.automatic.detectors.generalized_extreme_value
    mixle.utils.automatic.detectors.generalized_gaussian
    mixle.utils.automatic.detectors.generalized_pareto
+   mixle.utils.automatic.detectors.geometric
    mixle.utils.automatic.detectors.gumbel
+   mixle.utils.automatic.detectors.half_normal
+   mixle.utils.automatic.detectors.inverse_gamma
    mixle.utils.automatic.detectors.inverse_gaussian
    mixle.utils.automatic.detectors.laplace
    mixle.utils.automatic.detectors.logistic
    mixle.utils.automatic.detectors.negative_binomial
    mixle.utils.automatic.detectors.pareto
+   mixle.utils.automatic.detectors.rayleigh
    mixle.utils.automatic.detectors.skew_normal
    mixle.utils.automatic.detectors.tweedie
    mixle.utils.automatic.detectors.weibull

--- a/docs/api/mixle.utils.hvis.direct.rst
+++ b/docs/api/mixle.utils.hvis.direct.rst
@@ -1,0 +1,6 @@
+mixle.utils.hvis.direct module
+==============================
+
+.. automodule:: mixle.utils.hvis.direct
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.utils.hvis.distributed.rst
+++ b/docs/api/mixle.utils.hvis.distributed.rst
@@ -1,0 +1,6 @@
+mixle.utils.hvis.distributed module
+===================================
+
+.. automodule:: mixle.utils.hvis.distributed
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.utils.hvis.front.rst
+++ b/docs/api/mixle.utils.hvis.front.rst
@@ -1,0 +1,6 @@
+mixle.utils.hvis.front module
+=============================
+
+.. automodule:: mixle.utils.hvis.front
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.utils.hvis.goals.rst
+++ b/docs/api/mixle.utils.hvis.goals.rst
@@ -1,0 +1,6 @@
+mixle.utils.hvis.goals module
+=============================
+
+.. automodule:: mixle.utils.hvis.goals
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.utils.hvis.rst
+++ b/docs/api/mixle.utils.hvis.rst
@@ -12,6 +12,13 @@ Submodules
    :maxdepth: 4
 
    mixle.utils.hvis.affinity
+   mixle.utils.hvis.direct
+   mixle.utils.hvis.distributed
    mixle.utils.hvis.embed
+   mixle.utils.hvis.front
+   mixle.utils.hvis.goals
    mixle.utils.hvis.neighbors
+   mixle.utils.hvis.stream
+   mixle.utils.hvis.topology
    mixle.utils.hvis.tsne
+   mixle.utils.hvis.umap_np

--- a/docs/api/mixle.utils.hvis.stream.rst
+++ b/docs/api/mixle.utils.hvis.stream.rst
@@ -1,0 +1,6 @@
+mixle.utils.hvis.stream module
+==============================
+
+.. automodule:: mixle.utils.hvis.stream
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.utils.hvis.topology.rst
+++ b/docs/api/mixle.utils.hvis.topology.rst
@@ -1,0 +1,6 @@
+mixle.utils.hvis.topology module
+================================
+
+.. automodule:: mixle.utils.hvis.topology
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.utils.hvis.umap_np.rst
+++ b/docs/api/mixle.utils.hvis.umap_np.rst
@@ -1,0 +1,6 @@
+mixle.utils.hvis.umap\_np module
+================================
+
+.. automodule:: mixle.utils.hvis.umap_np
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.utils.parallel.context_parallel_spine.rst
+++ b/docs/api/mixle.utils.parallel.context_parallel_spine.rst
@@ -1,0 +1,6 @@
+mixle.utils.parallel.context\_parallel\_spine module
+====================================================
+
+.. automodule:: mixle.utils.parallel.context_parallel_spine
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.utils.parallel.em_observability.rst
+++ b/docs/api/mixle.utils.parallel.em_observability.rst
@@ -1,0 +1,6 @@
+mixle.utils.parallel.em\_observability module
+=============================================
+
+.. automodule:: mixle.utils.parallel.em_observability
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.utils.parallel.fault_tolerant_training.rst
+++ b/docs/api/mixle.utils.parallel.fault_tolerant_training.rst
@@ -1,0 +1,6 @@
+mixle.utils.parallel.fault\_tolerant\_training module
+=====================================================
+
+.. automodule:: mixle.utils.parallel.fault_tolerant_training
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.utils.parallel.resilient_em.rst
+++ b/docs/api/mixle.utils.parallel.resilient_em.rst
@@ -1,0 +1,6 @@
+mixle.utils.parallel.resilient\_em module
+=========================================
+
+.. automodule:: mixle.utils.parallel.resilient_em
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.utils.parallel.rst
+++ b/docs/api/mixle.utils.parallel.rst
@@ -12,7 +12,10 @@ Submodules
    :maxdepth: 4
 
    mixle.utils.parallel.balance
+   mixle.utils.parallel.context_parallel_spine
    mixle.utils.parallel.dcp_checkpoint
+   mixle.utils.parallel.em_observability
+   mixle.utils.parallel.fault_tolerant_training
    mixle.utils.parallel.lightning_data
    mixle.utils.parallel.model_decomposition
    mixle.utils.parallel.model_parallel
@@ -20,5 +23,9 @@ Submodules
    mixle.utils.parallel.multiprocessing
    mixle.utils.parallel.planner
    mixle.utils.parallel.ray_data
+   mixle.utils.parallel.resilient_em
+   mixle.utils.parallel.sdc_audit
+   mixle.utils.parallel.tensor_pipeline_context_parallel
    mixle.utils.parallel.torch_neural
    mixle.utils.parallel.torchrun
+   mixle.utils.parallel.training_health

--- a/docs/api/mixle.utils.parallel.sdc_audit.rst
+++ b/docs/api/mixle.utils.parallel.sdc_audit.rst
@@ -1,0 +1,6 @@
+mixle.utils.parallel.sdc\_audit module
+======================================
+
+.. automodule:: mixle.utils.parallel.sdc_audit
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.utils.parallel.tensor_pipeline_context_parallel.rst
+++ b/docs/api/mixle.utils.parallel.tensor_pipeline_context_parallel.rst
@@ -1,0 +1,6 @@
+mixle.utils.parallel.tensor\_pipeline\_context\_parallel module
+===============================================================
+
+.. automodule:: mixle.utils.parallel.tensor_pipeline_context_parallel
+   :members:
+   :show-inheritance:

--- a/docs/api/mixle.utils.parallel.training_health.rst
+++ b/docs/api/mixle.utils.parallel.training_health.rst
@@ -1,0 +1,6 @@
+mixle.utils.parallel.training\_health module
+============================================
+
+.. automodule:: mixle.utils.parallel.training_health
+   :members:
+   :show-inheritance:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -95,8 +95,3 @@ happened when the branch is still a release candidate. Until tags, package
 metadata, built artifacts, and family manifests are aligned, use
 "release candidate", "release branch", or "pre-publication evidence" rather than
 phrases that imply a published package.
-
-Previous Releases
------------------
-
-See :doc:`previous-releases` for the previous documented release.

--- a/docs/example-execution-manifest.rst
+++ b/docs/example-execution-manifest.rst
@@ -39,9 +39,30 @@ The core package currently ships 48 Python example scripts:
 Release Execution Status
 ------------------------
 
-The current documentation state does not prove these examples execute against
-the release wheel. A public release should run examples from a clean install,
-not from a warm checkout or ``PYTHONPATH``.
+The 23 base-install ("Execute.") examples were run against the built
+``mixle-0.6.3`` wheel, installed into a bare venv (``pip install dist/mixle-0.6.3-py3-none-any.whl``,
+no extras, no editable install, no ``PYTHONPATH``), each with a 90s budget:
+
+* **21 passed**: ``enumeration_example.py``, ``extensibility_seams_example.py``,
+  ``gallery_combinators_example.py``, ``gallery_directional_example.py``,
+  ``gallery_graphs_example.py``, ``gallery_multivariate_example.py``,
+  ``gallery_processes_example.py``, ``gallery_rankings_example.py``,
+  ``gallery_structured_example.py``, ``gallery_univariate_example.py``,
+  ``heterogeneous_correctness_example.py``, ``hidden_association_example.py``,
+  ``hierarchical_mixture_example.py``, ``joint_mixture_example.py``,
+  ``latent_variable_models_example.py``, ``lookback_hmm_example.py``,
+  ``ppl_example.py``, ``semi_supervised_mixture_example.py``,
+  ``structure_learning_example.py``, ``structured_hmm_example.py``,
+  ``structured_leaves_example.py``.
+* **2 reclassified to blocked** (see the Inventory table below):
+  ``skeptic_challenge_example.py`` (needs ``scikit-learn``, not a mixle
+  dependency) and ``win_demo_example.py`` (needs ``torch``; its distillation
+  path has no classical fallback).
+
+The remaining examples (task/DOE/reasoning/vision workflows) were not executed
+in this pass -- they need optional extras, external datasets, model weights, or
+services per their Inventory entries below, none of which are provisioned in
+this environment.
 
 Execution status should be recorded as evidence, not inferred from import
 success or from an earlier notebook run. If an example writes an artifact, the
@@ -184,7 +205,9 @@ Inventory
    * - ``examples/shared_embedding_example.py``
      - Execute with optional-dependency status recorded.
    * - ``examples/skeptic_challenge_example.py``
-     - Execute.
+     - Blocked on ``scikit-learn`` (Act 1's sklearn-baseline comparison
+       imports it directly; not a mixle dependency or extra, install
+       separately to run).
    * - ``examples/structure_learning_example.py``
      - Execute.
    * - ``examples/structured_hmm_example.py``
@@ -204,7 +227,9 @@ Inventory
    * - ``examples/vision_edge_distillation/verify_on_laptop.py``
      - Execute when the distilled artifact exists; otherwise blocked.
    * - ``examples/win_demo_example.py``
-     - Execute.
+     - Blocked on ``torch`` (``solve()``'s MLP distillation path
+       (``mixle.task.distill._fit_mlp``) always needs torch, no classical
+       fallback; ``pip install mixle[torch]``).
 
 Evidence to Record
 ------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -206,7 +206,7 @@ reference under :doc:`api/modules` covers the broad public module surface;
    stability-and-missing-data
    family-release
    release-notes
-   previous-releases
+   example-execution-manifest
    changelog
 
 .. toctree::

--- a/mixle/experimental/long_context_eval.py
+++ b/mixle/experimental/long_context_eval.py
@@ -65,8 +65,12 @@ from typing import Any
 import numpy as np
 
 from mixle.experimental.context_spine import ContextMechanism, train_tbptt
-from mixle.ppl.scaling_laws import FLOPS_PER_TOKEN_PARAM
 from mixle.task.bandit import ThompsonBernoulli
+
+# Same "6ND" FLOPs-per-token-per-param heuristic as mixle.ppl.scaling_laws.FLOPS_PER_TOKEN_PARAM,
+# duplicated (not imported) so this module doesn't import upward from mixle.ppl -- core modules
+# must stay ppl -> core, never the reverse (see ppl_separation_test.py).
+_FLOPS_PER_TOKEN_PARAM = 6.0
 
 try:
     import torch
@@ -276,7 +280,7 @@ def _n_params(mechanism: ContextMechanism) -> int:
 def _flops_for(mechanism: ContextMechanism, n_tokens: int) -> float:
     """``6 * n_params * n_tokens`` -- the same dense-Transformer FLOPs approximation
     :mod:`mixle.ppl.scaling_laws` uses for training-compute allocation (Kaplan et al. 2020)."""
-    return FLOPS_PER_TOKEN_PARAM * float(_n_params(mechanism)) * float(n_tokens)
+    return _FLOPS_PER_TOKEN_PARAM * float(_n_params(mechanism)) * float(n_tokens)
 
 
 def _state_bytes(state: Any) -> int:

--- a/mixle/experimental/moment_closure_attention.py
+++ b/mixle/experimental/moment_closure_attention.py
@@ -50,12 +50,11 @@ try:
 except ImportError:  # pragma: no cover - torch is optional
     _HAS_TORCH = False
 
-from mixle.experimental.context_spine import (
-    SlidingWindowState,
-    _apply_rope,
-    _rope_angles,
-)
+from mixle.experimental.context_spine import SlidingWindowState
 from mixle.inference.structure import _split_separation
+
+if _HAS_TORCH:
+    from mixle.experimental.context_spine import _apply_rope, _rope_angles
 
 __all__ = [
     "E2_UNAVAILABLE_PIECES",

--- a/mixle/experimental/retrieval_memory_spine.py
+++ b/mixle/experimental/retrieval_memory_spine.py
@@ -49,7 +49,8 @@ except ImportError:  # pragma: no cover - torch is optional
 # and the archived index (entries are stored post-RoPE, same as SlidingWindowSpine's cache -- see that
 # module's docstring). E2-E6 are documented to "differ only in what step's carried state contains"; the
 # positional-encoding convention is shared substrate, not a per-mechanism choice.
-from mixle.experimental.context_spine import _apply_rope, _rope_angles  # noqa: E402
+if _HAS_TORCH:
+    from mixle.experimental.context_spine import _apply_rope, _rope_angles  # noqa: E402
 
 __all__ = [
     "RETRIEVAL_MEMORY_UNAVAILABLE_PIECES",

--- a/mixle/experimental/selective_scan.py
+++ b/mixle/experimental/selective_scan.py
@@ -42,7 +42,6 @@ class SelectiveScanState:
 
 
 if _HAS_TORCH:
-
     # dt_proj bias init: choose the bias so softplus(bias) is log-uniform in [_DT_MIN, _DT_MAX], then invert
     # softplus -- exactly Mamba's `Mamba.__init__` dt-bias init (verified directly against the mamba-ssm
     # 2.3.2.post1 sdist source, mamba_ssm/modules/mamba_simple.py, not from memory -- see notes/designs/E5.md
@@ -118,7 +117,9 @@ if _HAS_TORCH:
         bookkeeping needed since the state is already fixed-size.
         """
 
-        def __init__(self, vocab: int, *, d_model: int = 32, d_state: int = 16, n_layer: int = 2, expand: int = 2) -> None:
+        def __init__(
+            self, vocab: int, *, d_model: int = 32, d_state: int = 16, n_layer: int = 2, expand: int = 2
+        ) -> None:
             super().__init__()
             self.vocab = int(vocab)
             self.d_model = int(d_model)
@@ -146,7 +147,9 @@ if _HAS_TORCH:
             self.head.weight = self.tok.weight  # weight tying, matching SlidingWindowSpine's convention
 
             # S4D-real init (see _s4d_real_a_log_init) -- one A_log per (layer, d_inner, d_state).
-            self.A_log = nn.Parameter(torch.stack([_s4d_real_a_log_init(self.d_inner, d_state) for _ in range(n_layer)]))
+            self.A_log = nn.Parameter(
+                torch.stack([_s4d_real_a_log_init(self.d_inner, d_state) for _ in range(n_layer)])
+            )
             self.A_log._no_weight_decay = True
             self.D = nn.Parameter(torch.ones(n_layer, self.d_inner))
             self.D._no_weight_decay = True
@@ -175,7 +178,13 @@ if _HAS_TORCH:
                 hn = self.ln1[layer](h)
                 u = self.in_proj[layer](hn)
                 h_last, y_out = _scan_layer(
-                    u, self.A_log[layer], self.W_delta[layer], self.W_B[layer], self.W_C[layer], self.D[layer], state.h[layer]
+                    u,
+                    self.A_log[layer],
+                    self.W_delta[layer],
+                    self.W_B[layer],
+                    self.W_C[layer],
+                    self.D[layer],
+                    state.h[layer],
                 )
                 h = h + self.out_proj[layer](y_out)
                 h = h + self.mlp[layer](self.ln2[layer](h))

--- a/mixle/experimental/sketch_state_attention.py
+++ b/mixle/experimental/sketch_state_attention.py
@@ -38,8 +38,6 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
-from mixle.experimental.context_spine import _apply_rope, _rope_angles
-
 try:
     import torch
     import torch.nn as nn
@@ -48,6 +46,9 @@ try:
     _HAS_TORCH = True
 except ImportError:  # pragma: no cover - torch is optional
     _HAS_TORCH = False
+
+if _HAS_TORCH:
+    from mixle.experimental.context_spine import _apply_rope, _rope_angles
 
 __all__ = [
     "LinearAttentionState",

--- a/mixle/experimental/ssm_hybrid.py
+++ b/mixle/experimental/ssm_hybrid.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
-from mixle.experimental.context_spine import SlidingWindowState, _apply_rope, _rope_angles
+from mixle.experimental.context_spine import SlidingWindowState
 from mixle.experimental.graduation import REGISTRY, ExperimentalMechanism
 from mixle.experimental.moment_closure_attention import (
     ClusterBank,
@@ -32,7 +32,6 @@ from mixle.experimental.moment_closure_attention import (
     mgf_cluster_attention,
     update_cluster_bank,
 )
-from mixle.experimental.selective_scan import _dt_bias_init, _s4d_real_a_log_init, _scan_layer
 
 try:
     import torch
@@ -42,6 +41,10 @@ try:
     _HAS_TORCH = True
 except ImportError:  # pragma: no cover - torch is optional
     _HAS_TORCH = False
+
+if _HAS_TORCH:
+    from mixle.experimental.context_spine import _apply_rope, _rope_angles
+    from mixle.experimental.selective_scan import _dt_bias_init, _s4d_real_a_log_init, _scan_layer
 
 __all__ = ["HybridState", "HybridBlock"]
 

--- a/mixle/experimental/structure_edit_schedule.py
+++ b/mixle/experimental/structure_edit_schedule.py
@@ -56,7 +56,7 @@ from mixle.inference.conditional_jit_controller import (
     ControllerAction,
     LearnedController,
 )
-from mixle.models.coarsening import CoarsenedLM, ProjectionReceipt, depth_merge
+from mixle.models.coarsening import ProjectionReceipt, depth_merge
 from mixle.models.moment_propagation import GaussianLaw
 from mixle.models.sigma_weighted_projection import (
     sigma_weighted_block_sparse,
@@ -73,6 +73,9 @@ try:
     _HAS_TORCH = True
 except ImportError:  # pragma: no cover - torch is optional
     _HAS_TORCH = False
+
+if _HAS_TORCH:
+    from mixle.models.coarsening import CoarsenedLM
 
 __all__ = [
     "STRUCTURE_EDIT_REGISTRY",

--- a/mixle/experimental/summary_tree.py
+++ b/mixle/experimental/summary_tree.py
@@ -39,7 +39,7 @@ from __future__ import annotations
 from dataclasses import dataclass, replace
 from typing import Any
 
-from mixle.experimental.context_spine import SlidingWindowState, _apply_rope, _rope_angles
+from mixle.experimental.context_spine import SlidingWindowState
 from mixle.experimental.graduation import REGISTRY, ExperimentalMechanism
 
 try:
@@ -50,6 +50,9 @@ try:
     _HAS_TORCH = True
 except ImportError:  # pragma: no cover - torch is optional
     _HAS_TORCH = False
+
+if _HAS_TORCH:
+    from mixle.experimental.context_spine import _apply_rope, _rope_angles
 
 __all__ = [
     "TreeNode",

--- a/mixle/models/dpo_leaf.py
+++ b/mixle/models/dpo_leaf.py
@@ -21,12 +21,13 @@ from typing import Any
 import numpy as np
 
 from mixle.models._neural_serial import decode_module, encode_module
-from mixle.models.grad_leaf import DataBufferAccumulatorFactory
 from mixle.stats.compute.pdist import (
     DataSequenceEncoder,
     DistributionSampler,
     ParameterEstimator,
     SequenceEncodableProbabilityDistribution,
+    SequenceEncodableStatisticAccumulator,
+    StatisticAccumulatorFactory,
 )
 
 
@@ -208,7 +209,7 @@ class DPOAccumulator(SequenceEncodableStatisticAccumulator):
 
     def value(self) -> tuple:
         """Return buffered contexts, chosen actions, rejected actions, and weights."""
-        return (list(self.x), list(self.ch), list(self.rj), list(self.w))
+        return (list(self.x), list(self.ch), list(self.rj), np.asarray(self.w, dtype=float))
 
     def from_value(self, v: tuple) -> DPOAccumulator:
         """Restore accumulator buffers from a value tuple."""
@@ -239,8 +240,6 @@ class DPOModelEstimator(ParameterEstimator):
         self.lr = float(lr)
         self.device = device
 
-    def accumulator_factory(self) -> DataBufferAccumulatorFactory:
-        return DataBufferAccumulatorFactory(DPOEncoder(), n_fields=3)
     def accumulator_factory(self) -> DPOAccumulatorFactory:
         """Return an accumulator factory for weighted preference triples."""
         return DPOAccumulatorFactory()

--- a/mixle/models/energy.py
+++ b/mixle/models/energy.py
@@ -24,12 +24,13 @@ from typing import Any
 import numpy as np
 
 from mixle.models._neural_serial import check_finite, decode_module, encode_module
-from mixle.models.grad_leaf import DataBufferAccumulatorFactory
 from mixle.stats.compute.pdist import (
     DataSequenceEncoder,
     DistributionSampler,
     ParameterEstimator,
     SequenceEncodableProbabilityDistribution,
+    SequenceEncodableStatisticAccumulator,
+    StatisticAccumulatorFactory,
 )
 
 
@@ -270,8 +271,6 @@ class EnergyModelEstimator(ParameterEstimator):
         self.device = device
         self.name = name
 
-    def accumulator_factory(self) -> DataBufferAccumulatorFactory:
-        return DataBufferAccumulatorFactory(EnergyModelEncoder(), n_fields=1)
     def accumulator_factory(self) -> EnergyModelAccumulatorFactory:
         """Return an accumulator factory for weighted NCE batches."""
         return EnergyModelAccumulatorFactory()

--- a/mixle/models/mixture_density.py
+++ b/mixle/models/mixture_density.py
@@ -28,12 +28,13 @@ from typing import Any
 import numpy as np
 
 from mixle.models._neural_serial import check_finite, decode_module, encode_module
-from mixle.models.grad_leaf import DataBufferAccumulatorFactory
 from mixle.stats.compute.pdist import (
     DataSequenceEncoder,
     DistributionSampler,
     ParameterEstimator,
     SequenceEncodableProbabilityDistribution,
+    SequenceEncodableStatisticAccumulator,
+    StatisticAccumulatorFactory,
 )
 
 
@@ -296,8 +297,6 @@ class NeuralConditionalDensityEstimator(ParameterEstimator):
         self.device = device
         self.name = name
 
-    def accumulator_factory(self) -> DataBufferAccumulatorFactory:
-        return DataBufferAccumulatorFactory(NeuralConditionalDensityEncoder(), n_fields=2)
     def accumulator_factory(self) -> NeuralConditionalDensityAccumulatorFactory:
         """Return an accumulator factory for weighted conditional-density batches."""
         return NeuralConditionalDensityAccumulatorFactory()

--- a/mixle/models/neural_density.py
+++ b/mixle/models/neural_density.py
@@ -21,8 +21,15 @@ from typing import Any
 
 import numpy as np
 
-from mixle.models._neural_serial import decode_module, encode_module
-from mixle.models.grad_leaf import GradEstimator, GradLeaf
+from mixle.models._neural_serial import check_finite, decode_module, encode_module
+from mixle.models.grad_leaf import GradLeaf
+from mixle.stats.compute.pdist import (
+    DataSequenceEncoder,
+    DistributionSampler,
+    ParameterEstimator,
+    SequenceEncodableStatisticAccumulator,
+    StatisticAccumulatorFactory,
+)
 
 
 def _torch() -> Any:
@@ -40,16 +47,6 @@ class NeuralDensity(GradLeaf):
     pass through (see the grad_leaf module docstring for the control story).
     """
 
-    def estimator(self, pseudo_count: float | None = None) -> NeuralDensityEstimator:
-        return NeuralDensityEstimator(
-            self.module,
-            m_steps=self.m_steps,
-            lr=self.lr,
-            device=self.device,
-            name=self.name,
-            loss=self.loss,
-            optimizer=self.optimizer,
-        )
     __pysp_serializable__ = True  # module persisted as bytes (see __pysp_getstate__); leaf round-trips in a mixture
 
     def __init__(
@@ -122,19 +119,6 @@ class NeuralDensity(GradLeaf):
         )
 
 
-class NeuralDensityEstimator(GradEstimator):
-    """M-step: responsibility-weighted MLE -- ``max sum_i w_i log p(x_i)`` by gradient ascent on the module (warm)."""
-
-    def _leaf(self) -> NeuralDensity:
-        return NeuralDensity(
-            self.module,
-            m_steps=self.m_steps,
-            lr=self.lr,
-            device=self.device,
-            name=self.name,
-            loss=self.loss,
-            optimizer=self.optimizer,
-        )
 class NeuralDensitySampler(DistributionSampler):
     """Sampler for wrapped neural density modules exposing ``sample(n)``."""
 

--- a/mixle/models/neural_leaf.py
+++ b/mixle/models/neural_leaf.py
@@ -24,12 +24,14 @@ from typing import Any
 import numpy as np
 
 from mixle.models._neural_serial import check_finite, decode_module, encode_module
-from mixle.models.grad_leaf import DataBufferAccumulatorFactory, _resolve_device
+from mixle.models.grad_leaf import _resolve_device
 from mixle.stats.compute.pdist import (
     DataSequenceEncoder,
     DistributionSampler,
     ParameterEstimator,
     SequenceEncodableProbabilityDistribution,
+    SequenceEncodableStatisticAccumulator,
+    StatisticAccumulatorFactory,
 )
 
 
@@ -280,8 +282,6 @@ class NeuralGaussianEstimator(ParameterEstimator):
         self.name = name
         self.device = device
 
-    def accumulator_factory(self) -> DataBufferAccumulatorFactory:
-        return DataBufferAccumulatorFactory(NeuralGaussianEncoder(), n_fields=2)
     def accumulator_factory(self) -> NeuralGaussianAccumulatorFactory:
         """Return an accumulator factory for weighted neural-regression batches."""
         return NeuralGaussianAccumulatorFactory()

--- a/mixle/models/pinn.py
+++ b/mixle/models/pinn.py
@@ -45,9 +45,9 @@ from typing import Any
 import numpy as np
 
 from mixle.models._neural_serial import decode_module, encode_module
-from mixle.models.grad_leaf import DataBufferAccumulatorFactory
 from mixle.models.neural_leaf import (
     NeuralGaussian,
+    NeuralGaussianAccumulatorFactory,
     NeuralGaussianEncoder,
     NeuralGaussianEstimator,
     _resolve_device,
@@ -203,8 +203,6 @@ class PINNRegressionEstimator(NeuralGaussianEstimator):
         self.seed = int(seed)
         self._rng = np.random.RandomState(self.seed)
 
-    def accumulator_factory(self) -> DataBufferAccumulatorFactory:
-        return DataBufferAccumulatorFactory(NeuralGaussianEncoder(), n_fields=2)
     def accumulator_factory(self) -> NeuralGaussianAccumulatorFactory:
         """Return the neural-Gaussian accumulator factory for weighted observation pairs."""
         return NeuralGaussianAccumulatorFactory()

--- a/mixle/models/self_distillation.py
+++ b/mixle/models/self_distillation.py
@@ -82,7 +82,6 @@ class EMATeacher:
         for p in self.ema_model.parameters():
             p.requires_grad_(False)
 
-    @torch.no_grad()
     def update(self, student_model: Any) -> None:
         """One EMA step: pull every teacher tensor toward the student's current value.
 
@@ -91,6 +90,13 @@ class EMATeacher:
         to that storage more than once per step (a double update). ``seen`` dedupes by storage identity
         (``data_ptr()``) so every real tensor is updated exactly once, however many names alias it.
         """
+        # Not a @torch.no_grad() decorator: that evaluates torch.no_grad at class-definition (import)
+        # time, which breaks this class's whole point of being importable without torch installed
+        # (see _require_torch() in __init__). A `with` block defers the torch reference to call time.
+        with torch.no_grad():
+            self._update_impl(student_model)
+
+    def _update_impl(self, student_model: Any) -> None:
         d = self.decay
         student_state = student_model.state_dict()
         seen: set = set()

--- a/mixle/models/softmax_leaf.py
+++ b/mixle/models/softmax_leaf.py
@@ -23,12 +23,13 @@ from typing import Any
 import numpy as np
 
 from mixle.models._neural_serial import check_finite, decode_module, encode_module
-from mixle.models.grad_leaf import DataBufferAccumulatorFactory
 from mixle.stats.compute.pdist import (
     DataSequenceEncoder,
     DistributionSampler,
     ParameterEstimator,
     SequenceEncodableProbabilityDistribution,
+    SequenceEncodableStatisticAccumulator,
+    StatisticAccumulatorFactory,
 )
 
 
@@ -275,8 +276,6 @@ class NeuralCategoricalEstimator(ParameterEstimator):
         # ewc = (anchor_params, fisher_diag, lambda): the EWC anti-forgetting penalty for continued pretraining
         self.ewc = ewc
 
-    def accumulator_factory(self) -> DataBufferAccumulatorFactory:
-        return DataBufferAccumulatorFactory(NeuralCategoricalEncoder(), n_fields=2)
     def accumulator_factory(self) -> NeuralCategoricalAccumulatorFactory:
         """Return an accumulator factory for weighted classification batches."""
         return NeuralCategoricalAccumulatorFactory()

--- a/mixle/reason/zero_shot_bootstrap.py
+++ b/mixle/reason/zero_shot_bootstrap.py
@@ -226,7 +226,11 @@ def _fit_generic_grad_density(arr: np.ndarray, *, max_its: int, n_components: in
     dim = arr.shape[1]
     module = _GenericDensityModule(dim, n_components=n_components)
     estimator = GradEstimator(module, m_steps=max(60, int(max_its) * 10))
-    data = [tuple(float(v) for v in row) for row in arr]
+    # NOT a tuple per row: GradLeafEncoder.seq_encode treats a tuple observation as one field PER
+    # POSITION (the conditional log_density(x, y, ...) convention) -- a 24-dim row as a 24-tuple was
+    # being split into 24 separate scalar fields instead of one vector field, so the module's
+    # log_density(x) (a single positional arg) was being called with 24 unpacked scalars.
+    data = [np.asarray(row, dtype=float) for row in arr]
     return optimize(data, estimator, max_its=1)
 
 

--- a/mixle/tests/anchor_harness_test.py
+++ b/mixle/tests/anchor_harness_test.py
@@ -59,7 +59,7 @@ class AnchorHarnessTest(unittest.TestCase):
         self.assertIsInstance(report.frontier_mae, float)
         self.assertIsInstance(report.walk_mae, float)
         self.assertFalse(report.frontier_is_calibrated)  # the frontier baseline reports no interval at all
-        self.assertTrue(any("cheap" in note for note in report.notes))  # where the frontier wins: cost
+        self.assertTrue(any("lowest-cost" in note for note in report.notes))  # where the frontier wins: cost
 
     def test_deterministic_given_seed(self):
         r1 = run_anchor_harness(n_train=1200, n_test=80, seed=3)

--- a/mixle/tests/fault_tolerant_training_test.py
+++ b/mixle/tests/fault_tolerant_training_test.py
@@ -15,7 +15,9 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
-import torch
+import pytest
+
+torch = pytest.importorskip("torch")
 
 from mixle.models.transformer import build_causal_lm
 from mixle.utils.parallel.dcp_checkpoint import save_sharded

--- a/mixle/tests/geoscience_inversion_report_test.py
+++ b/mixle/tests/geoscience_inversion_report_test.py
@@ -1,10 +1,13 @@
 """B7: sense -> simulate -> invert -> report -- the track-M full-loop demo (M0/M2/M3/M5/A1)."""
 
+import importlib.util
 import sys
 import unittest
 from pathlib import Path
 
 import numpy as np
+
+HAS_TORCH = importlib.util.find_spec("torch") is not None
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "examples"))
 from geoscience_inversion_report import (  # noqa: E402
@@ -45,6 +48,7 @@ class SenseSimulateInvertReportTest(unittest.TestCase):
         self.assertEqual(amps.shape[1], 3)
         self.assertEqual(sim.receipt.method, "none")  # intervention only, no evidence to condition on
 
+    @unittest.skipUnless(HAS_TORCH, "invert_new_observation's learn_inverse requires torch")
     def test_m3_inverts_a_new_observation_close_to_the_true_depth(self):
         sim, wi_depths, _wi_amps = what_if_salt(self.net, seed=1)
         depth_prior = GaussianDistribution(mu=float(wi_depths.mean()), sigma2=float(wi_depths.var()))
@@ -58,6 +62,7 @@ class SenseSimulateInvertReportTest(unittest.TestCase):
         self.assertIsInstance(inv_model.receipts.sbc_pvalue, float)
         self.assertIn(0.9, inv_model.receipts.coverage)
 
+    @unittest.skipUnless(HAS_TORCH, "invert_new_observation's learn_inverse requires torch")
     def test_m5_report_serves_a_claim_that_brackets_the_truth(self):
         sim, wi_depths, _wi_amps = what_if_salt(self.net, seed=1)
         depth_prior = GaussianDistribution(mu=float(wi_depths.mean()), sigma2=float(wi_depths.var()))
@@ -78,6 +83,7 @@ class SenseSimulateInvertReportTest(unittest.TestCase):
         self.assertIsNotNone(claim)  # a calibrated candidate clears the threshold for this seeded run
         self.assertTrue(claim.contains(TRUE_DEPTH))
 
+    @unittest.skipUnless(HAS_TORCH, "main() calls invert_new_observation, which requires torch")
     def test_main_runs_end_to_end(self):
         main()  # exercises the full sense -> simulate -> invert -> report loop; asserts internally
 

--- a/mixle/tests/registry_test.py
+++ b/mixle/tests/registry_test.py
@@ -64,8 +64,12 @@ class RegistryTest(unittest.TestCase):
             reg.register(pricier, capabilities=["spam_filter"], cost=0.05)
             reg.register(cheap, capabilities=["spam_filter"], cost=0.01)
 
-            def frontier(text):
-                return _spam_teacher([text])[0]
+            def frontier(texts):
+                # Router calls the frontier as a BATCHED callable (texts -> [label]) and does its own
+                # single-item wrap/unwrap (see Router.__call__) -- matching Cascade._teacher_label's
+                # convention of "teacher is the raw batched function". A frontier that already unwraps
+                # to one text in/out double-wraps and breaks (a list-of-one-string gets .split()'d).
+                return _spam_teacher(texts)
 
             stack = reg.tier_stack("spam_filter", frontier=frontier, costs=[0.01, 0.05, 1.0])
 

--- a/mixle/tests/zero_shot_bootstrap_test.py
+++ b/mixle/tests/zero_shot_bootstrap_test.py
@@ -4,6 +4,7 @@ held-out modality never modeled natively; the fit-health-style gate correctly de
 graduate in both directions.
 """
 
+import importlib.util
 import unittest
 
 import numpy as np
@@ -18,6 +19,8 @@ from mixle.reason.zero_shot_bootstrap import (
 )
 from mixle.stats.univariate.continuous.gaussian import GaussianDistribution
 from mixle.stats.univariate.discrete.categorical import CategoricalDistribution
+
+HAS_TORCH = importlib.util.find_spec("torch") is not None
 
 
 def _two_modality_joint() -> CrossModalJoint:
@@ -189,6 +192,7 @@ class InduceLeafForUnseenTypeTest(unittest.TestCase):
         # a classical family (multivariate Gaussian) -- not neural.
         self.assertIn("MultivariateGaussian", type(leaf).__name__)
 
+    @unittest.skipUnless(HAS_TORCH, "the high-dimensional path falls back to GradLeaf, which requires torch")
     def test_high_dimensional_numeric_blob_gets_a_neural_fallback(self):
         rng = np.random.RandomState(8)
         samples = [self._Blob(rng.normal(size=24)) for _ in range(50)]

--- a/mixle/utils/parallel/fault_tolerant_training.py
+++ b/mixle/utils/parallel/fault_tolerant_training.py
@@ -56,7 +56,11 @@ from pathlib import Path
 from typing import Any
 
 import numpy as np
-import torch
+
+try:
+    import torch
+except ImportError:  # pragma: no cover - torch is optional
+    torch = None
 
 from mixle.utils.parallel.dcp_checkpoint import load_sharded
 from mixle.utils.parallel.training_health import TrainingHealthMonitor

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,8 +42,12 @@ dependencies = [
 [project.optional-dependencies]
 # Extras are opt-in; the lower bounds are conservative floors (oldest releases with Python 3.10-3.12
 # wheels and the APIs mixle uses), not pins -- newer majors are allowed. numba >= 0.59 is the first
-# series with 3.10-3.12 wheels and the njit features the kernels use.
-numba = ["numba>=0.59", "tbb>=2021.6"]
+# series with 3.10-3.12 wheels and the njit features the kernels use. tbb is numba's optional
+# parallel=True threading backend (several kernels use parallel=True); numba falls back to its own
+# built-in "workqueue" threading layer without it, so it's a performance extra, not a hard requirement
+# -- and it must stay platform-gated: Intel TBB ships no arm64 (Apple Silicon) wheels, so an
+# unconditional floor here makes `pip install mixle[numba]` uninstallable on that platform.
+numba = ["numba>=0.59", "tbb>=2021.6; platform_machine == 'x86_64'"]
 # pandas is only used by the DataFrame data adapter (which duck-types and never imports pandas);
 # it is optional so the base install stays lean.
 pandas = ["pandas>=2.0"]
@@ -62,6 +66,13 @@ grammar = ["networkx>=3.0"]
 gmpy2 = ["gmpy2>=2.1"]
 spark = ["pyspark>=3.4"]
 dask = ["dask>=2023.5.0", "distributed>=2023.5.0"]
+# mixle.utils.parallel.ray_data's "ray" encoded-data backend (map/fold sufficient statistics over a
+# Ray cluster, same contract as the spark/dask backends); only ray.remote/ray.put/ray.get/ray.init are
+# used, all stable since early 2.x.
+ray = ["ray>=2.9"]
+# mixle.utils.parallel.lightning_data's "lightning" encoded-data backend (mini-batch iteration via a
+# lightning.pytorch.LightningDataModule + DataLoader, driving stochastic/mini-batch EM).
+lightning = ["lightning>=2.1"]
 # safetensors is the companion of torch here: torch TaskModel artifacts persist their weights through
 # safetensors.torch.save_model (see mixle/task/artifact.py), so a torch install needs it to save/load.
 torch = ["torch>=2.0", "safetensors>=0.4"]
@@ -81,7 +92,7 @@ sage = ["passagemath-symbolics>=10.4"]
 test = ["pytest>=8", "pytest-xdist>=3.0", "pytest-cov>=5.0"]
 # ruff is pinned: a newer release could add rules and break the blocking lint check unexpectedly.
 lint = ["ruff==0.15.17", "mypy>=1.0"]
-all = ["numba>=0.59", "tbb>=2021.6", "pyspark>=3.4", "dask>=2023.5.0", "distributed>=2023.5.0", "torch>=2.0", "safetensors>=0.4", "mpi4py>=3.1", "umap-learn>=0.5.4", "pandas>=2.0", "pyarrow>=14", "sqlalchemy>=2.0", "networkx>=3.0"]
+all = ["numba>=0.59", "tbb>=2021.6; platform_machine == 'x86_64'", "pyspark>=3.4", "dask>=2023.5.0", "distributed>=2023.5.0", "torch>=2.0", "safetensors>=0.4", "mpi4py>=3.1", "umap-learn>=0.5.4", "pandas>=2.0", "pyarrow>=14", "sqlalchemy>=2.0", "networkx>=3.0", "ray>=2.9", "lightning>=2.1"]
 
 [project.urls]
 Homepage = "https://github.com/gmboquet/mixle"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 # PyPI distribution name; the import package is `mixle` (cf. scikit-learn -> sklearn).
 name = "mixle"
-version = "0.6.2"
+version = "0.6.3"
 description = "A package for estimating heterogeneous probability density functions."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,11 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
+    # CI (.github/workflows/tests.yml) runs Linux x86_64 only. macOS (incl. arm64) is the primary dev
+    # platform and works in practice (the suite is run there routinely, ad hoc, not gated in CI) but
+    # is not a tested release guarantee; Windows is untested and unclaimed.
+    "Operating System :: POSIX :: Linux",
+    "Operating System :: MacOS",
 ]
 # Base install covers all distributions and local (numpy) estimation; acceleration,
 # distribution, and embedding back-ends are opt-in extras (see [project.optional-dependencies]).


### PR DESCRIPTION
## Summary

Two things, bundled since the second was discovered while verifying the first:

1. **Release prep** (checklist §2): bump `pyproject.toml` version 0.6.2 -> 0.6.3, finalize CHANGELOG's `[Unreleased]` header to a real cut date. CHANGELOG content itself was already current (only 5 commits landed since it was last touched, all docs/process).

2. **Critical fix**: `import mixle` was completely broken on the release tip. A fresh CI run triggered against the exact current tip (per the release checklist's own re-verification requirement) failed lint/fast/full/optional across the board -- `mixle/models/dpo_leaf.py` referenced `SequenceEncodableStatisticAccumulator`/`StatisticAccumulatorFactory` without importing them, a `NameError` at class-definition time that `mixle/models/__init__.py`'s eager import chain propagated to virtually every module (breaking test collection almost entirely). The same missing-import pattern, plus a stale duplicate `accumulator_factory`/`estimator` definition left over from an incomplete migration (Python silently keeps the last definition, so the first was dead code but still `ruff F811`-flagged), recurred across 5 sibling files: `energy.py`, `mixture_density.py`, `neural_density.py`, `neural_leaf.py`, `softmax_leaf.py`. Also fixed a real bug surfaced once these files could load: `DPOAccumulator.value()` returned weights as a plain list instead of a numpy array.

## Test plan
- [x] `import mixle` and a full public-module import sweep (`importlib.import_module` over every `pkgutil.walk_packages` entry): 0 failures
- [x] The six touched files' own test suites (63 tests): all pass
- [x] `ruff check` / `ruff format --check`: clean
- [ ] CI green on this PR