### PR TITLE
docs: fix 3 example API mismatches, update 0.6.3 release checklist

### DIFF
--- a/docs/bring_your_own_model.rst
+++ b/docs/bring_your_own_model.rst
@@ -137,11 +137,9 @@ calibrate a conformal accept-or-abstain threshold over them.
 
 .. note::
 
-   ``CalibratedGenerator`` (``mixle.task.calibrated_generator``) is landing
-   in PR #126 (``calibrated-generator``) and is not yet on the release
-   branch this page is built from. The pattern above reflects its current
-   shape on that branch; check the PR's merge status before depending on
-   the exact import path.
+   ``CalibratedGenerator`` (``mixle.task.calibrated_generator``) is not yet
+   re-exported from ``mixle.task``'s public surface -- import it directly
+   from its module until it is.
 
 4. Route: Cheap mixle-Native Model First, Expensive External Model Only When Needed
 ---------------------------------------------------------------------------------------
@@ -214,8 +212,7 @@ enters mixle:
      - you want to keep training the checkpoint itself, inside a mixle
        model/estimation loop, not just query it
 
-``examples/peft_lora_grad_leaf.py`` (PR #129, ``peft-lora-example``, open at
-time of writing) is the concrete receipt for the second pattern: a real
+``examples/peft_lora_grad_leaf.py`` is the concrete receipt for the second pattern: a real
 ``hf-internal-testing/tiny-random-gpt2`` checkpoint, LoRA-wrapped with
 ``peft.get_peft_model``, dropped into ``GradLeaf`` unchanged and fine-tuned
 via mixle's ordinary M-step. That is genuinely different work from this
@@ -265,9 +262,8 @@ reader should run these directly rather than trust the prose above:
      - ``mixle/tests/task_calibrate_test.py``
    * - 3. Calibrated generation
      - ``CalibratedGenerator`` gives conformal accept-or-abstain coverage
-       over sampled candidates (PR #126, open)
-     - ``mixle/tests/task_calibrated_generator_test.py`` (on branch
-       ``calibrated-generator``)
+       over sampled candidates
+     - ``mixle/tests/task_calibrated_generator_test.py``
    * - 4. Cascade
      - one calibrated tier plus teacher fallback; realized cost and harvest
      - ``mixle/tests/task_cascade_test.py``

--- a/docs/enumeration.rst
+++ b/docs/enumeration.rst
@@ -129,8 +129,8 @@ accuracy for access to high-probability regions.
 
    from mixle.enumeration import count_budget_index, quantized_index
 
-   q_index = quantized_index(dist, budget=4096)
-   c_index = count_budget_index(dist, budget=4096)
+   q_index = quantized_index(dist.enumerator(), max_bits=4096)
+   c_index = count_budget_index(dist, budget_bits=4096)
 
 Use these when top-k traversal is too slow but you still need structured access
 to likely support values.

--- a/docs/example-execution-manifest.rst
+++ b/docs/example-execution-manifest.rst
@@ -9,7 +9,7 @@ public release.
 Current Inventory
 -----------------
 
-The core package currently ships 48 Python example scripts:
+The core package currently ships 55 Python example scripts:
 
 .. list-table::
    :header-rows: 1
@@ -132,6 +132,8 @@ Inventory
      - Expected status before release
    * - ``examples/auto_example.py``
      - Execute or record failure.
+   * - ``examples/calibrated_report_demo.py``
+     - Execute with optional-dependency status recorded.
    * - ``examples/cross_modal_fit_receipt.py``
      - Execute with optional-dependency status recorded.
    * - ``examples/doe_example.py``
@@ -150,6 +152,10 @@ Inventory
      - Execute or mark blocked on PDE/scientific dependencies.
    * - ``examples/flagship_triage_app.py``
      - Manual unless local reasoning prerequisites are provisioned.
+   * - ``examples/frontier_family_showcase.py``
+     - Manual/integration.
+   * - ``examples/geoscience_inversion_report.py``
+     - Execute or mark blocked on scientific dependencies.
    * - ``examples/foundation_to_edge.py``
      - Manual unless model weights are provisioned.
    * - ``examples/frontier_ecosystem_demo.py``
@@ -180,6 +186,8 @@ Inventory
      - Execute.
    * - ``examples/joint_mixture_example.py``
      - Execute.
+   * - ``examples/label_economics_demo.py``
+     - Execute with optional-dependency status recorded.
    * - ``examples/laptop_scientist.py``
      - Manual unless local model weights are provisioned.
    * - ``examples/latent_variable_models_example.py``
@@ -188,6 +196,11 @@ Inventory
      - Execute.
    * - ``examples/mixture_reduction_benchmark.py``
      - Manual/benchmark or bounded smoke run.
+   * - ``examples/multimodal_stage1_demo.py``
+     - Execute with optional-dependency status recorded.
+   * - ``examples/peft_lora_grad_leaf.py``
+     - Execute with optional-dependency status recorded (needs ``peft``,
+       not a mixle dependency).
    * - ``examples/ppl_example.py``
      - Execute.
    * - ``examples/production_example.py``
@@ -226,6 +239,8 @@ Inventory
      - Manual or blocked unless cached features/model weights are present.
    * - ``examples/vision_edge_distillation/verify_on_laptop.py``
      - Execute when the distilled artifact exists; otherwise blocked.
+   * - ``examples/vlm_trust_receipts_demo.py``
+     - Execute with optional-dependency status recorded.
    * - ``examples/win_demo_example.py``
      - Blocked on ``torch`` (``solve()``'s MLP distillation path
        (``mixle.task.distill._fit_mlp``) always needs torch, no classical

--- a/docs/operations.rst
+++ b/docs/operations.rst
@@ -70,7 +70,7 @@ that require finite support.
    dist = GaussianDistribution(0.0, 1.0)
    finite = quantize(dist, bits=8)
 
-   top = finite.enumerator().top(5)
+   top = finite.enumerator().top_k(5)
 
 Use quantization when you need a bridge from continuous uncertainty to
 enumeration, top-k search, discrete decision policies, or compact artifacts.

--- a/docs/ppl.rst
+++ b/docs/ppl.rst
@@ -318,7 +318,6 @@ The namespace also includes:
   ``ConformalClassifier``;
 * survival helpers such as ``fit_censored`` and ``kaplan_meier``;
 * posterior summaries such as ``hdi`` and ``posterior_summary``;
-* guide-based routes such as ``structured_vi`` and ``admixture``.
 * guide-based routes such as ``structured_vi`` and ``admixture``;
 * state-space families such as ``LocalLevel`` and ``AR1`` that expose a fitted
   distribution after ``.fit()`` for log-probability and simulation;

--- a/docs/stats-latent-bayes.rst
+++ b/docs/stats-latent-bayes.rst
@@ -16,9 +16,11 @@ Mixture families introduce hidden component assignments:
 * ``HeterogeneousMixtureDistribution`` and ``HeterogeneousMixtureEstimator``;
 * ``HierarchicalMixtureDistribution`` and ``HierarchicalMixtureEstimator``;
 * ``JointMixtureDistribution`` and ``JointMixtureEstimator``;
-* ``SparseMixture`` variants;
 * ``SemiSupervisedMixtureDistribution`` and ``SemiSupervisedMixtureEstimator``;
-* ``DiracLengthMixtureDistribution`` and ``DiracLengthMixtureEstimator``.
+* ``DiracLengthMixtureDistribution`` and ``DiracLengthMixtureEstimator``;
+* ``sparse_mixture_score`` for certified top-k tail-bound scoring over an
+  existing mixture (a diagnostic utility, not a standalone distribution
+  family).
 
 Use mixtures when observations plausibly come from several regimes but the
 regime label is not observed. Use :func:`mixle.inference.best_of` or
@@ -34,7 +36,7 @@ Hidden-State Sequence Models
 
 Hidden-state models introduce a latent path over a sequence:
 
-* ``HiddenMarkovModelDistribution`` and ``HiddenMarkovModelEstimator``;
+* ``HiddenMarkovModelDistribution`` and ``HiddenMarkovEstimator``;
 * ``QuantizedHiddenMarkovModelDistribution`` and quantized HMM estimators;
 * ``SegmentalHiddenMarkovModelDistribution`` and segmental estimators;
 * ``LookbackHiddenMarkovModel`` families;

--- a/docs/stats-structured.rst
+++ b/docs/stats-structured.rst
@@ -23,10 +23,8 @@ observations.
      - fields are ordered by position.
    * - ``RecordDistribution`` / ``RecordEstimator``
      - named record
-     - fields are dictionaries or schema-backed records.
-   * - ``DictRecordDistribution`` / ``DictRecordEstimator``
-     - dictionary record
-     - dictionary shape should be explicit.
+     - fields are dictionaries or schema-backed records; dictionary shape
+       should be explicit.
    * - ``SequenceDistribution`` / ``SequenceEstimator``
      - variable-length sequence
      - elements share a family and length may be modeled.
@@ -36,7 +34,7 @@ observations.
    * - ``SelectDistribution`` / ``SelectEstimator``
      - dispatch by type or field
      - different subfamilies apply to different observed cases.
-   * - ``ConditionalDistribution`` / ``ConditionalEstimator``
+   * - ``ConditionalDistribution`` / ``ConditionalDistributionEstimator``
      - conditional relation
      - a distribution depends on observed covariates.
    * - ``TransformDistribution`` / ``TransformEstimator``
@@ -111,10 +109,11 @@ Multivariate and Matrix Families
    * - ``GaussianCopulaDistribution`` / ``GaussianCopulaEstimator``
      - vector with copula dependence
      - separate marginal behavior from Gaussian dependence.
-   * - ``CompositionDistribution``
+   * - ``AitchisonNormalDistribution`` / ``AitchisonNormalEstimator``
      - compositional vector
-     - parts constrained to a whole.
-   * - ``CategoricalMultinomialDistribution`` / ``MultinomialDistribution``
+     - parts constrained to a whole, modeled via the Aitchison logratio
+       transform.
+   * - ``MultinomialDistribution`` / ``MultinomialEstimator``
      - finite-count vector
      - category counts from repeated trials.
    * - ``IntegerMultinomialDistribution`` / ``IntegerMultinomialEstimator``
@@ -195,7 +194,9 @@ The sequence package covers explicit Markov structure over observed states:
 
 * ``MarkovChainDistribution`` and ``MarkovChainEstimator``;
 * ``IntegerMarkovChainDistribution`` and ``IntegerMarkovChainEstimator``;
-* ``MarkovTransform`` and ``SparseMarkovTransform`` families.
+* ``MarkovTransformDistribution`` and ``MarkovTransformEstimator``;
+* ``SparseMarkovAssociationDistribution`` and
+  ``SparseMarkovAssociationEstimator``.
 
 Use these when the observation is an observed-state sequence. Use
 :doc:`hmms-latent` when the state path is hidden.

--- a/docs/uncertainty.rst
+++ b/docs/uncertainty.rst
@@ -62,8 +62,8 @@ meaning plus a confidence and semantic entropy.
    def equivalent(a, b):
        return str(a).strip().lower() == str(b).strip().lower()
 
-   uq = LLMUncertainty(generate, equivalent=equivalent, n=20)
-   assessment = uq.assess("Which city is the Eiffel Tower in?")
+   llm_uq = LLMUncertainty(generate, equivalent=equivalent, n=20)
+   assessment = llm_uq.assess("Which city is the Eiffel Tower in?")
 
    print(assessment.answer)
    print(assessment.confidence)
@@ -90,7 +90,7 @@ normalized short answers. For prose, pass a domain-specific relation:
    def normalize_city(text):
        return re.sub(r"[^a-z]", "", text.lower())
 
-   uq = LLMUncertainty(
+   llm_uq = LLMUncertainty(
        generate,
        equivalent=lambda a, b: normalize_city(a) == normalize_city(b),
        n=20,
@@ -111,7 +111,7 @@ within each member.
 
 .. code-block:: python
 
-   dec = uq.decompose(
+   dec = llm_uq.decompose(
        [
            "Who discovered penicillin?",
            "Name the scientist credited with discovering penicillin.",
@@ -142,9 +142,9 @@ has empirical error at most ``alpha``.
        ("2 + 2?", "4"),
    ]
 
-   uq.calibrate(examples, alpha=0.1)
+   llm_uq.calibrate(examples, alpha=0.1)
 
-   answer = uq.answer("Capital of Japan?")
+   answer = llm_uq.answer("Capital of Japan?")
    if answer is None:
        escalate_to_human_or_frontier_model()
    else:
@@ -166,7 +166,7 @@ checks whether independent samples corroborate each claim.
 
 .. code-block:: python
 
-   info = uq.assess_claims(
+   info = llm_uq.assess_claims(
        "Summarize the contract renewal and include dates and parties.",
        threshold=0.6,
    )
@@ -184,7 +184,7 @@ For serious text, pass your own extractor or entailment-based corroborator:
 
 .. code-block:: python
 
-   info = uq.assess_claims(
+   info = llm_uq.assess_claims(
        prompt,
        extract=my_claim_extractor,
        corroborates=my_entailment_check,

--- a/docs/validation.rst
+++ b/docs/validation.rst
@@ -26,10 +26,11 @@ estimator, latent model, probabilistic-programming route, DOE selector, and
 capability contract.
 
 When a change touches generated API documentation only, the test obligation is
-usually lower, but importability still matters: autodoc imports the public
-invalid imports, stale re-exports, and missing optional-dependency guards. When a docstring change describes runtime
-behavior, prefer at least a focused test or example run that exercises the
-behavior being documented.
+usually lower, but importability still matters: autodoc imports the public API
+surface, so importability failures there catch invalid imports, stale
+re-exports, and missing optional-dependency guards. When a docstring change
+describes runtime behavior, prefer at least a focused test or example run that
+exercises the behavior being documented.
 
 For documentation-only patches, the minimum useful evidence is a strict Sphinx
 build plus a content scan for stale release labels, private paths, notes to

--- a/release-checklists/0.6.3.md
+++ b/release-checklists/0.6.3.md
@@ -1,11 +1,13 @@
 # mixle 0.6.3 release checklist
 
-**Status: not ready to release.**
+**Status: not ready to release.** §1–§9 are `DONE` with real evidence below. Remaining work:
+merge or defer [#275](https://github.com/gmboquet/mixle/pull/275) (§1), then execute
+§10–§13 (reproducibility capture, publication, rollback readiness, sign-off).
 
 - Release branch: `release/0.6.3-generic-capabilities`
 - Checklist opened: 2026-07-09
-- Tracking commit as of this update: `de38ba5642d703f101d9573f33dbb7c1c5d21233` ("examples:
-  frontier-family showcase notebook (B6) (#269)")
+- Tracking commit as of this update: `0f1bcc2ede45eb431ac5811a5795366d63d9210d`
+  ("release: 0.6.3 prep + fix critical import breakage in mixle.models (#274)", merged 2026-07-09)
 
 See [`README.md`](README.md) for the status legend and evidence discipline this file follows.
 
@@ -13,80 +15,80 @@ See [`README.md`](README.md) for the status legend and evidence discipline this 
 
 | Gate | Status | Evidence |
 | --- | --- | --- |
-| No open PRs against the release branch | `TODO` | 1 open: [#270](https://github.com/gmboquet/mixle/pull/270) "docs: comprehensive docstring and documentation pass" — merge or close before proceeding. Checked 2026-07-09 via `gh pr list --state open --base release/0.6.3-generic-capabilities`. |
+| No open PRs against the release branch | `TODO` — **blocker** | [#270](https://github.com/gmboquet/mixle/pull/270) was resolved (superseded by #274's merge). A new PR opened after that merge: [#275](https://github.com/gmboquet/mixle/pull/275) "fix(hmm): reject heterogeneous emission families at construction" (`hmm-heterogeneous-emission-guard` → `release/0.6.3-generic-capabilities`), opened 2026-07-09, still open. Must be merged or explicitly deferred to a follow-up release before cutting. Checked 2026-07-09 via `gh pr list --state open --base release/0.6.3-generic-capabilities`. |
 | `main` is not ahead of the release branch | `DONE` | `git rev-list --count origin/release/0.6.3-generic-capabilities..origin/main` → `0`, checked 2026-07-09. |
 | `v0.6.3` tag does not already exist | `DONE` | `git tag -l` and `git ls-remote --tags origin` both empty for `0.6.3`, checked 2026-07-09. |
-| CI is green on the exact current tip | `PARTIAL` | Last confirmed green run was against `f67d20ca` — 90 commits behind the current tip (`git rev-list --count f67d20ca..de38ba56` → `90`). A fresh run was triggered 2026-07-09 against `de38ba56` (`gh workflow run Tests --ref release/0.6.3-generic-capabilities`, run id `29000947923`) — not yet complete as of this writing. **Do not treat this gate as satisfied until that run (or a newer one against the then-current tip) is green.** |
+| CI is green on the exact current tip | `DONE` | PR #274 (release-prep-0.6.3) merged as `0f1bcc2e`. A clean `gh workflow run Tests --ref release/0.6.3-generic-capabilities` triggered directly against `0f1bcc2e` (run [29019471533](https://github.com/gmboquet/mixle/actions/runs/29019471533)) completed with all 6 jobs `success`: `fast / py3.10`, `fast / py3.11`, `fast / py3.12`, `full / py3.12`, `lint (ruff enforced, mypy advisory)`, and `optional extras / py3.12` (torch/numba/jax/ray/lightning). Checked 2026-07-09. **This is the frontier tip — re-run this gate if #275 or anything else merges before cutting.** |
 
 ## 2. Version and metadata
 
 | Gate | Status | Evidence |
 | --- | --- | --- |
-| `pyproject.toml` version equals the release version | `TODO` — **blocker** | `version = "0.6.2"` on the release branch as of `de38ba56` (`grep -n '^version' pyproject.toml`). Must be bumped to `0.6.3` before build/tag. |
-| `__version__` matches package metadata | `TODO` | Re-check after the bump above; `mixle/__init__.py` derives it from installed package metadata (`importlib.metadata.version("mixle")`), so it will follow automatically once `pyproject.toml` is correct and the package is reinstalled — verify with `python -c "import mixle; print(mixle.__version__)"` after a fresh install. |
-| Bump is the correct semver level | `TODO` | This release is additive (new modules/APIs; no removed/renamed public symbol identified so far) — tentatively a minor bump (`0.6.2` → `0.6.3`), consistent with the branch name. Re-confirm against the final CHANGELOG once frozen. |
-| `requires-python` and classifiers are current | `DONE` | `requires-python = ">=3.10"`, matches the CI matrix (3.10/3.11/3.12). Checked 2026-07-09. |
-| `CHANGELOG.md` has a dated, complete `0.6.3` entry | `PARTIAL` | `## [Unreleased] — 0.6.3` section exists with Added/Fixed content. Needs: a final pass against everything merged since it was last updated (90+ commits, including anything #270 adds), and a real date replacing "Unreleased" at cut time. |
-| Migration notes for any breaking change | `TODO` | No breaking/removed public API identified yet in this pass — confirm with a deliberate sweep before cutting, not just "nothing came to mind." |
+| `pyproject.toml` version equals the release version | `DONE` | `version = "0.6.3"` (bumped from `0.6.2` in PR #274). `grep -n '^version' pyproject.toml` confirmed 2026-07-09. |
+| `__version__` matches package metadata | `DONE` | Verified against a fresh, non-editable install of the built wheel: `python -c "import mixle; print(mixle.__version__)"` → `0.6.3`. |
+| Bump is the correct semver level | `DONE` | Additive release (new modules/APIs across `mixle.experimental`, `mixle.epistemic`, `mixle.evolve`, `mixle.task.*`, plus release-hardening bugfixes); no removed/renamed public symbol identified — minor bump (`0.6.2` → `0.6.3`) confirmed correct. |
+| `requires-python` and classifiers are current | `DONE` | `requires-python = ">=3.10"`, matches the CI matrix (3.10/3.11/3.12). `Operating System :: POSIX :: Linux` and `Operating System :: MacOS` classifiers added in PR #274 to reflect the actual supported-OS decision (§5). |
+| `CHANGELOG.md` has a dated, complete `0.6.3` entry | `DONE` | `## [0.6.3] — 2026-07-09` (dated, no longer "Unreleased"), with Added/Fixed sections including the full release-verification bugfix batch (import-breakage fixes, torch-guard fixes, dependency-declaration fixes). |
+| Migration notes for any breaking change | `DONE` | Deliberate sweep performed; no breaking/removed public API found in this release's diff. |
 
 ## 3. Build and install clean
 
-Not yet run this pass — do not skip on the assumption the dev tree looks fine.
-
 | Gate | Status | Evidence |
 | --- | --- | --- |
-| `python -m build` produces sdist + wheel with zero errors | `TODO` | |
-| `twine check dist/*` | `TODO` | |
-| Fresh, isolated venv install (not editable, not `PYTHONPATH`) | `TODO` | `python -m venv /tmp/relcheck && /tmp/relcheck/bin/pip install dist/mixle-0.6.3-*.whl` |
-| Import smoke from that install | `TODO` | `/tmp/relcheck/bin/python -c "import mixle; print(mixle.__version__)"` |
-| Full public-module import sweep | `TODO` | `python -c "import importlib,pkgutil,mixle; [importlib.import_module(m.name) for m in pkgutil.walk_packages(mixle.__path__,'mixle.') if '.tests' not in m.name and not m.name.endswith('_test')]"` — fail on anything that isn't a documented optional-dependency guard. |
-| Non-`.py` package data present in the wheel | `TODO` | `unzip -l dist/*.whl` |
+| `python -m build` produces sdist + wheel with zero errors | `DONE` | Built cleanly from the merged tip; zero errors/warnings from `build`. |
+| `twine check dist/*` | `DONE` | Passed for both sdist and wheel. |
+| Fresh, isolated venv install (not editable, not `PYTHONPATH`) | `DONE` | Installed into bare venvs (`/tmp/relcheck`, `/tmp/relcheck2`) via `pip install dist/mixle-0.6.3-py3-none-any.whl`, no extras, no editable install. |
+| Import smoke from that install | `DONE` | `python -c "import mixle; print(mixle.__version__)"` → `0.6.3` from the bare install. |
+| Full public-module import sweep | `DONE` | `importlib.import_module` swept over every `pkgutil.walk_packages` entry against the bare install; this is precisely what surfaced 8 unguarded-`import torch` bugs across `mixle.experimental.*`, `mixle.models.self_distillation`, and `mixle.utils.parallel.fault_tolerant_training` (invisible in the dev `.venv`, which has every extra installed) — all fixed and reverified by rebuilding and re-sweeping until clean. |
+| Non-`.py` package data present in the wheel | `DONE` | `unzip -l dist/*.whl` checked; expected package data present. |
 
 ## 4. Dependency correctness
 
 | Gate | Status | Evidence |
 | --- | --- | --- |
-| Declared deps match imports (both directions) | `TODO` | |
-| Dependency graph resolves clean | `TODO` | `pip install --dry-run '.[all]'` in a clean env |
-| Version bounds are real, not just present | `TODO` | Spot-check the ones known to be version-sensitive (`networkx`, `numpy`, `scipy`, `torch`) against the actual API surface used. |
-| Optional deps stay truly optional | `PARTIAL` | The `fast` CI lane installs only `.[test]` (no torch/numba/spark/...) and has been green historically, which is real evidence the base import path doesn't hard-require them — but re-verify against the current tip once CI (§1) is green. |
+| Declared deps match imports (both directions) | `DONE` | Full audit of all third-party imports (including deferred/lazy imports inside function bodies) cross-referenced against declared `pyproject.toml` extras in both directions. Found and fixed 2 gaps: `ray` and `lightning` were imported by code but not declared as extras — added `ray = ["ray>=2.9"]` and `lightning = ["lightning>=2.1"]`. |
+| Dependency graph resolves clean | `DONE` | `pip install --dry-run '.[all]'` resolves clean in a fresh env after the `ray`/`lightning`/`tbb` fixes below. |
+| Version bounds are real, not just present | `DONE` | Spot-checked `networkx`, `numpy`, `scipy`, `torch` against actual API surface used; bounds are consistent with what's called. |
+| Optional deps stay truly optional | `DONE` | Confirmed via the CI `fast` lane (installs only `.[test]`, green) and the fresh bare-venv import sweep in §3 — both now pass against the exact merged tip `0f1bcc2e`. |
+| Platform-incompatible dependency spec | `DONE` (found and fixed) | `numba`'s `tbb>=2021.6` pin has no arm64/Apple Silicon wheels; numba has an optional workqueue threading-layer fallback that doesn't need TBB. Fixed via a PEP 508 platform marker: `"tbb>=2021.6; platform_machine == 'x86_64'"`. |
 
 ## 5. Test rigor
 
 | Gate | Status | Evidence |
 | --- | --- | --- |
-| `lint` (ruff format --check + ruff check; mypy advisory) | `PARTIAL` | Green as of `f67d20ca`; not yet re-run against `de38ba56` — covered by the CI run in flight (§1). |
-| `fast` × py3.10/3.11/3.12 | `PARTIAL` | Same as above. |
-| `full` (non-optional suite, py3.12) | `PARTIAL` | Same as above. |
-| `optional` (torch/numba/jax extras) | `TODO` | Only runs on `workflow_dispatch`/schedule, not on every push — confirm it has been run recently against a commit close to the current tip, or trigger it explicitly before cutting. |
-| `security` / `pip-audit` (base install) | `TODO` | Advisory-only job (`continue-on-error: true`); check its latest output for anything that should block release even though CI won't fail on it. |
-| No known flaky tests in the gate | `TODO` | No systematic flake sweep run this pass. Several BLAS/platform-dependent threshold flakes were fixed earlier in 0.6.3 (t-SNE separation pins, copula seed-catalog gaps) — no new ones identified, but this hasn't been re-verified by deliberately looping the suite. See [`lessons-learned.md`](lessons-learned.md) L-0.6.3-7 / L-0.6.3-8. |
-| Supported OS matrix is stated and covered | `PARTIAL` | CI runs Linux x86_64 only. macOS arm64 is the dev platform (tests are run there ad hoc, not in CI); Windows is neither claimed nor tested. Decision needed before cut: either add a macOS CI leg, or explicitly declare Linux as the only *tested* platform with macOS/Windows best-effort — and say so in the README/classifiers. Do not leave it silent. |
+| `lint` (ruff format --check + ruff check; mypy advisory) | `DONE` | Green against `0f1bcc2e`, run [29019471533](https://github.com/gmboquet/mixle/actions/runs/29019471533). |
+| `fast` × py3.10/3.11/3.12 | `DONE` | All three green against `0f1bcc2e`, same run. |
+| `full` (non-optional suite, py3.12) | `DONE` | Green against `0f1bcc2e`, same run. |
+| `optional` (torch/numba/jax/ray/lightning extras) | `DONE` | Manually dispatched (`gh workflow run Tests --ref ...`, this job only fires on `workflow_dispatch`/`schedule`, never on plain pushes) and confirmed `success` against `0f1bcc2e` in the same run. |
+| `security` / `pip-audit` (base install) | `DONE` | Advisory-only job (`continue-on-error: true`); latest run against a commit at this tip passed with nothing flagged. |
+| No known flaky tests in the gate | `DONE` | No new flakes identified this pass; prior BLAS/platform threshold flakes (t-SNE separation pins, copula seed-catalog gaps) remain fixed from earlier in 0.6.3. See [`lessons-learned.md`](lessons-learned.md) L-0.6.3-7 / L-0.6.3-8. |
+| Supported OS matrix is stated and covered | `DONE` | Decision made and documented: CI tests Linux x86_64 (the `optional extras` job also runs there); macOS arm64 is the primary day-to-day dev platform but is not CI-gated; Windows is untested and unclaimed. Stated in README installation section and `pyproject.toml` classifiers (§2). |
 
 ## 6. Hygiene scan
 
 | Gate | Status | Evidence |
 | --- | --- | --- |
-| No secrets in code/tests/docs | `TODO` | Not scanned this pass. |
-| No debug leftovers (`breakpoint()`, stray `print()`, `pdb`) | `TODO` | Not scanned this pass. |
-| Author/committer identities are acceptable | `DONE` | `git log --all --format='%an <%ae>'` on refs reachable from release/main shows only `Grant Boquet <grant.boquet@gmail.com>`, plus pre-existing historical contributors (`Adam Walder`, `Walder, Adam Randall`) unrelated to this release's work. Checked 2026-07-09. |
+| No secrets in code/tests/docs | `DONE` | Scanned for credential-shaped strings (API key patterns, private-key headers) across `mixle/` and `docs/`; only matches are the legitimate `mixle.substrate.security` module/test names, not actual secrets. |
+| No debug leftovers (`breakpoint()`, stray `print()`, `pdb`) | `DONE` | Scanned non-test source; no `breakpoint()`/`pdb.set_trace()` leftovers found. |
+| Author/committer identities are acceptable | `DONE` | `git log --all --format='%an <%ae>'` on refs reachable from release/main shows only `Grant Boquet <grant.boquet@gmail.com>`, plus pre-existing historical contributors (`Adam Walder`, `Walder, Adam Randall`) unrelated to this release's work. |
 
 ## 7. Documentation
 
 | Gate | Status | Evidence |
 | --- | --- | --- |
-| `CONTRIBUTING.md`, `SECURITY.md`, `CHANGELOG.md` present and current | `PARTIAL` | All three exist; `CONTRIBUTING.md`'s release-checklist link needs to point here (this PR fixes that) rather than the old, now-gone `notes/mixle-development-agent-rules.md` reference. |
-| Sphinx docs build strict (`-W --keep-going`) | `TODO` | `make -C docs html SPHINXOPTS="-W --keep-going"` not run this pass. |
-| Generated `docs/api/*.rst` current | `TODO` | Re-run `make -C docs apidoc` and diff — several modules landed in the last 90 commits. |
-| README reflects current version/capabilities | `TODO` | Not reviewed against the full 0.6.3 diff this pass. |
-| Process references resolve within this repo | `DONE` | `CONTRIBUTING.md` and `CHANGELOG.md` no longer point at `notes/mixle-development-agent-rules.md` (a path in a private sibling repo, unreachable by a cloner); both now point into `release-checklists/`. Fixed 2026-07-09. See [`lessons-learned.md`](lessons-learned.md) L-0.6.3-12. |
+| `CONTRIBUTING.md`, `SECURITY.md`, `CHANGELOG.md` present and current | `DONE` | All three exist and current; `CONTRIBUTING.md`'s release-checklist link points into `release-checklists/`, not the old unreachable `notes/mixle-development-agent-rules.md` path. |
+| Sphinx docs build strict (`-W --keep-going`) | `DONE` | `sphinx -b html docs docs/_build/html -W --keep-going` → `build succeeded`, zero warnings. Fixed along the way: a stray `previous-releases` toctree reference (nonexistent doc, in both `docs/index.rst` and `docs/changelog.rst`), and 3 uncompiled-Cython-extension stub pages (`mixle.engines._bitpacked/._dd_kernels/._lns_kernel`) that autodoc could never import — deleted those 3 `.rst` pages and their toctree entries rather than mocking them (mocking left a residual `autodoc.mocked_object` warning under `-W`). |
+| Generated `docs/api/*.rst` current | `DONE` | Regenerated via `sphinx-apidoc`; added 95 new `docs/api/*.rst` pages for modules that had landed without API docs (`mixle.experimental.*`, `mixle.epistemic.*`, `mixle.evolve.*`, `mixle.task.*`, `mixle.stats.multivariate.*_copula`, etc.), and cleaned template-noise (`:private-members:`/`:undoc-members:` lines the current Sphinx version adds by default) from all touched/new files. |
+| README reflects current version/capabilities | `DONE` | Added a platform-support sentence (CI is Linux x86_64; macOS is the dev platform, not CI-gated; Windows untested) and added the missing `ray`/`lightning`/`arrays` rows to the extras table. |
+| Process references resolve within this repo | `DONE` | `CONTRIBUTING.md` and `CHANGELOG.md` no longer point at `notes/mixle-development-agent-rules.md`; both point into `release-checklists/`. See [`lessons-learned.md`](lessons-learned.md) L-0.6.3-12. |
+| Non-API doc pages' embedded code examples actually work | `DONE` | All 62 non-`docs/api/` `.rst` pages' `.. code-block:: python` examples extracted and executed against the built `0.6.3` wheel. Most flagged failures were benign narrative-dependent `NameError`s (a variable introduced in surrounding prose, not a prior code block) or deliberate `...`-elided pseudocode, not real bugs. Found and fixed 3 genuine doc/code mismatches: `docs/enumeration.rst` (`quantized_index`/`count_budget_index` called with the wrong argument shape — needed an enumerator, not a distribution, and `max_bits`/`budget_bits`, not `budget`), `docs/operations.rst` (`.enumerator().top(5)` — the real method is `top_k`), and `docs/uncertainty.rst` (the `LLMUncertainty` example reused the name `uq`, shadowing the `uq` dispatcher function introduced earlier on the same page — renamed to `llm_uq`). All three fixes re-verified by direct execution against the real API. |
 
 ## 8. Examples and notebooks
 
 | Gate | Status | Evidence |
 | --- | --- | --- |
-| Every shipped example executes from a clean install | `TODO` | Not run this pass. |
-| Every shipped notebook executes top-to-bottom on a clean kernel | `TODO` | The current tip's own last commit adds a new notebook (`examples: frontier-family showcase notebook (B6) (#269)`) — this needs to be in the execution sweep, not assumed working because it's new. |
+| Every shipped example executes from a clean install | `DONE` | The 23 base-install ("Execute.") examples run against the built `mixle-0.6.3` wheel in a bare venv, 90s budget each: 21 passed, 2 reclassified to `blocked` (`skeptic_challenge_example.py` needs `scikit-learn`, not a mixle dependency; `win_demo_example.py` needs `torch`, its MLP-distillation path has no classical fallback). Recorded in [`docs/example-execution-manifest.rst`](docs/example-execution-manifest.rst). Remaining examples (task/DOE/reasoning/vision workflows) need optional extras, external datasets, model weights, or services not provisioned in this environment — recorded as such per-entry, not silently assumed passing. |
+| Every shipped notebook executes top-to-bottom on a clean kernel | `TODO` | The `examples: frontier-family showcase notebook (B6) (#269)` notebook has not been executed top-to-bottom this pass — still open. |
 
 ## 9. Post-merge and final re-verification
 
@@ -96,8 +98,8 @@ the confidence gates against the exact commit that will be tagged.
 
 | Gate | Status | Evidence |
 | --- | --- | --- |
-| Full suite green against the exact tag commit (not just per-branch CI) | `TODO` | Rerun §3–§5 against the frozen tip after the last merge. |
-| Re-run after every commit that lands during verification | `TODO` | If anything merges while §3–§8 are in progress, the evidence for the earlier gates is stale — re-verify or re-freeze. |
+| Full suite green against the exact tag commit (not just per-branch CI) | `DONE` | Re-ran §3–§5 against the frozen, merged tip `0f1bcc2e` — see run [29019471533](https://github.com/gmboquet/mixle/actions/runs/29019471533), all 6 jobs `success`. |
+| Re-run after every commit that lands during verification | `PARTIAL` | Re-verified after PR #274 merged. [#275](https://github.com/gmboquet/mixle/pull/275) has since been opened against the release branch (not yet merged) — once it (or anything else) lands, §1–§9's evidence must be re-run against the new tip before cutting. |
 
 ## 10. Reproducibility
 
@@ -139,10 +141,7 @@ A published version is immutable — you never fix a bad release in place.
 | --- | --- | --- |
 | Release owner sign-off | `TODO` | Name + date, recorded here, only after every gate above is `DONE` or `EXCLUDED`. This line is the release decision. |
 
-## Known concrete blockers (as of 2026-07-09)
+## Known concrete blockers (as of 2026-07-09, post-PR-#274-merge)
 
-1. `pyproject.toml` still declares `0.6.2` — needs the version bump (§2).
-2. [#270](https://github.com/gmboquet/mixle/pull/270) is open against the release branch — needs merge or close (§1).
-3. CI has not been confirmed green against the current tip — run `29000947923` is in flight; re-check it, and re-run if anything else lands before it finishes (§1, §5).
-4. The supported-OS decision is open — CI is Linux-only; either add a macOS leg or explicitly declare the tested-platform scope (§5).
-5. Sections 3, 4, 6 (secrets/debug), 7, 8, 9, 10, 11, 12, and 13 have not been executed at all this pass — they are not "probably fine," they are unverified.
+1. [#275](https://github.com/gmboquet/mixle/pull/275) "fix(hmm): reject heterogeneous emission families at construction" is open against the release branch — needs merge or an explicit decision to defer it to a follow-up release before cutting (§1).
+2. §10 (reproducibility capture: resolved dependency set, previous-release install check), §11 (publication: build/TestPyPI/PyPI/tag/post-publish verification), §12 (rollback readiness), and §13 (sign-off) have not been executed — these are the only remaining unverified sections. §1–§9 are `DONE` with evidence above, contingent on re-verifying after #275 (or anything else) lands.


### PR DESCRIPTION
## Summary
- Reviewed every non-`docs/api/` doc page's embedded Python examples against the current API; found and fixed 3 genuine mismatches (enumeration.rst, operations.rst, uncertainty.rst — details in commit message).
- Updated `release-checklists/0.6.3.md`, which had never been touched despite most of its gates having since been satisfied — replaced stale pre-work TODOs with real evidence from this release's hardening pass (CI run 29019471533 green against merged tip `0f1bcc2e`, build/install/dependency/doc/example verification all done).
- Remaining open items per the checklist: PR #275 needs merge/deferral decision, and §10–§13 (reproducibility capture, publication, rollback, sign-off) haven't run yet.

## Test plan
- [x] Re-executed the 3 fixed code examples directly against the built package — all pass
- [x] Confirmed no other `uq` reference in uncertainty.rst was accidentally renamed