### PR TITLE
release: sync final 0.7.0 checklist state to main

### DIFF
--- a/release-checklists/0.7.0.md
+++ b/release-checklists/0.7.0.md
@@ -1,6 +1,8 @@
 # mixle 0.7.0 release checklist
 
-**Status: signed off, publishing.** §1–§10 are fully `DONE`. §7's doc code-example sweep found 9
+**Status: published.** mixle 0.7.0 is live on PyPI (https://pypi.org/project/mixle/0.7.0/), tagged
+at `v0.7.0`, and `mixle.org` is updated and deployed. §1–§10 are fully `DONE`. §7's doc code-example
+sweep found 9
 genuine bugs total, fixed across two commits: 4 in `fda357dd`, plus 5 more in `a8f53d8f` — recovered
 from a stalled background sub-agent's uncommitted working-tree edits, each independently re-verified
 against the actual source (one file, `evolution.rst`, was a duplicate of an already-applied fix;
@@ -11,8 +13,10 @@ list). CI re-run against the final tip (`a8f53d8f`) is green (Tests run
 [29041063573](https://github.com/gmboquet/mixle/actions/runs/29041063573)) — §1/§5/§7/§9's evidence
 below now cites this run. §8's notebook item is `EXCLUDED` (it referred to a notebook that was never
 actually shipped — see the gate's evidence); the example-execution gate is `DONE`. §11 (publication)
-is now underway. §12 is a documented understanding, no action needed. §13 (sign-off): given, release
-owner sign-off received 2026-07-10.
+is `DONE` except the TestPyPI dry-run, `EXCLUDED` for a pre-existing TestPyPI trusted-publisher gap
+unrelated to this release (see the gate's evidence) — real PyPI publish is confirmed live and
+post-publish-verified. §12 is a documented understanding, no action needed. §13 (sign-off): given,
+release owner sign-off received 2026-07-10.
 
 - Release branch: `release/0.7.0`
 - Checklist opened: 2026-07-09
@@ -138,12 +142,12 @@ that cross-package ordering is tracked by the release owner outside this repo (s
 
 | Step | Status | Evidence |
 | --- | --- | --- |
-| Build from the frozen commit: `python -m build`; `twine check dist/*` | `TODO` | |
-| TestPyPI dry run: `twine upload --repository testpypi dist/*`, then install back from TestPyPI in a clean env and smoke-run | `TODO` | |
-| PyPI publish: `twine upload dist/*` | `TODO` | |
-| Tag the exact published commit: `git tag -a v0.7.0 -m "mixle v0.7.0"` && `git push origin v0.7.0` (never `--force`) | `TODO` | |
-| Post-publish verification from the real index | `TODO` | |
-| Docs / changelog / website updated to the published version | `TODO` | |
+| Build from the frozen commit: `python -m build`; `twine check dist/*` | `DONE` | Built from `main`@`59ad4db9` (the merged tip) in a disposable worktree: `mixle-0.7.0.tar.gz` + `mixle-0.7.0-py3-none-any.whl`, zero errors. `twine check dist/*` → both `PASSED`. |
+| TestPyPI dry run: `twine upload --repository testpypi dist/*`, then install back from TestPyPI in a clean env and smoke-run | `EXCLUDED` | Dispatched `publish.yml` with `testpypi=true` — failed with PyPI's `invalid-publisher` (TestPyPI has no Trusted Publisher configured for `environment: testpypi`; that's a one-time maintainer setup step on test.pypi.org, not a repo/code issue). Real PyPI's Trusted Publisher (`environment: pypi`) is separately configured and already proven working (`v0.6.1`/`v0.6.2` both published successfully through this same workflow), so skipped the dry run rather than block the release on an unconfigured test-only registry. Release owner decision, 2026-07-10. |
+| PyPI publish: `twine upload dist/*` | `DONE` | Published via GitHub trusted publishing (OIDC, no stored tokens) by publishing the GitHub Release for `v0.7.0` — this triggers `.github/workflows/publish.yml`'s `publish-pypi` job on `release: published`. Run [29042868384](https://github.com/gmboquet/mixle/actions/runs/29042868384), `success`. Confirmed live: `https://pypi.org/pypi/mixle/0.7.0/json` → `200`, `info.version == "0.7.0"`, both `mixle-0.7.0-py3-none-any.whl` and `mixle-0.7.0.tar.gz` present. |
+| Tag the exact published commit: `git tag -a v0.7.0 -m "mixle v0.7.0"` && `git push origin v0.7.0` (never `--force`) | `DONE` | Tagged `59ad4db97ab920c1264eee81338039ac59dbb329` (the `main` merge-commit tip) as `v0.7.0`, pushed. GitHub Release `v0.7.0` created and published from the same commit with notes copied from `CHANGELOG.md`'s `[0.7.0]` entry: https://github.com/gmboquet/mixle/releases/tag/v0.7.0. |
+| Post-publish verification from the real index | `DONE` | Fresh venv, `pip install mixle==0.7.0` from the real (not Test) PyPI index: installs cleanly, `import mixle` works, constructed and sampled a `GaussianDistribution` end-to-end. `pip show mixle` confirms `Version: 0.7.0`. |
+| Docs / changelog / website updated to the published version | `DONE` | `CHANGELOG.md`'s `[0.7.0]` section was already current (dated 2026-07-09). `mixle.org` (separate static-site repo) updated: `index.html`/`concepts.html` version bumped 0.6.2 → 0.7.0, `releases.html` gained a real 0.7.0 release card sourced from the changelog with working PyPI/GitHub-tag links (verified live post-publish, not before), `sitemap.xml` lastmod bumped. Deployed via `deploy.sh` (rsync to the production host) and verified live: `https://mixle.org/` and `https://mixle.org/releases.html` both serve `0.7.0`. |
 
 ## 12. Rollback / incident readiness
 


### PR DESCRIPTION
release/0.7.0 gained one commit (f9025e62, the §11 publication-complete update) after the last main merge. Bringing it in before deleting the release branch.