### PR TITLE
fix(streaming): exact rebase escape hatch for IncrementalEstimator chunk replacement

### DIFF
--- a/mixle/inference/streaming.py
+++ b/mixle/inference/streaming.py
@@ -170,6 +170,37 @@ class StreamingEstimator(_StreamingBase):
         return self.model
 
 
+def _max_cancelled_bits(pre: Any, post: Any) -> float:
+    """Worst per-element magnitude collapse, in bits, between two payload snapshots.
+
+    ``log2(|pre| / |post|)`` measures how many leading bits a running statistic lost
+    when a payload was subtracted out of it -- the cheap form of the cancellation
+    escalation signal described in :mod:`mixle.engines.affine` (a subtraction at a
+    cancellation point blows up the relative-error bound).  Non-numeric leaves and
+    structure mismatches contribute 0: the guard may under-fire but never breaks
+    the update path.
+    """
+    if isinstance(pre, dict) and isinstance(post, dict):
+        return max((_max_cancelled_bits(pre[k], post[k]) for k in pre if k in post), default=0.0)
+    if isinstance(pre, (list, tuple)) and isinstance(post, (list, tuple)):
+        return max((_max_cancelled_bits(a, b) for a, b in zip(pre, post)), default=0.0)
+    if pre is None or post is None:
+        return 0.0
+    try:
+        a = np.abs(np.asarray(pre, dtype=np.float64))
+        b = np.abs(np.asarray(post, dtype=np.float64))
+    except (TypeError, ValueError):
+        return 0.0
+    if a.shape != b.shape or a.size == 0:
+        return 0.0
+    mask = a > 0.0
+    if not bool(np.any(mask)):
+        return 0.0
+    with np.errstate(divide="ignore"):
+        bits = np.log2(a[mask] / b[mask])
+    return float(np.max(bits))
+
+
 class IncrementalEstimator(_StreamingBase):
     """Neal-Hinton style incremental EM over replaceable data chunks.
 
@@ -178,6 +209,19 @@ class IncrementalEstimator(_StreamingBase):
     adds the new payload, and runs the ordinary estimator M-step on the pooled
     statistics.  No distribution-specific estimation code lives here; the class
     only uses ``scale(-1)``, ``combine()``, and ``estimate()``.
+
+    The subtract step is O(1) per revisit, but floating-point subtraction does not
+    invert addition: every revisit leaves roundoff residue in the running
+    statistics, and removing a payload whose magnitude dominated the running sums
+    can cancel catastrophically (e.g. the pooled second moment driven negative
+    after smaller chunks were absorbed at add time).  Because every chunk payload
+    is retained in ``chunk_values``, the exact state is always recoverable:
+    :meth:`rebase` rebuilds the running statistics by combining the stored
+    payloads in canonical order.  ``rebase_every=n`` does so automatically every
+    ``n`` updates; ``cancellation_bits=b`` watches each subtract and auto-rebases
+    when any statistic loses more than ``b`` bits of magnitude
+    (``cancellation_rebases`` counts the triggers).  Both default to off, keeping
+    the historical O(1) fast path unchanged.
     """
 
     def __init__(
@@ -189,7 +233,13 @@ class IncrementalEstimator(_StreamingBase):
         rng: RandomState | None = None,
         encoder=None,
         num_chunks: int = 1,
+        rebase_every: int | None = None,
+        cancellation_bits: float | None = None,
     ) -> None:
+        if rebase_every is not None and rebase_every < 1:
+            raise ValueError("rebase_every must be a positive integer or None; got %r." % (rebase_every,))
+        if cancellation_bits is not None and cancellation_bits <= 0.0:
+            raise ValueError("cancellation_bits must be positive or None; got %r." % (cancellation_bits,))
         super().__init__(
             estimator,
             model=model,
@@ -199,6 +249,9 @@ class IncrementalEstimator(_StreamingBase):
             encoder=encoder,
             num_chunks=num_chunks,
         )
+        self.rebase_every = rebase_every
+        self.cancellation_bits = cancellation_bits
+        self.cancellation_rebases = 0
         self.chunk_values = dict()
         self.nobs_by_chunk = dict()
 
@@ -224,19 +277,66 @@ class IncrementalEstimator(_StreamingBase):
         if self.running_accumulator is None:
             self.running_accumulator = self.estimator.accumulator_factory().make()
 
+        needs_rebase = False
         if chunk_id in self.chunk_values:
+            pre_value = copy.deepcopy(self.running_accumulator.value()) if self.cancellation_bits is not None else None
             old_acc = self.estimator.accumulator_factory().make()
             old_acc.from_value(copy.deepcopy(self.chunk_values[chunk_id]))
             old_acc.scale(-1.0)
             self.running_accumulator.combine(old_acc.value())
             self.nobs -= self.nobs_by_chunk[chunk_id]
+            if pre_value is not None and (
+                _max_cancelled_bits(pre_value, self.running_accumulator.value()) > self.cancellation_bits
+            ):
+                needs_rebase = True
 
         self.running_accumulator.combine(batch_acc.value())
         self.nobs += batch_nobs
         self.chunk_values[chunk_id] = copy.deepcopy(batch_acc.value())
         self.nobs_by_chunk[chunk_id] = batch_nobs
+        if needs_rebase:
+            self.cancellation_rebases += 1
+            self._rebase_stats()
+        elif self.rebase_every is not None and (self.step + 1) % self.rebase_every == 0:
+            self._rebase_stats()
         self.model = self.estimator.estimate(self.nobs, self.running_accumulator.value())
         self.step += 1
+        return self.model
+
+    def _canonical_chunk_ids(self) -> list:
+        """Chunk ids in canonical (sorted) order; insertion order if ids are unorderable."""
+        try:
+            return sorted(self.chunk_values)
+        except TypeError:
+            return list(self.chunk_values)
+
+    def _rebase_stats(self) -> None:
+        """Rebuild running statistics exactly from the stored chunk payloads."""
+        ids = self._canonical_chunk_ids()
+        acc = self.estimator.accumulator_factory().make()
+        acc.from_value(copy.deepcopy(self.chunk_values[ids[0]]))
+        for cid in ids[1:]:
+            acc.combine(copy.deepcopy(self.chunk_values[cid]))
+        self.running_accumulator = acc
+        nobs = 0.0
+        for cid in ids:
+            nobs += self.nobs_by_chunk[cid]
+        self.nobs = nobs
+
+    def rebase(self) -> SequenceEncodableProbabilityDistribution | None:
+        """Recompute the running statistics from the stored chunk payloads and re-estimate.
+
+        The subtract-based fast path in :meth:`update` accumulates roundoff residue
+        (and can cancel catastrophically); this rebuilds the exact canonical-order
+        reduction of ``chunk_values`` -- identical to a from-scratch reduce over the
+        current chunk set -- and refreshes the model from it.  No data re-encoding
+        happens; cost is one ``combine`` per stored chunk plus one M-step.  A no-op
+        when no chunks have been folded yet.
+        """
+        if not self.chunk_values:
+            return self.model
+        self._rebase_stats()
+        self.model = self.estimator.estimate(self.nobs, self.running_accumulator.value())
         return self.model
 
     def chunk_value(self, chunk_id: Any):
@@ -250,3 +350,4 @@ class IncrementalEstimator(_StreamingBase):
         super().reset()
         self.chunk_values = dict()
         self.nobs_by_chunk = dict()
+        self.cancellation_rebases = 0

--- a/mixle/tests/streaming_estimation_test.py
+++ b/mixle/tests/streaming_estimation_test.py
@@ -1,3 +1,4 @@
+import copy
 import unittest
 
 import numpy as np
@@ -270,6 +271,139 @@ class StreamingEstimatorTestCase(unittest.TestCase):
         expected = _batch_accumulator(estimator, start, chunk_a)
         expected.combine(_batch_accumulator(estimator, model_a, chunk_b).value())
         _assert_suff_close(self, inc.value(), expected.value())
+
+
+def _assert_suff_equal(test_case, actual, expected):
+    """Bitwise structural equality between payload trees (no tolerance)."""
+    if isinstance(actual, dict):
+        test_case.assertEqual(set(actual.keys()), set(expected.keys()))
+        for key in actual:
+            _assert_suff_equal(test_case, actual[key], expected[key])
+        return
+    if isinstance(actual, (tuple, list)):
+        test_case.assertEqual(len(actual), len(expected))
+        for a, e in zip(actual, expected):
+            _assert_suff_equal(test_case, a, e)
+        return
+    if isinstance(actual, np.ndarray) or isinstance(expected, np.ndarray):
+        test_case.assertTrue(np.array_equal(np.asarray(actual), np.asarray(expected)))
+        return
+    test_case.assertEqual(actual, expected)
+
+
+class IncrementalRebaseTestCase(unittest.TestCase):
+    """rebase() and its triggers: the exactness escape hatch for the subtract fast path."""
+
+    @staticmethod
+    def _canonical_reduce(inc):
+        """From-scratch reduction of the stored payloads in sorted-chunk_id order."""
+        ids = sorted(inc.chunk_values)
+        acc = inc.estimator.accumulator_factory().make()
+        acc.from_value(copy.deepcopy(inc.chunk_values[ids[0]]))
+        for cid in ids[1:]:
+            acc.combine(copy.deepcopy(inc.chunk_values[cid]))
+        nobs = 0.0
+        for cid in ids:
+            nobs += inc.nobs_by_chunk[cid]
+        return nobs, acc
+
+    @staticmethod
+    def _adversarial_chunks():
+        """One chunk at magnitude 1e9 among unit-scale chunks, all deterministic.
+
+        The big chunk's sum-of-squares payload (~1e21) absorbs the small chunks'
+        (~1e3) entirely at add time -- float64 spacing at 1e21 is ~1.3e5 -- so
+        revisiting the big chunk reveals the loss: the pooled second moment of
+        what remains goes negative.
+        """
+        jitter = (np.arange(1000) % 7 - 3.0) / 10.0
+        return {
+            "big": 1.0e9 + jitter,
+            "b": 1.0 + jitter,
+            "c": 1.0 - jitter,
+            "replacement": 1.0 + jitter / 2.0,
+        }
+
+    def _run_adversarial_revisit(self, inc):
+        chunks = self._adversarial_chunks()
+        inc.update(chunks["big"], chunk_id="a")
+        inc.update(chunks["b"], chunk_id="b")
+        inc.update(chunks["c"], chunk_id="c")
+        return inc.update(chunks["replacement"], chunk_id="a")
+
+    def test_revisit_cancellation_corrupts_stats_and_rebase_repairs(self):
+        inc = IncrementalEstimator(GaussianEstimator(), model=GaussianDistribution(0.0, 1.0))
+        subtract_model = self._run_adversarial_revisit(inc)
+
+        # the pathology, at the statistic level: the pooled second moment implied by
+        # the running (sum_wx, sum_wxx, sum_w) payload is NEGATIVE after the revisit
+        sum_x, sum_xx, sum_w, _ = inc.value()
+        self.assertLess(sum_xx / sum_w - (sum_x / sum_w) ** 2, 0.0)
+
+        nobs, expected_acc = self._canonical_reduce(inc)
+        expected_model = inc.estimator.estimate(nobs, expected_acc.value())
+        # at the model level the variance floor caught the negative moment, collapsing
+        # sigma2 orders of magnitude below the true pooled variance (~0.03)
+        self.assertLess(subtract_model.sigma2, expected_model.sigma2 / 100.0)
+
+        rebased = inc.rebase()
+        _assert_suff_equal(self, inc.value(), expected_acc.value())
+        self.assertEqual(inc.nobs, nobs)
+        self.assertEqual(rebased.mu, expected_model.mu)
+        self.assertEqual(rebased.sigma2, expected_model.sigma2)
+        self.assertGreater(rebased.sigma2, 0.01)
+
+    def test_cancellation_guard_auto_rebases(self):
+        inc = IncrementalEstimator(
+            GaussianEstimator(),
+            model=GaussianDistribution(0.0, 1.0),
+            cancellation_bits=20.0,
+        )
+        guarded_model = self._run_adversarial_revisit(inc)
+
+        self.assertEqual(inc.cancellation_rebases, 1)
+        nobs, expected_acc = self._canonical_reduce(inc)
+        expected_model = inc.estimator.estimate(nobs, expected_acc.value())
+        _assert_suff_equal(self, inc.value(), expected_acc.value())
+        self.assertEqual(guarded_model.sigma2, expected_model.sigma2)
+        self.assertGreater(guarded_model.sigma2, 0.01)
+
+    def test_benign_revisit_does_not_trigger_guard(self):
+        inc = IncrementalEstimator(
+            GaussianEstimator(),
+            model=GaussianDistribution(0.0, 1.0),
+            cancellation_bits=20.0,
+        )
+        inc.update(np.asarray([-2.0, -1.0, 0.0]), chunk_id="a")
+        inc.update(np.asarray([1.0, 2.0]), chunk_id="b")
+        inc.update(np.asarray([-3.0, -2.0]), chunk_id="a")
+        self.assertEqual(inc.cancellation_rebases, 0)
+
+    def test_rebase_every_matches_canonical_reduce(self):
+        inc = IncrementalEstimator(
+            GaussianEstimator(),
+            model=GaussianDistribution(0.0, 1.0),
+            rebase_every=2,
+        )
+        inc.update(np.asarray([-2.0, -1.0, 0.0]), chunk_id="a")
+        inc.update(np.asarray([1.0, 2.0]), chunk_id="b")
+        inc.update(np.asarray([-3.0, -2.0]), chunk_id="a")
+        inc.update(np.asarray([0.5, 1.5]), chunk_id="c")
+
+        nobs, expected_acc = self._canonical_reduce(inc)
+        _assert_suff_equal(self, inc.value(), expected_acc.value())
+        self.assertEqual(inc.nobs, nobs)
+
+    def test_constructor_validation_and_noop_rebase(self):
+        with self.assertRaises(ValueError):
+            IncrementalEstimator(GaussianEstimator(), rebase_every=0)
+        with self.assertRaises(ValueError):
+            IncrementalEstimator(GaussianEstimator(), cancellation_bits=0.0)
+
+        start = GaussianDistribution(0.0, 1.0)
+        inc = IncrementalEstimator(GaussianEstimator(), model=start)
+        self.assertIs(inc.rebase(), start)
+        self.assertIsNone(inc.running_accumulator)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

`IncrementalEstimator.update()` replaces a revisited chunk's contribution by
`old_acc.scale(-1.0)` + `running_accumulator.combine(...)`. Floating-point
subtraction does not invert addition, so this fast path has two failure modes:

1. **Drift**: every revisit adds two rounding events to the running statistics,
   permanently. The running payload is never bitwise-equal to a fresh reduction
   over the current chunk set.
2. **Catastrophic cancellation**: when one chunk's payload dominates the running
   sums in magnitude, the smaller chunks' contributions are absorbed at *add*
   time (below the float spacing of the large total), and subtracting the large
   payload out reveals the loss. In a deterministic Gaussian fixture with one
   chunk at magnitude 1e9 among unit-scale chunks, the pooled second moment
   implied by the running payload goes **negative** after the revisit; the
   estimator's variance floor then silently masks the corruption (sigma2
   collapses to the floor, orders of magnitude below the true ~0.03).

## Fix

Every chunk payload is already retained in `chunk_values`, so the exact state is
always recoverable without re-encoding any data:

- `rebase()` — rebuilds the running statistics by combining the stored payloads
  in canonical (sorted `chunk_id`) order, identical to a from-scratch reduce
  over the current chunk set, then re-estimates. Cost: one `combine` per stored
  chunk plus one M-step.
- `rebase_every=n` — triggers the rebase automatically every n updates.
- `cancellation_bits=b` — watches each subtract and auto-rebases when any
  statistic loses more than b bits of magnitude (worst-element
  `log2(|pre|/|post|)`, the cancellation escalation signal described in
  `mixle/engines/affine.py`); `cancellation_rebases` counts the triggers.

Both knobs default to off — **the historical O(1) Neal–Hinton fast path is
unchanged** unless a caller opts in.

## Tests

`IncrementalRebaseTestCase` in `streaming_estimation_test.py`:
- deterministic (no-RNG) reproduction of the negative-second-moment pathology,
  asserting the raw-statistic corruption and the floored-sigma2 collapse;
- `rebase()` restores **bitwise** agreement with the canonical reduce and exact
  parameter agreement with the estimate from it;
- the guard fires exactly once on the adversarial revisit and not at all on
  benign revisits;
- `rebase_every` leaves the running payload bitwise-equal to the canonical
  reduce;
- constructor validation and the empty-state no-op.

Full file: 12 passed (+1 subtests), ruff clean.

## Worklist alignment

Q5.1 (invariants for stable families — a fitted variance must never be a
silently-floored artifact of statistic corruption) and Q5.2 (numerical stress
panels — the adversarial-magnitude fixture is exactly such a panel case).
Additive-only: no public behavior changes by default, no API removals.
