### PR TITLE
Add 0.8.0 release checklist

### DIFF
--- a/release-checklists/0.8.0.md
+++ b/release-checklists/0.8.0.md
@@ -1,0 +1,217 @@
+# mixle 0.8.0 release checklist
+
+**Status: in preparation.** 0.8.0 is the **credibility, stability, and proof** release — its purpose
+is to turn mixle from a broad, fast-moving research package into one whose supported core,
+performance, artifacts, and public claims can be independently trusted. It is governed by a detailed
+release contract, [`notes/0.8.0_WORKLIST.md`](../notes/0.8.0_WORKLIST.md); this file is the
+public-facing gate view of that contract. Each gate below cites its worklist item ID and the minimum
+evidence grade the worklist requires for it (E0–E5, defined in the worklist §2.3).
+
+- Release branch: `release/0.8.0`
+- Checklist opened: 2026-07-10
+- Tracking commit as of this update: `068dbe6a` (branch cut point from `main`)
+
+See [`README.md`](README.md) for the status legend and evidence discipline this file follows. Unlike
+prior releases, 0.8.0 gates require at least **E2 (clean-wheel)** evidence for stable-core claims and
+**E3 (real workload)** for performance and backend claims — "passed in an editable checkout" does not
+satisfy a stable-core gate here.
+
+## 0. Feature-freeze discipline (worklist §1.3)
+
+This is a governance gate, not a task list item: it must hold for the whole cycle.
+
+| Gate | Status | Evidence |
+| --- | --- | --- |
+| Every merged PR maps to a worklist item ID | `TODO` | Enforced per PR; the mapping table lives in the roadmap's Track Q. New-capability cards (roadmap A1–A3, G/H/I/J/L/M) are deferred post-0.8; D/E/P proceed only under `mixle.experimental`. |
+| New capability does not enter the stable core during the freeze | `TODO` | Experimental work stays under `mixle.experimental` or on branches (worklist §1.3.5); confirm at RC1 that no stable public symbol was added without a written decision-log exception. |
+| A change adding more public surface than it removes has a written exception | `TODO` | Checked against the API manifest diff (§2) at RC1. |
+
+## 1. Branch, ancestry, and release control (worklist G0.1–G0.5)
+
+| Gate | Status | Evidence |
+| --- | --- | --- |
+| Authoritative stabilization branch with understood ancestry (G0.1, E2) | `PARTIAL` | `release/0.8.0` created 2026-07-10 from `origin/main` tip `068dbe6a` via the GitHub refs API; ancestry is a clean fast-forward from `main`. Remains `PARTIAL` until the final tip's ancestry is re-attested at RC1. |
+| Release decision log established (G0.2) | `TODO` | Create a tracked decision log (waivers, exceptions, ownership) referenced by every waiver here. |
+| Feature freeze enforced (G0.3) | `TODO` | See §0; enforced per PR. |
+| Ownership and review boundaries defined (G0.4) | `TODO` | Author ≠ reviewer for P0 core changes; the junior executor is an AUTHOR only, never a reviewer (roadmap Q3). File the ownership table. |
+| Live release risk register maintained (G0.5) | `TODO` | Open the risk register; link from this header. |
+| No open PRs against the release branch | `TODO` | `gh pr list --repo gmboquet/mixle --state open` at RC1. |
+| No pre-existing `v0.8.0` tag | `TODO` | `git ls-remote --tags origin` at RC1. |
+| CI green on the exact tip | `TODO` | Fresh dispatch against the release tip; CI-on-an-old-SHA is not evidence. |
+
+## 2. Product boundary and API maturity (worklist A1.1–A1.7)
+
+| Gate | Status | Evidence |
+| --- | --- | --- |
+| Complete public API inventoried and versioned (A1.1, E2) | `TODO` | Generate a public-API manifest (every exported symbol across `mixle` and subpackages); review and check it into the repo. |
+| Maturity tiers defined with enforceable meaning (A1.2, E2) | `TODO` | A machine-checkable maturity registry (stable / incubating / experimental) covering every public namespace. |
+| Stable claim surface reduced to what can be supported (A1.3) | `TODO` | Demote broad surface to incubating; record the diff. |
+| Frontier-training prototypes moved/labeled experimental (A1.4) | `TODO` | Confirm E-track and frontier code lives under `mixle.experimental` and cannot inherit stable wording by being importable (A1.2 enforcement). |
+| Deprecation and compatibility policy established (A1.5) | `TODO` | Written policy + a `DeprecationWarning` mechanism. |
+| Accidental/duplicate public surface removed (A1.6) | `TODO` | Audit for duplicate exports; remove or alias with a decision-log note. |
+| Large modules audited without blind refactors (A1.7) | `TODO` | Identify oversized stable-core modules; document, do not churn. |
+
+## 3. Packaging and artifact integrity (worklist P2.1–P2.6)
+
+| Gate | Status | Evidence |
+| --- | --- | --- |
+| Clean-wheel install + import sweep is a blocking CI job (P2.1, E2) | `TODO` | A CI job that builds the wheel and imports every public module from a bare install (extends the 0.7.0 manual sweep into an enforced gate). |
+| Base-install optional-dependency guards tested (P2.2, E2) | `TODO` | Import every module with only base deps installed; each optional-dep path degrades cleanly (the numba/mpi class of bug from 0.7.0 §3). |
+| Extras resolver matrix (P2.3, E2) | `TODO` | `pip install --dry-run` across each declared extra and `.[all]`; all resolve. |
+| Supported Python × OS matrix (P2.4, E2) | `TODO` | Python 3.10/3.11/3.12 on Linux x86_64 and macOS arm64, CI-gated for the base path. |
+| Artifact reproducibility metadata (P2.5) | `TODO` | Record wheel SHA-256, build inputs, and resolved lock per RC. |
+| Install-from-public-PyPI smoke after release (P2.6, E2) | `TODO` | Post-publish install from PyPI in a clean env. |
+
+## 4. Test-system credibility (worklist T3.1–T3.7)
+
+| Gate | Status | Evidence |
+| --- | --- | --- |
+| Test tiers redesigned around purpose + time budget (T3.1) | `TODO` | Tiers documented; the smoke/PR gate meets a stated runtime budget. Baseline: the `conftest.py` marker system (fast/slow/optional/experimental) already exists — formalize its budgets. |
+| Collection-time inflation eliminated (T3.2) | `TODO` | Collection does no heavy import/compute; measured. |
+| Warning ownership explicit; stable-core gate has no unexpected warnings (T3.3) | `TODO` | `filterwarnings=error` on the stable-core gate with an owned allowlist. |
+| Coverage gates reflecting maturity (T3.4) | `TODO` | Stable-core branch-coverage threshold agreed and enforced. |
+| Flaky / order-dependent test detection (T3.5, E2) | `TODO` | A repeated-run (≈20×) + randomized-order campaign; zero unexplained flakes. Baseline: `conftest.py` already snapshots/restores global RNG/engine/dtype state per test. |
+| Negative-control tests for release gates (T3.6) | `TODO` | Each gate has a test proving it FAILS on a planted defect (a gate that can't fail is not a gate). |
+| Legacy-compat tests separated from product tests (T3.7) | `TODO` | Partition and label. |
+
+## 5. Static analysis and maintainability (worklist Y4.1–Y4.5)
+
+| Gate | Status | Evidence |
+| --- | --- | --- |
+| Type checking enforced for the declared stable core (Y4.1, E2) | `TODO` | mypy/pyright passes for the typed-core namespace list; currently mypy is advisory in the 0.7.0 lint gate — make it blocking for the stable core only. |
+| Public signature + docstring checks (Y4.2) | `TODO` | Every stable public symbol has a signature test and a docstring. |
+| Broad `except` handling audited (Y4.3) | `TODO` | Inventory bare/broad excepts in the stable core; justify or narrow. |
+| Architecture dependency checks (Y4.4) | `TODO` | Enforce layering (extends the existing `compute_metadata_test.py` AST-boundary pattern). |
+| Generated-code / copy-paste risk reduced (Y4.5) | `TODO` | Identify duplicated blocks; consolidate where safe. |
+| `ruff check` + `ruff format --check` clean on the tip | `PARTIAL` | `ruff check mixle/` → "All checks passed!" against `068dbe6a`, 2026-07-10. Re-verify on the final tip; add `ruff format --check` to the record. |
+
+## 6. Numerical and statistical correctness (worklist Q5.1–Q5.6)
+
+| Gate | Status | Evidence |
+| --- | --- | --- |
+| Invariants defined + tested for every stable family (Q5.1) | `TODO` | Per-family invariant tests (normalization, parameter recovery, log-density sanity). |
+| Numerical stress panels (Q5.2, E2/E3) | `TODO` | Extreme/degenerate inputs across families; no NaN/inf/silent-garbage. Maps to roadmap K1/K2. |
+| Weighted estimation verified end to end (Q5.3) | `TODO` | Weights honored through EM/accumulators. |
+| EM monotonicity + convergence reporting verified (Q5.4) | `TODO` | Free energy monotone; convergence receipts. |
+| Cross-checks against independent references (Q5.5, E3) | `TODO` | Match scipy/statsmodels on shared estimators within tolerance. |
+| Random-state discipline audited (Q5.6) | `PARTIAL` | Deterministic-by-default fits are pinned by `fit_seed_test.py` (roadmap notes this as DONE→Q5.6); remaining fit paths still to be swept for argless RNG. |
+
+## 7. Automatic-modeling robustness (worklist I6.1–I6.5)
+
+| Gate | Status | Evidence |
+| --- | --- | --- |
+| Automatic-modeling contract specified (I6.1) | `TODO` | Document the guarantees of the auto-modeling entry points. |
+| Adversarial input corpus (I6.2, E2) | `TODO` | Fixtures for empty datasets, all-missing columns, one-shot iterators, `"False"`/`"0"` strings, mismatched record lengths, unseen categoricals, constant columns, tiny samples, correlated-field disagreement — each yields a deterministic model or an actionable error, never silent coercion/truncation. Maps to roadmap A6; baseline `contract_errors_test.py` exists (scope to confirm in the audit). |
+| Route selection explainable and testable (I6.3) | `TODO` | Every automatic choice emits a receipt naming why. |
+| Held-out model-selection benchmarks (I6.4) | `TODO` | Selection accuracy on held-out families. |
+| Automatic-search cost bounded (I6.5) | `TODO` | A cost ceiling with a test. |
+
+## 8. Performance and benchmark discipline (worklist B7.1–B7.6)
+
+| Gate | Status | Evidence |
+| --- | --- | --- |
+| Benchmark harness tracked in git (B7.1, E3) | `TODO` | The harness that produced every published number is versioned in-repo. Maps to roadmap A7; baseline `bench_receipts_test.py` exists. |
+| Benchmark methodology corrected (B7.2) | `TODO` | Warmup, repeats, fixed data, honest baselines. |
+| All published measurements re-run on 0.8.0 (B7.3, E3) | `TODO` | Regenerate every performance claim from retained artifacts on the RC. |
+| Performance regression gate (B7.4, E2/E3) | `TODO` | CI flags stable-path regressions beyond a floor. |
+| Only measured stable-path bottlenecks fixed (B7.5) | `TODO` | No speculative optimization. |
+| Honest crossover behavior published (B7.6) | `TODO` | Document where mixle loses to a baseline. |
+
+## 9. Distributed and optional-backend evidence (worklist D8.1–D8.6)
+
+| Gate | Status | Evidence |
+| --- | --- | --- |
+| Backend support levels defined (D8.1, E2) | `TODO` | A support matrix (supported / experimental / documented-only) for mpi, spark, ray, dask, torchrun. |
+| "Any backend" wording replaced with verified wording (D8.2) | `TODO` | Docs claim only exercised backends. |
+| Each claimed backend exercised in CI or scheduled jobs (D8.3, E3) | `TODO` | Maps to roadmap K3/K4/K5. Baseline: backend tests exist but are `optional`-marked (spark/ray/dask/torchrun); wire at least one into an enforced or scheduled job. |
+| Reduction + serialization overhead measured (D8.4) | `TODO` | Numbers, not adjectives. |
+| MPI reduction architecture consistent (D8.5) | `TODO` | Roadmap K3–K5. |
+| Real GPU claims validated (D8.6, E3, conditional) | `TODO` | On real hardware or explicitly demoted. |
+
+## 10. Neural models and frontier positioning (worklist N9.1–N9.7)
+
+| Gate | Status | Evidence |
+| --- | --- | --- |
+| Neural product boundary decided (N9.1) | `TODO` | What is supported vs. experimental vs. research. |
+| Frontier-training language removed or qualified (N9.2) | `TODO` | README/docs sweep. |
+| Inefficient LM pretraining path fixed or demoted (N9.3) | `TODO` | The overlapping-window / one-target-per-forward waste: implement packed dense teacher forcing or demote to experimental with honest wording (roadmap Q2b — also affects E-track baselines). |
+| Data-scale limitations explicit (N9.4) | `TODO` | Honest ceilings. |
+| Sharding math separated from executed training (N9.5) | `TODO` | README FSDP2/torchrun sentence + `LM.fit(distributed=...)` docs distinguish executed paths from validated-but-simulated sharding (roadmap Q2a). |
+| Bring-your-own-model interoperability validated (N9.6, E3) | `TODO` | HF/peft artifact → callable teacher → distill/calibrate/route (roadmap B5, C2). |
+| Real frontier integration framed as post-0.8 (N9.7) | `TODO` | Design-note-only in 0.8; F7 pilot deferred. |
+
+## 11. Three flagship real-data workflows (worklist F10.1–F10.5)
+
+| Gate | Status | Evidence |
+| --- | --- | --- |
+| Flagship A — heterogeneous records in native form (F10.1, E3) | `TODO` | Real public data, from the clean wheel. |
+| Flagship B — structured temporal/latent model (F10.2, E3) | `TODO` | Real public data, from the clean wheel. |
+| Flagship C — calibrated teacher/student cascade (F10.3, E3) | `TODO` | Real public data, from the clean wheel. |
+| Flagship workflows are release gates (F10.4) | `TODO` | Each runs in CI (or a scheduled job) as a blocking gate. |
+| Misleading showcase examples retired (F10.5) | `TODO` | Remove/relabel synthetic "demos" that imply real-data validation. |
+
+## 12. Serialization, lifecycle, and deployment boundaries (worklist M11.1–M11.5)
+
+| Gate | Status | Evidence |
+| --- | --- | --- |
+| Artifact compatibility contract defined (M11.1, E2) | `TODO` | What loads across which versions. |
+| Cross-version compatibility fixtures (M11.2) | `TODO` | Load prior-version artifacts in CI. |
+| Persistence separated from training resume (M11.3) | `TODO` | Distinct, tested paths. |
+| Provenance + replay claims verified (M11.4) | `TODO` | Baseline: `provenance_test.py`, `checkpoint_test.py`, `lineage_test.py`, `serving_test.py` exist — confirm they cover the claimed guarantees. |
+| Deployment claims kept bounded (M11.5) | `TODO` | No "production-ready" without E5. |
+
+## 13. Documentation and positioning (worklist X12.1–X12.7)
+
+| Gate | Status | Evidence |
+| --- | --- | --- |
+| README rewritten around the stable thesis (X12.1) | `TODO` | Stable core foregrounded; experimental clearly separated. |
+| Placeholder quickstart data replaced (X12.2) | `TODO` | Real, runnable quickstart. |
+| "What mixle is not" page (X12.3) | `TODO` | Explicit non-claims. |
+| Claim-evidence ledger generated (X12.4, E2/E3) | `TODO` | Every public claim → its evidence grade + artifact. |
+| Version-aware docs (X12.5) | `TODO` | Docs pinned to versions. |
+| Terminology + consistency audit (X12.6) | `TODO` | README/quickstart/examples/maturity guide/release notes agree. |
+| Performance + failure behavior documented (X12.7) | `TODO` | Not only happy paths. Roadmap C1/C2 map here (X12.x). |
+
+## 14. Security, dependencies, and hygiene (worklist S13.1–S13.5)
+
+| Gate | Status | Evidence |
+| --- | --- | --- |
+| Dependency audit actionable (S13.1, E2) | `TODO` | `pip-audit` gate with an owned triage path (0.7.0 ran it manually — make it blocking). |
+| Static security checks for artifact/registry paths (S13.2) | `TODO` | Path-traversal / unsafe-load scanning. |
+| Secrets + generated local artifacts audited (S13.3) | `TODO` | No secrets in code/tests/docs; no stray local artifacts (cf. roadmap HOP-0 preconditions about embedded keys in sibling repos — out of scope here but tracked). |
+| Dependency lower-bound tests (S13.4) | `TODO` | Install at declared minimums; suite passes. |
+| Resource cleanup tests (S13.5) | `TODO` | No leaked files/handles/procs. |
+| Author/committer identities acceptable | `TODO` | `git log --format='%an <%ae>' origin/main..origin/release/0.8.0` at RC1. |
+
+## 15. External reproduction and research credibility (worklist E14.1–E14.5)
+
+| Gate | Status | Evidence |
+| --- | --- | --- |
+| Two independent release testers recruited (E14.1, E4) | `TODO` | **Needs human** — release owner recruits. |
+| Adversarial statistical review (E14.2) | `TODO` | **Needs human/external** reviewer distinct from authors. |
+| Adversarial systems review (E14.3) | `TODO` | **Needs human/external**. |
+| One real external use case collected (E14.4, E3) | `TODO` | **Needs human**. |
+| Reproducibility bundle published (E14.5, E4) | `TODO` | Scripts + locked deps + expected outputs; two independent clean-install reproductions recorded. |
+
+## 16. Release-candidate process and publication (worklist R15.1–R15.7)
+
+| Gate | Status | Evidence |
+| --- | --- | --- |
+| Alpha 1 — boundary + artifact correctness (R15.1) | `TODO` | §1–§3 gates pass. |
+| Alpha 2 — stable-core correctness (R15.2) | `TODO` | §4–§7 gates pass. |
+| Beta 1 — performance + backend evidence (R15.3) | `TODO` | §8–§9 gates pass. |
+| Beta 2 — flagship workflows + documentation (R15.4) | `TODO` | §11, §13 gates pass. |
+| RC1 — freeze + independent review (R15.5) | `TODO` | §0, §2 manifest, §15 reviews. |
+| RC2 — final artifact rehearsal (R15.6) | `TODO` | Full clean-wheel rehearsal. |
+| `python -m build` + `twine check dist/*` clean | `TODO` | At RC2. |
+| TestPyPI dry run | `TODO` | Confirm the TestPyPI trusted-publisher gap (documented as `EXCLUDED` in 0.7.0 §11) before relying on it. |
+| PyPI publish + tag `v0.8.0` + post-publish verify (R15.7) | `TODO` | In dependency order across the family. |
+| Rollback path understood (patch, or yank-not-delete) | `TODO` | Documented before publish. |
+
+## 17. Sign-off
+
+| Gate | Status | Evidence |
+| --- | --- | --- |
+| Every P0 gate `Verified`; every incomplete P1 has a public limitation + written waiver | `TODO` | Per the worklist §3 exit criteria. |
+| Final release-candidate audit finds no unresolved critical/high defect | `TODO` | |
+| Named, dated release-owner sign-off | `TODO` | Only after everything above is `DONE`/`Verified` or `EXCLUDED`/`Waived`. |


### PR DESCRIPTION
Adds `release-checklists/0.8.0.md` — the public, git-tracked gate view of the 0.8.0 credibility worklist.

0.8.0 is the credibility/stability/proof release, so its gates are stricter than prior releases: every gate maps to a worklist item ID and its minimum evidence grade (E2 for stable-core claims, E3 for performance/backend), and stable-core evidence must come from the built wheel, not an editable checkout.

- [x] Follows the `release-checklists/README.md` status legend and evidence discipline (command + SHA + result + date for DONE).
- [x] Covers all 32 blocking gates in the worklist gate matrix plus the standard publish/rollback/sign-off flow, grouped by workstream (governance, API maturity, packaging, test credibility, static analysis, numerical correctness, automatic-modeling robustness, performance, backends, neural positioning, flagship workflows, serialization, docs, security, external reproduction, RC process).
- [x] Statuses open as `TODO`; branch-ancestry and lint baselines recorded `PARTIAL` against the branch cut point `068dbe6a`.

Complements the private worklist and the roadmap's Track Q (which routes capability cards to post-0.8 / experimental). Docs-only.