### PR TITLE
Bump version to 0.8.0.dev0 and open the 0.8.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to mixle are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [0.8.0] — Unreleased
+
+The credibility, stability, and proof release: turning mixle from a broad, fast-moving research
+package into one whose supported core, performance, artifacts, and public claims can be independently
+trusted. Tracked by the release checklist in `release-checklists/0.8.0.md`. New capability is deferred
+to post-0.8 or kept under `mixle.experimental` per the feature freeze.
+
+### Added
+
+- A public-API manifest (`api_manifest.json`) and a drift gate so any change to the exported surface
+  is a reviewed diff.
+- Release-engineering gates: a weighted-estimation contract test, a base-install optional-import guard,
+  a tracked benchmark harness, a pull-request template, and the 0.8.0 release checklist.
+
 ## [0.7.0] — 2026-07-09
 
 Workstream: generic AI-capability platform pieces on top of the core estimation engine (task

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 # PyPI distribution name; the import package is `mixle` (cf. scikit-learn -> sklearn).
 name = "mixle"
-version = "0.7.0"
+version = "0.8.0.dev0"
 description = "A package for estimating heterogeneous probability density functions."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
The `release/0.8.0` branch still declared `version = "0.7.0"` in `pyproject.toml`, so `mixle.__version__` (read from installed package metadata) and any wheel built from the branch would misreport the release in preparation.

- [x] Set the PEP 440 in-development marker `0.8.0.dev0` (validated with `packaging.version.Version`; `is_devrelease` = True). The bare `0.8.0` is set at release time; `.dev0` keeps the unreleased branch from claiming a finished version.
- [x] `__version__` is sourced from metadata (`importlib.metadata.version("mixle")`), so it tracks this automatically — nothing hardcoded to change.
- [x] Opened the `## [0.8.0] — Unreleased` changelog section describing the credibility-release scope.

Fixes the stale-version-metadata drift flagged by the release audit. Metadata only.