### PR TITLE
Fail loudly when TP/PP/CP sharding is requested but not integrated (worklist N9.5)

### DIFF
--- a/mixle/tests/tensor_pipeline_context_parallel_test.py
+++ b/mixle/tests/tensor_pipeline_context_parallel_test.py
@@ -22,7 +22,9 @@ including an honestly-reported real-world SLOWDOWN at that model scale without N
 receipt, not a speedup claim).
 """
 
+import os
 import unittest
+from unittest import mock
 
 import numpy as np
 
@@ -183,10 +185,26 @@ class FitDistributedSurfaceTest(unittest.TestCase):
         ids, v = self._corpus()
         lm = LM(vocab=v, d_model=32, n_layer=4, n_head=4, block=16)
         before = float(lm.nll(ids))
-        lm.fit(ids, distributed=True, epochs=2, batch_size=16, tp_size=2, pp_size=2, cp_size=2)
+        # tp/pp/cp > 1 is the validated-plan / data-parallel-only path, which must be opted into
+        # explicitly (see N9.5): the sharding is simulated at this scale, not integrated into training.
+        with mock.patch.dict(os.environ, {"MIXLE_EXPERIMENTAL_NDPARALLEL": "1"}):
+            lm.fit(ids, distributed=True, epochs=2, batch_size=16, tp_size=2, pp_size=2, cp_size=2)
         after = float(lm.nll(ids))
         self.assertTrue(np.isfinite(after))
         self.assertLessEqual(after, before + 5.0)  # training ran and produced a sane (finite, bounded) loss
+
+    def test_fit_distributed_tp_without_optin_raises(self):
+        # Without the opt-in, requesting tensor/pipeline/context sharding must NOT silently fall through
+        # to data-parallel (which would replicate a model the caller asked to shard). It must fail loudly.
+        from mixle.models.language_model import LM
+
+        ids, v = self._corpus()
+        lm = LM(vocab=v, d_model=32, n_layer=4, n_head=4, block=16)
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("MIXLE_EXPERIMENTAL_NDPARALLEL", None)
+            with self.assertRaises(NotImplementedError) as ctx:
+                lm.fit(ids, distributed=True, epochs=1, batch_size=16, tp_size=2)
+        self.assertIn("not integrated", str(ctx.exception))
 
     def test_fit_distributed_default_still_works_without_parallelism_dims(self):
         from mixle.models.language_model import LM

--- a/mixle/utils/parallel/torch_neural.py
+++ b/mixle/utils/parallel/torch_neural.py
@@ -146,6 +146,18 @@ class StreamingTokenEncodedData(EncodedDataHandle):
             from mixle.utils.parallel.tensor_pipeline_context_parallel import validate_tp_pp_cp_plan
 
             validate_tp_pp_cp_plan(module, self.tp_size, self.pp_size, self.cp_size)
+            # The plan is validated but per-axis process groups are NOT integrated into training here:
+            # execution below is data-parallel (DDP) only. Running silently would replicate a model the
+            # caller asked to shard -- OOM or a wrong scaling claim, not what they requested. Fail loudly
+            # unless the caller explicitly opts into the validated-plan / data-parallel-only path.
+            if os.environ.get("MIXLE_EXPERIMENTAL_NDPARALLEL") != "1":
+                raise NotImplementedError(
+                    "tp_size/pp_size/cp_size > 1 validates the N-D-parallel plan, but per-axis process "
+                    "groups are not integrated into training -- execution would be data-parallel only, "
+                    "silently ignoring the requested tensor/pipeline/context sharding. Set "
+                    "MIXLE_EXPERIMENTAL_NDPARALLEL=1 to proceed data-parallel-only with the plan "
+                    "validated, or leave tp_size/pp_size/cp_size at 1."
+                )
         wrapped = self._wrap_for_scale(module, device)
         opt = torch.optim.AdamW(wrapped.parameters(), lr=lr)
         ce = torch.nn.CrossEntropyLoss()


### PR DESCRIPTION
Implements worklist item **N9.5 — Separate sharding math from integrated training**.

**Behavior change.** `_TorchNeuralParallel.pysp_seq_estimate` validated a `tp_size/pp_size/cp_size > 1` plan and then trained **data-parallel (DDP) only** — the requested tensor/pipeline/context sharding was silently ignored. A caller who set `tp_size=2` because the model doesn't fit on one device would get a replicated model (OOM) or a false scaling claim, with no signal the sharding was dropped.

- [x] Now raises `NotImplementedError` with a clear message when `tp/pp/cp > 1` and per-axis process groups aren't integrated, **unless** `MIXLE_EXPERIMENTAL_NDPARALLEL=1` explicitly opts into the validated-plan / data-parallel-only path.
- [x] The default path (`tp=pp=cp=1`) is byte-for-byte unchanged.
- [x] The existing fit-surface smoke test now opts in explicitly (it deliberately exercises the simulated data-parallel path); a new test asserts the un-opted-in path raises. Sharding-MATH tests are unaffected.

**Verification:** `pytest tensor_pipeline_context_parallel_test.py -m ""` → **10 passed, 1 skipped** (real-GPU). No public API added.