### PR TITLE
Materialize one-shot iterators before profiling (worklist I6.2)

### DIFF
--- a/mixle/tests/automatic_oneshot_iterator_test.py
+++ b/mixle/tests/automatic_oneshot_iterator_test.py
@@ -1,0 +1,50 @@
+"""One-shot iterators are materialized before profiling (worklist I6.2).
+
+``mixle.utils.automatic`` profiles its input by iterating the record stream more than once (schema
+detection, then empirical sufficient statistics / fitting). A one-shot iterator -- a generator,
+``map``/``filter``/``zip``, or a file object -- returns itself from ``__iter__`` and is exhausted after
+the first pass, so without materializing it the profiler would silently work on an empty stream on the
+second pass and build a wrong model with no error. ``normalize_input`` must materialize such an iterator
+to a reusable list while leaving a real sequence (list/tuple/ndarray) untouched.
+"""
+
+import unittest
+
+import numpy as np
+
+from mixle.utils.automatic.profiling import normalize_input
+
+
+class OneShotIteratorTest(unittest.TestCase):
+    def test_one_shot_iterators_are_materialized(self):
+        data = [0.1, 0.5, 0.9, 1.2, 0.3]
+        # a generator, a bare iterator, and a map object are all one-shot -> materialized to the list
+        self.assertEqual(normalize_input(x for x in data), data)
+        self.assertEqual(normalize_input(iter(data)), data)
+        self.assertEqual(normalize_input(map(float, data)), data)
+        # and the result is a reusable list, not another one-shot iterator
+        materialized = normalize_input(x for x in data)
+        self.assertEqual(list(materialized), list(materialized))  # a second pass still sees the records
+
+    def test_reusable_sequences_are_left_unchanged(self):
+        lst = [1.0, 2.0, 3.0]
+        self.assertIs(normalize_input(lst), lst)
+        tup = (1.0, 2.0, 3.0)
+        self.assertIs(normalize_input(tup), tup)
+        arr = np.array([1.0, 2.0, 3.0])
+        self.assertIs(normalize_input(arr), arr)
+
+    def test_get_estimator_on_a_generator_matches_the_list(self):
+        from mixle.utils.automatic import get_estimator
+
+        data = [0.1, 0.5, 0.9, 1.2, 0.3, 0.7, 1.1, 0.4]
+        # profiling a generator detects the same family as profiling the equivalent list (before the fix
+        # the generator was consumed mid-profiling and could silently select a different/degenerate model)
+        self.assertEqual(
+            type(get_estimator(x for x in data)).__name__,
+            type(get_estimator(list(data))).__name__,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mixle/utils/automatic/profiling.py
+++ b/mixle/utils/automatic/profiling.py
@@ -2118,6 +2118,9 @@ def normalize_input(data, *, rdd_cap: int = 200000):
     * a pandas ``DataFrame`` (duck-typed via ``columns``/``itertuples``; pandas is never imported) ->
       one record per row across its columns (scalar for a single column, tuple otherwise);
     * a Spark ``RDD`` -> the first ``rdd_cap`` rows (profiling works on a bounded sample);
+    * a one-shot iterator (generator, ``map``/``filter``/``zip``, a file object) -> materialized to a
+      list, because the profiler iterates the records more than once (schema detection, then fitting)
+      and a one-shot iterator would be exhausted after the first pass;
     * anything else (a list / sequence) is returned unchanged.
     """
     if hasattr(data, "records") and hasattr(data, "structure"):  # a mixle DataSource
@@ -2139,6 +2142,15 @@ def normalize_input(data, *, rdd_cap: int = 200000):
             return data.take(int(rdd_cap))
     except Exception:
         pass
+    # A one-shot iterator returns itself from __iter__ and is consumed on the first pass; the profiler
+    # reads the records more than once (schema detection, then fitting), so an un-materialized iterator
+    # would silently fit a wrong/empty model on the second pass. Materialize it to a reusable list. A
+    # reusable sequence (list/tuple/ndarray) yields a fresh iterator and is left unchanged.
+    try:
+        if iter(data) is data:
+            return list(data)
+    except TypeError:
+        pass  # not iterable -- leave it to the caller's own validation
     return data
 
 


### PR DESCRIPTION
Implements the one-shot-iterator case of worklist item **I6.2 — adversarial input corpus** (silent-coercion class).

**Bug.** `mixle.utils.automatic` iterates its input records more than once (schema detection, then empirical sufficient statistics / fitting). `normalize_input` returned a one-shot iterator — a generator, `map`/`filter`/`zip`, or a file object — **unchanged**, so the second pass saw an exhausted stream and silently built a wrong or degenerate model with no error.

- [x] A self-returning iterator (`iter(data) is data`) is now materialized to a reusable list.
- [x] A real sequence (`list`/`tuple`/`ndarray`) yields a fresh iterator each pass and is left untouched (returned by identity).
- [x] Verified `get_estimator(x for x in data)` now detects the same family and fits identically to `get_estimator(list(data))` (before the fix they diverged).
- [x] Consumer suites unchanged: `automatic_test.py` + `automatic_datumnode_edgecases_test.py` → **39 passed**.

Distinct from the 0.7.0 `MaterializedSource` one-shot-iterator fix (`mixle.data`); this is the automatic-profiling path. No public API added.