### PR TITLE
Qualify README overclaims and gate them (worklist D8.2, N9.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ latent-variable model are the same kind of object, so they compose freely and a 
 fits the whole thing.
 
 Fitting follows from the structure, not a flag — closed form where a part has one, gradient descent for a
-neural leaf, EM for latent variables, all in one loop. The same model runs on any engine (NumPy, Numba, GPU)
-and scales across any backend (Spark, Dask, Ray, MPI) by changing one argument — no rewrite. It models what
+neural leaf, EM for latent variables, all in one loop. The same model runs on the built-in engines (NumPy,
+Numba, GPU) and distributes over Spark, Dask, Ray, or MPI by switching one argument. It models what
 you actually have — numbers, text, categories, mixed and missing values, directional and angular data,
 rankings, graphs — all the same way.
 
@@ -30,8 +30,8 @@ rankings, graphs — all the same way.
   your data or your PyTorch module and it does the heavy lifting.
 - **Lower cost.** Distill a slow, expensive model — a frontier LLM, an API, a rule — into a tiny local one
   that answers the easy cases itself and escalates only the hard ones.
-- **Honest uncertainty.** It is calibrated to know when it is unsure and defer rather than guess — safe to
-  put in front of users.
+- **Honest uncertainty.** It is calibrated to know when it is unsure and defer rather than guess — so you
+  can gate on its confidence instead of trusting every answer.
 
 **Docs:** [gmboquet.github.io/mixle](https://gmboquet.github.io/mixle/) · **Release notes:**
 [CHANGELOG.md](CHANGELOG.md)

--- a/mixle/tests/readme_claims_test.py
+++ b/mixle/tests/readme_claims_test.py
@@ -1,0 +1,36 @@
+"""Guard the README against retired overclaims (worklist D8.2 / N9.2).
+
+0.8.0 is a credibility release: public claims are qualified and evidenced, not universal absolutes.
+This gate fails if a retired overclaim reappears in the README, so the honest wording cannot silently
+regress.
+"""
+
+import unittest
+from pathlib import Path
+
+_README = Path(__file__).resolve().parents[2] / "README.md"
+
+# Retired because they overclaim: "any engine" / "any backend" / "no rewrite" assert universal,
+# unverified portability across engines/backends (several distributed backends are not CI-exercised);
+# "safe to put in front of users" is an unqualified safety claim (a safety claim needs E5 evidence,
+# not expected in 0.8.0). Keep this list in sync with the claim-evidence discipline in the worklist.
+_BANNED = (
+    "any engine",
+    "any backend",
+    "no rewrite",
+    "safe to put in front of users",
+)
+
+
+class ReadmeClaimsTest(unittest.TestCase):
+    def test_readme_exists(self):
+        self.assertTrue(_README.exists(), f"README not found at {_README}")
+
+    def test_no_retired_overclaims(self):
+        text = _README.read_text(encoding="utf-8").lower()
+        found = [phrase for phrase in _BANNED if phrase in text]
+        self.assertFalse(found, f"README contains retired overclaim(s) — qualify or remove: {found}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements the concrete README items of worklist **D8.2 (replace "any backend" wording)** and **N9.2 (qualify "safe to put in front of users")**.

Two claims overclaimed for a credibility release:
- "runs on **any engine** … scales across **any backend** (Spark, Dask, Ray, MPI) … **no rewrite**" — universal, unverified portability; several distributed backends are not CI-exercised. → "runs on the built-in engines (NumPy, Numba, GPU) and distributes over Spark, Dask, Ray, or MPI by switching one argument."
- "**safe to put in front of users**" — an unqualified safety claim (needs E5 evidence, not expected in 0.8.0). → "so you can gate on its confidence instead of trusting every answer."

- [x] Wording qualified, substance (the one-argument backend switch; the deferral mechanism) preserved.
- [x] `readme_claims_test.py` gates against regression — **negative control verified**: re-adding "any backend" fails the test with `['any backend']`.
- [x] Left the broader editorial rewrite (the "Lab-grade AI" framing, X12.1) for the owner — this PR is the two specific, worklist-named overclaims only.

Docs + a guard test; no code changed.