### PR TITLE
Add a blocking clean-wheel install + import-sweep CI job (worklist P2.1)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -90,6 +90,34 @@ jobs:
           path: coverage.xml
           retention-days: 30
 
+  clean-wheel:
+    name: clean-wheel install + import sweep
+    # A base install of the BUILT WHEEL (not an editable checkout, no optional extras) must import every
+    # public module. An optional dependency imported at a module's top level breaks `import mixle...` for
+    # every base-install user -- a regression that shipped in the wheel before (numba, mpi4py).
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Build the wheel
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build --wheel --outdir dist
+      - name: Install the wheel into a clean base env (no extras, not editable)
+        run: |
+          python -m venv "$RUNNER_TEMP/cleanvenv"
+          "$RUNNER_TEMP/cleanvenv/bin/python" -m pip install --upgrade pip
+          "$RUNNER_TEMP/cleanvenv/bin/python" -m pip install dist/*.whl
+          "$RUNNER_TEMP/cleanvenv/bin/python" -m pip check
+      - name: Import smoke + full public-module sweep from the clean wheel
+        # Run as a script (its dir, not the repo root, is on sys.path) so the source tree cannot shadow
+        # the installed package; the script asserts it is importing the site-packages wheel.
+        run: '"$RUNNER_TEMP/cleanvenv/bin/python" scripts/import_sweep.py'
+
   optional:
     name: optional extras / py3.12
     runs-on: ubuntu-latest

--- a/scripts/import_sweep.py
+++ b/scripts/import_sweep.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+"""Import every public ``mixle`` module; exit non-zero if any fails (worklist P2.1).
+
+Run this against a CLEAN base install of the built wheel (no extras). An optional dependency imported
+at a module's top level breaks ``import mixle...`` for every base-install user -- a class of regression
+that shipped in the wheel before (numba, mpi4py). Sweeping the installed package catches it before
+release.
+
+Invoke as ``python scripts/import_sweep.py`` (the script's directory, not the repo root, is on
+``sys.path[0]``, so the source tree cannot shadow the installed package). The ``site-packages`` guard
+refuses to "pass" against an editable/source checkout -- pass ``--allow-editable`` only for a local
+smoke run where you understand it is not the wheel.
+"""
+
+import importlib
+import pkgutil
+import sys
+
+import mixle
+
+
+def main() -> int:
+    if "site-packages" not in mixle.__file__ and "--allow-editable" not in sys.argv:
+        print(f"refusing to sweep a source/editable checkout (not the wheel): {mixle.__file__}", file=sys.stderr)
+        return 2
+    failures: list[str] = []
+    swept = 0
+    for module in pkgutil.walk_packages(mixle.__path__, prefix="mixle."):
+        name = module.name
+        if ".tests" in name or name.endswith("_test"):
+            continue
+        swept += 1
+        try:
+            importlib.import_module(name)
+        except Exception as exc:  # noqa: BLE001 -- any import failure is a base-install regression
+            failures.append(f"  {name}: {type(exc).__name__}: {exc}")
+    print(f"swept {swept} public modules from {mixle.__file__}")
+    if failures:
+        print(
+            "import failures (an unguarded optional import breaks the base install):",
+            file=sys.stderr,
+        )
+        print("\n".join(failures), file=sys.stderr)
+        return 1
+    print("all public modules import cleanly from the clean install")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Implements worklist item **P2.1 — Make clean-wheel validation a blocking CI job**.

Adds a `clean-wheel` job to `tests.yml`: build the wheel → install it into a fresh base env (no extras, **not** editable) → `pip check` → import **every** public module. An optional dependency imported at a module's top level breaks `import mixle...` for every base-install user — a regression that shipped in the wheel twice (numba, mpi4py) and was only caught by a *manual* sweep in 0.7.0. This makes it a gate on every PR.

- [x] The sweep is a committed script (`scripts/import_sweep.py`) invoked so its own directory — not the repo root — is on `sys.path`, so the source tree can't shadow the installed wheel; the script also asserts it's importing the `site-packages` copy (and refuses an editable checkout).
- [x] **Verified locally end to end** on `release/0.8.0`: `python -m build --wheel` → fresh 3.12 venv → `pip install dist/*.whl` → **687 public modules swept, 0 failures**.
- [x] Complements the static P2.2 optional-import guard (which runs in every env); this exercises the real wheel in a base env.

CI + a script; no product code changed.