### PR TITLE
Stop the mixle.experimental leak into stable program.py + gate the boundary (worklist Y4.4)

### DIFF
--- a/mixle/program.py
+++ b/mixle/program.py
@@ -9,8 +9,39 @@ so it now lives under :mod:`mixle.experimental`. For the common cases prefer the
     Categorical(logits=Net(out=10)).fit(y, given={"x": X})   # neural classification, zero closures
     Normal(Net(out=1), free).fit(y, given={"x": X})          # neural mean + learned noise (the blend)
 
-This module re-exports the old API so existing imports keep working; new code should import from
-``mixle.experimental.program`` (or use the declarative surface above).
+Existing ``from mixle.program import X`` imports keep working (with a :class:`DeprecationWarning`); new
+code should import from ``mixle.experimental.program`` (or use the declarative surface above).
+
+This is a stable-namespace module, so it must not pull ``mixle.experimental`` into the stable import
+graph. It therefore resolves the moved API lazily, through ``importlib`` on a string rather than a
+static ``import mixle.experimental`` -- keeping the experimental boundary (enforced by
+``experimental_boundary_test``) clean while the old name keeps redirecting.
 """
 
-from mixle.experimental.program import *  # noqa: F401, F403
+from __future__ import annotations
+
+import warnings
+from typing import Any
+
+_MOVED = "mixle.experimental.program"
+
+
+def __getattr__(name: str) -> Any:
+    import importlib
+
+    try:
+        value = getattr(importlib.import_module(_MOVED), name)
+    except AttributeError:
+        raise AttributeError(f"module 'mixle.program' has no attribute {name!r}") from None
+    warnings.warn(
+        f"mixle.program is deprecated and moved to {_MOVED}; import {name!r} from there instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return value
+
+
+def __dir__() -> list[str]:
+    import importlib
+
+    return sorted(n for n in dir(importlib.import_module(_MOVED)) if not n.startswith("_"))

--- a/mixle/tests/experimental_boundary_test.py
+++ b/mixle/tests/experimental_boundary_test.py
@@ -1,0 +1,74 @@
+"""Stable code must not statically import ``mixle.experimental`` (worklist Y4.4 / A1.4).
+
+Experimental mechanisms live under ``mixle.experimental`` and must not enter the stable import graph --
+or the stable public surface -- merely by being importable. This gate scans every non-experimental,
+non-test module and fails if it contains a static ``import mixle.experimental...`` or
+``from mixle.experimental... import ...`` (absolute or relative).
+
+A deliberate deprecation shim (e.g. ``mixle.program``) may still bridge to the experimental module the
+API moved to, but only through a dynamic ``importlib.import_module(...)`` call on a string -- which
+keeps ``mixle.experimental`` out of the static stable-import graph and makes the bridge an explicit,
+scoped act rather than a silent dependency. This runs by AST, so it needs no imports and holds in any
+environment; it runs in the standard fast/full CI gates.
+"""
+
+import ast
+import unittest
+from pathlib import Path
+
+_PKG_ROOT = Path(__file__).resolve().parents[1]
+_TARGET = "mixle.experimental"
+
+
+def _module_name(path: Path) -> str:
+    rel = path.relative_to(_PKG_ROOT.parent)  # e.g. mixle/utils/parallel/foo.py
+    parts = list(rel.with_suffix("").parts)
+    if parts[-1] == "__init__":
+        parts = parts[:-1]
+    return ".".join(parts)
+
+
+def _resolve(node: ast.ImportFrom, module_name: str) -> str:
+    """Absolute module a ``from ... import`` targets, resolving a relative import against its file."""
+    if not node.level:
+        return node.module or ""
+    base = module_name.split(".")[: -node.level]  # level 1 == the file's own package
+    if node.module:
+        base = base + node.module.split(".")
+    return ".".join(base)
+
+
+def _experimental_imports(path: Path) -> list[tuple[int, str]]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    module_name = _module_name(path)
+    hits: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == _TARGET or alias.name.startswith(_TARGET + "."):
+                    hits.append((node.lineno, alias.name))
+        elif isinstance(node, ast.ImportFrom):
+            target = _resolve(node, module_name)
+            if target == _TARGET or target.startswith(_TARGET + "."):
+                hits.append((node.lineno, target))
+    return hits
+
+
+class ExperimentalBoundaryTest(unittest.TestCase):
+    def test_stable_modules_do_not_statically_import_experimental(self):
+        offenders: list[str] = []
+        for path in sorted(_PKG_ROOT.rglob("*.py")):
+            rel = path.relative_to(_PKG_ROOT)
+            if rel.parts[0] == "experimental" or "tests" in rel.parts:
+                continue
+            for lineno, target in _experimental_imports(path):
+                offenders.append(f"  {path.relative_to(_PKG_ROOT.parent)}:{lineno}: imports {target}")
+        self.assertFalse(
+            offenders,
+            "stable modules must not statically import mixle.experimental (bridge via "
+            "importlib.import_module on a string in an explicit deprecation shim instead):\n" + "\n".join(offenders),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements worklist item **Y4.4 / A1.4 — experimental must not enter the stable surface**.

**The leak.** `mixle/program.py` is a stable-namespace compat shim for the program API that moved to `mixle.experimental.program`. Its `from mixle.experimental.program import *` pulled experimental code into the stable import graph and public surface — exactly what the freeze forbids. Audit result: **that was the only real leak** — nothing internal imports `mixle.program`, and the other `mixle.experimental` references (`context_parallel_spine.py`, `qat.py`, `neural_leaf.py`) are docstring/comment mentions, not imports.

**The fix.** Rewrite the shim to resolve the moved API lazily via `importlib.import_module` on a string in `__getattr__`:
- old `from mixle.program import X` keeps working, now with a `DeprecationWarning`;
- there is **no static `import mixle.experimental`**, so experimental stays out of the stable import graph.

**The gate.** `experimental_boundary_test.py` — an AST check that fails if any non-experimental, non-test module statically imports `mixle.experimental` (absolute or relative, any scope). It runs in the standard fast/full CI gates (no separate job needed).

- [x] Gate passes; **negative control verified** (injecting `import mixle.experimental` into a stable module fails it with a precise message).
- [x] Shim redirects correctly (`mixle.program.LoRALinear is mixle.experimental.program.LoRALinear`) and warns.
- [x] `program_test.py` (imports `experimental.program` directly) unaffected — **15 passed**.