### PR TITLE
Correct the dependency floors, drop Python 3.10, and add a min-versions gate (worklist S13.4)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.11", "3.12"]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -59,6 +59,27 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -e ".[test]"
       - name: Run fast tests
+        run: python -m pytest -m fast -n auto
+
+  min-versions:
+    name: min-versions (oldest declared floors)
+    # Install at the OLDEST declared dependency floors (constraints-min.txt) on the oldest supported
+    # Python and run the fast suite, so a floor that is missing an API, unbuildable, or numerically
+    # incompatible fails here instead of silently passing on whatever newer version pip resolves.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Install package at the declared minimum dependency versions
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -c constraints-min.txt -e ".[test]"
+          python -c "import numpy, scipy, mpmath; print('numpy', numpy.__version__, 'scipy', scipy.__version__, 'mpmath', mpmath.__version__)"
+      - name: Run fast tests at the minimum floors
         run: python -m pytest -m fast -n auto
 
   full:

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ rankings, graphs — all the same way.
 
 ## Installation
 
-Python 3.10+ (developed on 3.12), on PyPI as `mixle`. CI tests Linux x86_64; macOS (incl. Apple Silicon)
+Python 3.11+ (developed on 3.12), on PyPI as `mixle`. CI tests Linux x86_64; macOS (incl. Apple Silicon)
 is the day-to-day dev platform and works in practice but isn't CI-gated; Windows is untested.
 
 ```sh

--- a/constraints-min.txt
+++ b/constraints-min.txt
@@ -1,0 +1,14 @@
+# Minimum declared runtime dependency versions (worklist S13.4).
+#
+# The `min-versions` CI job installs the package with these constraints (on the oldest supported
+# Python) and runs the fast suite, so a declared floor that is missing an API mixle uses, has no wheel
+# on a supported Python, or is numerically incompatible fails here instead of silently passing on
+# whatever newer version happened to resolve.
+#
+# These are the OLDEST versions the full fast suite is verified green against -- see the rationale on
+# the `dependencies` floors in pyproject.toml. Keep in sync with those `>=` floors. Test tooling
+# (pytest/xdist/cov) is intentionally left unpinned: this gate tests mixle's code against its declared
+# runtime-dependency floors, not old test-harness versions.
+numpy==2.4.0
+scipy==1.16.0
+mpmath==1.3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ name = "mixle"
 version = "0.7.0"
 description = "A package for estimating heterogeneous probability density functions."
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 license = "MIT"
 license-files = ["LICENSE", "NOTICE"]
 authors = [{ name = "Grant Boquet", email = "grant.boquet@gmail.com" }]
@@ -21,7 +21,6 @@ keywords = [
 classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Development Status :: 4 - Beta",
@@ -34,13 +33,15 @@ classifiers = [
 ]
 # Base install covers all distributions and local (numpy) estimation; acceleration,
 # distribution, and embedding back-ends are opt-in extras (see [project.optional-dependencies]).
-# Lower bounds reflect the oldest releases that carry every API mixle calls and that are routinely
-# tested (numpy >=1.26 for the stable ndarray/linalg/errstate surface; scipy >=1.10 for
-# special.logsumexp + stats.binomtest/kstwo used by the inference layer; mpmath >=1.3). They are
-# floors, not pins -- newer majors are allowed.
+# Lower bounds are the OLDEST releases the full fast suite is verified green against, not aspirational
+# minimums: numpy < 2.1 hits genuine product IndexError bugs (cross_validation / robust covariance) and
+# numpy < 2.4 makes the t-SNE/embedding layout version-fragile; scipy < 1.11.2 has no Python 3.12 wheel
+# and scipy < 1.13 loses von Mises / wrapped Cauchy normalization precision (scipy >=1.16 also pairs
+# with numpy 2.4). These pins move together and are enforced by the `min-versions` CI job
+# (constraints-min.txt on the oldest supported Python). newer majors are allowed.
 dependencies = [
-    "numpy>=1.26",
-    "scipy>=1.11",
+    "numpy>=2.4",
+    "scipy>=1.16",
     "mpmath>=1.3",
 ]
 
@@ -179,7 +180,7 @@ show_missing = true
 
 [tool.ruff]
 line-length = 120
-target-version = "py310"
+target-version = "py311"
 # Demo scripts under examples/ are illustrative and not held to library lint rules.
 extend-exclude = ["examples"]
 


### PR DESCRIPTION
Implements worklist item **S13.4 — Define dependency lower-bound tests** by first making the lower bounds *true*.

**The declared floors did not work.** A minimum-version install (numpy 1.26.0, scipy 1.11.2) failed **13** fast tests. Bisecting showed genuine incompatibilities, not tight thresholds:
- scipy 1.11.0/1.11.1 have **no Python 3.12 wheel** (1.11.2 is first);
- scipy < 1.13 loses **von Mises / wrapped Cauchy** normalization precision;
- **numpy 2.0.0 hits real product `IndexError` bugs** (`cross_validation.py`, `robust.py`);
- numpy < 2.4 makes the **t-SNE / embedding layout version-fragile** (a refresh on unchanged data drifts far past its continuity bound — residual 8.5× the bound at numpy 2.1–2.3);
- and **numpy > 2.2 requires Python ≥ 3.11**, so no floor works across 3.10–3.12.

**Resolution (a deliberate, breaking decision):**
- [x] **Drop Python 3.10** (near end-of-life, Oct 2026) → `requires-python >= 3.11`; classifier + CI matrix + ruff target + README updated.
- [x] Set floors to the **oldest versions the full fast suite is verified green against**: `numpy>=2.4, scipy>=1.16, mpmath>=1.3` — **4252 passed, 0 failed** at numpy 2.4.0 / scipy 1.16.0.
- [x] Add `constraints-min.txt` + a blocking `min-versions` CI job (Python 3.11) that installs those floors and runs the fast suite, so this can't silently regress.
- [x] Rewrite the stale floors comment (it claimed `scipy >=1.10` while the dep was `>=1.11`) with the real, evidence-backed rationale.

Config/CI only — no product code changed here. (The underlying t-SNE numpy-version-fragility and the numpy-2.0.0 product IndexErrors are avoided by the floor, not fixed; hardening them to support older numpy would be separate product work.)