### PR TITLE
Make the base-install pip-audit gate blocking with a waiver file (worklist S13.1)

### DIFF
--- a/.github/pip-audit-ignore.txt
+++ b/.github/pip-audit-ignore.txt
@@ -1,0 +1,15 @@
+# pip-audit waivers for the base-install security gate (worklist S13.1).
+#
+# The "pip-audit (base install)" job in security.yml is BLOCKING: a known vulnerability in a base
+# runtime dependency (numpy / scipy / mpmath and their transitive deps) fails CI. To accept a specific
+# finding temporarily -- e.g. an advisory with no fixed release yet, or one that does not affect how
+# mixle uses the package -- add one line here:
+#
+#   <VULN-ID>   # short reason; review by YYYY-MM-DD
+#
+# for example:
+#   GHSA-xxxx-xxxx-xxxx   # no fix released yet; not reachable from mixle; review by 2026-10-01
+#
+# Blank lines and lines starting with '#' are ignored; only the first whitespace-delimited token on a
+# non-comment line is passed to pip-audit as --ignore-vuln. The base install is currently clean, so
+# there are no active waivers.

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -39,5 +39,10 @@ jobs:
           python -m pip install -e .
           python -m pip install pip-audit
       - name: Audit resolved dependencies
-        continue-on-error: true
-        run: pip-audit
+        # Blocking: a known vulnerability in a base dependency fails CI. To accept a specific finding
+        # temporarily, add its ID (with a reason + review date) to .github/pip-audit-ignore.txt; only
+        # IDs listed there are waived.
+        run: |
+          IGNORES=$(grep -vE '^[[:space:]]*#|^[[:space:]]*$' .github/pip-audit-ignore.txt | awk '{printf " --ignore-vuln %s", $1}')
+          echo "waived vulns:${IGNORES:- (none)}"
+          pip-audit $IGNORES


### PR DESCRIPTION
Implements worklist item **S13.1 — Make dependency audit actionable**.

The `pip-audit (base install)` job ran with `continue-on-error: true`, so a known vulnerability in a base runtime dependency was reported and then ignored. This makes it **blocking** and adds an actionable waiver path.

- [x] Removed `continue-on-error`; a new vulnerability in numpy / scipy / mpmath (or their transitive deps) now fails CI.
- [x] Added `.github/pip-audit-ignore.txt`: accept a finding temporarily by listing its ID with a reason + review date; only those IDs are passed as `--ignore-vuln`.
- [x] **Verified base install is clean** (`pip-audit` → "No known vulnerabilities found"), so the gate is green with no active waivers; the waiver parser yields no ignores for the empty file and the correct `--ignore-vuln` for a listed ID.

CI + config only.
