### PR TITLE
Gate the Banking77 real-data flagship in CI (worklist F10.4)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -111,3 +111,9 @@ jobs:
         # -m "" overrides the default `-m fast` addopts; the torchrun tests aren't `fast`, so without this
         # the selection is empty and pytest exits 5 ("no tests collected"), failing the job.
         run: MIXLE_RUN_TORCHRUN_SMOKE=1 python -m pytest mixle/tests/torchrun_encoded_data_test.py mixle/tests/torch_neural_test.py -q -m ""
+      - name: Install the Banking77 flagship dataset dependency
+        run: python -m pip install datasets
+      - name: Run the Banking77 real-data flagship smoke
+        # The one flagship on real public data (F10.4): bounded run of the teacher/student cascade. It
+        # skips itself if the dataset can't be fetched (offline), so a network blip is a skip, not a fail.
+        run: python -m pytest mixle/tests/real_receipt_banking77_smoke_test.py -q -m ""

--- a/examples/real_receipt_banking77.py
+++ b/examples/real_receipt_banking77.py
@@ -26,12 +26,28 @@ the gate. Run: ``python examples/real_receipt_banking77.py`` (~4 min; downloads 
 from __future__ import annotations
 
 import numpy as np
-from datasets import load_dataset
 
 from mixle.task import scorecard, solve
 
 
-def main() -> None:
+def run(
+    *,
+    n_seed: int = 3000,
+    n_round: int = 1000,
+    n_rounds: int = 6,
+    n_test: int = 1500,
+    student: str = "mlp",
+    verbose: bool = True,
+) -> dict:
+    """Run the Banking77 solve loop and return its measured results.
+
+    The defaults reproduce the headline run in the module docstring. The sizes are parameters so a fast
+    bounded version can be gated in CI (see ``real_receipt_banking77_smoke_test``); ``main`` keeps the
+    full defaults. Returns ``{"card", "accuracy", "rounds"}`` where ``rounds`` is a list of
+    ``{"escalation", "accuracy"}`` per improve round.
+    """
+    from datasets import load_dataset
+
     ds = load_dataset("banking77")
     names = ds["train"].features["label"].names
     train_all = [(r["text"], names[r["label"]]) for r in ds["train"]]
@@ -44,36 +60,47 @@ def main() -> None:
     def oracle(t: str) -> str:  # the frontier stand-in: always right, priced per call
         return gold[t]
 
-    seed_texts = [t for t, _ in train_all[:3000]]
-    rounds = [[t for t, _ in train_all[3000 + i * 1000 : 3000 + (i + 1) * 1000]] for i in range(6)]
+    seed_texts = [t for t, _ in train_all[:n_seed]]
+    rounds = [[t for t, _ in train_all[n_seed + i * n_round : n_seed + (i + 1) * n_round]] for i in range(n_rounds)]
     test_texts = [t for t, _ in test]
 
-    import sys
-
-    student = "generative" if "--generative" in sys.argv else "mlp"
     kw = {"student": "generative", "pseudo_count": 4.0} if student == "generative" else {"epochs": 250}
     sol = solve(oracle, seed_texts, alpha=0.1, seed=0, **kw)
     card = scorecard(
         sol,
         oracle,
-        test_texts[:1500],
+        test_texts[:n_test],
         student_cost=0.0001,
         teacher_cost=0.03,
         task="banking77 intents (77 classes)",
     )
-    print(card.table())
+    if verbose:
+        print(card.table())
+        print("\nescalation-decay: serve fresh queries, harvest, improve — per round")
+        print("round | escalation | end-to-end accuracy")
 
-    print("\nescalation-decay: serve 1k fresh queries, harvest, improve — six rounds")
-    print("round | escalation | end-to-end accuracy")
+    round_results = []
     for i, chunk in enumerate(rounds):
+        if not chunk:
+            continue
         before = sol.cascade.stats.n_escalated
         answers = [sol(t) for t in chunk]
         esc = (sol.cascade.stats.n_escalated - before) / len(chunk)
         acc = float(np.mean([a == gold[t] for a, t in zip(answers, chunk)]))
-        print(f"  {i}   |   {esc:.3f}    |   {acc:.3f}")
+        round_results.append({"escalation": esc, "accuracy": acc})
+        if verbose:
+            print(f"  {i}   |   {esc:.3f}    |   {acc:.3f}")
         sol.improve()
 
-    print("\nevery number above was measured by this run — change the seed and check.")
+    if verbose:
+        print("\nevery number above was measured by this run — change the seed and check.")
+    return {"card": card, "metrics": card.as_dict(), "rounds": round_results}
+
+
+def main() -> None:
+    import sys
+
+    run(student="generative" if "--generative" in sys.argv else "mlp")
 
 
 if __name__ == "__main__":

--- a/mixle/tests/real_receipt_banking77_smoke_test.py
+++ b/mixle/tests/real_receipt_banking77_smoke_test.py
@@ -1,0 +1,48 @@
+"""Banking77 flagship smoke gate (worklist F10.4).
+
+The Banking77 example (``examples/real_receipt_banking77.py``) is the one flagship that runs the
+teacher/student cascade against a REAL public dataset. This is its fast, bounded gate: a small run
+(torch-free generative student, ~1.2k seed / 60 test) that exercises the whole pipeline end to end --
+solve -> conformal-gated cascade -> scorecard -> one improve round -- and asserts the receipt is
+well-formed.
+
+Needs the ``datasets`` package (``mixle[scientist]``) and network access to fetch Banking77; it skips
+cleanly when either is missing, so it never fails a base-install run. It runs for real in the optional
+CI lane, which installs ``datasets``.
+"""
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+_HAS_DATASETS = importlib.util.find_spec("datasets") is not None
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "examples"))
+
+
+@unittest.skipUnless(_HAS_DATASETS, "datasets (mixle[scientist]) not installed")
+class Banking77FlagshipSmokeTest(unittest.TestCase):
+    def test_bounded_run_produces_a_wellformed_receipt(self):
+        # Fetching the dataset is the only network step; skip (don't fail) when it is unavailable.
+        try:
+            from datasets import load_dataset
+
+            load_dataset("banking77")
+        except Exception as exc:  # noqa: BLE001 -- offline / dataset-host down is a skip, not a failure
+            self.skipTest(f"Banking77 unavailable (offline?): {type(exc).__name__}: {exc}")
+
+        from real_receipt_banking77 import run
+
+        result = run(n_seed=1155, n_round=40, n_rounds=1, n_test=60, student="generative", verbose=False)
+        metrics = result["metrics"]
+        self.assertEqual(metrics["task"], "banking77 intents (77 classes)")
+        self.assertEqual(metrics["n_test"], 60)
+        for key in ("end_to_end_accuracy", "local_agreement", "escalation_rate"):
+            self.assertTrue(0.0 <= metrics[key] <= 1.0, f"{key} out of range: {metrics[key]}")
+        self.assertGreater(metrics["escalation_rate"], 0.0)  # a small student on 77 classes must escalate
+        self.assertEqual(len(result["rounds"]), 1)
+        self.assertTrue(0.0 <= result["rounds"][0]["accuracy"] <= 1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements the Flagship C slice of worklist item **F10.4 — Make flagship workflows release gates**.

The Banking77 example (`examples/real_receipt_banking77.py`) is the one flagship that runs the teacher/student cascade against a **real public dataset**, but nothing ran it in CI.

- [x] Refactored its body into a parametrized `run(...)` (main keeps the full headline defaults, so the example is unchanged when run directly).
- [x] Added a **bounded smoke test** — torch-free `generative` student, ~1.2k seed / 60 test — that drives the whole pipeline end to end (solve → conformal-gated cascade → scorecard → one improve round) and asserts a well-formed receipt (accuracy/agreement/escalation in range, escalation > 0, one round recorded).
- [x] The test needs `datasets` + network and **skips cleanly** when either is missing (offline → skip, not fail); the **optional CI lane** installs `datasets` and runs it for real.
- [x] Verified locally: bounded `run()` ~5s; smoke passes in ~12s (includes the dataset fetch).

Discovered in passing (not fixed here): `solve` raises `KeyError` on a calibration label unseen in training when the seed is too small to cover all 77 classes — a real unseen-categorical fragility worth a follow-up.
