### PR TITLE
Relabel the LM streaming fit path honestly (worklist N9.3)

### DIFF
--- a/mixle/models/language_model.py
+++ b/mixle/models/language_model.py
@@ -133,7 +133,14 @@ class LM:
         pp_size: int = 1,
         cp_size: int = 1,
     ) -> LM:
-        """Pretrain (or continue) on a token-id array via the streaming estimator; the corpus is never buffered.
+        """Small-scale reference pretraining (or continuation) on a token-id array via the streaming
+        estimator; the corpus is never buffered.
+
+        This is a streaming pretraining path: it scores one next-token target per ``block``-length window --
+        the right shape for an unbounded stream, but only a fraction (~``1/block``) of the token supervision
+        that packed dense teacher forcing would extract from the same tokens. It is therefore a reference /
+        continuation path for small-scale runs, not a frontier pretraining engine; for dense per-position
+        supervision on a bounded corpus use :meth:`fit_pairs`.
 
         ``tp_size``/``pp_size``/``cp_size`` (only meaningful with ``distributed=True``) are the F1 N-D
         parallelism dimensions -- tensor/pipeline/context parallel, ORTHOGONAL to the data-parallel axis


### PR DESCRIPTION
Implements the demote-with-honest-wording option of worklist item **N9.3 — Fix or demote the inefficient LM pretraining path**.

`LM.fit`'s docstring called it "Pretrain (or continue)", which reads as a frontier pretraining engine. In fact it is a *streaming* path that scores **one next-token target per `block`-length window** — the right shape for an unbounded stream, but only ~`1/block` of the token supervision that packed dense teacher forcing would extract (the codebase already documents this in `fit_pairs`).

- [x] Relabels it as a **small-scale reference / continuation path**, not a frontier pretraining engine, and points at `fit_pairs` for dense per-position supervision on bounded corpora.
- [x] Docstring only — no behavior change; imports + lint clean.

The alternative (implementing packed dense teacher forcing for the streaming path) is a genuine engineering change and a reasonable follow-on; this PR takes the honest-wording option the worklist offers.
