### PR TITLE
Add a release-artifact fingerprint script + test (worklist P2.5)

### DIFF
--- a/mixle/tests/release_metadata_test.py
+++ b/mixle/tests/release_metadata_test.py
@@ -1,0 +1,55 @@
+"""The release-artifact fingerprinter is correct (worklist P2.5).
+
+``scripts/release_metadata.py`` records the SHA-256, size, and filename of a release artifact so the
+exact file that passed the release gates can be verified later. This checks the fingerprint against
+``hashlib`` on a temporary artifact -- if the digest or size were wrong, the reproducibility record
+would be worthless.
+"""
+
+import hashlib
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "release_metadata.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("release_metadata", _SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class ReleaseMetadataTest(unittest.TestCase):
+    def test_script_exists(self):
+        self.assertTrue(_SCRIPT.is_file(), f"missing {_SCRIPT}")
+
+    def test_fingerprint_matches_hashlib(self):
+        mod = _load()
+        payload = b"mixle-release-artifact-fixture" * 1000  # > the 1 MiB streaming chunk boundary? no, but streamed
+        with tempfile.TemporaryDirectory() as d:
+            wheel = Path(d) / "mixle-9.9.9-py3-none-any.whl"
+            wheel.write_bytes(payload)
+            meta = mod.artifact_metadata(wheel)
+        self.assertEqual(meta["filename"], "mixle-9.9.9-py3-none-any.whl")
+        self.assertEqual(meta["size_bytes"], len(payload))
+        self.assertEqual(meta["sha256"], hashlib.sha256(payload).hexdigest())
+        self.assertIn("python", meta)
+        self.assertIn("platform", meta)
+
+    def test_large_artifact_streams_correctly(self):
+        # exceed the 1 MiB read chunk so the streaming digest is exercised across multiple reads
+        mod = _load()
+        payload = b"\x00\x01\x02\x03" * (400 * 1024)  # 1.6 MiB
+        with tempfile.TemporaryDirectory() as d:
+            f = Path(d) / "big.whl"
+            f.write_bytes(payload)
+            meta = mod.artifact_metadata(f)
+        self.assertEqual(meta["size_bytes"], len(payload))
+        self.assertEqual(meta["sha256"], hashlib.sha256(payload).hexdigest())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/release_metadata.py
+++ b/scripts/release_metadata.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+"""Record reproducibility metadata for a release artifact (worklist P2.5).
+
+Given a built wheel or sdist, emit a JSON record with the filename, size, and full SHA-256, plus the
+Python version and platform it was fingerprinted on -- the immutable fingerprint a release must retain
+so the exact artifact can be verified byte for byte later (e.g. that the file on PyPI is the one that
+passed the release gates). Usage::
+
+    python scripts/release_metadata.py dist/mixle-0.8.0-py3-none-any.whl [--out artifact-metadata.json]
+
+The resolved dependency set (``pip freeze`` of the clean install) is captured separately by the release
+checklist; this script fingerprints the artifact file itself.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import platform
+import sys
+from pathlib import Path
+
+
+def artifact_metadata(path: Path) -> dict:
+    """Filename, size, and SHA-256 of a release artifact, plus the current Python/platform."""
+    digest = hashlib.sha256()
+    size = 0
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b""):
+            digest.update(chunk)
+            size += len(chunk)
+    return {
+        "filename": path.name,
+        "size_bytes": size,
+        "sha256": digest.hexdigest(),
+        "python": platform.python_version(),
+        "platform": platform.platform(),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Fingerprint a release artifact (worklist P2.5).")
+    parser.add_argument("artifact", type=Path, help="path to a built wheel or sdist")
+    parser.add_argument("--out", type=Path, default=None, help="write the JSON record here (also printed)")
+    args = parser.parse_args()
+    if not args.artifact.is_file():
+        print(f"not a file: {args.artifact}", file=sys.stderr)
+        return 2
+    text = json.dumps(artifact_metadata(args.artifact), indent=2, sort_keys=True)
+    if args.out is not None:
+        args.out.write_text(text + "\n", encoding="utf-8")
+    print(text)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Implements worklist item **P2.5 — Add artifact reproducibility metadata**.

Adds `scripts/release_metadata.py`: given a built wheel/sdist it emits a JSON record — filename, size, full **SHA-256** (streamed, so large artifacts are fine), plus the Python/platform — the immutable fingerprint a release must retain so the exact artifact that passed the gates can be verified later against what lands on PyPI.

- [x] Test checks the fingerprint against `hashlib` on a temporary artifact, including one that exceeds the 1 MiB streaming chunk boundary (multi-read digest).
- [x] **Verified**: 3 tests pass; the script prints a correct record for a real file.

The resolved dependency set (`pip freeze`) is captured separately by the release checklist; this fingerprints the artifact file itself. Script + test only.
