### PR TITLE
task: calibrate survives a held-out label the student never learned

### DIFF
--- a/mixle/task/calibrate.py
+++ b/mixle/task/calibrate.py
@@ -75,8 +75,14 @@ class CalibratedTaskModel:
         """Set the conformal threshold from held-out ``(texts, teacher_labels)`` for ``1 - alpha`` set coverage."""
         index = {label: i for i, label in enumerate(self.labels)}
         prob = self._proba(list(texts))
-        true_idx = np.asarray([index[str(y)] for y in teacher_labels])
-        cal_true = prob[np.arange(len(true_idx)), true_idx]
+        # A held-out label the student's model has no class for cannot be scored -- the student assigns it
+        # probability 0, so it is a calibration point the student is guaranteed to miss. Record 0.0 rather
+        # than raising KeyError on an unseen level: the conformal threshold must see these misses (they
+        # make the set-valued predictor correctly more conservative), not crash the calibration pass.
+        cal_true = np.array(
+            [prob[i, index[str(y)]] if str(y) in index else 0.0 for i, y in enumerate(teacher_labels)],
+            dtype=float,
+        )
         self.qhat = conformal_label_threshold(cal_true, alpha=self.alpha)
         return self
 

--- a/mixle/tests/calibrate_unseen_label_test.py
+++ b/mixle/tests/calibrate_unseen_label_test.py
@@ -1,0 +1,57 @@
+"""Conformal calibration must survive a held-out label the student never learned.
+
+``CalibratedTaskModel.calibrate`` builds an index over the student's own labels and looks up each
+teacher label's true-class score. A real teacher (or a real dataset split) can hand back a label the
+student's class set does not contain -- a rare intent absent from the seed, a new category. That label
+has no column in the student's probability vector, so its true-class score is 0: the student is
+guaranteed to miss it, and the conformal threshold must *see* that miss (it makes the set-valued
+predictor correctly more conservative), not crash the whole calibration pass with a ``KeyError``.
+
+These tests use a tiny fixed-probability fake adapter (no torch) so they exercise exactly the
+``calibrate`` lookup/scoring path and nothing else.
+"""
+
+import unittest
+from types import SimpleNamespace
+
+import numpy as np
+
+from mixle.task.calibrate import CalibratedTaskModel
+
+
+def _fake_task(labels, row_prob):
+    """A TaskModel-shaped stub: an adapter with ``labels`` + a constant ``proba_batch``."""
+    row = np.asarray(row_prob, dtype=float)
+    adapter = SimpleNamespace(
+        labels=list(labels),
+        proba_batch=lambda model, inputs: np.tile(row, (len(inputs), 1)),
+    )
+    return SimpleNamespace(adapter=adapter, model=None)
+
+
+class UnseenCalibrationLabelTest(unittest.TestCase):
+    def test_unseen_label_does_not_crash(self):
+        # 'phishing' is not in the student's label set -> used to KeyError on index[str(y)].
+        task = _fake_task(["ham", "spam"], [0.7, 0.3])
+        model = CalibratedTaskModel(task, alpha=0.1).calibrate(["a", "b", "c", "d"], ["ham", "spam", "phishing", "ham"])
+        self.assertTrue(np.isfinite(model.qhat) or model.qhat == float("inf"))
+
+    def test_unseen_label_scored_as_a_miss(self):
+        # An unseen true label gets true-class score 0 (nonconformity 1.0), so a calibration set
+        # salted with unseen labels yields a threshold at least as conservative as the all-seen one.
+        task = _fake_task(["ham", "spam"], [0.7, 0.3])
+        n = 50
+        seen = CalibratedTaskModel(task, alpha=0.1).calibrate(["x"] * n, ["ham"] * n)
+        salted = CalibratedTaskModel(task, alpha=0.1).calibrate(["x"] * n, ["ham"] * (n - 10) + ["phishing"] * 10)
+        self.assertGreaterEqual(salted.qhat, seen.qhat)
+
+    def test_all_unseen_labels_still_produces_a_threshold(self):
+        # Degenerate but must not crash: every calibration label is unseen -> every score 0.
+        task = _fake_task(["ham", "spam"], [0.7, 0.3])
+        model = CalibratedTaskModel(task, alpha=0.1).calibrate(["x"] * 20, ["mystery"] * 20)
+        # Every point is a max-nonconformity miss, so the threshold saturates at 1.0.
+        self.assertAlmostEqual(model.qhat, 1.0, places=9)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

`CalibratedTaskModel.calibrate` looked up each teacher label with `index[str(y)]`
against an index built from the *student's own* labels. When a calibration/held-out
split contained a label the student's class set did not include, that lookup raised
`KeyError` and aborted the entire calibration pass.

This is the unseen-categorical fragility flagged in the F10.4 Banking77 receipt (#314):
at small seed sizes the seed does not cover all 77 intents, so calibration on the full
label space crashed.

## Fix

An unseen held-out label has no column in the student's probability vector, so its
true-class score is `0` — the student is guaranteed to miss it. `calibrate` now records
`0.0` for such points instead of crashing. Semantically this is correct: the conformal
threshold must *see* these misses (nonconformity `1.0`, the maximum), which make the
set-valued predictor correctly more conservative rather than silently dropping the point
or failing the run.

Points whose labels the student *does* know are scored exactly as before, so `qhat` is
unchanged on any all-seen calibration set.

## Test

`mixle/tests/calibrate_unseen_label_test.py` — torch-free (fixed-probability fake adapter),
so it exercises exactly the `calibrate` lookup/scoring path:

- an unseen label no longer raises `KeyError`;
- an unseen label is scored as a max-nonconformity miss, so salting a calibration set with
  unseen labels yields a threshold **at least as conservative** as the all-seen one;
- the degenerate all-unseen case saturates `qhat` at `1.0` instead of crashing.

## Evidence

`pytest mixle/tests/calibrate_unseen_label_test.py` → 3 passed. `ruff format --check` +
`ruff check` clean on both changed files.

Worklist: I6.2 (unseen-categorical robustness).
