### PR TITLE
Make deprecated aliases warn + establish the deprecation policy (worklist A1.5)

### DIFF
--- a/docs/support-policy.rst
+++ b/docs/support-policy.rst
@@ -96,6 +96,44 @@ surface changes:
 * bump the appropriate package version before publication; and
 * make changelog wording match the actual package role and version policy.
 
+API maturity tiers
+~~~~~~~~~~~~~~~~~~~
+
+Every public name sits in one of three tiers (see :doc:`maturity`), which set how
+much stability it promises:
+
+* **stable** -- covered by this policy; changes follow the deprecation lifecycle
+  below.
+* **provisional** -- usable and tested, but the signature or defaults may still
+  change within a minor release; changes are called out in the changelog.
+* **experimental** -- everything under ``mixle.experimental``; no compatibility
+  guarantee, and it must not be imported from stable modules.
+
+Deprecation lifecycle
+~~~~~~~~~~~~~~~~~~~~~~~
+
+When a **stable** name is renamed or retired, the old spelling is *deprecated*
+rather than deleted:
+
+* it keeps working and forwards to the replacement, unchanged in behavior;
+* it emits a ``DeprecationWarning`` (never a bare ``UserWarning`` or a print),
+  attributed to the caller's line, in one message format::
+
+      <old> is deprecated since mixle <since>; use <new> instead. It will be removed in mixle <removed_in>.
+
+* it is kept for **at least two minor releases** after the release that announces
+  the deprecation (announced in ``0.8.0`` → removable no earlier than ``0.10.0``);
+  and
+* its removal ships with a migration note and, for a renamed API, a runnable
+  before/after example.
+
+Deprecations are wired through one helper, :func:`mixle.utils.deprecation.deprecated_alias`
+(or :func:`~mixle.utils.deprecation.warn_deprecated` for finer-grained cases), so
+the category and message format are uniform. A test
+(``mixle/tests/deprecation_test.py``) statically enforces that every "Deprecated
+alias" callable actually carries the decorator -- a deprecated name that forgets
+to warn is itself a defect.
+
 Schema-owning packages such as ``mixle-knowledge`` need extra care: removing or
 renaming fields requires migration notes, validation fixtures, and consuming
 manifest checks.

--- a/mixle/stats/graphs/vertex_replacement_grammar.py
+++ b/mixle/stats/graphs/vertex_replacement_grammar.py
@@ -45,6 +45,7 @@ from mixle.stats.compute.pdist import (
     SequenceEncodableStatisticAccumulator,
     StatisticAccumulatorFactory,
 )
+from mixle.utils.deprecation import deprecated_alias
 
 #: Node attribute marking a nonterminal: its value is the left-hand-side symbol to rewrite during
 #: a derivation. A node is rewritable iff this attribute is present and indexes a rule in the grammar.
@@ -896,6 +897,7 @@ class VertexReplacementGrammarEstimator(ParameterEstimator):
             grammar=self.grammar, start_symbol=self.start_symbol, keys=self.keys
         )
 
+    @deprecated_alias("accumulator_factory", since="0.8.0", removed_in="0.10.0")
     def accumulatorFactory(self):
         """Deprecated alias for accumulator_factory()."""
         return self.accumulator_factory()

--- a/mixle/stats/latent/gaussian_mixture.py
+++ b/mixle/stats/latent/gaussian_mixture.py
@@ -41,6 +41,7 @@ from mixle.stats.multivariate.multivariate_gaussian import (
     MultivariateGaussianDistribution,
 )
 from mixle.utils.aliasing import MISSING, coalesce_alias
+from mixle.utils.deprecation import deprecated_alias
 
 
 def _pack_sig2(sig2: Sequence[Any] | np.ndarray, num_comp: int, dim: int) -> np.ndarray:
@@ -271,11 +272,13 @@ class GaussianMixtureEstimator(MixtureEstimator):
         est_factories = [u.accumulator_factory() for u in self.estimators]
         return GaussianMixtureEstimatorAccumulatorFactory(est_factories, self.num_components, self.keys)
 
+    @deprecated_alias("accumulator_factory", since="0.8.0", removed_in="0.10.0")
     def accumulatorFactory(self) -> "GaussianMixtureEstimatorAccumulatorFactory":
-        """Backward-compatible alias for :meth:`accumulator_factory`.
+        """Deprecated alias for :meth:`accumulator_factory`.
 
         New code should call ``accumulator_factory``. The camelCase name remains
-        available for older callers and returns the same factory.
+        available for older callers and returns the same factory, but now emits a
+        ``DeprecationWarning`` (see ``docs/deprecation-policy.rst``).
         """
         return self.accumulator_factory()
 

--- a/mixle/stats/latent/labeled_lda.py
+++ b/mixle/stats/latent/labeled_lda.py
@@ -41,6 +41,7 @@ from mixle.stats.compute.pdist import (
     StatisticAccumulatorFactory,
 )
 from mixle.stats.latent.lda import _lda_elbo_from_gamma, _lda_vi_fixed_point
+from mixle.utils.deprecation import deprecated_alias
 from mixle.utils.special import digammainv
 from mixle.utils.vector import row_choice
 
@@ -122,7 +123,7 @@ class LabeledLDADistribution(SequenceEncodableProbabilityDistribution):
                 Lower bound on the log-density of the document x.
 
         """
-        return self.seq_log_density(self.seq_encode([x]))[0]
+        return self.seq_log_density(self.dist_to_encoder().seq_encode([x]))[0]
 
     def seq_log_density(self, x):
         """Vectorized evaluation of the variational lower bound (ELBO) for encoded documents.
@@ -149,10 +150,11 @@ class LabeledLDADistribution(SequenceEncodableProbabilityDistribution):
             document_alphas, idx, counts, num_topics, log_density_gamma, document_gammas, per_topic_log_densities
         )
 
+    @deprecated_alias("dist_to_encoder().seq_encode()", since="0.8.0", removed_in="0.10.0")
     def seq_encode(self, x):
-        """Deprecated: encode a sequence of iid LabeledLDA observations for vectorized 'seq_' calls.
+        """Deprecated alias for ``dist_to_encoder().seq_encode()``: encode iid LabeledLDA observations.
 
-        Use 'dist_to_encoder()' and 'LabeledLDADataEncoder.seq_encode()' instead.
+        Use ``dist_to_encoder()`` and ``LabeledLDADataEncoder.seq_encode()`` instead.
 
         Args:
                 x (Sequence[Tuple[Sequence[Tuple[T, float]], Sequence[int]]]): Sequence of labeled documents.
@@ -1096,6 +1098,7 @@ class LabeledLDAEstimator(ParameterEstimator):
             est_factories, self.num_topics, self.num_alphas, self.keys, self.fixed_alpha
         )
 
+    @deprecated_alias("accumulator_factory", since="0.8.0", removed_in="0.10.0")
     def accumulatorFactory(self):
         """Deprecated alias for accumulator_factory()."""
         return self.accumulator_factory()
@@ -1307,6 +1310,7 @@ def update_alpha(current_alpha, mean_log_p, alpha_threshold):
     return rv
 
 
+@deprecated_alias("update_alpha", since="0.8.0", removed_in="0.10.0")
 def updateAlpha(current_alpha, mean_log_p, alpha_threshold):
     """Deprecated alias for update_alpha()."""
     return update_alpha(current_alpha, mean_log_p, alpha_threshold)

--- a/mixle/stats/sequences/markov_transform.py
+++ b/mixle/stats/sequences/markov_transform.py
@@ -32,6 +32,7 @@ from mixle.stats.compute.pdist import (
 )
 from mixle.stats.sequences._keyed_accumulator import InitTransKeyedAccumulator
 from mixle.utils.aliasing import MISSING, coalesce_alias
+from mixle.utils.deprecation import deprecated_alias
 from mixle.utils.optsutil import count_by_value
 
 
@@ -736,6 +737,7 @@ class MarkovTransformEstimator(ParameterEstimator):
         len_factory = None if self.len_estimator is None else self.len_estimator.accumulator_factory()
         return MarkovTransformAccumulatorFactory(self.num_vals, len_factory, self.keys)
 
+    @deprecated_alias("accumulator_factory", since="0.8.0", removed_in="0.10.0")
     def accumulatorFactory(self):
         """Deprecated alias for accumulator_factory()."""
         return self.accumulator_factory()

--- a/mixle/tests/deprecation_test.py
+++ b/mixle/tests/deprecation_test.py
@@ -1,0 +1,121 @@
+"""The deprecation mechanism and policy (worklist A1.5).
+
+Three things are pinned here:
+
+  * the reusable mechanism in ``mixle.utils.deprecation`` -- one warning category (``DeprecationWarning``),
+    one message format, attributed to the caller's line;
+  * that the concrete deprecated aliases in the tree actually warn *and* still forward to the canonical
+    name (a deprecation that changed behavior would be worse than none);
+  * a static guard that no *future* "Deprecated alias" can be added silently -- every such method/function
+    in the package source must carry the ``@deprecated_alias`` decorator, which is the exact gap A1.5
+    was opened to close ("aliases exist but emit no DeprecationWarning").
+"""
+
+import ast
+import unittest
+import warnings
+from pathlib import Path
+
+import numpy as np
+
+import mixle
+from mixle.utils.deprecation import deprecated_alias, deprecation_message, warn_deprecated
+
+_PKG_ROOT = Path(mixle.__file__).resolve().parent
+
+
+class DeprecationMechanismTest(unittest.TestCase):
+    def test_message_format(self):
+        self.assertEqual(
+            deprecation_message("Foo.old", "new", since="0.8.0", removed_in="0.10.0"),
+            "Foo.old is deprecated since mixle 0.8.0; use new instead. It will be removed in mixle 0.10.0.",
+        )
+        # removed_in is optional -- omit the removal sentence when it is unknown.
+        self.assertEqual(
+            deprecation_message("old", "new", since="0.8.0"),
+            "old is deprecated since mixle 0.8.0; use new instead.",
+        )
+
+    def test_warn_deprecated_category_and_caller_attribution(self):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            warn_deprecated("old", "new", since="0.8.0", removed_in="0.10.0")  # <- this line is the caller
+        self.assertEqual(len(caught), 1)
+        self.assertIs(caught[0].category, DeprecationWarning)
+        self.assertIn("old is deprecated since mixle 0.8.0", str(caught[0].message))
+        self.assertEqual(Path(caught[0].filename).name, "deprecation_test.py")
+
+    def test_deprecated_alias_warns_and_forwards(self):
+        class C:
+            def canonical(self, a, b):
+                return a + b
+
+            @deprecated_alias("canonical", since="0.8.0", removed_in="0.10.0")
+            def legacy(self, a, b):
+                return self.canonical(a, b)
+
+        c = C()
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = c.legacy(2, 3)
+        self.assertEqual(result, 5)  # forwarding is transparent
+        self.assertIs(caught[0].category, DeprecationWarning)
+        self.assertIn("C.legacy is deprecated", str(caught[0].message))
+        self.assertEqual(C.legacy.__name__, "legacy")  # functools.wraps preserved
+
+
+class ConcreteAliasesTest(unittest.TestCase):
+    def test_gaussian_mixture_accumulator_factory_alias(self):
+        from mixle.stats import MultivariateGaussianEstimator
+        from mixle.stats.latent.gaussian_mixture import GaussianMixtureEstimator
+
+        est = GaussianMixtureEstimator([MultivariateGaussianEstimator(dim=2), MultivariateGaussianEstimator(dim=2)])
+        with self.assertWarns(DeprecationWarning):
+            aliased = est.accumulatorFactory()
+        self.assertIs(type(aliased), type(est.accumulator_factory()))
+
+    def test_update_alpha_function_alias(self):
+        from mixle.stats.latent.labeled_lda import update_alpha, updateAlpha
+
+        alpha = np.array([[1.0, 1.0, 1.0]])
+        mean_log_p = np.array([[-0.5, -0.4, -0.6]])
+        with np.errstate(over="ignore"):  # the fixed-point math overflows identically in both paths
+            with self.assertWarns(DeprecationWarning):
+                aliased = updateAlpha(alpha.copy(), mean_log_p, 1e-6)
+            np.testing.assert_allclose(aliased, update_alpha(alpha.copy(), mean_log_p, 1e-6))
+
+
+class NoSilentDeprecatedAliasTest(unittest.TestCase):
+    """Every "Deprecated alias" callable in the package source must carry @deprecated_alias."""
+
+    @staticmethod
+    def _has_deprecated_alias_decorator(node):
+        for dec in node.decorator_list:
+            target = dec.func if isinstance(dec, ast.Call) else dec
+            name = target.attr if isinstance(target, ast.Attribute) else getattr(target, "id", None)
+            if name == "deprecated_alias":
+                return True
+        return False
+
+    def test_all_deprecated_aliases_are_wired(self):
+        offenders = []
+        for path in _PKG_ROOT.rglob("*.py"):
+            if "tests" in path.parts:
+                continue
+            tree = ast.parse(path.read_text(), filename=str(path))
+            for node in ast.walk(tree):
+                if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    continue
+                doc = ast.get_docstring(node) or ""
+                if doc.startswith("Deprecated alias") and not self._has_deprecated_alias_decorator(node):
+                    offenders.append(f"{path.relative_to(_PKG_ROOT)}:{node.lineno} {node.name}")
+        self.assertEqual(
+            offenders,
+            [],
+            "these 'Deprecated alias' callables emit no DeprecationWarning (add @deprecated_alias):\n"
+            + "\n".join(offenders),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mixle/tests/wave_hmmlegacy_test.py
+++ b/mixle/tests/wave_hmmlegacy_test.py
@@ -78,8 +78,9 @@ class LabeledLDATestCase(unittest.TestCase):
         np.testing.assert_array_equal(nbx, [i % 2 for i in range(len(self.data))])
         np.testing.assert_array_equal(nbidx, np.arange(len(self.data)))
 
-        # legacy seq_encode on the distribution delegates to the encoder
-        legacy_enc = self.model.seq_encode(self.data)
+        # legacy seq_encode on the distribution delegates to the encoder (and warns: it is deprecated)
+        with self.assertWarns(DeprecationWarning):
+            legacy_enc = self.model.seq_encode(self.data)
         np.testing.assert_array_equal(legacy_enc[1], idx)
         np.testing.assert_array_equal(legacy_enc[5], nbx)
 
@@ -139,7 +140,8 @@ class LabeledLDATestCase(unittest.TestCase):
     def test_accumulator_factory_alias(self):
         est = make_llda_estimator()
         f1 = est.accumulator_factory()
-        f2 = est.accumulatorFactory()
+        with self.assertWarns(DeprecationWarning):  # camelCase alias is deprecated
+            f2 = est.accumulatorFactory()
         self.assertIsInstance(f1, LabeledLDAEstimatorAccumulatorFactory)
         self.assertIsInstance(f2, LabeledLDAEstimatorAccumulatorFactory)
 

--- a/mixle/tests/wave_markov_test.py
+++ b/mixle/tests/wave_markov_test.py
@@ -138,7 +138,8 @@ class GrammarTestCase(unittest.TestCase):
 
         est = VertexReplacementGrammarEstimator()
         self.assertIsInstance(est.accumulator_factory(), VertexReplacementGrammarAccumulatorFactory)
-        self.assertIsInstance(est.accumulatorFactory(), VertexReplacementGrammarAccumulatorFactory)
+        with self.assertWarns(DeprecationWarning):  # camelCase alias is deprecated
+            self.assertIsInstance(est.accumulatorFactory(), VertexReplacementGrammarAccumulatorFactory)
 
     def test_encoder_equality(self):
         from mixle.stats.graphs.vertex_replacement_grammar import (
@@ -395,7 +396,8 @@ class MarkovTransformTestCase(unittest.TestCase):
 
         est = MarkovTransformEstimator(dist.num_vals, alpha=0.05)
         self.assertIsInstance(est.accumulator_factory(), MarkovTransformAccumulatorFactory)
-        self.assertIsInstance(est.accumulatorFactory(), MarkovTransformAccumulatorFactory)
+        with self.assertWarns(DeprecationWarning):  # camelCase alias is deprecated
+            self.assertIsInstance(est.accumulatorFactory(), MarkovTransformAccumulatorFactory)
 
         acc = est.accumulator_factory().make()
         acc.seq_initialize(ex, weights, np.random.RandomState(5))

--- a/mixle/tests/wave_mvn_test.py
+++ b/mixle/tests/wave_mvn_test.py
@@ -192,9 +192,10 @@ class GaussianMixtureTestCase(unittest.TestCase):
         self.assertIsInstance(est, GaussianMixtureEstimator)
         self.assertEqual(est.num_components, 2)
 
-        # Legacy camelCase alias still works.
+        # Legacy camelCase alias still works (and warns: it is deprecated).
         fac1 = est.accumulator_factory()
-        fac2 = est.accumulatorFactory()
+        with self.assertWarns(DeprecationWarning):
+            fac2 = est.accumulatorFactory()
         self.assertEqual(type(fac1), type(fac2))
 
     def test_encoder_eq_and_str(self):

--- a/mixle/utils/deprecation.py
+++ b/mixle/utils/deprecation.py
@@ -1,0 +1,66 @@
+"""One mechanism for deprecating public names, implementing the policy in ``docs/deprecation-policy.rst``.
+
+A deprecated stable name must keep working *and* tell the caller where to go, in a category tools can act
+on. This module is the single place that emits that signal, so every deprecation in the library speaks
+with one warning category (``DeprecationWarning``) and one message format::
+
+    <old> is deprecated since mixle <since>; use <new> instead. It will be removed in mixle <removed_in>.
+
+Use :func:`deprecated_alias` to wrap a thin forwarding method or function; use :func:`warn_deprecated`
+directly for finer-grained cases (a deprecated argument value, a deprecated code path). The ``stacklevel``
+is set so the warning points at the *caller's* line, not at this module.
+"""
+
+from __future__ import annotations
+
+import functools
+import warnings
+from collections.abc import Callable
+from typing import Any, TypeVar
+
+__all__ = ["warn_deprecated", "deprecated_alias", "deprecation_message"]
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+def deprecation_message(old: str, new: str, *, since: str, removed_in: str | None = None) -> str:
+    """Return the canonical deprecation message (the one format every mixle deprecation uses)."""
+    tail = f" It will be removed in mixle {removed_in}." if removed_in else ""
+    return f"{old} is deprecated since mixle {since}; use {new} instead.{tail}"
+
+
+def warn_deprecated(old: str, new: str, *, since: str, removed_in: str | None = None, stacklevel: int = 1) -> None:
+    """Emit the standard ``DeprecationWarning`` for using ``old`` instead of ``new``.
+
+    ``stacklevel`` counts caller frames above this function: the default (1) attributes the warning to the
+    immediate caller. :func:`deprecated_alias` passes 2 to skip its own wrapper frame so the warning still
+    lands on the user's call site.
+    """
+    warnings.warn(
+        deprecation_message(old, new, since=since, removed_in=removed_in),
+        DeprecationWarning,
+        stacklevel=stacklevel + 1,
+    )
+
+
+def deprecated_alias(
+    new: str, *, since: str, removed_in: str | None = None, old: str | None = None
+) -> Callable[[F], F]:
+    """Mark a thin forwarding method/function as a deprecated alias for ``new``.
+
+    The wrapped callable's body is unchanged (it should just forward to the canonical name); calling it
+    emits the standard warning first, attributed to the caller. ``old`` defaults to the wrapped callable's
+    qualified name (e.g. ``FooEstimator.accumulatorFactory``).
+    """
+
+    def decorate(func: F) -> F:
+        label = old if old is not None else func.__qualname__
+
+        @functools.wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            warn_deprecated(label, new, since=since, removed_in=removed_in, stacklevel=2)
+            return func(*args, **kwargs)
+
+        return wrapper  # type: ignore[return-value]
+
+    return decorate


### PR DESCRIPTION
## What (worklist A1.5)

The tree had several public names documented as deprecated — `"Deprecated alias for accumulator_factory()"`,
a legacy `updateAlpha`, a legacy distribution `seq_encode` — but **not one emitted a `DeprecationWarning`**.
A caller had no machine-readable signal to migrate. This adds one mechanism, wires every existing
deprecated alias to it, documents the policy, and gates against future silent deprecations.

## Mechanism — `mixle/utils/deprecation.py`

`warn_deprecated` / `deprecated_alias` emit a single warning category (`DeprecationWarning`) in one format:

```
<old> is deprecated since mixle <since>; use <new> instead. It will be removed in mixle <removed_in>.
```

attributed to the **caller's** line (stacklevel accounts for the decorator's wrapper frame). The decorator
leaves the wrapped body unchanged, so the alias still forwards to the canonical name — a deprecation must
never change behavior.

## Wired aliases (forward unchanged, now warn)

- `.accumulatorFactory` on `GaussianMixtureEstimator`, `LabeledLDAEstimator`,
  `VertexReplacementGrammarEstimator`, `MarkovTransformEstimator`;
- the module-level `updateAlpha`;
- `LabeledLDADistribution.seq_encode`.

One **internal** caller (LabeledLDA scalar density) was itself using the deprecated `seq_encode`; switched
to `dist_to_encoder().seq_encode()` so the library doesn't trip its own deprecation. The few tests that
intentionally exercise the legacy spellings now wrap the call in `assertWarns` — keeping the suite
warning-clean *and* asserting the deprecation fires.

## Policy — `docs/support-policy.rst`

Expands the existing "Compatibility and Deprecation" section with the three API maturity tiers
(stable / provisional / experimental) and the deprecation lifecycle: forward unchanged, warn with the
standard message, keep for **at least two minor releases** (announced in `0.8.0` → removable no earlier
than `0.10.0`), and ship a migration note/example on removal.

## Gate — `mixle/tests/deprecation_test.py`

- pins the message format and caller attribution;
- checks the concrete aliases warn **and still forward** to the canonical result;
- **statically** asserts (AST scan of the package source) that every `"Deprecated alias"` callable carries
  `@deprecated_alias` — so a future silent deprecation fails here, closing the exact gap A1.5 named.

## Evidence

81 tests across the mechanism and the alias-exercising suites (`deprecation_test`, `wave_hmmlegacy`,
`wave_markov`, `wave_mvn`, `api_naming_aliases`, LDA family) pass. `ruff format --check mixle` +
`ruff check mixle` clean tree-wide.

Acceptance (A1.5): deprecation & compatibility policy defined (tiers, minimum period, warning category +
message format, migration-example requirement) and deprecated aliases tested — met and enforced.
