### PR TITLE
Make artifact JSON writes atomic so a failed save can't corrupt an artifact (worklist S13.5)

### DIFF
--- a/mixle/task/artifact.py
+++ b/mixle/task/artifact.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import json
 import os
+import tempfile
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -33,6 +34,31 @@ MANIFEST_NAME = "manifest.json"
 WEIGHTS_NAME = "weights.safetensors"
 JSON_MODEL_NAME = "model.json"
 ARRAYS_NAME = "arrays.npz"
+
+
+def _atomic_json_dump(dst: str, obj: Any, **dump_kwargs: Any) -> None:
+    """Serialize ``obj`` as JSON to ``dst`` atomically: write a sibling temp file, fsync, then ``os.replace``.
+
+    A plain ``open(dst, "w")`` truncates ``dst`` *before* serialization runs, so a non-serializable model (or
+    a crash mid-``json.dump``) leaves a truncated, unloadable artifact -- or destroys the previous good one.
+    Writing to a temp file in the same directory and swapping it in with ``os.replace`` (atomic on POSIX and
+    Windows) makes the write all-or-nothing: on any failure the temp file is removed and ``dst`` is untouched.
+    """
+    directory = os.path.dirname(dst) or "."
+    fd, tmp = tempfile.mkstemp(dir=directory, prefix=".tmp-artifact-", suffix=".json")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(obj, f, **dump_kwargs)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, dst)
+    except BaseException:
+        # Serialization failed or was interrupted: drop the temp file, leave dst as it was.
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
 
 
 # --- builder registry: name -> (**config) -> nn.Module ------------------------------------------------------
@@ -131,8 +157,7 @@ def read_manifest(path: str) -> TaskManifest:
 
 
 def _write_manifest(path: str, manifest: TaskManifest) -> None:
-    with open(os.path.join(path, MANIFEST_NAME), "w") as f:
-        json.dump(manifest.to_dict(), f, indent=2, sort_keys=True)
+    _atomic_json_dump(os.path.join(path, MANIFEST_NAME), manifest.to_dict(), indent=2, sort_keys=True)
 
 
 # --- torch payload: builder + config + tied-safe weights ----------------------------------------------------
@@ -193,8 +218,7 @@ def save_json(
 
     ensure_pysp_serialization_registry()
     os.makedirs(path, exist_ok=True)
-    with open(os.path.join(path, JSON_MODEL_NAME), "w") as f:
-        json.dump(to_serializable(model), f)
+    _atomic_json_dump(os.path.join(path, JSON_MODEL_NAME), to_serializable(model))
     _write_manifest(path, TaskManifest(payload="json", task=task, io=io or {}, meta=meta or {}))
     return path
 

--- a/mixle/tests/artifact_atomic_write_test.py
+++ b/mixle/tests/artifact_atomic_write_test.py
@@ -1,0 +1,78 @@
+"""Artifact writes are atomic: a failed serialization never corrupts an artifact (worklist S13.5 / M11.3).
+
+``save_json`` and the manifest writer used ``open(path, "w")``, which truncates the target *before*
+serialization runs. A non-serializable model -- or a crash mid-``json.dump`` -- therefore left a truncated,
+unloadable ``model.json`` and, worse, destroyed any previous good artifact at that path. The write now goes
+through a temp file swapped in with ``os.replace``, so it is all-or-nothing. These are the failure-injection
+tests for that contract: the operation fails loudly, the prior artifact survives, and no temp file leaks.
+"""
+
+import glob
+import os
+import tempfile
+import unittest
+
+import mixle.stats as st
+from mixle.task.artifact import JSON_MODEL_NAME, _atomic_json_dump, load_json, save_json
+from mixle.utils.serialization import SerializationError
+
+_TMP_GLOB = ".tmp-artifact-*"
+
+
+class AtomicJsonDumpTest(unittest.TestCase):
+    def test_writes_content_and_leaves_no_temp(self):
+        with tempfile.TemporaryDirectory() as d:
+            dst = os.path.join(d, "out.json")
+            _atomic_json_dump(dst, {"a": 1, "b": [2, 3]}, sort_keys=True)
+            with open(dst) as f:
+                self.assertEqual(f.read(), '{"a": 1, "b": [2, 3]}')
+            self.assertEqual(glob.glob(os.path.join(d, _TMP_GLOB)), [])
+
+    def test_mid_write_failure_creates_no_file_and_no_temp(self):
+        with tempfile.TemporaryDirectory() as d:
+            dst = os.path.join(d, "out.json")
+            with self.assertRaises(TypeError):  # a set is not JSON-serializable -> json.dump raises mid-write
+                _atomic_json_dump(dst, {1, 2, 3})
+            self.assertFalse(os.path.exists(dst))  # target was never created
+            self.assertEqual(glob.glob(os.path.join(d, _TMP_GLOB)), [])  # temp cleaned up
+
+    def test_failure_preserves_existing_file(self):
+        with tempfile.TemporaryDirectory() as d:
+            dst = os.path.join(d, "out.json")
+            _atomic_json_dump(dst, {"good": True})
+            original = open(dst).read()
+            with self.assertRaises(TypeError):
+                _atomic_json_dump(dst, {1, 2, 3})
+            self.assertEqual(open(dst).read(), original)  # untouched by the failed write
+            self.assertEqual(glob.glob(os.path.join(d, _TMP_GLOB)), [])
+
+
+class SaveJsonAtomicityTest(unittest.TestCase):
+    def test_round_trip(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "art")
+            model = st.GaussianDistribution(1.5, 2.0)
+            save_json(path, model)
+            loaded, _ = load_json(path)
+            self.assertAlmostEqual(loaded.log_density(0.3), model.log_density(0.3), places=12)
+
+    def test_failed_overwrite_keeps_previous_artifact_loadable(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "art")
+            save_json(path, st.GaussianDistribution(1.5, 2.0))
+            before = open(os.path.join(path, JSON_MODEL_NAME)).read()
+
+            # object() is not registered for serialization -> save must fail without touching the good artifact.
+            with self.assertRaises(SerializationError):
+                save_json(path, object())
+
+            self.assertEqual(open(os.path.join(path, JSON_MODEL_NAME)).read(), before)
+            self.assertEqual(glob.glob(os.path.join(path, _TMP_GLOB)), [])
+            loaded, _ = load_json(path)  # still loadable
+            self.assertAlmostEqual(
+                loaded.log_density(0.3), st.GaussianDistribution(1.5, 2.0).log_density(0.3), places=12
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What (worklist S13.5 / M11.3)

`save_json` and the manifest writer used `open(path, "w")`, which **truncates the target before
serialization runs**. A non-serializable model — or a crash mid-`json.dump` — therefore left a truncated,
unloadable `model.json`, and worse, **destroyed any previously good artifact** at that path. A failed save
must not damage durable state.

## Fix

Both writes now go through `_atomic_json_dump`: serialize to a sibling temp file, `fsync`, then
`os.replace` (atomic on POSIX and Windows within a directory). On any failure the temp file is removed and
the target is left exactly as it was. Success behavior and on-disk format are unchanged.

## Failure-injection tests

`mixle/tests/artifact_atomic_write_test.py` (torch-free):

- the helper writes correct content and leaves **no** temp file;
- a mid-write `json` failure (a `set`) creates **no** target and **no** temp file;
- a failed write **over an existing file** leaves it byte-identical;
- `save_json`'s happy round-trip, plus a failed overwrite (`SerializationError` from `object()`) that keeps
  the previous artifact **loadable**.

Each of these would fail on the old in-place writer (which empties the target on `open`).

## Evidence

`pytest mixle/tests/artifact_atomic_write_test.py` → 5 passed. Regression: `task_artifact` (6),
`serialization` (12), `task_model` (6) pass unchanged. `ruff format --check` + `ruff check` clean.

Acceptance (S13.5): a failure-injected save shows clean shutdown — target intact, no leaked temp file.
