### PR TITLE
Make optimize/fit/best_of quiet by default (worklist Q5.4)

### DIFF
--- a/mixle/inference/estimation.py
+++ b/mixle/inference/estimation.py
@@ -5,7 +5,6 @@ objects.
 
 """
 
-import sys
 from collections.abc import Sequence
 from functools import partial
 from typing import IO, Any, NamedTuple, TypeVar
@@ -369,7 +368,7 @@ def _em_loop(
     max_its: int,
     delta: float | None,
     enc_vdata: Any | None = None,
-    out: IO | None = sys.stdout,
+    out: IO | None = None,
     print_iter: int = 1,
     monotone: bool = True,
     track_best: bool = True,
@@ -623,7 +622,7 @@ def optimize(
     vdata: Sequence[T] | None = None,
     enc_data: list[tuple[int, E0]] | None = None,
     enc_vdata: list[tuple[int, E0]] | None = None,
-    out: IO = sys.stdout,
+    out: IO | None = None,
     print_iter: int = 1,
     num_chunks: int = 1,
     engine: Any | None = None,
@@ -678,7 +677,8 @@ def optimize(
         enc_data (Optional[List[Tuple[int, E]]]): Optional encoded data of form
             List[Tuple[int, E]]. Formed from data if None.
         enc_vdata (Optional[List[Tuple[int, E0]]]): Optional sequence encoded validation set.
-        out (IO): IO stream to write out iterations of EM algorithm. Pass out=None to silence all output.
+        out (IO | None): Stream for per-iteration EM progress lines. Defaults to ``None`` (quiet, so the
+            library does not spam stdout in normal use); pass ``out=sys.stdout`` to watch convergence.
         print_iter (int): Print the log-likelihood difference every print_iter iterations; the final converged
             iteration is always reported. Pass print_iter=0 to suppress the periodic lines (keeping only the
             converged line), or out=None to silence entirely.
@@ -993,7 +993,7 @@ def fit(
         and kwargs.get("prev_estimate") is None
         and kwargs.get("strategy") is None
     ):
-        structured = _maybe_structured_model(data, max_its, kwargs.get("out", sys.stdout), kwargs.get("rng"))
+        structured = _maybe_structured_model(data, max_its, kwargs.get("out"), kwargs.get("rng"))
         if structured is not None:
             return structured
     estimator = _coerce_estimator(estimator, data)
@@ -1032,7 +1032,7 @@ def best_of(
     init_estimator: ParameterEstimator | ProbabilityDistribution | None = None,
     enc_data: list[tuple[int, E0]] | None = None,
     enc_vdata: Sequence[tuple[int, E0]] | None = None,
-    out: IO = sys.stdout,
+    out: IO | None = None,
     print_iter: int = 1,
     reuse_estep_ll: bool = True,
     objective: str = "auto",

--- a/mixle/tests/optimize_quiet_default_test.py
+++ b/mixle/tests/optimize_quiet_default_test.py
@@ -1,0 +1,61 @@
+"""The fit verbs are quiet by default (worklist Q5.4).
+
+``optimize`` / ``fit`` / ``best_of`` used to default ``out=sys.stdout``, so any ordinary fit sprayed
+per-iteration ``Iteration N: ...`` lines onto the caller's stdout -- unsolicited output that a library
+should not produce. The default is now ``None`` (silent); progress is strictly opt-in via ``out=``. These
+tests pin both halves: no output unless asked, and the requested stream still receives it.
+"""
+
+import contextlib
+import io
+import unittest
+
+import numpy as np
+
+from mixle.inference.estimation import best_of, fit, optimize
+from mixle.stats import MultivariateGaussianEstimator
+from mixle.stats.latent.gaussian_mixture import GaussianMixtureEstimator
+
+
+def _data(seed=0):
+    rng = np.random.RandomState(seed)
+    return [list(x) for x in np.vstack([rng.randn(120, 2), rng.randn(120, 2) + 5.0])]
+
+
+def _est():
+    return GaussianMixtureEstimator([MultivariateGaussianEstimator(dim=2), MultivariateGaussianEstimator(dim=2)])
+
+
+class OptimizeQuietDefaultTest(unittest.TestCase):
+    def test_optimize_is_silent_by_default(self):
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            optimize(_data(), _est(), max_its=8)
+        self.assertEqual(buf.getvalue(), "")
+
+    def test_fit_is_silent_by_default(self):
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            fit(_data(), _est(), max_its=8, delta=None)
+        self.assertEqual(buf.getvalue(), "")
+
+    def test_best_of_is_silent_by_default(self):
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            best_of(_data(), None, _est(), 2, 5, 0.1, 1e-9, np.random.RandomState(0))
+        self.assertEqual(buf.getvalue(), "")
+
+    def test_progress_is_opt_in(self):
+        # Passing an explicit stream still produces per-iteration progress -- the capability is intact.
+        stream = io.StringIO()
+        optimize(_data(), _est(), max_its=8, out=stream)
+        self.assertIn("Iteration", stream.getvalue())
+        # and it did not leak to stdout in the process.
+        stdout_buf = io.StringIO()
+        with contextlib.redirect_stdout(stdout_buf):
+            optimize(_data(), _est(), max_its=8, out=io.StringIO())
+        self.assertEqual(stdout_buf.getvalue(), "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What (worklist Q5.4)

`optimize`, `fit`, and `best_of` defaulted `out=sys.stdout`, so **every ordinary fit** sprayed
per-iteration `Iteration N: ln[p(Data|Model)]=…` lines onto the caller's stdout — the unsolicited
"iteration spam in normal library use" Q5.4 exists to remove. The default is now `out=None` (silent);
per-iteration progress is strictly **opt-in** via `out=sys.stdout` (or any stream).

## Behavior change (console output only)

⚠️ This changes default **console output**, nothing else. Fitted models, convergence, and every numeric
result are byte-identical — only the stream defaults change. Callers who want progress pass `out=`
explicitly (many already do).

Safe because every `out.write` path is already guarded by `if out is not None` (the progress writer
returns early on `None`). The now-unused `import sys` is removed, and the `optimize` docstring — which
told callers to "pass `out=None` to silence" a default that no longer prints — is corrected.

## Tests

`mixle/tests/optimize_quiet_default_test.py`: `optimize`/`fit`/`best_of` emit **nothing** to stdout by
default; an explicit `out=` stream still receives the `Iteration` progress (opt-in intact, no stdout leak).

## Evidence

4 new tests pass. Regression (previously ran under the noisy default): `em_strategies` (18),
`objective_resolution` (5), `mixture_stability` (8), `resilient_em` (6), `fused_em` (8) — all unchanged.
`ruff format --check` + `ruff check` clean. No test in the suite asserted on the old default stdout output.

Acceptance (Q5.4): default console output is quiet unless requested — met.
