### PR TITLE
Add a machine-readable API maturity registry (worklist A1.2)

### DIFF
--- a/docs/maturity.rst
+++ b/docs/maturity.rst
@@ -14,6 +14,11 @@ full scope of what Mixle can do.
 Maturity Map
 ------------
 
+This map has a machine-readable mirror in :mod:`mixle.maturity`: ``maturity_of("mixle.stats.latent")``
+returns the tier (``stable`` / ``provisional`` / ``experimental``, matching the deprecation policy in
+:doc:`support-policy`) for any dotted module name, resolving by longest prefix. A test keeps the two in
+sync, so this table and the registry cannot drift apart.
+
 .. list-table::
    :header-rows: 1
 

--- a/mixle/maturity.py
+++ b/mixle/maturity.py
@@ -1,0 +1,76 @@
+"""Machine-readable API maturity registry (worklist A1.2).
+
+``docs/maturity.rst`` describes, in prose, how mature each public surface is. This is the machine-readable
+mirror of that map: a single source of truth a tool (or the API manifest, worklist A1.6) can query to learn
+the maturity tier of any dotted module name. The three tiers match the deprecation policy in
+``docs/support-policy.rst`` (worklist A1.5):
+
+* ``STABLE`` -- covered by the compatibility policy; changes follow the deprecation lifecycle.
+* ``PROVISIONAL`` -- usable and tested, but signatures/defaults may still change within a minor release.
+* ``EXPERIMENTAL`` -- no compatibility guarantee (only ``mixle.experimental``).
+
+:func:`maturity_of` resolves a dotted name by longest matching prefix, so ``mixle.stats.latent.hidden_markov``
+inherits ``mixle.stats``'s tier while ``mixle.inference.production`` overrides the ``mixle.inference`` tier.
+Surfaces not listed default to :data:`DEFAULT_MATURITY` (``PROVISIONAL``) -- the conservative choice: a
+surface makes no stability promise until it is explicitly recorded as stable.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+__all__ = ["Maturity", "MATURITY_REGISTRY", "DEFAULT_MATURITY", "maturity_of", "status_of"]
+
+
+class Maturity(str, Enum):
+    """API maturity tier. String-valued so it serializes as its name in JSON manifests."""
+
+    STABLE = "stable"
+    PROVISIONAL = "provisional"
+    EXPERIMENTAL = "experimental"
+
+
+# module prefix -> (tier, human status label mirrored from docs/maturity.rst). More specific prefixes win.
+MATURITY_REGISTRY: dict[str, tuple[Maturity, str]] = {
+    "mixle.stats": (Maturity.STABLE, "Stable core"),
+    "mixle.inference": (Maturity.STABLE, "Stable core (optimize + direct estimation)"),
+    "mixle.inference.production": (Maturity.PROVISIONAL, "Practical helpers, not a platform"),
+    "mixle.enumeration": (Maturity.PROVISIONAL, "Usable, evolving"),
+    "mixle.ops": (Maturity.PROVISIONAL, "Usable, evolving"),
+    "mixle.ppl": (Maturity.PROVISIONAL, "Active development"),
+    "mixle.process": (Maturity.PROVISIONAL, "Active development"),
+    "mixle.models": (Maturity.PROVISIONAL, "Incubating applied helpers"),
+    "mixle.task": (Maturity.PROVISIONAL, "Active application/research workflows"),
+    "mixle.reason": (Maturity.PROVISIONAL, "Active application/research workflows"),
+    "mixle.substrate": (Maturity.PROVISIONAL, "New local application runtime"),
+    "mixle.pool": (Maturity.PROVISIONAL, "New local application runtime"),
+    "mixle.telemetry": (Maturity.PROVISIONAL, "New local application runtime"),
+    "mixle.scientist": (Maturity.PROVISIONAL, "Optional assembled workflow"),
+    "mixle.doe": (Maturity.PROVISIONAL, "Active application/research workflows"),
+    "mixle.evolve": (Maturity.PROVISIONAL, "Active application/research workflows"),
+    "mixle.experimental": (Maturity.EXPERIMENTAL, "No compatibility guarantee"),
+}
+
+DEFAULT_MATURITY = Maturity.PROVISIONAL
+
+
+def _resolve(name: str) -> tuple[Maturity, str] | None:
+    """Return the registry entry for the longest prefix of ``name`` (dot-boundary aware), or None."""
+    parts = name.split(".")
+    for depth in range(len(parts), 0, -1):
+        prefix = ".".join(parts[:depth])
+        if prefix in MATURITY_REGISTRY:
+            return MATURITY_REGISTRY[prefix]
+    return None
+
+
+def maturity_of(name: str) -> Maturity:
+    """Return the :class:`Maturity` tier of a dotted module name (longest-prefix match; default provisional)."""
+    entry = _resolve(name)
+    return entry[0] if entry is not None else DEFAULT_MATURITY
+
+
+def status_of(name: str) -> str:
+    """Return the human status label for a dotted module name, mirroring ``docs/maturity.rst``."""
+    entry = _resolve(name)
+    return entry[1] if entry is not None else "Unclassified (provisional by default)"

--- a/mixle/tests/maturity_registry_test.py
+++ b/mixle/tests/maturity_registry_test.py
@@ -1,0 +1,86 @@
+"""The machine-readable maturity registry mirrors the docs and A1.5 tiers (worklist A1.2).
+
+``mixle.maturity`` is the machine-readable form of ``docs/maturity.rst``. These tests keep the two in sync
+(a surface documented as stable must resolve as stable, etc.), pin the longest-prefix resolution and the
+conservative default, and enforce consistency with the deprecation policy's tiers (worklist A1.5): only
+``mixle.experimental`` is EXPERIMENTAL.
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+from mixle.maturity import DEFAULT_MATURITY, MATURITY_REGISTRY, Maturity, maturity_of, status_of
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MATURITY_DOC = REPO_ROOT / "docs" / "maturity.rst"
+
+
+def _documented_surfaces():
+    """Parse (surface, status) pairs from the Maturity Map list-table in docs/maturity.rst."""
+    lines = MATURITY_DOC.read_text().splitlines()
+    pairs = []
+    surfaces, status = None, None
+    for ln in lines:
+        m_row = re.match(r"\s*\*\s*-\s*(.+)", ln)
+        m_cont = re.match(r"\s*-\s*(.+)", ln)
+        if m_row:
+            if surfaces:
+                for s in surfaces:
+                    pairs.append((s, status))
+            surfaces = re.findall(r"``(mixle[\w.]*)``", m_row.group(1))
+            status = None
+        elif m_cont and surfaces and status is None:
+            status = m_cont.group(1).strip()
+    if surfaces:
+        for s in surfaces:
+            pairs.append((s, status))
+    return [(s, st) for s, st in pairs if s and st]
+
+
+class MaturityDocSyncTest(unittest.TestCase):
+    def test_registry_matches_documented_maturity(self):
+        surfaces = _documented_surfaces()
+        self.assertGreaterEqual(len(surfaces), 10, "failed to parse the maturity map from docs/maturity.rst")
+        for surface, status in surfaces:
+            expected = Maturity.STABLE if status.startswith("Stable core") else Maturity.PROVISIONAL
+            self.assertEqual(
+                maturity_of(surface),
+                expected,
+                f"{surface!r} is documented as {status!r} but the registry resolves it to "
+                f"{maturity_of(surface).value!r}",
+            )
+
+
+class MaturityResolutionTest(unittest.TestCase):
+    def test_longest_prefix_inheritance(self):
+        self.assertEqual(maturity_of("mixle.stats.latent.hidden_markov"), Maturity.STABLE)
+        self.assertEqual(maturity_of("mixle.inference.optimize"), Maturity.STABLE)
+
+    def test_more_specific_prefix_overrides(self):
+        # mixle.inference is stable, but mixle.inference.production is only practical-helper provisional.
+        self.assertEqual(maturity_of("mixle.inference"), Maturity.STABLE)
+        self.assertEqual(maturity_of("mixle.inference.production.registry"), Maturity.PROVISIONAL)
+
+    def test_experimental_namespace(self):
+        self.assertEqual(maturity_of("mixle.experimental"), Maturity.EXPERIMENTAL)
+        self.assertEqual(maturity_of("mixle.experimental.program"), Maturity.EXPERIMENTAL)
+
+    def test_unclassified_defaults_to_provisional(self):
+        self.assertEqual(maturity_of("mixle.some_unlisted_surface"), DEFAULT_MATURITY)
+        self.assertEqual(DEFAULT_MATURITY, Maturity.PROVISIONAL)
+        self.assertIn("provisional", status_of("mixle.some_unlisted_surface").lower())
+
+
+class MaturityPolicyConsistencyTest(unittest.TestCase):
+    def test_only_experimental_namespace_is_experimental(self):
+        experimental = {k for k, (tier, _) in MATURITY_REGISTRY.items() if tier is Maturity.EXPERIMENTAL}
+        self.assertEqual(experimental, {"mixle.experimental"})
+
+    def test_stable_surfaces_are_the_documented_core(self):
+        stable = {k for k, (tier, _) in MATURITY_REGISTRY.items() if tier is Maturity.STABLE}
+        self.assertEqual(stable, {"mixle.stats", "mixle.inference"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What (worklist A1.2)

`docs/maturity.rst` described maturity only in prose — nothing could answer "how stable is this surface?"
programmatically (the A1.2 gap: *"no machine registry"*). Adds `mixle.maturity`: a registry mapping module
prefixes to a tier — **STABLE / PROVISIONAL / EXPERIMENTAL**, the same three tiers the deprecation policy
uses (#324 / A1.5) — plus `maturity_of()` / `status_of()` that resolve any dotted module name by **longest
matching prefix**:

```python
>>> from mixle.maturity import maturity_of
>>> maturity_of("mixle.stats.latent.hidden_markov")   # inherits mixle.stats
<Maturity.STABLE>
>>> maturity_of("mixle.inference.production.registry") # overrides mixle.inference (stable)
<Maturity.PROVISIONAL>
>>> maturity_of("mixle.experimental.program")
<Maturity.EXPERIMENTAL>
```

Surfaces not listed default to `PROVISIONAL` — the conservative choice (no stability promise until a
surface is explicitly recorded stable). The registry mirrors the maturity map **exactly**; unlisted
top-level surfaces are intentionally left to the default rather than assigned invented tiers.

## Kept in sync

`mixle/tests/maturity_registry_test.py` parses `docs/maturity.rst` and asserts the registry resolves every
documented surface to the matching tier — so the table and the registry **cannot drift apart**. Further
tests pin longest-prefix resolution, the more-specific-prefix override, the experimental namespace, the
provisional default, and A1.5 consistency (only `mixle.experimental` is EXPERIMENTAL). `maturity.rst` now
cross-references the registry.

## Evidence

7 tests pass. `ruff format --check` + `ruff check` clean.

Acceptance (A1.2): a machine-readable maturity registry consistent with the documented labels — met. This
is the surface A1.6 (maturity in the API manifest) consumes once A1.1 (#295) lands.
