### PR TITLE
Contain registry paths against symlink escape (worklist S13.2)

### DIFF
--- a/mixle/inference/production/registry.py
+++ b/mixle/inference/production/registry.py
@@ -49,10 +49,26 @@ class Registry:
         self.root = root
         os.makedirs(root, exist_ok=True)
 
-    def _dir(self, name: str) -> str:
+    def _model_dir(self, name: str, *, create: bool) -> str:
+        """Resolve the on-disk directory for model ``name``, refusing any path that escapes the store root.
+
+        ``_safe_segment`` blocks traversal *inside* the name string, but a symlink pre-placed in the root
+        (from an untrusted or restored registry, or a tar extraction) named like a model would still let a
+        read or write follow it outside the root. Reject an entry that is a symlink, or whose real path is
+        not contained in the root's real path, before any ``open`` / ``makedirs`` follows it.
+        """
         d = os.path.join(self.root, _safe_segment(name))
-        os.makedirs(d, exist_ok=True)
+        if os.path.lexists(d):
+            root_real = os.path.realpath(self.root)
+            real = os.path.realpath(d)
+            if os.path.islink(d) or (real != root_real and not real.startswith(root_real + os.sep)):
+                raise ValueError(f"unsafe registry name {name!r}: entry resolves outside the store root")
+        if create:
+            os.makedirs(d, exist_ok=True)
         return d
+
+    def _dir(self, name: str) -> str:
+        return self._model_dir(name, create=True)
 
     def names(self) -> list[str]:
         """Registered model names."""
@@ -60,7 +76,7 @@ class Registry:
 
     def versions(self, name: str) -> list[str]:
         """Version ids for ``name`` in registration order (``v1``, ``v2``, ...)."""
-        d = os.path.join(self.root, _safe_segment(name))
+        d = self._model_dir(name, create=False)
         if not os.path.isdir(d):
             return []
         vs = [f[:-5] for f in os.listdir(d) if f.endswith(".json")]
@@ -150,20 +166,20 @@ class Registry:
     def get(self, name: str, version: str = "latest") -> tuple[Any, dict | None]:
         """Load ``(model, header)`` for a version (``"latest"`` = highest-numbered)."""
         version = self._resolve_version(name, version)
-        with open(os.path.join(self.root, name, version + ".json")) as f:
+        with open(os.path.join(self._model_dir(name, create=False), version + ".json")) as f:
             payload = json.load(f)
         return from_serializable(payload["model"]), payload.get("header")
 
     def header(self, name: str, version: str = "latest") -> dict | None:
         """Just the provenance header of a version (no model deserialization)."""
         version = self._resolve_version(name, version)
-        with open(os.path.join(self.root, name, version + ".json")) as f:
+        with open(os.path.join(self._model_dir(name, create=False), version + ".json")) as f:
             return json.load(f).get("header")
 
     def metadata(self, name: str, version: str = "latest") -> dict:
         """Just the ``metadata`` of a version (no model deserialization) -- e.g. a checkpoint's iteration."""
         version = self._resolve_version(name, version)
-        with open(os.path.join(self.root, name, version + ".json")) as f:
+        with open(os.path.join(self._model_dir(name, create=False), version + ".json")) as f:
             return json.load(f).get("metadata") or {}
 
     def promote(self, name: str, version: str, alias: str = "production") -> None:
@@ -175,7 +191,7 @@ class Registry:
 
     def current(self, name: str, alias: str = "production") -> tuple[Any, dict | None]:
         """Load the model an ``alias`` points at (falls back to ``latest`` if the alias is unset)."""
-        p = os.path.join(self.root, _safe_segment(name), _safe_segment(alias, "alias") + ".alias")
+        p = os.path.join(self._model_dir(name, create=False), _safe_segment(alias, "alias") + ".alias")
         # the version READ FROM the alias file is still resolved against the known version list by get(),
         # so a tampered alias file cannot traverse either.
         version = open(p).read().strip() if os.path.exists(p) else "latest"

--- a/mixle/tests/dpo_and_registry_hardening_test.py
+++ b/mixle/tests/dpo_and_registry_hardening_test.py
@@ -111,3 +111,30 @@ def test_registry_normal_names_still_work():
         reg = Registry(os.path.join(tmp, "root"))
         d = reg._dir("good-model.v2")
         assert os.path.isdir(d) and os.path.dirname(d) == os.path.join(tmp, "root")
+
+
+def test_registry_rejects_symlinked_entry_that_escapes_root():
+    # _safe_segment validates the name string, but a symlink pre-placed in the root (from an untrusted or
+    # restored registry, or a tar extraction) named like a model would let a read/write follow it outside
+    # the root. Every path that touches such an entry must refuse it, and nothing may escape.
+    import mixle.stats as st
+    from mixle.inference.production.registry import Registry
+
+    with tempfile.TemporaryDirectory() as tmp:
+        root = os.path.join(tmp, "root")
+        outside = os.path.join(tmp, "outside")
+        os.makedirs(root)
+        os.makedirs(outside)
+        os.symlink(outside, os.path.join(root, "evil"))  # attacker-controlled symlink named like a model
+
+        reg = Registry(root)
+        with pytest.raises(ValueError):
+            reg.register(st.GaussianDistribution(0.0, 1.0), "evil")  # write must not follow the symlink
+        with pytest.raises(ValueError):
+            reg.versions("evil")  # read/list must not follow it either
+        with pytest.raises(ValueError):
+            reg.get("evil")
+        with pytest.raises(ValueError):
+            reg.current("evil")
+
+        assert os.listdir(outside) == []  # nothing was written outside the root


### PR DESCRIPTION
## What (worklist S13.2)

`_safe_segment` rejects a name/alias that isn't a single path component, closing `../escape` traversal
*inside the name string*. But it does **not** stop a **symlink** pre-placed in the store root (from an
untrusted or restored registry, or a tar extraction) named like a model.

**Demonstrated escape** (before this change): with `root/evil -> /some/outside/dir`,
`register(model, "evil")` wrote `v1.json` **outside** the root, and `versions` / `get` / `current`
followed the symlink to read outside it.

## Fix

`Registry._model_dir(name, create)` resolves the model directory and, **before** any `open` / `makedirs`
follows it, refuses an entry that is a symlink or whose real path is not contained in the root's real path.
Routed `_dir` (register/promote), `versions`, `get`, `header`, `metadata`, and `current` through it.

The version argument was already safe — `_resolve_version` rejects any version not in the known list, so a
tampered alias file cannot traverse — so only the symlink-on-name hole remained.

## Test

A failure-injection test in `dpo_and_registry_hardening_test.py`: a symlink pre-placed in the root named
like a model is refused by `register` / `versions` / `get` / `current`, and **nothing is written outside
the root**. It fails on the old code (which followed the symlink).

## Evidence

7 hardening tests pass. Regression: `registry` (3), `serving` (6), `provenance` (14), `lifecycle` (9),
`encoded_data_backend_registry` (10), `ppl_provenance` (3) — all pass unchanged. `ruff` clean.

Acceptance (S13.2): registry path safety covers symlink-based escape, tested — met.
