### PR TITLE
Stop the fused-kernel disk cache from being a local code-execution vector (worklist S13)

### DIFF
--- a/mixle/stats/compute/fused_codegen.py
+++ b/mixle/stats/compute/fused_codegen.py
@@ -883,12 +883,57 @@ def _emit(plan: FusedPlan) -> dict[str, list[str]]:
 import hashlib  # noqa: E402
 import importlib.util  # noqa: E402
 import os  # noqa: E402
+import stat  # noqa: E402
 import sys  # noqa: E402
 import tempfile  # noqa: E402
 import threading  # noqa: E402
 
-_CACHE_DIR = os.environ.get("MIXLE_FUSED_CACHE_DIR") or os.path.join(tempfile.gettempdir(), "mixle_fused_cache")
+
+def _default_cache_dir() -> str:
+    """A per-user cache directory. A single shared ``/tmp/mixle_fused_cache`` lets another user pre-place the
+    module the loader imports and ``exec``s -- arbitrary code execution -- so isolate the cache by uid."""
+    suffix = f"_{os.getuid()}" if hasattr(os, "getuid") else ""
+    return os.path.join(tempfile.gettempdir(), f"mixle_fused_cache{suffix}")
+
+
+_CACHE_DIR = os.environ.get("MIXLE_FUSED_CACHE_DIR") or _default_cache_dir()
 _NJIT_LOCK = threading.Lock()
+
+
+def _owned_privately(path: str, *, require_dir: bool) -> bool:
+    """True iff ``path`` is a real dir/file we own that no other user can write (no symlink, no g/o-write).
+
+    ``lstat`` (not ``stat``) so a symlink can never pass as its -- possibly attacker-owned -- target.
+    """
+    try:
+        info = os.lstat(path)
+    except OSError:
+        return False
+    if require_dir and not stat.S_ISDIR(info.st_mode):
+        return False
+    if not require_dir and not stat.S_ISREG(info.st_mode):
+        return False
+    if hasattr(os, "getuid") and info.st_uid != os.getuid():
+        return False
+    return not (info.st_mode & (stat.S_IWGRP | stat.S_IWOTH))
+
+
+def _private_cache_dir() -> str | None:
+    """Return the cache dir once it is guaranteed private to us (0700, we own it), else ``None``.
+
+    ``None`` tells the caller to compile in memory only -- correct result, no disk cache, no chance of
+    importing code from a directory another user can write.
+    """
+    try:
+        os.makedirs(_CACHE_DIR, mode=0o700, exist_ok=True)
+        info = os.lstat(_CACHE_DIR)
+        # Heal a directory we own that an older (insecure) build may have created group/other-writable.
+        own = not hasattr(os, "getuid") or info.st_uid == os.getuid()
+        if stat.S_ISDIR(info.st_mode) and own and (info.st_mode & (stat.S_IWGRP | stat.S_IWOTH)):
+            os.chmod(_CACHE_DIR, 0o700)
+    except OSError:
+        return None
+    return _CACHE_DIR if _owned_privately(_CACHE_DIR, require_dir=True) else None
 
 
 def _njit(src: str, fname: str) -> Callable:
@@ -909,9 +954,14 @@ def _njit(src: str, fname: str) -> Callable:
         if modname in sys.modules:
             return getattr(sys.modules[modname], fname)
         try:
-            os.makedirs(_CACHE_DIR, exist_ok=True)
-            path = os.path.join(_CACHE_DIR, modname + ".py")
-            if not os.path.exists(path):
+            cache_dir = _private_cache_dir()
+            if cache_dir is None:
+                raise OSError("fused cache dir is not private to this user; compiling in memory")
+            path = os.path.join(cache_dir, modname + ".py")
+            # Write our own source unless a file we privately own is already there. Never import a
+            # pre-existing file we do not own: it could be attacker-planted (arbitrary code execution).
+            # os.replace over a symlink replaces the link itself, so this cannot be redirected outside.
+            if not _owned_privately(path, require_dir=False):
                 module_src = f"import numpy as np\nimport numba\n\n\n@numba.njit(fastmath=True, cache=True)\n{src}\n"
                 tmp = f"{path}.{os.getpid()}.tmp"
                 with open(tmp, "w") as fh:

--- a/mixle/tests/fused_cache_security_test.py
+++ b/mixle/tests/fused_cache_security_test.py
@@ -1,0 +1,79 @@
+"""The fused-kernel disk cache cannot be used for code execution by another user (worklist S13).
+
+``_njit`` writes generated numba source to a cache file and then imports+``exec``s it. The old loader put
+that cache in a single shared ``/tmp/mixle_fused_cache`` and imported whatever file was already at the
+predicted path -- so on a multi-user host another user could pre-place ``_pysp_fused_<digest>.py`` and get
+arbitrary code execution as the victim. These tests pin the containment: a per-user 0700 cache directory,
+ownership verification before any import, and a planted file never being executed.
+"""
+
+import os
+import stat
+import tempfile
+import unittest
+
+import mixle.stats.compute.fused_codegen as fc
+
+
+class CacheDirPrivacyTest(unittest.TestCase):
+    def test_default_cache_dir_is_per_user(self):
+        d = fc._default_cache_dir()
+        if hasattr(os, "getuid"):
+            self.assertIn(str(os.getuid()), d)  # not a single dir shared across users
+
+    def test_private_cache_dir_is_0700_and_owned(self):
+        d = fc._private_cache_dir()
+        self.assertIsNotNone(d)
+        self.assertEqual(stat.S_IMODE(os.lstat(d).st_mode), 0o700)
+
+    def test_group_or_other_writable_dir_is_not_trusted(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            os.chmod(tmp, 0o777)
+            self.assertFalse(fc._owned_privately(tmp, require_dir=True))
+
+    def test_symlinked_cache_file_is_not_trusted(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            target = os.path.join(tmp, "evil.py")
+            with open(target, "w") as f:
+                f.write("x = 1\n")
+            link = os.path.join(tmp, "cache_entry.py")
+            os.symlink(target, link)
+            # a symlink is not a regular file we privately own -> the loader must not import it
+            self.assertFalse(fc._owned_privately(link, require_dir=False))
+
+
+class PlantedFileNotExecutedTest(unittest.TestCase):
+    def test_planted_symlink_at_cache_path_is_overwritten_not_executed(self):
+        import pytest
+
+        pytest.importorskip("numba")
+
+        src = "def _fused_sec_probe(x):\n    return x * 2.0\n"
+        import hashlib
+
+        digest = hashlib.sha1(src.encode()).hexdigest()[:16]  # noqa: S324 -- cache key, mirrors the module
+        path = os.path.join(fc._private_cache_dir(), f"_pysp_fused_{digest}.py")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            evil = os.path.join(tmp, "evil.py")
+            with open(evil, "w") as f:
+                f.write(
+                    "import os\nos.environ['MIXLE_FUSED_SEC_BREACH'] = '1'\n"
+                    "def _fused_sec_probe(x):\n    return -999.0\n"
+                )
+            os.environ.pop("MIXLE_FUSED_SEC_BREACH", None)
+            if os.path.lexists(path):
+                os.remove(path)
+            os.symlink(evil, path)  # attacker symlink at the exact predicted cache path
+
+            fn = fc._njit(src, "_fused_sec_probe")
+
+            self.assertEqual(fn(21.0), 42.0)  # our kernel ran, not the planted -999 one
+            self.assertIsNone(os.environ.get("MIXLE_FUSED_SEC_BREACH"))  # attacker code never executed
+            self.assertFalse(os.path.islink(path))  # the symlink was replaced with our own source
+            if os.path.lexists(path):
+                os.remove(path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What (worklist S13 — security hardening)

The fused-kernel JIT cache wrote generated numba source to a file and then **imported + `exec`'d it**. Two
flaws made that a **local arbitrary-code-execution** vector on a multi-user host:

1. the cache lived in a single shared directory, `/tmp/mixle_fused_cache`, writable by every user; and
2. the loader imported whatever file was already at the predicted path (`if not os.path.exists(path)`),
   trusting a pre-existing `_pysp_fused_<digest>.py` without checking **who wrote it**.

So another user could pre-place the module the victim's process imports and run code as the victim.

**PoC (confirmed):** a file planted at the predicted cache path is imported and executed — the attacker's
`os.environ` write fired and its module attribute was visible.

## Fix

- **Per-user cache dir**: the default is now uid-suffixed (`mixle_fused_cache_<uid>`) and created `0700`.
- **`_private_cache_dir()`** verifies the directory is a real dir we own with no group/other write (healing
  a looser one we own, refusing a symlink or a directory owned by someone else); otherwise it returns
  `None` and compilation falls back to the **existing in-memory `exec`** (correct result, no disk cache).
- **Ownership check before import**: the loader imports a cache file only if it is a regular file we
  privately own. A pre-existing file we don't own (e.g. an attacker symlink) is **overwritten** with our
  own trusted source via a temp file + `os.replace`, never imported. (`os.replace` over a symlink replaces
  the link, so it can't be redirected outside.)

## Test

`mixle/tests/fused_cache_security_test.py`: default dir is per-user; `_private_cache_dir` is `0700`;
group/other-writable dirs and symlinked cache files are refused; and **end-to-end**, a malicious symlink
planted at the exact cache path is overwritten and never executed (the kernel returns the correct value,
the attacker's environment write never happens).

## Evidence

5 security tests pass. Regression: `fused_codegen` (46) and `fused_em` (15) pass unchanged. `ruff` clean.
