### PR TITLE
Deploy pure models as safe JSON instead of pickle; document the pickle trust boundary (worklist S13/N9.2)

### DIFF
--- a/mixle/lifecycle.py
+++ b/mixle/lifecycle.py
@@ -241,34 +241,71 @@ class Model:
         return solve(teacher, inputs, **solve_kw)
 
     def deploy(self, path: str) -> str:
-        """Persist a durable artifact directory (model + manifest); :meth:`Model.load` restores it."""
+        """Persist a durable artifact directory (model + manifest); :meth:`Model.load` restores it.
+
+        A registry-serializable model is written as safe, type-tagged JSON (``model.json``); a model the
+        serialization registry cannot represent (e.g. a torch-backed leaf) falls back to a pickle
+        (``model.pkl``). The ``format`` recorded in the manifest tells :meth:`Model.load` which to read, so
+        the common pure-model path never needs an unsafe pickle load.
+        """
         d = self._require_fitted()
         out = Path(path)
         out.mkdir(parents=True, exist_ok=True)
-        with open(out / "model.pkl", "wb") as f:
-            pickle.dump(d, f)
+        fmt = self._write_model(out, d)
         manifest = {
             "family": type(d).__name__,
             "created_at": time.time(),
             "fit": self._fit_info,
             "notes": self.notes,
+            "format": fmt,
             "mixle_artifact": "lifecycle.Model/v1",
         }
         (out / "manifest.json").write_text(json.dumps(manifest, indent=2, default=str))
         return str(out)
 
+    @staticmethod
+    def _write_model(out: Path, d: Any) -> str:
+        """Write ``d`` as safe JSON when the registry can represent it, else pickle. Returns the format used."""
+        try:
+            from mixle.utils.serialization import ensure_pysp_serialization_registry, to_serializable
+
+            ensure_pysp_serialization_registry()
+            text = json.dumps(to_serializable(d))
+        except Exception:  # noqa: BLE001 - not registry-serializable (torch leaf, custom object): use pickle
+            with open(out / "model.pkl", "wb") as f:
+                pickle.dump(d, f)
+            return "pickle"
+        (out / "model.json").write_text(text)
+        return "json"
+
     @classmethod
     def load(cls, path: str) -> Model:
-        """Restore a :class:`Model` from an artifact directory created by :meth:`deploy`."""
+        """Restore a :class:`Model` from an artifact directory created by :meth:`deploy`.
+
+        .. warning::
+
+           A ``pickle``-format artifact (a torch-backed model, or one written by an older mixle) is loaded
+           with :func:`pickle.load`, which **executes arbitrary code** from the file -- only load such an
+           artifact from a source you trust. JSON-format artifacts (the default for pure mixle models) are
+           deserialized through the type-tagged registry and do not execute arbitrary code.
+        """
         p = Path(path)
-        with open(p / "model.pkl", "rb") as f:
-            fitted = pickle.load(f)
+        try:
+            manifest = json.loads((p / "manifest.json").read_text())
+        except (OSError, ValueError):
+            manifest = {}
+        fmt = manifest.get("format", "pickle")  # artifacts predating the format field are pickle-only
+        if fmt == "json":
+            from mixle.utils.serialization import ensure_pysp_serialization_registry, from_serializable
+
+            ensure_pysp_serialization_registry()
+            fitted = from_serializable(json.loads((p / "model.json").read_text()))
+        else:
+            with open(p / "model.pkl", "rb") as f:
+                fitted = pickle.load(f)  # noqa: S301 - trusted-source only; see the warning above
         m = cls(fitted)
         m.fitted = fitted
-        try:
-            m.notes = list(json.loads((p / "manifest.json").read_text()).get("notes", []))
-        except (OSError, ValueError):
-            pass
+        m.notes = list(manifest.get("notes", []))
         return m
 
     # --- the analysis verbs (delegate to the inference front doors) -------------------------------

--- a/mixle/tests/lifecycle_test.py
+++ b/mixle/tests/lifecycle_test.py
@@ -94,6 +94,44 @@ class LifecycleTest(unittest.TestCase):
             back = mixle.Model.load(path)
             self.assertAlmostEqual(back(-3.0), m(-3.0), places=10)
 
+    def test_pure_model_deploys_as_safe_json_without_pickle(self):
+        # A registry-serializable model must not be persisted as an executable pickle: loading a deployed
+        # artifact from an untrusted source would otherwise be arbitrary code execution.
+        import json
+        import os
+
+        import mixle
+        from mixle.stats import CategoricalEstimator
+
+        m = mixle.Model(CategoricalEstimator()).fit(["a", "b", "a", "a", "c", "a", "b"])
+        with tempfile.TemporaryDirectory() as d:
+            path = m.deploy(d + "/cat")
+            files = os.listdir(path)
+            self.assertNotIn("model.pkl", files)  # no pickle artifact for a pure model
+            self.assertIn("model.json", files)
+            self.assertEqual(json.loads(open(os.path.join(path, "manifest.json")).read())["format"], "json")
+            back = mixle.Model.load(path)
+            self.assertAlmostEqual(back.fitted.log_density("a"), m.fitted.log_density("a"), places=10)
+
+    def test_legacy_pickle_artifact_still_loads(self):
+        # Artifacts written before the JSON format (manifest without a "format" field) still load via pickle.
+        import json
+        import os
+        import pickle
+
+        import mixle
+        from mixle.stats import CategoricalEstimator
+
+        fitted = mixle.Model(CategoricalEstimator()).fit(["a", "b", "a"]).fitted
+        with tempfile.TemporaryDirectory() as d:
+            with open(os.path.join(d, "model.pkl"), "wb") as f:
+                pickle.dump(fitted, f)
+            with open(os.path.join(d, "manifest.json"), "w") as f:
+                f.write(json.dumps({"notes": ["legacy"]}))  # no "format" -> defaults to pickle
+            back = mixle.Model.load(d)
+            self.assertEqual(back.notes, ["legacy"])
+            self.assertAlmostEqual(back.fitted.log_density("a"), fitted.log_density("a"), places=10)
+
     @unittest.skipUnless(_HAS_TORCH, "torch not installed")
     def test_distill_self_teacher_labels_own_clusters(self):
         import mixle


### PR DESCRIPTION
## What (worklist S13 / N9.2 honesty)

`lifecycle.Model.deploy` always **pickled** the fitted model, and `Model.load` always `pickle.load`'d it —
with no note that pickle deserialization **executes arbitrary code**. Loading a deployed artifact from an
untrusted source (a shared registry, a downloaded model) was therefore silent arbitrary code execution,
presented as ordinary "durable artifact" persistence.

## Fix

- `deploy` writes a registry-serializable model as **safe, type-tagged JSON** (`model.json`) through
  `mixle.utils.serialization`, recording `format="json"` in the manifest.
- Only a model the registry can't represent (e.g. a torch-backed leaf) falls back to a pickle
  (`model.pkl`, `format="pickle"`).
- `load` reads the format from the manifest and uses the safe `from_serializable` path for JSON artifacts —
  so the **common pure-model case never touches pickle**.
- **Backward compatible**: artifacts written before the format field have no `"format"` key and default to
  the pickle path.
- The remaining pickle branch carries a docstring **warning** that it executes arbitrary code and must only
  load trusted artifacts.

## Tests

- a pure model deploys with `model.json` and **no** `model.pkl` (`format="json"`) and round-trips;
- a legacy pickle artifact (manifest without a `format` field) still loads with its notes intact.

## Evidence

11 lifecycle tests pass (9 existing + 2 new). `ruff format --check` + `ruff check` clean.

Complements #325 (atomic artifact writes) and #330 / #331 (registry symlink + fused-cache RCE): the
deploy/load path is now safe-by-default and honest about the residual pickle trust boundary.
