### PR TITLE
Enforce ruff BLE (blind-except) so no new bare except can be added (worklist Y4.3)

### DIFF
--- a/mixle/capability.py
+++ b/mixle/capability.py
@@ -213,7 +213,7 @@ class Enumerable(PredicateCapability):
 
         try:
             return bool(supports_enumeration(obj))
-        except Exception:
+        except Exception:  # noqa: BLE001
             return False
 
 
@@ -228,7 +228,7 @@ class FiniteSupport(PredicateCapability):
             return False
         try:
             n = fn()
-        except Exception:
+        except Exception:  # noqa: BLE001
             return False
         return isinstance(n, int) and n >= 0
 
@@ -262,7 +262,7 @@ class Shardable(PredicateCapability):
 
         try:
             return bool(decomposition_for(obj).is_shardable)
-        except Exception:
+        except Exception:  # noqa: BLE001
             return False
 
 
@@ -293,7 +293,7 @@ class ConjugateUpdatable(PredicateCapability):
 
         try:
             return bool(is_conjugate_family(obj))
-        except Exception:
+        except Exception:  # noqa: BLE001
             return False
 
 
@@ -316,7 +316,7 @@ class ExactDensity(PredicateCapability):
             return False
         try:
             return fn() is DensitySemantics.EXACT
-        except Exception:
+        except Exception:  # noqa: BLE001
             return False
 
 
@@ -828,7 +828,7 @@ def describe(obj: Any) -> str:
                 lines = [base, "  fit route: %s — %s" % (plan["route"], plan["reason"])]
                 lines += ["             · %s" % c for c in plan.get("caveats", [])]
                 return "\n".join(lines)
-            except Exception:
+            except Exception:  # noqa: BLE001
                 pass
         return base
 
@@ -894,7 +894,7 @@ def _safe_supports(obj: Any, cap_name: str) -> bool:
         return False
     try:
         return supports(obj, cap)
-    except Exception:
+    except Exception:  # noqa: BLE001
         return False
 
 
@@ -909,7 +909,7 @@ def what_supports(capability: type, among: Any) -> list[str]:
         try:
             if supports(obj, capability):
                 out.append(getattr(obj, "__name__", type(obj).__name__))
-        except Exception:
+        except Exception:  # noqa: BLE001
             continue
     return out
 

--- a/mixle/data/schema.py
+++ b/mixle/data/schema.py
@@ -219,7 +219,7 @@ def _type_for(dist: Any) -> FieldType:
             return Count()
         if supports(dist, Continuous):
             return Real()
-    except Exception:
+    except Exception:  # noqa: BLE001
         pass
     cls = type(dist).__name__.lower()
     if "categor" in cls:

--- a/mixle/data/sources/array_source.py
+++ b/mixle/data/sources/array_source.py
@@ -127,7 +127,7 @@ class HDF5ArraySource(_ArrayVolumeSource):
         """Close the underlying HDF5 file handle. Idempotent."""
         try:
             self._file.close()
-        except Exception:
+        except Exception:  # noqa: BLE001
             pass
 
     def __enter__(self) -> HDF5ArraySource:
@@ -139,7 +139,7 @@ class HDF5ArraySource(_ArrayVolumeSource):
     def __del__(self) -> None:
         try:
             self.close()
-        except Exception:
+        except Exception:  # noqa: BLE001
             pass
 
 

--- a/mixle/data/sources/graph_source.py
+++ b/mixle/data/sources/graph_source.py
@@ -14,7 +14,7 @@ import numpy as np
 
 try:
     import scipy.sparse as sp
-except Exception:  # pragma: no cover - scipy is a package dependency in normal use.
+except Exception:  # pragma: no cover - scipy is a package dependency in normal use.  # noqa: BLE001
     sp = None
 
 from mixle.stats.compute.pdist import DataSequenceEncoder
@@ -85,7 +85,7 @@ def _networkx_like_to_adjacency(graph: Any) -> tuple[np.ndarray, np.ndarray | No
                     value = attrs["block"]
                 elif "block_assignment" in attrs:
                     value = attrs["block_assignment"]
-        except Exception:
+        except Exception:  # noqa: BLE001
             value = None
         assignments.append(value)
         found_assignment = found_assignment or value is not None
@@ -174,7 +174,7 @@ def _coerce_pair_tuple(x: Any, directed: bool, fallback_assignments: Any | None)
     try:
         adj = _as_adjacency(x[0])
         assignments = x[1] if x[1] is not None else fallback_assignments
-    except Exception:
+    except Exception:  # noqa: BLE001
         adj = _as_adjacency(x)
         assignments = fallback_assignments
     return GraphObservation(adj, _as_assignments(assignments, adj.shape[0]))
@@ -184,7 +184,7 @@ def _coerce_pair_list(x: Any, directed: bool, fallback_assignments: Any | None) 
     try:
         adj = _as_adjacency(x[0])
         assignments = x[1] if x[1] is not None else fallback_assignments
-    except Exception:
+    except Exception:  # noqa: BLE001
         adj = _as_adjacency(x)
         assignments = fallback_assignments
     return GraphObservation(adj, _as_assignments(assignments, adj.shape[0]))

--- a/mixle/data/validate.py
+++ b/mixle/data/validate.py
@@ -52,7 +52,7 @@ def check_dataset(
     for i, r in enumerate(recs):
         try:
             conformed.append(schema.conform_record(r))
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001
             issues.append(f"record {i}: does not conform to schema ({type(exc).__name__}: {exc})")
             conformed.append(None)
     if check_support:
@@ -63,7 +63,7 @@ def check_dataset(
                 lp = model.log_density(r)
                 if not np.isfinite(lp):
                     issues.append(f"record {i}: outside the model's support (log-density {lp})")
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001
                 issues.append(f"record {i}: could not be scored ({type(exc).__name__}: {exc})")
     report = DataReport(ok=not issues, n_checked=len(recs), schema=schema_desc, issues=issues)
     if raise_on_error and not report.ok:

--- a/mixle/doe/sensitivity.py
+++ b/mixle/doe/sensitivity.py
@@ -34,7 +34,7 @@ def _sobol_unit(n: int, d: int, seed: int) -> np.ndarray:
         from scipy.stats import qmc
 
         return _qmc_unit(qmc.Sobol, d, n, True, np.random.RandomState(seed))
-    except Exception:  # pragma: no cover - qmc fallback
+    except Exception:  # pragma: no cover - qmc fallback  # noqa: BLE001
         return np.random.RandomState(seed).random((n, d))
 
 

--- a/mixle/doe/trust_region.py
+++ b/mixle/doe/trust_region.py
@@ -187,7 +187,7 @@ def turbo_minimize(
         try:
             gp = _fit_surrogate(xu, yz, None, fit_kwargs)
             picks_u = _thompson_batch(gp, xu, yz, cand, q, rng)
-        except Exception:  # GP/Cholesky failure -> shrink the region and retry next iteration
+        except Exception:  # GP/Cholesky failure -> shrink the region and retry next iteration  # noqa: BLE001
             tr.update(False)
             continue
         improved = False

--- a/mixle/enumeration/density_rank.py
+++ b/mixle/enumeration/density_rank.py
@@ -130,7 +130,7 @@ def density_rank(
     try:
         # vectorized: one seq_log_density pass instead of n_samples per-sample log_density calls
         lp = np.asarray(dist.seq_log_density(dist.dist_to_encoder().seq_encode(samples)), dtype=float)
-    except Exception:
+    except Exception:  # noqa: BLE001
         lp = np.asarray([float(dist.log_density(y)) for y in samples], dtype=float)
     g = float(np.count_nonzero(lp >= t - tol)) / n_samples
     stderr = math.sqrt(max(g * (1.0 - g), 0.0) / n_samples)

--- a/mixle/enumeration/quantization/parallel.py
+++ b/mixle/enumeration/quantization/parallel.py
@@ -53,7 +53,7 @@ def resolve_workers(num_workers: int | None = None) -> int:
         n = len(Resources.local().devices)
         if n >= 1:
             return n
-    except Exception:
+    except Exception:  # noqa: BLE001
         pass
     return max(1, os.cpu_count() or 1)
 

--- a/mixle/evolve/closed_loop.py
+++ b/mixle/evolve/closed_loop.py
@@ -159,7 +159,7 @@ def _acquire_priority(champion: Any, failures: Sequence[Any], k: int, *, strateg
     try:
         adapter = _ConstantProbaAdapter(champion)
         return acquire(failures, adapter, k, strategy=strategy)
-    except Exception:
+    except Exception:  # noqa: BLE001
         return failures[: min(k, len(failures))]
 
 
@@ -424,7 +424,7 @@ class ClosedLoopSelfEvolution:
                     )
                     self.champion = candidate.model
                     promoted = True
-        except Exception:
+        except Exception:  # noqa: BLE001
             delta = 0.0
 
         self.bandit.reward(ctx, op_name, delta)

--- a/mixle/evolve/improve.py
+++ b/mixle/evolve/improve.py
@@ -111,7 +111,7 @@ def improve(
             if not op.applicable(model, train, ctx=ctx):
                 continue
             candidate = op.propose(model, train, ctx=ctx)
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001
             if ledger is not None:
                 ledger.record(
                     operator=op.name,

--- a/mixle/evolve/population.py
+++ b/mixle/evolve/population.py
@@ -303,7 +303,7 @@ class Population:
                     report.rewards.append(0.0)
                     continue
                 candidate = op.propose(parent.model, data, ctx=ctx)
-            except Exception:
+            except Exception:  # noqa: BLE001
                 self.bandit.reward(op.name, 0.0, cost)
                 report.rewards.append(0.0)
                 continue

--- a/mixle/evolve/search.py
+++ b/mixle/evolve/search.py
@@ -172,7 +172,7 @@ def _held_out_score(
         if not np.isfinite(canonical):
             return 1.0e18, None
         return canonical, model
-    except Exception:
+    except Exception:  # noqa: BLE001
         return 1.0e18, None
 
 
@@ -335,7 +335,7 @@ def _search_bandit(
         cfg = space.sample(rng)
         try:
             seeds.append(build_fn(cfg))
-        except Exception:
+        except Exception:  # noqa: BLE001
             continue
     if not seeds:
         raise ValueError("search(method='bandit'): build_fn produced no valid seed models from the space.")

--- a/mixle/evolve/verify.py
+++ b/mixle/evolve/verify.py
@@ -78,7 +78,7 @@ def _calibration_no_regression(
         obj = calibration_objective(seed=seed)
         champ_cal = obj.scalar(champion, data)
         chal_cal = obj.scalar(challenger, data)
-    except Exception as exc:  # calibration is best-effort: no sampler/cdf -> treat as a pass
+    except Exception as exc:  # calibration is best-effort: no sampler/cdf -> treat as a pass  # noqa: BLE001
         return True, {"calibration": "unavailable", "reason": str(exc)}
     ok = bool(chal_cal <= champ_cal + calib_tol)
     return ok, {"champion_calib": champ_cal, "challenger_calib": chal_cal, "calib_tol": calib_tol, "ok": ok}
@@ -187,7 +187,7 @@ def challenger_beats_champion(
             # in these calls challenger is 'A', champion is 'B' -> challenger wins iff favored == 'A'
             if not (vuong["favored"] == "A" and clarke["favored"] == "A"):
                 favored = "tie"
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001
             evidence["nonnested_error"] = str(exc)
 
     # ELPD 2-SE band (Bayesian models with LOO/WAIC pointwise arrays)

--- a/mixle/inference/decision.py
+++ b/mixle/inference/decision.py
@@ -60,7 +60,7 @@ def _loss_samples(loss: Loss, action: Any, draws: Sequence[Any]) -> np.ndarray:
         arr = np.asarray(loss(action, np.asarray(draws)), dtype=float).reshape(-1)
         if arr.size == len(draws):
             return arr
-    except Exception:
+    except Exception:  # noqa: BLE001
         pass
     return np.asarray([float(loss(action, d)) for d in draws], dtype=float)
 

--- a/mixle/inference/errors_in_variables.py
+++ b/mixle/inference/errors_in_variables.py
@@ -138,7 +138,7 @@ def propagate_uncertainty(
         out = np.asarray(func(s), dtype=float)
         if out.shape[0] != s.shape[0]:
             raise ValueError
-    except Exception:
+    except Exception:  # noqa: BLE001
         out = np.array([np.asarray(func(row), dtype=float) for row in s])
     levels = np.asarray(quantiles, dtype=float)
     return {

--- a/mixle/inference/fusion_policy.py
+++ b/mixle/inference/fusion_policy.py
@@ -44,5 +44,5 @@ def should_auto_fuse(model: Any, enc_data: Any, max_its: int) -> bool:
             return False
         n = sum(int(c[0]) for c in enc_data) if isinstance(enc_data, list) else 0
         return n * max(int(max_its), 1) >= _FUSION_MIN_WORKLOAD
-    except Exception:
+    except Exception:  # noqa: BLE001
         return False

--- a/mixle/inference/heterogeneous_executor.py
+++ b/mixle/inference/heterogeneous_executor.py
@@ -53,7 +53,7 @@ def _shard_estep(estimator: Any, model: Any, shard: Any, compute_dtype: Any = No
 
             if fusible_estep(model):
                 return n, fused_accumulate(model, enc, weights, compute_dtype=compute_dtype)
-        except Exception:
+        except Exception:  # noqa: BLE001
             pass  # fall back to the exact float64 accumulator path
     acc = estimator.accumulator_factory().make()
     acc.seq_update(enc, weights, model)

--- a/mixle/inference/mcmc/gradients.py
+++ b/mixle/inference/mcmc/gradients.py
@@ -23,7 +23,7 @@ def torch_available() -> bool:
     """Return True if Torch can be imported (autograd gradients are available)."""
     try:
         import torch  # noqa: F401
-    except Exception:
+    except Exception:  # noqa: BLE001
         return False
     return True
 

--- a/mixle/inference/mcmc/nuts_torch.py
+++ b/mixle/inference/mcmc/nuts_torch.py
@@ -50,7 +50,7 @@ def _make_value_and_grad(logp: Callable[[Any], Any], theta0: Any, use_compile: b
             lp, g = vg(theta0)
             if g.shape == theta0.shape and math.isfinite(float(lp.detach())):
                 return vg, True
-        except Exception:
+        except Exception:  # noqa: BLE001
             pass
     vg = _wrap(logp)
     lp, g = vg(theta0)

--- a/mixle/inference/node_report.py
+++ b/mixle/inference/node_report.py
@@ -135,7 +135,7 @@ def _update_kind(dist: ProbabilityDistribution) -> str:
 
     try:
         estimator = dist.estimator()
-    except Exception:
+    except Exception:  # noqa: BLE001
         estimator = None
     if estimator is not None:
         est_name = type(estimator).__name__.lower()
@@ -162,7 +162,7 @@ def _residual_mc(dist: ProbabilityDistribution, n_mc: int, seed: int) -> float:
     """Monte-Carlo self-NLL: ``-mean(log_density(x))`` over ``n_mc`` self-samples (see module docstring)."""
     try:
         samples = dist.sampler(seed).sample(int(n_mc))
-    except Exception:
+    except Exception:  # noqa: BLE001
         return float("nan")
     if samples is None:
         # A Neutral/no-op node (e.g. NullDistribution) legitimately samples nothing.
@@ -173,7 +173,7 @@ def _residual_mc(dist: ProbabilityDistribution, n_mc: int, seed: int) -> float:
     for x in samples:
         try:
             lp = float(dist.log_density(x))
-        except Exception:
+        except Exception:  # noqa: BLE001
             continue
         if np.isfinite(lp):
             total += -lp
@@ -221,7 +221,7 @@ def _health_receipts(dist: ProbabilityDistribution) -> dict[str, Any]:
             try:
                 if np.all(np.isfinite(value)) and np.linalg.cond(value) > _ILL_CONDITIONED_COND_NUMBER:
                     receipts["ill_conditioned"] = True
-            except Exception:
+            except Exception:  # noqa: BLE001
                 pass
     return receipts
 

--- a/mixle/inference/planning.py
+++ b/mixle/inference/planning.py
@@ -159,7 +159,7 @@ def _is_exp_family(obj: Any) -> bool:
         from mixle.capability import ExponentialFamily, supports
 
         return bool(supports(obj, ExponentialFamily))
-    except Exception:
+    except Exception:  # noqa: BLE001
         return False
 
 
@@ -168,7 +168,7 @@ def _has_exact_density(obj: Any) -> bool:
         from mixle.capability import ExactDensity, supports
 
         return bool(supports(obj, ExactDensity))
-    except Exception:
+    except Exception:  # noqa: BLE001
         return False
 
 

--- a/mixle/inference/precision_plan.py
+++ b/mixle/inference/precision_plan.py
@@ -82,7 +82,7 @@ def recommend_compute_precision(
         return PrecisionPlan(np.float64, "no model to inspect -> float64")
     try:
         from mixle.stats.compute.fused_codegen import fusible
-    except Exception:  # pragma: no cover - numba optional
+    except Exception:  # pragma: no cover - numba optional  # noqa: BLE001
         return PrecisionPlan(np.float64, "fused codegen unavailable -> float64")
     if not fusible(model):
         return PrecisionPlan(np.float64, "model has no fused reduced-precision kernel -> float64")

--- a/mixle/inference/production/drift.py
+++ b/mixle/inference/production/drift.py
@@ -82,7 +82,7 @@ def _log_densities(model: Any, data: Any) -> np.ndarray:
     try:
         enc = model.dist_to_encoder().seq_encode(list(data))
         return np.asarray(model.seq_log_density(enc), dtype=float)
-    except Exception:
+    except Exception:  # noqa: BLE001
         return np.asarray([model.log_density(x) for x in data], dtype=float)
 
 
@@ -164,7 +164,7 @@ def detect_drift(
             from mixle.data.schema import Schema
 
             names = [f.name for f in Schema.for_model(model).fields]
-        except Exception:
+        except Exception:  # noqa: BLE001
             names = None
         ref_cols = _columns(reference, len(names) if names else 1)
         cur_cols = _columns(current, len(names) if names else 1)

--- a/mixle/inference/production/provenance.py
+++ b/mixle/inference/production/provenance.py
@@ -25,7 +25,7 @@ from mixle.data.hashing import model_hash as _model_hash
 def _version(mod: str) -> str | None:
     try:
         return __import__(mod).__version__
-    except Exception:
+    except Exception:  # noqa: BLE001
         return None
 
 
@@ -40,7 +40,7 @@ def _git_commit() -> str | None:
             ["git", "-C", root, "rev-parse", "--short", "HEAD"], capture_output=True, text=True, timeout=2
         )
         return r.stdout.strip() or None
-    except Exception:
+    except Exception:  # noqa: BLE001
         return None
 
 
@@ -62,7 +62,7 @@ def _schema_of(model: Any) -> list[tuple[str, str]]:
         from mixle.data.schema import Schema
 
         return [(f.name, repr(f.type)) for f in Schema.for_model(model).fields]
-    except Exception:
+    except Exception:  # noqa: BLE001
         return []
 
 
@@ -74,7 +74,7 @@ def _resource_usage() -> dict:
         ru = resource.getrusage(resource.RUSAGE_SELF)
         peak_mb = ru.ru_maxrss / 1e6 if sys.platform == "darwin" else ru.ru_maxrss / 1e3  # macOS bytes, Linux KB
         return {"cpu_time_s": ru.ru_utime + ru.ru_stime, "peak_rss_mb": round(peak_mb, 1)}
-    except Exception:
+    except Exception:  # noqa: BLE001
         return {}
 
 
@@ -90,7 +90,7 @@ def _final_loglik(model: Any, data: Any) -> float | None:
 
         enc = model.dist_to_encoder().seq_encode(list(_records(data)))
         return float(np.sum(model.seq_log_density(enc)))
-    except Exception:
+    except Exception:  # noqa: BLE001
         return None
 
 
@@ -98,7 +98,7 @@ def _safe_model_hash(model: Any) -> str | None:
     """Fingerprint a model's serialized parameters, or ``None`` if it isn't serializable."""
     try:
         return _model_hash(model)
-    except Exception:
+    except Exception:  # noqa: BLE001
         return None
 
 
@@ -287,7 +287,7 @@ def fit_with_provenance(
     header = build_header(model, data, training=training, started=t0, finished=t1, resources=usage)
     try:
         model.header = header
-    except Exception:
+    except Exception:  # noqa: BLE001
         pass
     return model, header
 

--- a/mixle/inference/production/serving.py
+++ b/mixle/inference/production/serving.py
@@ -60,7 +60,7 @@ class Service:
         try:
             enc = self.model.dist_to_encoder().seq_encode(recs)
             lp = np.asarray(self.model.seq_log_density(enc), dtype=float)
-        except Exception:
+        except Exception:  # noqa: BLE001
             lp = np.asarray([self._safe_logd(r) for r in recs], dtype=float)
         dt = time.time() - t0
         finite = np.isfinite(lp)
@@ -80,7 +80,7 @@ class Service:
     def _safe_logd(self, r: Any) -> float:
         try:
             return float(self.model.log_density(r))
-        except Exception:
+        except Exception:  # noqa: BLE001
             return float("-inf")
 
     def check_drift(self, records: Any) -> Any:

--- a/mixle/inference/structure.py
+++ b/mixle/inference/structure.py
@@ -314,7 +314,7 @@ def glm_gain(
     try:
         edge = fit_glm_edge(list(zip(p.tolist(), c.tolist())), family)
         ll_glm = float(np.sum(edge.seq_log_density((p, c))))
-    except Exception:
+    except Exception:  # noqa: BLE001
         return float("-inf")
     if not np.isfinite(ll_glm):
         return float("-inf")

--- a/mixle/inference/target.py
+++ b/mixle/inference/target.py
@@ -427,7 +427,7 @@ def _nuts_jax(
     try:
         ss = mcmc.last_state.adapt_state.step_size
         step_size = float(np.asarray(ss).reshape(-1)[0])
-    except Exception:
+    except Exception:  # noqa: BLE001
         pass
     chain_arrays = [samples[c] for c in range(chains)]
     return _pool_chains(chain_arrays, d, chains, 0, step_size, backend="jax")

--- a/mixle/inference/uq.py
+++ b/mixle/inference/uq.py
@@ -108,7 +108,7 @@ def _is_torch_module(obj: Any) -> bool:
             import torch.nn as nn
 
             return isinstance(obj, nn.Module)
-        except Exception:
+        except Exception:  # noqa: BLE001
             return True
     return False
 

--- a/mixle/models/dpo_leaf.py
+++ b/mixle/models/dpo_leaf.py
@@ -281,7 +281,7 @@ def _register_serializable() -> None:
     # mixle.models classes aren't in the stats/analysis auto-walk, so opt in explicitly for to_json/from_json.
     try:
         from mixle.utils.serialization import register_serializable_class
-    except Exception:  # pragma: no cover
+    except Exception:  # pragma: no cover  # noqa: BLE001
         return
     register_serializable_class(DPOModel)
 

--- a/mixle/models/energy.py
+++ b/mixle/models/energy.py
@@ -535,7 +535,7 @@ def _register_serializable() -> None:
     # mixle.models classes aren't in the stats/analysis auto-walk, so opt in explicitly for to_json/from_json.
     try:
         from mixle.utils.serialization import register_serializable_class
-    except Exception:  # pragma: no cover
+    except Exception:  # pragma: no cover  # noqa: BLE001
         return
     register_serializable_class(EnergyModel)
 

--- a/mixle/models/feature_map.py
+++ b/mixle/models/feature_map.py
@@ -207,7 +207,7 @@ class FeatureMapEstimator(ParameterEstimator):
 def _register_serializable() -> None:
     try:
         from mixle.utils.serialization import register_serializable_class
-    except Exception:  # pragma: no cover - serialization support is optional at import
+    except Exception:  # pragma: no cover - serialization support is optional at import  # noqa: BLE001
         return
     register_serializable_class(FeatureMapDensity)
 

--- a/mixle/models/mixture_density.py
+++ b/mixle/models/mixture_density.py
@@ -665,7 +665,7 @@ def _register_serializable() -> None:
     # mixle.models classes aren't in the stats/analysis auto-walk, so opt in explicitly for to_json/from_json.
     try:
         from mixle.utils.serialization import register_serializable_class
-    except Exception:  # pragma: no cover
+    except Exception:  # pragma: no cover  # noqa: BLE001
         return
     register_serializable_class(NeuralConditionalDensity)
 

--- a/mixle/models/neural_density.py
+++ b/mixle/models/neural_density.py
@@ -591,7 +591,7 @@ _register_module_class("AutoregressiveCategorical", _build_autoregressive_catego
 def _register_serializable() -> None:
     try:
         from mixle.utils.serialization import register_serializable_class
-    except Exception:  # pragma: no cover - serialization support is optional at import
+    except Exception:  # pragma: no cover - serialization support is optional at import  # noqa: BLE001
         return
     register_serializable_class(NeuralDensity)
 

--- a/mixle/models/neural_families.py
+++ b/mixle/models/neural_families.py
@@ -147,7 +147,7 @@ class DiscreteAR(_NeuralFamily):
 def _register_serializable() -> None:
     try:
         from mixle.utils.serialization import register_serializable_class
-    except Exception:  # pragma: no cover - serialization support is optional at import
+    except Exception:  # pragma: no cover - serialization support is optional at import  # noqa: BLE001
         return
     for cls in (VAE, Flow, MAF, DiscreteAR):
         register_serializable_class(cls)

--- a/mixle/models/neural_leaf.py
+++ b/mixle/models/neural_leaf.py
@@ -318,7 +318,7 @@ def _register_serializable() -> None:
     # mixle.models classes aren't in the stats/analysis auto-walk, so opt in explicitly for to_json/from_json.
     try:
         from mixle.utils.serialization import register_serializable_class
-    except Exception:  # pragma: no cover
+    except Exception:  # pragma: no cover  # noqa: BLE001
         return
     register_serializable_class(NeuralGaussian)
 

--- a/mixle/models/pinn.py
+++ b/mixle/models/pinn.py
@@ -265,7 +265,7 @@ class PINNRegressionEstimator(NeuralGaussianEstimator):
 def _register_serializable() -> None:
     try:
         from mixle.utils.serialization import register_serializable_class
-    except Exception:  # pragma: no cover
+    except Exception:  # pragma: no cover  # noqa: BLE001
         return
     register_serializable_class(PINNRegression)
 

--- a/mixle/models/softmax_leaf.py
+++ b/mixle/models/softmax_leaf.py
@@ -325,7 +325,7 @@ def _register_serializable() -> None:
     # mixle.models classes aren't in the stats/analysis auto-walk, so opt in explicitly for to_json/from_json.
     try:
         from mixle.utils.serialization import register_serializable_class
-    except Exception:  # pragma: no cover
+    except Exception:  # pragma: no cover  # noqa: BLE001
         return
     register_serializable_class(NeuralCategorical)
 

--- a/mixle/models/sparsity_2_4.py
+++ b/mixle/models/sparsity_2_4.py
@@ -226,12 +226,12 @@ def cusparselt_status() -> dict[str, Any]:
     if cusparselt is not None:
         try:
             status["cusparselt_is_available"] = bool(cusparselt.is_available())
-        except Exception as e:  # pragma: no cover - defensive
+        except Exception as e:  # pragma: no cover - defensive  # noqa: BLE001
             status["cusparselt_is_available"] = False
             status["cusparselt_is_available_error"] = repr(e)
         try:
             status["cusparselt_version"] = cusparselt.version()
-        except Exception as e:  # pragma: no cover - defensive
+        except Exception as e:  # pragma: no cover - defensive  # noqa: BLE001
             status["cusparselt_version"] = None
             status["cusparselt_version_error"] = repr(e)
     status["has_sparse_semi_structured_tensor"] = hasattr(torch.sparse, "SparseSemiStructuredTensor")

--- a/mixle/models/streaming_transformer_leaf.py
+++ b/mixle/models/streaming_transformer_leaf.py
@@ -313,7 +313,7 @@ def _register_serializable() -> None:
     # mixle.models classes aren't in the stats/analysis auto-walk, so opt in explicitly for to_json/from_json.
     try:
         from mixle.utils.serialization import register_serializable_class
-    except Exception:  # pragma: no cover
+    except Exception:  # pragma: no cover  # noqa: BLE001
         return
     register_serializable_class(StreamingTransformer)
 

--- a/mixle/ppl/autograd.py
+++ b/mixle/ppl/autograd.py
@@ -28,7 +28,7 @@ def torch_available() -> bool:
     """Return whether Torch can be imported for analytic-gradient PPL routes."""
     try:
         import torch  # noqa: F401
-    except Exception:
+    except Exception:  # noqa: BLE001
         return False
     return True
 
@@ -494,7 +494,7 @@ def grad_target(rv: RandomVariable, data, missing: str = "error"):
         return None
     try:
         scorers = _scorers()
-    except Exception:
+    except Exception:  # noqa: BLE001
         return None
     if isinstance(rv._family, CompositeFamily):
         if rv._family.name == "Mixture":
@@ -502,7 +502,7 @@ def grad_target(rv: RandomVariable, data, missing: str = "error"):
                 return None  # mixture-of-leaves missing handling not wired here; caller raises clearly
             try:
                 return _mixture_grad_target(rv, data, scorers)
-            except Exception:
+            except Exception:  # noqa: BLE001
                 return None
         return None
     from mixle.ppl.inference import _is_det_expr, _require_flat, _target_parts

--- a/mixle/ppl/core.py
+++ b/mixle/ppl/core.py
@@ -1545,7 +1545,7 @@ class RandomVariable:
             cd = None
             try:
                 cd = _convolve(lower(a, target="dist"), lower(b, target="dist"))
-            except Exception:
+            except Exception:  # noqa: BLE001
                 cd = None
             if cd is not None:
                 return RandomVariable._bound(cd).log_prob(x)

--- a/mixle/ppl/inference.py
+++ b/mixle/ppl/inference.py
@@ -297,7 +297,7 @@ def _encoder_for(fam):
         defaults = {"real": 0.0, "positive": 1.0, "unit": 0.5}
         try:
             kwargs = fam.to_dist(*[defaults[s] for s in fam.support])
-        except Exception:
+        except Exception:  # noqa: BLE001
             kwargs = fam.to_dist(*([1.0] * fam.arity))
     return fam.dist_cls(**kwargs).dist_to_encoder()
 
@@ -595,7 +595,7 @@ def _build_target(rv: RandomVariable, data, extra_latents=()):
         try:
             d = build(vals)
             ll = float(np.sum(d.seq_log_density(enc)))
-        except Exception:
+        except Exception:  # noqa: BLE001
             return _NEG_INF
         if not math.isfinite(ll):
             return _NEG_INF
@@ -888,7 +888,7 @@ def _finalize_chains(rv, slots, results, build) -> RandomVariable:
     post.rhat = {s.name: float(rhat[k]) for k, s in enumerate(slots)}
     try:
         post.ess = float(sum(np.atleast_1d(r.effective_sample_size()).min() for r in results))
-    except Exception:
+    except Exception:  # noqa: BLE001
         post.ess = None
     _attach_convergence(post, slots, np.stack([u[:n] for u in us], axis=0), results)
 
@@ -1275,7 +1275,7 @@ def _grouped_target(rv: RandomVariable, data, want_grad: bool):
                 val = _eval(t, torch)
                 (g,) = torch.autograd.grad(val, t)
                 return g.detach().numpy()
-        except Exception:
+        except Exception:  # noqa: BLE001
             grad = None
 
     def build(vals):
@@ -2155,7 +2155,7 @@ def _prior_to_dict(prior_rv):
     builder = _PRIOR_DICT_BUILDERS.get(prior_rv._family.name)
     try:
         return builder(prior_rv._args) if builder is not None else None
-    except Exception:
+    except Exception:  # noqa: BLE001
         return None
 
 
@@ -2165,7 +2165,7 @@ def _prior_probe_value(prior_rv):
     try:
         d = prior_rv._family.make_dist(tuple(prior_rv._args), prior_rv._name)
         return float(np.ravel(d.sampler(seed=0).sample(1))[0])
-    except Exception:
+    except Exception:  # noqa: BLE001
         return 1.0
 
 
@@ -2186,7 +2186,7 @@ def _stats_conjugate_probe(rv):
         probe_value = _prior_probe_value(prior_rv)
         probe_args = tuple(probe_value if i == idx else rv._args[i] for i in range(len(rv._args)))
         stats_dist = rv._family.make_dist(probe_args, rv._name)
-    except Exception:
+    except Exception:  # noqa: BLE001
         return None
     from mixle.stats.bayes.conjugate import is_conjugate_family
 
@@ -2215,7 +2215,7 @@ def _stats_conjugate_fit(rv: RandomVariable, data, *, prior_override=None):
     try:
         sp = conjugate_posterior(stats_dist, arr, prior=prior_dict)
         mean_dict = sp.mean()
-    except Exception:
+    except Exception:  # noqa: BLE001
         return None
     if len(mean_dict) != 1:  # single-target conjugates only (joint NIG / NIW handled elsewhere)
         return None

--- a/mixle/ppl/provenance.py
+++ b/mixle/ppl/provenance.py
@@ -42,6 +42,6 @@ def fit_with_provenance(rv: Any, data: Any, *, seed: int | None = None, **fit_kw
     header = build_header(model, data, training=training, started=t0, finished=t1, resources=usage)
     try:
         fitted.header = header
-    except Exception:
+    except Exception:  # noqa: BLE001
         pass
     return fitted, header

--- a/mixle/ppl/summarize.py
+++ b/mixle/ppl/summarize.py
@@ -58,7 +58,7 @@ def posterior_summary(fitted: RandomVariable, *, hdi_prob: float = 0.94) -> dict
         draws = None
         try:
             draws = np.asarray(fitted.posterior(name), dtype=float).ravel()
-        except Exception:
+        except Exception:  # noqa: BLE001
             draws = None
         if draws is not None and draws.size > 1:
             lo, hi = hdi(draws, hdi_prob)

--- a/mixle/reason/zero_shot_bootstrap.py
+++ b/mixle/reason/zero_shot_bootstrap.py
@@ -113,7 +113,7 @@ def _try_automatic_profiler(rows, *, rng, max_its):
     try:
         prototype = get_prototype(rows, seed=0)
         fitted = optimize(rows, prototype, max_its=max_its, rng=rng)
-    except Exception:
+    except Exception:  # noqa: BLE001
         return None
     if isinstance(fitted, IgnoredDistribution):
         return None
@@ -332,7 +332,7 @@ def _model_typicality(model: Any, value: float) -> float:
             u = float(model.cdf(value))
             if math.isfinite(u):
                 return float(2.0 * abs(min(max(u, 0.0), 1.0) - 0.5))
-        except Exception:
+        except Exception:  # noqa: BLE001
             pass
     if supports(model, HasMoments):
         try:
@@ -340,7 +340,7 @@ def _model_typicality(model: Any, value: float) -> float:
             std = float(model.variance()) ** 0.5
             z = abs(value - mean) / max(std, 1.0e-9)
             return float(z / (1.0 + z))
-        except Exception:
+        except Exception:  # noqa: BLE001
             pass
     return 0.5
 

--- a/mixle/stats/combinator/exponential_tilt.py
+++ b/mixle/stats/combinator/exponential_tilt.py
@@ -465,7 +465,7 @@ class ExponentialTiltedEstimator(ParameterEstimator):
         def g(th: float) -> float:
             try:
                 return self._mean_grad_logz(th) - mean_t
-            except Exception:
+            except Exception:  # noqa: BLE001
                 return float("nan")
 
         lo, hi = -1.0, 1.0

--- a/mixle/stats/combinator/transform.py
+++ b/mixle/stats/combinator/transform.py
@@ -273,7 +273,7 @@ class TransformDistribution(SequenceEncodableProbabilityDistribution):
             if self.density_correction:
                 rv += self.transform.log_abs_det_inverse_jacobian(x)
             return rv
-        except Exception:
+        except Exception:  # noqa: BLE001
             return -np.inf
 
     def seq_log_density(self, x: tuple[Any, np.ndarray, np.ndarray]) -> np.ndarray:
@@ -425,7 +425,7 @@ class TransformAccumulator(SequenceEncodableStatisticAccumulator):
         """Accumulate one inverse-transformed observation when it is valid."""
         try:
             inv = self.transform.inverse(x)
-        except Exception:
+        except Exception:  # noqa: BLE001
             return
         self.accumulator.update(inv, weight, None if estimate is None else estimate.dist)
 
@@ -458,7 +458,7 @@ class TransformAccumulator(SequenceEncodableStatisticAccumulator):
         """Initialize from one inverse-transformed observation when it is valid."""
         try:
             inv = self.transform.inverse(x)
-        except Exception:
+        except Exception:  # noqa: BLE001
             return
         self.accumulator.initialize(inv, weight, rng)
 
@@ -599,7 +599,7 @@ class TransformDataEncoder(DataSequenceEncoder):
                     log_jac[i] = self.transform.log_abs_det_inverse_jacobian(y)
                     if not np.isfinite(log_jac[i]):
                         valid[i] = False
-            except Exception:
+            except Exception:  # noqa: BLE001
                 inv_values.append(fill)
                 log_jac[i] = -np.inf
                 valid[i] = False

--- a/mixle/stats/compute/declarations.py
+++ b/mixle/stats/compute/declarations.py
@@ -643,7 +643,7 @@ def _build_generic_numba_kernel(
         result = (kernel, n_data, ordered_params)
     except _UnsupportedNumbaLowering:
         result = None
-    except Exception:
+    except Exception:  # noqa: BLE001
         result = None
 
     _GENERIC_NUMBA_KERNEL_CACHE[dist_type] = result
@@ -1214,7 +1214,7 @@ def _statistic_layout_issues(declaration: DistributionDeclaration, suff_stat: An
     issues = []
     try:
         values = declaration.statistic_values(suff_stat)
-    except Exception as exc:
+    except Exception as exc:  # noqa: BLE001
         return ("%s statistics do not match declaration: %s" % (path, exc),)
 
     names = tuple(values.keys())
@@ -1497,7 +1497,7 @@ def _weighted_histogram(stat: Any, weights: Any, engine: Any) -> dict[int, float
 def _host_legacy_value(value: Any, engine: Any) -> Any:
     try:
         arr = np.asarray(engine.to_numpy(value))
-    except Exception:
+    except Exception:  # noqa: BLE001
         return value
     if arr.ndim == 0:
         return float(arr)
@@ -1521,7 +1521,7 @@ def _all_same(values: Sequence[Any]) -> bool:
     for value in values[1:]:
         try:
             equal = np.array_equal(first, value)
-        except Exception:
+        except Exception:  # noqa: BLE001
             equal = first == value
         if not bool(equal):
             return False

--- a/mixle/stats/compute/fused_codegen.py
+++ b/mixle/stats/compute/fused_codegen.py
@@ -922,7 +922,7 @@ def _njit(src: str, fname: str) -> Callable:
             sys.modules[modname] = mod
             spec.loader.exec_module(mod)  # type: ignore[union-attr]
             return getattr(mod, fname)
-        except Exception:
+        except Exception:  # noqa: BLE001
             ns: dict[str, Any] = {"np": np}
             exec(src, ns)  # noqa: S102 -- generated from fixed templates, no user input
             return numba.njit(fastmath=True)(ns[fname])

--- a/mixle/stats/compute/pdist.py
+++ b/mixle/stats/compute/pdist.py
@@ -1168,7 +1168,7 @@ def _object_signature(x: Any) -> Any:
 def _accumulator_signature(accumulator: StatisticAccumulator, role: str) -> Any:
     try:
         value_sig = _freeze_for_signature(accumulator.value())
-    except Exception as err:
+    except Exception as err:  # noqa: BLE001
         value_sig = ("value-error", type(err).__name__, str(err))
     return (type(accumulator).__module__, type(accumulator).__qualname__, role, value_sig)
 

--- a/mixle/stats/compute/stacked.py
+++ b/mixle/stats/compute/stacked.py
@@ -556,7 +556,7 @@ def _place_component_array(value: Any, engine: ComputeEngine, axis: int) -> Any:
         return value
     try:
         arr = np.asarray(value)
-    except Exception:
+    except Exception:  # noqa: BLE001
         arr = None
     if arr is not None:
         if arr.dtype.kind in ("O", "U", "S"):
@@ -577,7 +577,7 @@ def _engine_to_numpy(value: Any, engine: ComputeEngine) -> Any:
         return [_engine_to_numpy(child, engine) for child in value]
     try:
         return np.asarray(engine.to_numpy(value))
-    except Exception:
+    except Exception:  # noqa: BLE001
         return value
 
 
@@ -594,7 +594,7 @@ def _engine_local_to_numpy(value: Any, engine: ComputeEngine) -> Any:
     if callable(local_fn):
         try:
             return _tensor_like_to_numpy(local_fn())
-        except Exception:
+        except Exception:  # noqa: BLE001
             pass
     return _engine_to_numpy(value, engine)
 
@@ -608,7 +608,7 @@ def _tensor_like_to_numpy(value: Any) -> Any:
         value = cpu()
     try:
         return np.asarray(value)
-    except Exception:
+    except Exception:  # noqa: BLE001
         return value
 
 
@@ -623,7 +623,7 @@ def _local_component_bounds(value: Any, local_count: int) -> tuple[int, int]:
                 if offsets and sizes:
                     start = offsets[0]
                     return start, start + sizes[0]
-        except Exception:
+        except Exception:  # noqa: BLE001
             pass
     return 0, int(local_count)
 

--- a/mixle/stats/compute/torch_mixture.py
+++ b/mixle/stats/compute/torch_mixture.py
@@ -60,7 +60,7 @@ class TorchMixture:
             try:
                 scores = model.kernel(engine=self.engine).component_scores(payload)
                 return np.asarray(self.engine.to_numpy(scores), dtype=np.float64)
-            except Exception:
+            except Exception:  # noqa: BLE001
                 # Fall back to the legacy numpy path if the model has no modular kernel for this
                 # engine (or the kernel raises). This intentionally swallows kernel errors; set a
                 # breakpoint here when debugging a silently-degraded engine path.
@@ -89,7 +89,7 @@ class TorchMixture:
             comp = kernel.component_scores(payload) + self.engine.asarray(model.log_w)[None, :]
             denom = self.engine.logsumexp(comp, axis=1)
             return self.engine.exp(comp - denom[:, None])
-        except Exception:
+        except Exception:  # noqa: BLE001
             # Fall back to the legacy numpy posterior if no modular kernel is available (or it
             # raises). Intentionally swallows kernel errors to keep the engine path optional.
             return self.engine.asarray(model.seq_posterior(payload))
@@ -133,7 +133,7 @@ class TorchMixture:
             stats = model.kernel(engine=self.engine, estimator=estimator).accumulate(
                 payload, self.engine.asarray(row_weights)
             )
-        except Exception:
+        except Exception:  # noqa: BLE001
             # Fall back to the legacy accumulator M-step if no modular kernel exists for this
             # (model, estimator, engine) combination (or it raises). Swallows kernel errors by design.
             acc = estimator.accumulator_factory().make()
@@ -240,7 +240,7 @@ class TorchMixture:
         try:
             scores = model.kernel(engine=self.engine).score(payload)
             return np.asarray(self.engine.to_numpy(scores), dtype=np.float64)
-        except Exception:
+        except Exception:  # noqa: BLE001
             # Fall back to the legacy numpy scorer when no modular kernel is available (or it
             # raises). Intentionally swallows kernel errors to keep the engine path optional.
             return np.asarray(model.seq_log_density(payload), dtype=np.float64)

--- a/mixle/stats/latent/mixture.py
+++ b/mixle/stats/latent/mixture.py
@@ -644,7 +644,7 @@ class MixtureDistribution(SequenceEncodableProbabilityDistribution):
                 continue
             try:
                 enumerator = comp.enumerator()
-            except Exception:
+            except Exception:  # noqa: BLE001
                 return False
             for value, _lp in enumerator:
                 key = freeze(value)

--- a/mixle/stats/univariate/continuous/beta.py
+++ b/mixle/stats/univariate/continuous/beta.py
@@ -177,7 +177,7 @@ class BetaDistribution(SequenceEncodableProbabilityDistribution):
         """Return the log-density or log-mass at a single observation."""
         try:
             xx = float(x)
-        except Exception:
+        except Exception:  # noqa: BLE001
             return -np.inf
         if not np.isfinite(xx) or xx <= 0.0 or xx >= 1.0:
             return -np.inf

--- a/mixle/stats/univariate/continuous/gamma.py
+++ b/mixle/stats/univariate/continuous/gamma.py
@@ -215,7 +215,7 @@ class GammaDistribution(SequenceEncodableProbabilityDistribution):
         """
         try:
             xx = float(x)
-        except Exception:
+        except Exception:  # noqa: BLE001
             return 0.0
         if not np.isfinite(xx) or xx <= 0.0:
             return 0.0
@@ -238,7 +238,7 @@ class GammaDistribution(SequenceEncodableProbabilityDistribution):
         """
         try:
             xx = float(x)
-        except Exception:
+        except Exception:  # noqa: BLE001
             return -np.inf
         if not np.isfinite(xx) or xx <= 0.0:
             return -np.inf

--- a/mixle/stats/univariate/continuous/pareto.py
+++ b/mixle/stats/univariate/continuous/pareto.py
@@ -116,7 +116,7 @@ class ParetoDistribution(SequenceEncodableProbabilityDistribution):
         """Return the log-density or log-mass at a single observation."""
         try:
             xx = float(x)
-        except Exception:
+        except Exception:  # noqa: BLE001
             return -np.inf
         if not np.isfinite(xx) or xx < self.xm:
             return -np.inf

--- a/mixle/stats/univariate/discrete/bernoulli.py
+++ b/mixle/stats/univariate/discrete/bernoulli.py
@@ -155,7 +155,7 @@ class BernoulliDistribution(SequenceEncodableProbabilityDistribution):
                 return True
             if x == 0:
                 return False
-        except Exception:
+        except Exception:  # noqa: BLE001
             return None
         return None
 

--- a/mixle/stats/univariate/discrete/binomial.py
+++ b/mixle/stats/univariate/discrete/binomial.py
@@ -220,7 +220,7 @@ class BinomialDistribution(SequenceEncodableProbabilityDistribution):
         n = self.n
         try:
             xx = float(x)
-        except Exception:
+        except Exception:  # noqa: BLE001
             return -np.inf
         if self.min_val is not None:
             xx -= self.min_val
@@ -283,7 +283,7 @@ class BinomialDistribution(SequenceEncodableProbabilityDistribution):
         n = self.n
         try:
             xx = float(x)
-        except Exception:
+        except Exception:  # noqa: BLE001
             return -np.inf
         if self.min_val is not None:
             xx -= self.min_val

--- a/mixle/stats/univariate/discrete/geometric.py
+++ b/mixle/stats/univariate/discrete/geometric.py
@@ -202,7 +202,7 @@ class GeometricDistribution(SequenceEncodableProbabilityDistribution):
         """
         try:
             xx = float(x)
-        except Exception:
+        except Exception:  # noqa: BLE001
             return -np.inf
         if not np.isfinite(xx) or xx < 1 or np.floor(xx) != xx:
             return -np.inf

--- a/mixle/stats/univariate/discrete/point_mass.py
+++ b/mixle/stats/univariate/discrete/point_mass.py
@@ -27,11 +27,11 @@ def _same_value(a: Any, b: Any) -> bool:
     if isinstance(a, np.ndarray) or isinstance(b, np.ndarray):
         try:
             return bool(np.array_equal(a, b))
-        except Exception:
+        except Exception:  # noqa: BLE001
             return False
     try:
         return freeze(a) == freeze(b)
-    except Exception:
+    except Exception:  # noqa: BLE001
         return a == b
 
 

--- a/mixle/stats/univariate/discrete/poisson.py
+++ b/mixle/stats/univariate/discrete/poisson.py
@@ -208,7 +208,7 @@ class PoissonDistribution(SequenceEncodableProbabilityDistribution):
         """
         try:
             xx = float(x)
-        except Exception:
+        except Exception:  # noqa: BLE001
             return -np.inf
         if not np.isfinite(xx) or xx < 0 or np.floor(xx) != xx:
             return -np.inf

--- a/mixle/system.py
+++ b/mixle/system.py
@@ -180,7 +180,7 @@ class System:
 
         try:
             result = with_fallback(_call_teacher, _teacher_down_fallback, mode="teacher_down")
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001
             return None, {
                 "produced_by": None,
                 "status": "failed",

--- a/mixle/task/model.py
+++ b/mixle/task/model.py
@@ -275,11 +275,11 @@ class StructuredClassifierIO:
             rows = [self._augment(v, label) for v in values]
             try:
                 out[:, k] = np.asarray(model.seq_log_density(model.dist_to_encoder().seq_encode(rows)))
-            except Exception:  # unseen conditioning value in some row: fall back to per-row scoring
+            except Exception:  # unseen conditioning value in some row: fall back to per-row scoring  # noqa: BLE001
                 for i, row in enumerate(rows):
                     try:
                         out[i, k] = float(model.log_density(row))
-                    except Exception:
+                    except Exception:  # noqa: BLE001
                         out[i, k] = -np.inf
         return out
 

--- a/mixle/task/orchestrate.py
+++ b/mixle/task/orchestrate.py
@@ -101,7 +101,7 @@ def orchestrate(
 
         try:
             observation = world.step(step)
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001
             # atypical/failed step: record the failure, then give the plan model one chance to re-plan
             # around it before giving up -- the trace shows what actually happened, not just the outcome
             trace.steps.append(TraceStep(tool=_tool_name(step), args=step.get("args", {}), result={"error": str(exc)}))
@@ -112,7 +112,7 @@ def orchestrate(
                 break
             try:
                 observation = world.step(retry_step)
-            except Exception as retry_exc:
+            except Exception as retry_exc:  # noqa: BLE001
                 trace.steps.append(
                     TraceStep(
                         tool=_tool_name(retry_step), args=retry_step.get("args", {}), result={"error": str(retry_exc)}

--- a/mixle/task/solve.py
+++ b/mixle/task/solve.py
@@ -48,7 +48,7 @@ def _label_with(teacher: Callable[..., Any], items: list) -> list:
         out = teacher(items)
         if isinstance(out, (list, tuple)) and len(out) == len(items):
             return list(out)
-    except Exception:
+    except Exception:  # noqa: BLE001
         pass
     return [teacher(x) for x in items]
 

--- a/mixle/tests/consistency_fixes_regression_test.py
+++ b/mixle/tests/consistency_fixes_regression_test.py
@@ -94,13 +94,13 @@ def test_d1_all_engines_provide_required_ops():
         from mixle.engines import SYMBOLIC_ENGINE
 
         engines.append(SYMBOLIC_ENGINE)
-    except Exception:
+    except Exception:  # noqa: BLE001
         pass
     try:
         from mixle.engines.torch_engine import TorchEngine
 
         engines.append(TorchEngine())
-    except Exception:
+    except Exception:  # noqa: BLE001
         pass
     for eng in engines:
         missing = [op for op in ComputeEngine.REQUIRED_OPS if getattr(eng, op, None) is None]

--- a/mixle/tests/dirac_length_engine_test.py
+++ b/mixle/tests/dirac_length_engine_test.py
@@ -11,7 +11,7 @@ try:
     from mixle.engines import TorchEngine
 
     _TORCH = TorchEngine(device="cpu", dtype="float64")
-except Exception:
+except Exception:  # noqa: BLE001
     _TORCH = None
 
 

--- a/mixle/tests/distribution_additions_test.py
+++ b/mixle/tests/distribution_additions_test.py
@@ -315,7 +315,7 @@ class StandardDistributionAdditionsTestCase(unittest.TestCase):
     def test_fused_kernel_log_density_matches_seq(self):
         try:
             from mixle.stats.compute.fused_kernels import CompiledMixture
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001
             self.skipTest("compiled kernels unavailable: %s" % exc)
 
         dists = [
@@ -341,7 +341,7 @@ class StandardDistributionTorchTestCase(unittest.TestCase):
     def test_torch_em_matches_seq_for_bernoulli_mixture(self):
         try:
             from mixle.stats.compute.torch_mixture import TorchMixture
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001
             self.skipTest("torch engine unavailable: %s" % exc)
 
         model = MixtureDistribution([BernoulliDistribution(0.2), BernoulliDistribution(0.8)], [0.4, 0.6])
@@ -365,7 +365,7 @@ class StandardDistributionTorchTestCase(unittest.TestCase):
     def test_torch_em_matches_seq_for_negative_binomial_mixture(self):
         try:
             from mixle.stats.compute.torch_mixture import TorchMixture
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001
             self.skipTest("torch engine unavailable: %s" % exc)
 
         model = MixtureDistribution(
@@ -395,7 +395,7 @@ class StandardDistributionTorchTestCase(unittest.TestCase):
     def test_torch_log_density_matches_seq_for_new_continuous_leaves(self):
         try:
             from mixle.stats.compute.torch_mixture import TorchMixture
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001
             self.skipTest("torch engine unavailable: %s" % exc)
 
         dists = [

--- a/mixle/tests/engine_accumulate_parity_test.py
+++ b/mixle/tests/engine_accumulate_parity_test.py
@@ -16,7 +16,7 @@ try:
     from mixle.engines import TorchEngine
 
     _TORCH = TorchEngine(device="cpu", dtype="float64")
-except Exception:
+except Exception:  # noqa: BLE001
     _TORCH = None
 
 
@@ -67,7 +67,7 @@ class EngineAccumulateParityTestCase(unittest.TestCase):
                 continue
             try:
                 est = dist.estimator()
-            except Exception:
+            except Exception:  # noqa: BLE001
                 continue
             enc = dist.dist_to_encoder().seq_encode(data)
             weights = np.linspace(0.5, 1.5, len(data))

--- a/mixle/tests/graph_engine_test.py
+++ b/mixle/tests/graph_engine_test.py
@@ -16,7 +16,7 @@ try:
     from mixle.engines import TorchEngine
 
     _TORCH = TorchEngine(device="cpu", dtype="float64")
-except Exception:
+except Exception:  # noqa: BLE001
     _TORCH = None
 
 

--- a/mixle/tests/gumbel_test.py
+++ b/mixle/tests/gumbel_test.py
@@ -30,7 +30,7 @@ class GumbelTestCase(unittest.TestCase):
             import torch
 
             from mixle.engines import TorchEngine
-        except Exception as exc:  # pragma: no cover - torch optional
+        except Exception as exc:  # pragma: no cover - torch optional  # noqa: BLE001
             self.skipTest("torch unavailable: %s" % exc)
         engine = TorchEngine(dtype=torch.float64)
         backend = np.asarray(engine.to_numpy(dist.backend_seq_log_density(enc, engine)))

--- a/mixle/tests/half_normal_test.py
+++ b/mixle/tests/half_normal_test.py
@@ -30,7 +30,7 @@ class HalfNormalTestCase(unittest.TestCase):
             import torch
 
             from mixle.engines import TorchEngine
-        except Exception as exc:  # pragma: no cover - torch optional
+        except Exception as exc:  # pragma: no cover - torch optional  # noqa: BLE001
             self.skipTest("torch unavailable: %s" % exc)
         engine = TorchEngine(dtype=torch.float64)
         backend = np.asarray(engine.to_numpy(dist.backend_seq_log_density(enc, engine)))

--- a/mixle/tests/hidden_association_engine_test.py
+++ b/mixle/tests/hidden_association_engine_test.py
@@ -13,7 +13,7 @@ try:
     from mixle.engines import TorchEngine
 
     _TORCH = TorchEngine(device="cpu", dtype="float64")
-except Exception:
+except Exception:  # noqa: BLE001
     _TORCH = None
 
 

--- a/mixle/tests/hmixture_engine_test.py
+++ b/mixle/tests/hmixture_engine_test.py
@@ -17,7 +17,7 @@ try:
     from mixle.engines import TorchEngine
 
     _TORCH = TorchEngine(device="cpu", dtype="float64")
-except Exception:
+except Exception:  # noqa: BLE001
     _TORCH = None
 
 

--- a/mixle/tests/hmm_engine_test.py
+++ b/mixle/tests/hmm_engine_test.py
@@ -18,7 +18,7 @@ try:
     from mixle.engines import TorchEngine
 
     _TORCH = TorchEngine(device="cpu", dtype="float64")
-except Exception:
+except Exception:  # noqa: BLE001
     _TORCH = None
 
 

--- a/mixle/tests/hmm_heterogeneous_emissions_test.py
+++ b/mixle/tests/hmm_heterogeneous_emissions_test.py
@@ -45,7 +45,7 @@ try:
             return -0.5 * (x - self.p) ** 2 - 0.9189385332046727
 
     _HAVE_NEURAL = True
-except Exception:  # pragma: no cover - environment dependent
+except Exception:  # pragma: no cover - environment dependent  # noqa: BLE001
     _HAVE_NEURAL = False
 
 

--- a/mixle/tests/int_hidden_association_engine_test.py
+++ b/mixle/tests/int_hidden_association_engine_test.py
@@ -14,7 +14,7 @@ try:
     from mixle.engines import TorchEngine
 
     _TORCH = TorchEngine(device="cpu", dtype="float64")
-except Exception:
+except Exception:  # noqa: BLE001
     _TORCH = None
 
 

--- a/mixle/tests/int_plsi_engine_test.py
+++ b/mixle/tests/int_plsi_engine_test.py
@@ -11,7 +11,7 @@ try:
     from mixle.engines import TorchEngine
 
     _TORCH = TorchEngine(device="cpu", dtype="float64")
-except Exception:
+except Exception:  # noqa: BLE001
     _TORCH = None
 
 

--- a/mixle/tests/inverse_gamma_test.py
+++ b/mixle/tests/inverse_gamma_test.py
@@ -30,7 +30,7 @@ class InverseGammaTestCase(unittest.TestCase):
             import torch
 
             from mixle.engines import TorchEngine
-        except Exception as exc:  # pragma: no cover - torch optional
+        except Exception as exc:  # pragma: no cover - torch optional  # noqa: BLE001
             self.skipTest("torch unavailable: %s" % exc)
         engine = TorchEngine(dtype=torch.float64)
         backend = np.asarray(engine.to_numpy(dist.backend_seq_log_density(enc, engine)))

--- a/mixle/tests/jmixture_engine_test.py
+++ b/mixle/tests/jmixture_engine_test.py
@@ -12,7 +12,7 @@ try:
     from mixle.engines import TorchEngine
 
     _TORCH = TorchEngine(device="cpu", dtype="float64")
-except Exception:
+except Exception:  # noqa: BLE001
     _TORCH = None
 
 

--- a/mixle/tests/lda_engine_test.py
+++ b/mixle/tests/lda_engine_test.py
@@ -13,7 +13,7 @@ try:
     from mixle.engines import TorchEngine
 
     _TORCH = TorchEngine(device="cpu", dtype="float64")
-except Exception:
+except Exception:  # noqa: BLE001
     _TORCH = None
 
 

--- a/mixle/tests/leaf_engine_test.py
+++ b/mixle/tests/leaf_engine_test.py
@@ -19,7 +19,7 @@ try:
     from mixle.engines import TorchEngine
 
     _TORCH = TorchEngine(device="cpu", dtype="float64")
-except Exception:
+except Exception:  # noqa: BLE001
     _TORCH = None
 
 

--- a/mixle/tests/llda_engine_test.py
+++ b/mixle/tests/llda_engine_test.py
@@ -14,7 +14,7 @@ try:
     from mixle.engines import TorchEngine
 
     _TORCH = TorchEngine(device="cpu", dtype="float64")
-except Exception:
+except Exception:  # noqa: BLE001
     _TORCH = None
 
 VOCAB = ["w0", "w1", "w2", "w3"]

--- a/mixle/tests/logseries_test.py
+++ b/mixle/tests/logseries_test.py
@@ -36,7 +36,7 @@ class LogSeriesTestCase(unittest.TestCase):
             import torch
 
             from mixle.engines import TorchEngine
-        except Exception as exc:  # pragma: no cover - torch optional
+        except Exception as exc:  # pragma: no cover - torch optional  # noqa: BLE001
             self.skipTest("torch unavailable: %s" % exc)
         engine = TorchEngine(dtype=torch.float64)
         backend = np.asarray(engine.to_numpy(dist.backend_seq_log_density(enc, engine)))

--- a/mixle/tests/lookback_hmm_engine_test.py
+++ b/mixle/tests/lookback_hmm_engine_test.py
@@ -19,7 +19,7 @@ try:
     from mixle.engines import TorchEngine
 
     _TORCH = TorchEngine(device="cpu", dtype="float64")
-except Exception:
+except Exception:  # noqa: BLE001
     _TORCH = None
 
 W = [0.6, 0.4]

--- a/mixle/tests/markov_transform_engine_test.py
+++ b/mixle/tests/markov_transform_engine_test.py
@@ -19,7 +19,7 @@ try:
     from mixle.engines import TorchEngine
 
     _TORCH = TorchEngine(device="cpu", dtype="float64")
-except Exception:
+except Exception:  # noqa: BLE001
     _TORCH = None
 
 

--- a/mixle/tests/mvt_test.py
+++ b/mixle/tests/mvt_test.py
@@ -31,7 +31,7 @@ class MultivariateStudentTTestCase(unittest.TestCase):
             import torch
 
             from mixle.engines import TorchEngine
-        except Exception as exc:  # pragma: no cover - torch optional
+        except Exception as exc:  # pragma: no cover - torch optional  # noqa: BLE001
             self.skipTest("torch unavailable: %s" % exc)
         dist = _dist()
         x = dist.sampler(seed=2).sample(50)

--- a/mixle/tests/pcfg_engine_test.py
+++ b/mixle/tests/pcfg_engine_test.py
@@ -21,7 +21,7 @@ try:
     from mixle.engines import TorchEngine
 
     _TORCH = TorchEngine(device="cpu", dtype="float64")
-except Exception:
+except Exception:  # noqa: BLE001
     _TORCH = None
 
 

--- a/mixle/tests/peft_lora_grad_leaf_smoke_test.py
+++ b/mixle/tests/peft_lora_grad_leaf_smoke_test.py
@@ -27,7 +27,7 @@ from mixle.models import GradLeaf  # noqa: E402
 def _offline_or_skip():
     try:
         build_peft_wrapped_module(seed=0)
-    except Exception as exc:  # pragma: no cover - depends on network/HF Hub availability
+    except Exception as exc:  # pragma: no cover - depends on network/HF Hub availability  # noqa: BLE001
         pytest.skip(f"tiny HF checkpoint unavailable (likely offline): {exc}")
 
 

--- a/mixle/tests/ppca_test.py
+++ b/mixle/tests/ppca_test.py
@@ -37,7 +37,7 @@ class ProbabilisticPCATestCase(unittest.TestCase):
             import torch
 
             from mixle.engines import TorchEngine
-        except Exception as exc:  # pragma: no cover - torch optional
+        except Exception as exc:  # pragma: no cover - torch optional  # noqa: BLE001
             self.skipTest("torch unavailable: %s" % exc)
         dist = _dist()
         enc = dist.dist_to_encoder().seq_encode(dist.sampler(seed=2).sample(8))

--- a/mixle/tests/ppl_engine_test.py
+++ b/mixle/tests/ppl_engine_test.py
@@ -41,7 +41,7 @@ class EngineTestCase(unittest.TestCase):
             m = Mix([Normal(free, free), Normal(free, free)]).fit(
                 data, backend="mp", num_workers=2, rng=np.random.RandomState(2)
             )
-        except Exception as e:  # environment without usable mp
+        except Exception as e:  # environment without usable mp  # noqa: BLE001
             self.skipTest(f"mp backend unavailable: {e}")
         means = sorted(c.mu for c in m.dist.components)
         self.assertAlmostEqual(means[0], -5.0, delta=0.3)

--- a/mixle/tests/quantized_hmm_test.py
+++ b/mixle/tests/quantized_hmm_test.py
@@ -22,7 +22,7 @@ try:
     from mixle.engines import TorchEngine
 
     _TORCH = TorchEngine(device="cpu", dtype="float64")
-except Exception:
+except Exception:  # noqa: BLE001
     _TORCH = None
 from mixle.enumeration.algorithms import freeze
 from mixle.stats.latent.quantized_hidden_markov_model import (

--- a/mixle/tests/quotient_leaf_test.py
+++ b/mixle/tests/quotient_leaf_test.py
@@ -39,7 +39,7 @@ try:
 
     _cifar = hf_datasets.load_dataset("cifar10")
     _HAS_CIFAR = True
-except Exception:
+except Exception:  # noqa: BLE001
     _HAS_CIFAR = False
 
 

--- a/mixle/tests/rdpg_test.py
+++ b/mixle/tests/rdpg_test.py
@@ -28,7 +28,7 @@ class RandomDotProductGraphTestCase(unittest.TestCase):
             import torch
 
             from mixle.engines import TorchEngine
-        except Exception as exc:  # pragma: no cover - torch optional
+        except Exception as exc:  # pragma: no cover - torch optional  # noqa: BLE001
             self.skipTest("torch unavailable: %s" % exc)
         dist = RandomDotProductGraphDistribution(_X)
         enc = dist.dist_to_encoder().seq_encode(dist.sampler(seed=2).sample(5))

--- a/mixle/tests/segmental_engine_test.py
+++ b/mixle/tests/segmental_engine_test.py
@@ -11,7 +11,7 @@ try:
     from mixle.engines import TorchEngine
 
     _TORCH = TorchEngine(device="cpu", dtype="float64")
-except Exception:
+except Exception:  # noqa: BLE001
     _TORCH = None
 
 

--- a/mixle/tests/spark_encoded_data_test.py
+++ b/mixle/tests/spark_encoded_data_test.py
@@ -30,7 +30,7 @@ def _ensure_java_home() -> None:
         out = subprocess.run(["/usr/libexec/java_home"], capture_output=True, text=True, timeout=5)
         if out.returncode == 0 and out.stdout.strip():
             candidates.append(out.stdout.strip())
-    except Exception:
+    except Exception:  # noqa: BLE001
         pass
     for prefix in ("/opt/homebrew/opt", "/usr/local/opt"):  # Homebrew (Apple silicon / Intel)
         for jdk in ("openjdk@17", "openjdk@21", "openjdk@11", "openjdk"):
@@ -59,7 +59,7 @@ def _spark_context():
             .config("spark.sql.shuffle.partitions", "2")
             .getOrCreate()
         )
-    except Exception:
+    except Exception:  # noqa: BLE001
         # no usable JVM (e.g. Java not installed); treat as unavailable
         return None
     return spark.sparkContext

--- a/mixle/tests/spark_executor_test.py
+++ b/mixle/tests/spark_executor_test.py
@@ -42,7 +42,7 @@ def setUpModule() -> None:
             conf=SparkConf().setMaster("local[2]").setAppName("mixle-test").set("spark.ui.enabled", "false")
         )
         _SC.setLogLevel("ERROR")
-    except Exception as e:  # pragma: no cover - environment dependent
+    except Exception as e:  # pragma: no cover - environment dependent  # noqa: BLE001
         raise unittest.SkipTest("could not start Spark: %s" % e)
 
 

--- a/mixle/tests/sparse_markov_engine_test.py
+++ b/mixle/tests/sparse_markov_engine_test.py
@@ -18,7 +18,7 @@ try:
     from mixle.engines import TorchEngine
 
     _TORCH = TorchEngine(device="cpu", dtype="float64")
-except Exception:
+except Exception:  # noqa: BLE001
     _TORCH = None
 
 

--- a/mixle/tests/sparsity_2_4_test.py
+++ b/mixle/tests/sparsity_2_4_test.py
@@ -307,7 +307,7 @@ class InferenceSpeedupEvidenceTest(unittest.TestCase):
             torch.sparse.to_sparse_semi_structured(w24)
             real_kernel_available = True
             failure_reason = None
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             real_kernel_available = False
             failure_reason = repr(e)
         print(

--- a/mixle/tests/ss_mixture_engine_test.py
+++ b/mixle/tests/ss_mixture_engine_test.py
@@ -12,7 +12,7 @@ try:
     from mixle.engines import TorchEngine
 
     _TORCH = TorchEngine(device="cpu", dtype="float64")
-except Exception:
+except Exception:  # noqa: BLE001
     _TORCH = None
 
 

--- a/mixle/tests/structured_hmm_test.py
+++ b/mixle/tests/structured_hmm_test.py
@@ -398,7 +398,7 @@ class JitForwardTest(unittest.TestCase):
     def test_jit_forward_matches_numpy(self):
         try:
             import jax  # noqa: F401
-        except Exception:
+        except Exception:  # noqa: BLE001
             self.skipTest("jax not installed")
         from mixle.stats.latent.structured_hmm import jit_forward_loglik
 
@@ -573,7 +573,7 @@ class NumbaFastFitTest(unittest.TestCase):
     def test_fast_dense_fit_equals_numpy_fit(self):
         try:
             from mixle.utils.optional_deps import HAS_NUMBA
-        except Exception:
+        except Exception:  # noqa: BLE001
             HAS_NUMBA = False
         if not HAS_NUMBA:
             self.skipTest("numba not installed")

--- a/mixle/tests/task_realteacher_smoke_test.py
+++ b/mixle/tests/task_realteacher_smoke_test.py
@@ -47,7 +47,7 @@ def _real_newsgroups_teacher():
         # download_if_missing=False => raise (not hang on the network) when the corpus is not cached.
         tr = fetch_20newsgroups(subset="train", categories=cats, remove=strip, download_if_missing=False)
         te = fetch_20newsgroups(subset="test", categories=cats, remove=strip, download_if_missing=False)
-    except Exception:
+    except Exception:  # noqa: BLE001
         return None
 
     vec = TfidfVectorizer(max_features=5000, stop_words="english")

--- a/mixle/tests/tree_hmm_engine_test.py
+++ b/mixle/tests/tree_hmm_engine_test.py
@@ -12,7 +12,7 @@ try:
     from mixle.engines import TorchEngine
 
     _TORCH = TorchEngine(device="cpu", dtype="float64")
-except Exception:
+except Exception:  # noqa: BLE001
     _TORCH = None
 
 

--- a/mixle/tests/von_mises_test.py
+++ b/mixle/tests/von_mises_test.py
@@ -46,7 +46,7 @@ class VonMisesTestCase(unittest.TestCase):
             import torch
 
             from mixle.engines import TorchEngine
-        except Exception as exc:  # pragma: no cover - torch optional
+        except Exception as exc:  # pragma: no cover - torch optional  # noqa: BLE001
             self.skipTest("torch unavailable: %s" % exc)
         engine = TorchEngine(dtype=torch.float64)
         backend = np.asarray(engine.to_numpy(dist.backend_seq_log_density(enc, engine)))

--- a/mixle/utils/automatic/detectors/beta.py
+++ b/mixle/utils/automatic/detectors/beta.py
@@ -29,7 +29,7 @@ def _fit(arr: np.ndarray) -> tuple[float, float] | None:
         return None
     try:
         a, b, _loc, _scale = stats.beta.fit(arr, floc=0.0, fscale=1.0)
-    except Exception:
+    except Exception:  # noqa: BLE001
         return None
     if not (math.isfinite(a) and math.isfinite(b) and a > 0.0 and b > 0.0):
         return None

--- a/mixle/utils/automatic/detectors/exgaussian.py
+++ b/mixle/utils/automatic/detectors/exgaussian.py
@@ -49,7 +49,7 @@ def _fit(arr: np.ndarray) -> tuple[float, float, float] | None:
         from scipy import stats
 
         k, loc, scale = stats.exponnorm.fit(arr)
-    except Exception:
+    except Exception:  # noqa: BLE001
         return None
     if not (k > 0.0 and scale > 0.0 and math.isfinite(k) and math.isfinite(scale) and math.isfinite(loc)):
         return None
@@ -75,7 +75,7 @@ def _score(arr: np.ndarray, nobs: int) -> float | None:
         sigma = math.sqrt(sigma2)
         k = 1.0 / (lam * sigma)
         nll_nats = -float(np.mean(stats.exponnorm.logpdf(arr, k, loc=mu, scale=sigma)))
-    except Exception:
+    except Exception:  # noqa: BLE001
         return None
     if not math.isfinite(nll_nats):
         return None

--- a/mixle/utils/automatic/detectors/generalized_extreme_value.py
+++ b/mixle/utils/automatic/detectors/generalized_extreme_value.py
@@ -25,7 +25,7 @@ def _fit_params(arr: np.ndarray):
         return None
     try:
         c, loc, scale = stats.genextreme.fit(arr)
-    except Exception:
+    except Exception:  # noqa: BLE001
         return None
     if not (np.isfinite(c) and np.isfinite(loc) and np.isfinite(scale)) or scale <= 0.0:
         return None

--- a/mixle/utils/automatic/detectors/generalized_gaussian.py
+++ b/mixle/utils/automatic/detectors/generalized_gaussian.py
@@ -35,7 +35,7 @@ def _fit(arr: np.ndarray):
 
     try:
         beta, loc, scale = stats.gennorm.fit(arr)
-    except Exception:
+    except Exception:  # noqa: BLE001
         return None
     if not (scale > 0.0 and beta > 0.0):
         return None

--- a/mixle/utils/automatic/detectors/generalized_pareto.py
+++ b/mixle/utils/automatic/detectors/generalized_pareto.py
@@ -67,7 +67,7 @@ def _score(arr: np.ndarray, nobs: int) -> float | None:
         if not (scale > 0.0) or not math.isfinite(scale) or not math.isfinite(shape):
             return None
         nll_nats = -float(np.mean(stats.genpareto.logpdf(arr, shape, loc=loc, scale=scale)))
-    except Exception:
+    except Exception:  # noqa: BLE001
         return None
     if not math.isfinite(nll_nats):
         return None
@@ -96,7 +96,7 @@ def _cdf(arr: np.ndarray):
         if not (scale > 0.0) or not math.isfinite(scale) or not math.isfinite(shape):
             return None
         return stats.genpareto.cdf(arr, shape, loc=loc, scale=scale)
-    except Exception:
+    except Exception:  # noqa: BLE001
         return None
 
 

--- a/mixle/utils/automatic/detectors/gumbel.py
+++ b/mixle/utils/automatic/detectors/gumbel.py
@@ -43,7 +43,7 @@ def _fit(arr: np.ndarray) -> tuple[float, float] | None:
         from scipy import stats
 
         loc, scale = stats.gumbel_r.fit(arr)
-    except Exception:
+    except Exception:  # noqa: BLE001
         return None
     if not (scale > 0.0 and math.isfinite(scale) and math.isfinite(loc)):
         return None

--- a/mixle/utils/automatic/detectors/inverse_gamma.py
+++ b/mixle/utils/automatic/detectors/inverse_gamma.py
@@ -14,7 +14,7 @@ def _fit(arr: np.ndarray) -> tuple[float, float] | None:
         from scipy import stats
 
         a, _loc, scale = stats.invgamma.fit(arr, floc=0.0)  # fix loc at 0: a positive-support family
-    except Exception:
+    except Exception:  # noqa: BLE001
         return None
     if not (a > 0.0 and scale > 0.0 and math.isfinite(a) and math.isfinite(scale)):
         return None

--- a/mixle/utils/automatic/detectors/logistic.py
+++ b/mixle/utils/automatic/detectors/logistic.py
@@ -23,7 +23,7 @@ def _fit(arr: np.ndarray):
 
     try:
         loc, scale = stats.logistic.fit(arr)
-    except Exception:
+    except Exception:  # noqa: BLE001
         return None
     if not (scale > 0.0) or not math.isfinite(scale) or not math.isfinite(loc):
         return None

--- a/mixle/utils/automatic/detectors/skew_normal.py
+++ b/mixle/utils/automatic/detectors/skew_normal.py
@@ -44,7 +44,7 @@ def _fit(arr: np.ndarray):
 
     try:
         shape, loc, scale = stats.skewnorm.fit(arr)
-    except Exception:
+    except Exception:  # noqa: BLE001
         return None
     if not (scale > 0.0) or not (np.isfinite(shape) and np.isfinite(loc) and np.isfinite(scale)):
         return None

--- a/mixle/utils/automatic/detectors/weibull.py
+++ b/mixle/utils/automatic/detectors/weibull.py
@@ -24,7 +24,7 @@ def _fit(arr: np.ndarray):
 
     try:
         shape, loc, scale = stats.weibull_min.fit(arr, floc=0.0)
-    except Exception:
+    except Exception:  # noqa: BLE001
         return None
     if not (np.isfinite(shape) and np.isfinite(scale) and shape > 0.0 and scale > 0.0):
         return None

--- a/mixle/utils/automatic/profiling.py
+++ b/mixle/utils/automatic/profiling.py
@@ -2126,7 +2126,7 @@ def normalize_input(data, *, rdd_cap: int = 200000):
 
             if isinstance(data, DataSource):
                 return list(data.records())
-        except Exception:
+        except Exception:  # noqa: BLE001
             pass
     if hasattr(data, "columns") and hasattr(data, "itertuples"):  # a pandas DataFrame (duck-typed)
         from mixle.data.sources.pandas_source import dataframe_records
@@ -2137,7 +2137,7 @@ def normalize_input(data, *, rdd_cap: int = 200000):
 
         if RDD_TYPES and isinstance(data, RDD_TYPES):  # a Spark RDD -> a bounded local sample
             return data.take(int(rdd_cap))
-    except Exception:
+    except Exception:  # noqa: BLE001
         pass
     return data
 

--- a/mixle/utils/hvis/affinity.py
+++ b/mixle/utils/hvis/affinity.py
@@ -591,7 +591,7 @@ def _resolve_affinity(
         if getattr(mix_model, "components", None) is not None and data is not None:
             try:
                 return local_factors(mix_model, data, field_weights=field_weights)
-            except Exception:
+            except Exception:  # noqa: BLE001
                 return "bhattacharyya"
         return "bhattacharyya"
 

--- a/mixle/utils/hvis/umap_np.py
+++ b/mixle/utils/hvis/umap_np.py
@@ -111,7 +111,7 @@ def _spectral_init(graph: scipy.sparse.coo_matrix, emb_dim: int, rng: np.random.
             raise ValueError("not enough eigenvectors")
         y = y / max(float(np.abs(y).max()), 1.0e-12) * 10.0
         return y + rng.normal(0.0, 1.0e-4, size=(n, emb_dim))
-    except Exception:
+    except Exception:  # noqa: BLE001
         return rng.uniform(-10.0, 10.0, size=(n, emb_dim))
 
 

--- a/mixle/utils/parallel/fault_tolerant_training.py
+++ b/mixle/utils/parallel/fault_tolerant_training.py
@@ -319,7 +319,7 @@ class SimulatedRank:
                 if not self._go.wait(timeout=5.0):
                     return  # never released -> simulated crash: exit with no result
                 self._result = StepResult(self.rank_id, step, float(loss.item()), float(grad_norm.item()), grads)
-            except BaseException as e:  # surface on the driver, mirroring resilient_em's worker error path
+            except BaseException as e:  # noqa: BLE001 - surface on the driver, mirroring resilient_em's worker path
                 self._error = e
                 self._started.set()
             finally:

--- a/mixle/utils/parallel/multiprocessing.py
+++ b/mixle/utils/parallel/multiprocessing.py
@@ -111,7 +111,7 @@ def _worker_main(conn) -> None:
             else:
                 conn.send(("err", "unknown command %r" % (cmd,)))
 
-        except BaseException as e:  # surface worker failures on the driver
+        except BaseException as e:  # surface worker failures on the driver  # noqa: BLE001
             import traceback
 
             conn.send(("err", "%s\n%s" % (e, traceback.format_exc())))
@@ -280,5 +280,5 @@ class MPEncodedData(EncodedDataHandle):
         try:
             if self._conns:
                 self.close()
-        except Exception:
+        except Exception:  # noqa: BLE001
             pass

--- a/mixle/utils/parallel/planner.py
+++ b/mixle/utils/parallel/planner.py
@@ -294,7 +294,7 @@ class Resources:
                 dev_idx = rank % cuda_count
                 try:
                     mem = int(torch.cuda.get_device_properties(dev_idx).total_memory)
-                except Exception:
+                except Exception:  # noqa: BLE001
                     mem = per_device_memory
                 devices.append(
                     DeviceSpec(
@@ -1339,7 +1339,7 @@ def _dask_worker_count(client: Any) -> int:
         info = client.scheduler_info()
         workers = info.get("workers", {}) if isinstance(info, dict) else {}
         return max(1, len(workers))
-    except Exception:
+    except Exception:  # noqa: BLE001
         return 1
 
 
@@ -1629,7 +1629,7 @@ def calibrate_resources(
                     precision=device.precision if precision is None else precision_name(precision),
                 )
             )
-        except Exception:
+        except Exception:  # noqa: BLE001
             updated.append(device)
     calibrated = Resources(tuple(updated))
     _record_calibration(
@@ -1699,7 +1699,7 @@ def estimate_estimator_stat_nbytes(estimator: Any) -> int:
     try:
         acc = estimator.accumulator_factory().make()
         return _object_nbytes(acc.value(), set(), depth=0, max_depth=8)
-    except Exception:
+    except Exception:  # noqa: BLE001
         return 0
 
 
@@ -1860,7 +1860,7 @@ def _object_nbytes(x: Any, seen: set, depth: int, max_depth: int) -> int:
         return total
     try:
         return encoded_nbytes(x)
-    except Exception:
+    except Exception:  # noqa: BLE001
         return 0
 
 

--- a/mixle/utils/parallel/resilient_em.py
+++ b/mixle/utils/parallel/resilient_em.py
@@ -193,7 +193,7 @@ def _worker_main(conn) -> None:
             else:
                 conn.send(("err", "unknown command %r" % (cmd,)))
 
-        except BaseException as e:  # surface worker failures on the driver
+        except BaseException as e:  # surface worker failures on the driver  # noqa: BLE001
             import traceback
 
             try:
@@ -550,5 +550,5 @@ class ResilientMPEncodedData(EncodedDataHandle):
         try:
             if self._conns:
                 self.close()
-        except Exception:
+        except Exception:  # noqa: BLE001
             pass

--- a/mixle/utils/parallel/sdc_audit.py
+++ b/mixle/utils/parallel/sdc_audit.py
@@ -176,7 +176,7 @@ def _receipt(
     def _safe_repr(payload: bytes) -> str:
         try:
             return repr(pickle.loads(payload))[:2000]
-        except Exception as e:  # a corrupted payload may not even unpickle -- that's fine, still a receipt
+        except Exception as e:  # noqa: BLE001 - a corrupted payload may not even unpickle; still a receipt
             return "<unpicklable: %s>" % e
 
     return SDCAuditReceipt(

--- a/mixle/utils/serialization.py
+++ b/mixle/utils/serialization.py
@@ -21,7 +21,7 @@ import numpy as np
 
 try:
     import scipy.sparse as sp
-except Exception:  # pragma: no cover - scipy is a package dependency in normal use.
+except Exception:  # pragma: no cover - scipy is a package dependency in normal use.  # noqa: BLE001
     sp = None
 
 
@@ -131,7 +131,7 @@ def ensure_pysp_serialization_registry() -> None:
         for _, cls in inspect.getmembers(automatic, inspect.isclass):
             if cls.__module__ == automatic.__name__ and issubclass(cls, (StatsDistribution, StatsEstimator)):
                 register_serializable_class(cls)
-    except Exception:
+    except Exception:  # noqa: BLE001
         # Automatic estimator support is optional for the serializer.  The core
         # stats/bstats registries above should still be available.
         pass
@@ -144,7 +144,7 @@ def ensure_pysp_serialization_registry() -> None:
         for _, cls in inspect.getmembers(structure, inspect.isclass):
             if cls.__module__ == structure.__name__ and getattr(cls, "__pysp_serializable__", False):
                 register_serializable_class(cls)
-    except Exception:
+    except Exception:  # noqa: BLE001
         # Optional: the core stats registry above is enough for pure-stats models.
         pass
 

--- a/mixle/utils/special.py
+++ b/mixle/utils/special.py
@@ -337,7 +337,7 @@ def valid_integer(x: Any, *, nonneg: bool = False) -> bool:
     """
     try:
         xx = float(x)
-    except Exception:
+    except Exception:  # noqa: BLE001
         return False
     if not (np.isfinite(xx) and math.floor(xx) == xx):
         return False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,7 +184,7 @@ target-version = "py310"
 extend-exclude = ["examples"]
 
 [tool.ruff.lint]
-select = ["E", "F", "W", "I", "B", "UP"]
+select = ["E", "F", "W", "I", "B", "UP", "BLE"]
 ignore = [
     "F403", # `from mixle.engines.arithmetic import *` is an intentional dispatch namespace
     "F405", #   (mixle.engines.arithmetic defines __all__); the star is deliberate, not accidental.


### PR DESCRIPTION
## What (worklist Y4.3)

The tree already used `# noqa: BLE001` in a few places, but the rule was **never selected** — so the other
**200** blind `except Exception` / `except BaseException` sites were unguarded and a new one could be added
freely (the Y4.3 gap: *"201 broad excepts; ruff BLE not selected"*).

## Approach — the standard ruff ratchet

- Add `BLE` to the ruff lint `select`.
- Annotate every existing site with `# noqa: BLE001` via ruff's own `--add-noqa`.

Result: the current 200 sites are **explicitly marked** (visible debt, shrinkable file-by-file), and any
**new** blind except now fails `ruff check`. This is the accepted way to introduce a lint rule to a large
codebase without a risky 200-site behavioral rewrite (many of these excepts are legitimately broad — a
report path that must never break a fit, a worker error surfaced to the driver, an unpicklable payload).

The annotations are inert comments — **no behavior change**. Two multiline `except (Exception) as e:` blocks
were collapsed to a single line so the noqa lands on the line ruff anchors the violation to.

## Evidence

`ruff check mixle` + `ruff format --check mixle` clean tree-wide. **Negative control:** a newly introduced
blind except is flagged `BLE001`. Imports and a smoke of the lifecycle/calibrate suites pass. 126 files
changed (200 `# noqa: BLE001` + 1 config line).
