### PR TITLE
Separate legacy backward-compatibility tests from product tests (worklist T3.7)

### DIFF
--- a/mixle/tests/conftest.py
+++ b/mixle/tests/conftest.py
@@ -44,6 +44,9 @@ FILE_MARKERS: dict[str, MarkerTuple] = {
     "conformal_test.py": ("ppl", "integration", "slow"),
     "fused_codegen_test.py": ("numba", "optional"),
     "jax_engine_test.py": ("jax", "optional"),
+    # Backward-compatibility-only tests (renamed class / kwarg aliases). Tagged `legacy` so a product-only
+    # run can exclude them with `-m "not legacy"`; they still run in the default `fast` gate.
+    "api_naming_aliases_test.py": ("legacy",),
     "fused_em_hmm_family_test.py": ("hmm", "integration", "slow"),
     "fused_em_variational_test.py": ("latent", "integration", "slow"),
     "hmm_sampler_batching_test.py": ("hmm", "stochastic", "slow"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,6 +126,7 @@ markers = [
     "optional: tests that require optional extras or external executables.",
     "benchmark: timing-oriented tests; not part of correctness gates.",
     "experimental: tests for mixle.experimental mechanisms without graduation receipts yet (see mixle/experimental/README.md).",
+    "legacy: backward-compatibility tests for renamed/aliased APIs; run product-only with -m 'not legacy'.",
     "stochastic: tests whose assertions depend on random sampling.",
     "integration: end-to-end workflow tests across multiple modules.",
     "distribution: distribution interface, density, sampler, estimator, and encoder tests.",


### PR DESCRIPTION
## What (worklist T3.7)

Register a `legacy` pytest marker and tag `api_naming_aliases_test.py` — the tree's backward-compatibility
suite (renamed class-name aliases, constructor keyword aliases, the `aliasing` helper) that exists **only**
to keep old spellings working and would be deleted with the shims.

A **product-only** run can now exclude it with `-m "not legacy"`, while it still runs in the default `fast`
gate so compatibility stays covered by default.

## Evidence

- `-m legacy` → selects the 16 alias tests;
- `-m "not legacy"` → deselects them (clean product-only run);
- `-m fast` → still collects them (compat covered by default);
- `--strict-markers` satisfied (marker registered in `pyproject.toml`).

The marker infrastructure extends to the deprecation-alias (#324) and cross-version-fixture (#313) compat
suites as they land.

Acceptance (T3.7): legacy compatibility tests are separable from product tests — met.
