### PR TITLE
Add a measured 'Limits and Validation' section to the HMM guide (worklist X12.7)

### DIFF
--- a/docs/hmms-latent.rst
+++ b/docs/hmms-latent.rst
@@ -338,3 +338,50 @@ API Map
      - HSMM with duration distributions
    * - ``InputOutputHMM``
      - transition chosen by exogenous input
+
+Limits and Validation
+---------------------
+
+Complexity and memory
+~~~~~~~~~~~~~~~~~~~~~~~
+
+For an HMM with ``K`` hidden states scored on a sequence of ``N`` observations, the
+forward/backward recursions are ``O(N * K^2)`` time -- the ``K^2`` is the transition
+matrix-vector product at each step -- and ``O(N * K)`` memory for the per-step posteriors
+(plus the cost of scoring ``K`` emissions per step, which depends on the leaf family). Each
+EM iteration is one forward/backward pass, so training cost scales the same way in ``N`` and
+``K``. A dense transition matrix is the ``K^2`` term; the ``LowRankTransition`` /
+``SparseTransition`` operators in the table above exist to reduce it when ``K`` is large.
+
+Numerical behavior on long sequences
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The forward recursion is scaled (rescaled per step, accumulating the log of each scale), so a
+single long sequence does **not** silently underflow to ``-inf``. Measured on a 3-state HMM:
+a length-20000 discrete sequence scores a finite log-likelihood, and the scalar ``log_density``
+and vectorized ``seq_log_density`` routes agree to ``~5e-9`` over those 20000 steps. A genuinely
+impossible observation -- a categorical symbol outside every state's support, or a point in a
+zero-probability region -- scores a clean ``-inf`` in **both** routes, never ``NaN``.
+
+Unsupported combinations and common errors
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* A discrete HMM estimator's ``pseudo_count`` is a ``(transition, initial)`` tuple, not a
+  scalar; passing a single float raises ``TypeError``. Use ``pseudo_count=(1.0, 1.0)``.
+* A held-out categorical symbol never seen during training has zero emission mass under every
+  state, so a sequence containing it scores ``-inf`` (see above). Cover the symbol set in the
+  training/seed data, or smooth the emission support, before scoring held-out data.
+* A single very long sequence is numerically fine, but chunking it into subsequences is still
+  recommended -- both for throughput (shorter independent chains vectorize better) and so that
+  held-out scoring degrades gracefully rather than returning one ``-inf`` for the whole series
+  on a single impossible observation.
+
+Validation
+~~~~~~~~~~~
+
+Validate a fitted HMM against a reference implementation, comparing held-out log-likelihood
+(not just fitted parameters, which are exchangeable under state relabeling). ``hmmlearn`` is the
+standard reference for discrete and Gaussian HMMs. Measured parity example: on a real discretized
+series, mixle's held-out per-observation log-likelihood matched ``hmmlearn`` to within ``5e-4``
+(``-2.2181`` vs ``-2.2177``). Keep the initialization, restart, chunking, and decoding policies
+with the model record so the number is reproducible.


### PR DESCRIPTION
## What (worklist X12.7)

The HMM guide covered the happy path but not **complexity, memory, numerical limits, unsupported
combinations, or how to validate** — what X12.7 asks stable guides to state. Adds a *Limits and Validation*
section to `docs/hmms-latent.rst`, grounded in actual measurements:

- **Complexity/memory**: forward-backward is `O(N·K²)` time, `O(N·K)` memory (K states, N observations), and
  why the low-rank/sparse transition operators exist.
- **Numerical behavior**: the scaled forward recursion does **not** underflow on long sequences — a
  length-20000 discrete sequence scores a finite log-likelihood with scalar/vectorized agreement to `~5e-9`
  (measured) — and an impossible observation scores a clean `-inf` in both routes, never `NaN`.
- **Unsupported combinations / common errors**: the discrete `pseudo_count=(transition, initial)` tuple (a
  scalar raises `TypeError`), a held-out categorical symbol with zero mass zeroing a sequence to `-inf`, and
  when to chunk a long sequence.
- **Validation**: compare held-out log-likelihood (not exchangeable parameters) against `hmmlearn` — measured
  parity example, mixle `-2.2181` vs hmmlearn `-2.2177` (within `5e-4`).

## Evidence

The cited numbers were **re-verified against the current library** before writing (N=20000 finite +
scalar≡vectorized to 5e-9; impossible symbol → -inf both routes). The page parses as RST (docutils,
errors-only).

Acceptance (X12.7): a limits-and-validation section grounded in measurements — met for the HMM guide (the
same template applies to the other stable guides).
