### PR TITLE
Make mypy blocking for a strict typed-core (worklist Y4.1)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,8 +35,14 @@ jobs:
         run: ruff format --check mixle
       - name: ruff check
         run: ruff check mixle
-      # mypy stays advisory until the type-checking backlog is addressed (config in pyproject.toml).
-      - name: mypy
+      # A curated typed-core is checked strictly and BLOCKING (worklist Y4.1): these modules are fully
+      # annotated and clean under disallow_untyped_defs (see the [[tool.mypy.overrides]] typed-core list in
+      # pyproject.toml). --follow-imports=skip keeps the check to these modules' own annotations so a
+      # dependency's or an untyped sibling's errors cannot leak in. The list grows as more modules qualify.
+      - name: mypy (typed core, blocking)
+        run: mypy --follow-imports=skip mixle/scorecard.py mixle/spend.py mixle/system.py mixle/registry.py
+      # The whole-tree mypy stays advisory until the rest of the type-checking backlog is addressed.
+      - name: mypy (whole tree, advisory)
         continue-on-error: true
         run: mypy
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -214,3 +214,17 @@ no_implicit_optional = true
 [[tool.mypy.overrides]]
 module = "mixle.tests.*"
 ignore_errors = true
+
+# Typed-core (worklist Y4.1): these modules are fully annotated and clean under strict mypy
+# (disallow_untyped_defs). They are checked BLOCKING in CI (the "mypy (typed core)" step), unlike the
+# advisory whole-tree run. Grow this list as more modules reach the bar -- that is how the type-checked
+# core expands without a single boil-the-ocean pass.
+[[tool.mypy.overrides]]
+module = [
+    "mixle.scorecard",
+    "mixle.spend",
+    "mixle.system",
+    "mixle.registry",
+]
+disallow_untyped_defs = true
+disallow_incomplete_defs = true


### PR DESCRIPTION
## What (worklist Y4.1)

mypy ran whole-tree but `continue-on-error`, so type regressions never failed CI. Rather than boil the ocean
(the tree is only partially typed), this establishes a **typed-core**: `mixle.scorecard`, `mixle.spend`,
`mixle.system`, and `mixle.registry` are fully annotated and clean under `disallow_untyped_defs` /
`disallow_incomplete_defs`.

- A new `[[tool.mypy.overrides]]` block records them as the strict typed-core.
- A new **BLOCKING** CI step (`mypy (typed core)`) checks exactly those with `--follow-imports=skip` — so a
  dependency's or an untyped sibling's errors cannot leak in, and an untyped def added to any of them **fails
  CI**.
- The whole-tree mypy stays as a separate **advisory** step until the rest of the backlog is addressed.

The list is meant to **grow module-by-module** as more of the tree reaches the bar — the mechanism the
existing config comment (*"tighten incrementally … per-module overrides"*) anticipated.

## Evidence

- the four modules pass strict mypy (`Success: no issues found in 4 source files`, exit 0);
- **negative control:** adding an untyped def to one produces a `no-untyped-def` error;
- `tests.yml` is valid YAML.

Acceptance (Y4.1): a blocking type-check on a typed core, extensible incrementally — met.
