### PR TITLE
Establish the 0.8.0 release decision log (worklist G0.2)

### DIFF
--- a/release-checklists/0.8.0-decisions.md
+++ b/release-checklists/0.8.0-decisions.md
@@ -1,0 +1,136 @@
+# 0.8.0 Release Decision Log
+
+Append-only record of 0.8.0 scope changes, waivers, API breaks, benchmark-methodology changes, and claim
+changes (worklist **G0.2**). The rule: **no release decision lives only in a PR thread or a local note** —
+if it changes scope, breaks an API, waives a P1, or changes a published claim or a benchmark method, it gets
+an entry here.
+
+Each entry records: **date · decision · alternatives · evidence · owner · reviewer · expiration · worklist
+ID**. Entries are added, never edited in place (correct a decision with a new superseding entry). A decision
+proposed in an open PR is recorded with **reviewer: pending**; it becomes **accepted** when that PR is
+reviewed and merged into `release/0.8.0`.
+
+Owner is the release owner (grant.boquet@gmail.com) unless stated. Dates are UTC.
+
+---
+
+## D-0001 · Drop Python 3.10; floor numpy ≥ 2.4, scipy ≥ 1.16
+
+- **Date:** 2026-07-11
+- **Decision:** Raise `requires-python` to `>=3.11` and the runtime floors to `numpy>=2.4`, `scipy>=1.16`,
+  `mpmath>=1.3`; drop the 3.10 classifier and set `ruff`/`mypy` targets to py311.
+- **Alternatives considered:** keep 3.10 + older floors (rejected: scipy<1.13 `von_mises` precision, numpy
+  2.0.0 `IndexError` bugs, numpy<2.4 t-SNE/atlas fragility, and tests using numpy-2.0-only `np.trapezoid`
+  all failed the min-version job); pin exact versions (rejected: floors, not pins, keep newer majors usable).
+- **Evidence:** min-versions CI job bisecting the true floor; 4252 tests pass at the new floors.
+- **Reviewer:** pending — PR #310
+- **Expiration:** revisit at 0.9.0 (numpy/scipy floors move forward as the ecosystem does).
+- **Worklist:** S13.4
+
+## D-0002 · pip-audit is a blocking gate with an explicit waiver file
+
+- **Date:** 2026-07-11
+- **Decision:** Make the base-install `pip-audit` CI gate blocking (remove `continue-on-error`); un-waived
+  vulnerabilities fail the build. Waivers live in `.github/pip-audit-ignore.txt`, one advisory ID per line
+  with a reason — this is the P1-waiver mechanism referenced by this log.
+- **Alternatives considered:** keep pip-audit advisory (rejected: a security release cannot advise-only);
+  pin the whole graph (rejected: floors + waivers keep it maintainable).
+- **Evidence:** the gate fails on an un-waived vuln; the waiver file suppresses a specific advisory.
+- **Reviewer:** pending — PR #311
+- **Expiration:** each waiver entry should carry its own expiry/re-review date when added.
+- **Worklist:** S13.1
+
+## D-0003 · optimize / fit / best_of are quiet by default (console-output behavior change)
+
+- **Date:** 2026-07-11
+- **Decision:** Change the default of `out` from `sys.stdout` to `None` on `optimize`, `fit`, and `best_of`.
+  Per-iteration progress is now opt-in via `out=`. Fitted models and every numeric result are unchanged.
+- **Alternatives considered:** keep printing by default (rejected: a library must not spray stdout in normal
+  use); a global verbosity flag (rejected: `out=` already exists and is per-call explicit).
+- **Evidence:** no test asserted on the old default stdout; the full non-optional suite is unchanged.
+- **Reviewer:** pending — PR #327
+- **Expiration:** none (stable behavior going forward).
+- **Worklist:** Q5.4
+
+## D-0004 · Deprecation policy: warn, keep ≥ 2 minor releases, then remove
+
+- **Date:** 2026-07-11
+- **Decision:** A deprecated stable name emits a `DeprecationWarning` (one message format), keeps working and
+  forwarding unchanged, and is removed no earlier than two minor releases after the announcing release
+  (announced in 0.8.0 → removable no earlier than 0.10.0). Removal ships a migration note/example.
+- **Alternatives considered:** remove-on-next-minor (rejected: too aggressive for stable names); never remove
+  (rejected: unbounded compatibility debt).
+- **Evidence:** the mechanism + policy doc; a static test that every "Deprecated alias" callable warns.
+- **Reviewer:** pending — PR #324
+- **Expiration:** none (standing policy).
+- **Worklist:** A1.5
+
+## D-0005 · Unclassified public surfaces default to `provisional` maturity
+
+- **Date:** 2026-07-11
+- **Decision:** The machine-readable maturity registry maps only the surfaces the maturity doc classifies;
+  every other public surface resolves to `provisional` (no stability promise until explicitly recorded
+  stable). Only `mixle.experimental` is `experimental`.
+- **Alternatives considered:** classify all 34 top-level surfaces up front (rejected: would invent tiers the
+  maturity doc does not state); default to `stable` (rejected: over-promises).
+- **Evidence:** registry ↔ maturity-doc sync test; the manifest reports 2 stable / 1 experimental / 32
+  provisional.
+- **Reviewer:** pending — PR #329, PR #340
+- **Expiration:** none (default policy; individual surfaces get explicit tiers as they are classified).
+- **Worklist:** A1.2, A1.6
+
+## D-0006 · Coverage gate is a conservative catastrophic-regression floor (45%), not a target
+
+- **Date:** 2026-07-11
+- **Decision:** Add `--cov-fail-under=45` to the base-install `full` CI job. This is a floor set well below
+  the real number (the fast suite alone covers ~72% locally with backends installed) so it trips only on a
+  large regression (e.g. a dropped test directory), not on ordinary changes. Raise it once the optional
+  extras job also reports coverage and the two are combined.
+- **Alternatives considered:** no coverage gate (rejected: no regression tripwire); a threshold near the true
+  number (rejected: base install skips optional backends, so it would misrepresent and block unrelated PRs).
+- **Evidence:** measured fast-suite coverage 72% with `branch=true`; base-only is lower but well above 45%.
+- **Reviewer:** pending — PR #334
+- **Expiration:** revisit when the combined (base + optional) coverage number exists.
+- **Worklist:** T3.4
+
+## D-0007 · Introduce ruff BLE (blind-except) via a full-tree noqa ratchet
+
+- **Date:** 2026-07-11
+- **Decision:** Select ruff `BLE001` and annotate the 200 existing blind-`except` sites (across 126 files)
+  with `# noqa: BLE001` via `ruff --add-noqa`, so no *new* blind except can be added while the existing debt
+  is explicit and shrinkable. Many existing sites are legitimately broad (report paths that must never break
+  a fit, worker errors surfaced to a driver).
+- **Alternatives considered:** rewrite all 200 sites now (rejected: large, per-site judgment, risk of
+  behavior change); per-file-ignores for 126 files (rejected: hides new violations in grandfathered files).
+- **Evidence:** ruff clean tree-wide; a new blind except is flagged (negative control).
+- **Reviewer:** pending — PR #333
+- **Expiration:** the noqa count should trend down; no hard expiry.
+- **Worklist:** Y4.3
+
+## D-0008 · mypy is blocking for a typed-core, advisory for the rest
+
+- **Date:** 2026-07-11
+- **Decision:** Make mypy blocking for a curated typed-core (`mixle.scorecard`, `mixle.spend`,
+  `mixle.system`, `mixle.registry`) that is clean under `disallow_untyped_defs`; the whole-tree mypy stays
+  advisory. The typed-core list grows module-by-module.
+- **Alternatives considered:** make whole-tree mypy blocking now (rejected: the tree is only partially
+  typed); keep mypy fully advisory (rejected: type regressions never fail CI).
+- **Evidence:** the four modules pass strict mypy; an untyped def added to one fails the gate.
+- **Reviewer:** pending — PR #339
+- **Expiration:** none (list expands over time).
+- **Worklist:** Y4.1
+
+## D-0009 · Deploy pure models as safe JSON; keep pickle only for torch-backed models
+
+- **Date:** 2026-07-11
+- **Decision:** `lifecycle.Model.deploy` writes a registry-serializable model as type-tagged JSON; only a
+  model the registry cannot represent falls back to pickle, recorded in the manifest `format`. `Model.load`
+  reads the format and uses the safe path for JSON. The remaining pickle path is documented as executing
+  arbitrary code (trusted-source only). This is a claim/security-behavior change: "durable artifact" no
+  longer implies an unsafe pickle load for the common case.
+- **Alternatives considered:** keep pickle everywhere with only a docstring warning (rejected: pickle-RCE
+  stays the default for pure models); drop pickle entirely (rejected: torch-backed models need it).
+- **Evidence:** a pure model deploys with no `model.pkl`; old pickle artifacts still load (backward compat).
+- **Reviewer:** pending — PR #332
+- **Expiration:** none.
+- **Worklist:** S13 (security), N9.2 (honest claims)

--- a/release-checklists/README.md
+++ b/release-checklists/README.md
@@ -8,6 +8,10 @@ This folder is the tracked, public record of what has to be true before a `mixle
 - **`lessons-learned.md`** — a cumulative, cross-release record of what went wrong (or nearly did),
   where each lesson is tied to the checklist gate that now catches it. This is what keeps the
   checklist from being a static wish-list: it grows from real failures.
+- **`<version>-decisions.md`** (`0.8.0-decisions.md`, …) — the append-only release decision log for a
+  version: every scope change, waiver, API break, benchmark-methodology change, and claim change, with
+  date, alternatives, evidence, owner, reviewer, expiration, and worklist ID. No release decision may
+  live only in a PR thread or a local note.
 
 This is a checklist of **gates**, not a task list. An unchecked item means the release is not
 ready, full stop — there is no "ship now, verify later" for anything marked here.


### PR DESCRIPTION
## What (worklist G0.2)

Add `release-checklists/0.8.0-decisions.md` — an **append-only** record so no 0.8.0 scope change, waiver,
API break, benchmark-methodology change, or claim change lives only in a PR thread or a local note (`notes/`
is gitignored, so this goes in the tracked `release-checklists/`).

Each entry carries **date · decision · alternatives · evidence · owner · reviewer · expiration · worklist
ID**. A decision proposed in an open PR is recorded `reviewer: pending` and becomes `accepted` on merge.

## Seeded with the real decisions this cycle

Nine substantive decisions, each linked to its worklist ID and PR:

| # | Decision | Worklist / PR |
|---|----------|---------------|
| D-0001 | Drop Python 3.10; floor numpy≥2.4 / scipy≥1.16 | S13.4 / #310 |
| D-0002 | Blocking pip-audit + waiver file | S13.1 / #311 |
| D-0003 | `optimize`/`fit`/`best_of` quiet by default | Q5.4 / #327 |
| D-0004 | Deprecation policy (warn, ≥2 minors, remove) | A1.5 / #324 |
| D-0005 | Unclassified surfaces default to `provisional` | A1.2 / #329, #340 |
| D-0006 | Conservative coverage floor (45%) | T3.4 / #334 |
| D-0007 | ruff BLE ratchet | Y4.3 / #333 |
| D-0008 | mypy blocking typed-core | Y4.1 / #339 |
| D-0009 | Deploy pure models as safe JSON | S13 / N9.2 / #332 |

`release-checklists/README.md` now documents the log.

Acceptance (G0.2): every scope exception and P1 waiver has an entry; no release decision lives only in chat
or a local note — met (the log is the mechanism; entries move to accepted on merge).
