### PR TITLE
Add an extras resolver matrix CI job (worklist P2.3)

### DIFF
--- a/.github/workflows/extras-matrix.yml
+++ b/.github/workflows/extras-matrix.yml
@@ -1,0 +1,61 @@
+name: Extras resolver matrix
+
+# Worklist P2.3: install every documented extra (and [all]) in ISOLATION in a fresh environment, and prove
+# that (a) it resolves and installs, (b) the dependency graph stays consistent (`pip check` -- catches an
+# extra that silently downgrades or uninstalls a required package), and (c) mixle still imports. Heavy, so
+# it runs on manual dispatch and the weekly schedule, not on every PR. `fail-fast: false` keeps each extra
+# independent, so the run is a self-diagnosing matrix: one extra that cannot install on the runner is a
+# visible red cell, not a masked failure. macOS/arm64 and other OS/arch combinations are verified in the
+# release owner's environment and recorded in the release checklist; this job pins the Linux x86_64 baseline.
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "23 9 * * 1"
+
+jobs:
+  extra:
+    name: "install .[${{ matrix.extra }}]"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        extra:
+          - numba
+          - torch
+          - jax
+          - pandas
+          - arrow
+          - sql
+          - mongo
+          - hadoop
+          - arrays
+          - grammar
+          - spark
+          - dask
+          - ray
+          - lightning
+          - mpi
+          - umap
+          - sympy
+          - sage
+          - scientist
+          - all
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      # A few extras build native code and need system headers. Install them only for the extras that do.
+      - name: System build dependencies
+        run: |
+          if [ "${{ matrix.extra }}" = "mpi" ]; then
+            sudo apt-get update && sudo apt-get install -y libopenmpi-dev openmpi-bin
+          fi
+      - name: Install .[${{ matrix.extra }}] in isolation
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install ".[${{ matrix.extra }}]"
+      - name: pip check (no extra downgraded or broke a required dependency)
+        run: python -m pip check
+      - name: mixle still imports
+        run: python -c "import mixle; print('mixle', mixle.__version__, 'imports with [${{ matrix.extra }}]')"


### PR DESCRIPTION
## What (worklist P2.3)

`.github/workflows/extras-matrix.yml` — install **every documented extra** and `[all]` in **isolation** in a
fresh environment and prove:

1. it resolves and installs;
2. `pip check` still passes — catching an extra that silently **downgrades or uninstalls** a required
   package (P2.3 calls this out explicitly);
3. mixle still imports.

The matrix is exactly the worklist's list (`numba, torch, jax, pandas, arrow, sql, mongo, hadoop, arrays,
grammar, spark, dask, ray, lightning, mpi, umap, sympy, sage, scientist, all`) — each confirmed to be a real
extra in `pyproject`. `mpi` gets its system build deps (`libopenmpi-dev`, `openmpi-bin`) first.

`fail-fast: false` keeps each extra independent, so the run is a **self-diagnosing matrix**: an extra that
can't install on the runner is a visible red cell, not a masked failure — which is the point (the job
*discovers* which extras resolve cleanly). Heavy, so it runs on manual dispatch + the weekly schedule, not
per-PR. macOS/arm64 combinations are the release owner's environment; this pins the Linux x86_64 baseline.

## Evidence

- the install pattern (fresh venv → `pip install ".[extra]"` → `pip check` → import) was **verified locally**
  against a representative extra (`pip check`: "No broken requirements found"; `mixle` + the extra import);
- valid YAML; every matrix extra exists in `pyproject`.

Acceptance (P2.3): install checks for every documented extra and `[all]`, with `pip check` guarding against
accidental downgrades — met.
