### PR TITLE
Add the 0.8.0 release risk register (worklist G0.5)

### DIFF
--- a/release-checklists/0.8.0-risks.md
+++ b/release-checklists/0.8.0-risks.md
@@ -1,0 +1,117 @@
+# 0.8.0 Release Risk Register
+
+Live, ranked register of the risks to shipping 0.8.0 (worklist **G0.5**). Reviewed weekly; **every high
+risk must have an active mitigation or an explicit release limitation** recorded here. Each entry:
+**probability · impact · mitigation · trigger · owner**. Ranked by probability × impact (highest first).
+
+Owner defaults to the release owner (grant.boquet@gmail.com). "Mitigation" links to the gate or decision
+that reduces the risk; a gate in an open PR is not yet in effect on `release/0.8.0`.
+
+---
+
+## R-01 · Single-maintainer review bottleneck — **HIGH**
+
+- **Probability:** high · **Impact:** high (blocks the entire release; the work is done but unreviewed).
+- **Now:** the 0.8.0 credibility work landed as a large stack of PRs into `release/0.8.0`, all awaiting one
+  reviewer. Nothing merges until they are reviewed.
+- **Mitigation:** merge in dependency order — low-churn gates first (weighted-estimation, API-manifest,
+  optional-import guard, clean-wheel sweep), then the PRs that touch shared files (`tests.yml` optional job,
+  `pyproject.toml`, `conftest.py`) in number order to minimize conflicts. Keep each PR single-purpose and
+  scoped to one worklist ID so review is fast.
+- **Trigger:** the release branch has not advanced in a week, or open-PR count is not trending down.
+- **Owner:** release owner.
+
+## R-02 · Merge conflicts among stacked PRs — **HIGH**
+
+- **Probability:** high · **Impact:** medium (rework, not a shipped defect).
+- **Now:** several PRs edit the same files — the `optional` job in `tests.yml` (the flagship + parity
+  steps), `pyproject.toml` (version, floors, ruff select, markers, filterwarnings), and `conftest.py`
+  (`FILE_MARKERS`). Merged out of order they conflict.
+- **Mitigation:** merge the `tests.yml`/`pyproject.toml`/`conftest.py`-touching PRs in ascending PR number;
+  rebase the rest on the updated branch; the stacked A1.6 PR is retargeted to `release/0.8.0` only after
+  A1.2 lands.
+- **Trigger:** a merge reports a conflict in a shared file.
+- **Owner:** release owner.
+
+## R-03 · API churn surprises users — **MEDIUM-HIGH**
+
+- **Probability:** medium · **Impact:** high (a behavior change breaks a user's script silently).
+- **Now:** this cycle changes defaults (`optimize`/`fit`/`best_of` quiet-by-default), floors (drop Python
+  3.10), and introduces deprecations.
+- **Mitigation:** the deprecation policy (warn, keep ≥2 minor releases) and the decision log entries
+  D-0001/D-0003/D-0004; each behavior change is called out in its PR body and the changelog.
+- **Trigger:** a changelog entry for a behavior change is missing, or a rename ships without a deprecation.
+- **Owner:** release owner.
+
+## R-04 · Clean-wheel / base-install regression — **MEDIUM**
+
+- **Probability:** medium · **Impact:** high (the package doesn't import for a plain user).
+- **Mitigation:** the blocking clean-wheel install + import-sweep job, the base-install optional-import
+  guard, and the collection-hygiene gate (heavy frameworks stay behind `importorskip`).
+- **Trigger:** the clean-wheel job fails, or a new top-level optional import lands.
+- **Owner:** release owner.
+
+## R-05 · Optional-dependency breakage — **MEDIUM**
+
+- **Probability:** medium · **Impact:** medium (a `pip install mixle[x]` fails or downgrades a core dep).
+- **Mitigation:** the extras resolver matrix (`pip install .[extra]` + `pip check` per extra) and the
+  min-versions job.
+- **Trigger:** a cell in the extras matrix goes red, or `pip check` reports a conflict.
+- **Owner:** release owner.
+
+## R-06 · Stochastic / numerical flakiness — **MEDIUM**
+
+- **Probability:** medium · **Impact:** medium (a flaky gate erodes trust or blocks unrelated PRs).
+- **Mitigation:** per-test global-state isolation (pinned by the order-independence test), fixed seeds
+  (random-state discipline), the numerical stress panel, and generous pinned thresholds.
+- **Trigger:** a test passes locally but flakes in CI, or fails only under a different worker order.
+- **Owner:** release owner.
+
+## R-07 · Backend claims outrun hardware evidence — **MEDIUM**
+
+- **Probability:** medium · **Impact:** high (a false "runs on any backend at scale" claim).
+- **Mitigation:** the backend support matrix with honest per-backend status; TP/PP/CP raise when requested
+  but not integrated; frontier-training surfaces labeled as prototypes; README overclaims qualified.
+- **Trigger:** a doc or README describes a backend/scale as supported without CI or hardware evidence.
+- **Owner:** release owner.
+
+## R-08 · Serialization incompatibility — **MEDIUM**
+
+- **Probability:** low-medium · **Impact:** high (a saved model won't load in the new version).
+- **Mitigation:** cross-version load fixtures (0.7.0 artifacts), atomic artifact writes, and safe-JSON
+  deployment for pure models.
+- **Trigger:** the cross-version fixtures test fails, or a manifest schema field changes without a fixture.
+- **Owner:** release owner.
+
+## R-09 · Benchmark irreproducibility — **LOW-MEDIUM**
+
+- **Probability:** low-medium · **Impact:** medium (a perf claim can't be reproduced).
+- **Mitigation:** the benchmark harness is tracked in git; benchmark-methodology changes get a decision-log
+  entry; timing tests use generous pinned floors, not exact numbers.
+- **Trigger:** a benchmark number in docs has no runnable harness behind it.
+- **Owner:** release owner.
+
+## R-10 · Test-suite runtime prevents frequent execution — **LOW-MEDIUM**
+
+- **Probability:** low-medium · **Impact:** medium (slow gates get skipped, letting regressions in).
+- **Mitigation:** the `fast` gate (~25 s under `-n auto`) runs every commit; slow/optional tiers run in
+  full/scheduled jobs; collection stays lean in the base environment (collection-hygiene gate).
+- **Trigger:** the fast gate exceeds a couple of minutes, or contributors routinely skip it.
+- **Owner:** release owner.
+
+## R-11 · Stale documentation from older branches — **LOW**
+
+- **Probability:** low · **Impact:** medium (docs describe behavior that shipped differently).
+- **Mitigation:** docs build in CI; the claim-evidence ledger and "What Mixle Is Not" page bound claims;
+  the maturity registry/manifest is drift-gated against the maturity doc.
+- **Trigger:** a docs build references a removed symbol, or a claim has no ledger row.
+- **Owner:** release owner.
+
+## R-12 · Package-family version skew — **LOW**
+
+- **Probability:** low · **Impact:** medium (a sibling pins an incompatible `mixle`).
+- **Now:** out of this repo's scope (cross-package coordination is the release owner's, tracked in the family
+  release process), but recorded here because it can block this package's release.
+- **Mitigation:** the family-release process and support-policy's cross-package linkage.
+- **Trigger:** a sibling declares a `mixle` requirement incompatible with 0.8.0.
+- **Owner:** release owner (family-level).


### PR DESCRIPTION
## What (worklist G0.5)

`release-checklists/0.8.0-risks.md` — a **live, ranked** register of the 12 risks to shipping 0.8.0, each
with **probability · impact · mitigation · trigger · owner**, ranked by probability × impact.

Covers the worklist's minimum risk set (single-maintainer review bottleneck, API churn, clean-wheel
regressions, optional-dependency breakage, stochastic/numerical flakiness, benchmark irreproducibility,
backend claims outrunning hardware evidence, stale docs, serialization incompatibility, test-suite runtime,
package-family version skew) plus the **merge-conflict** risk this release's large PR stack actually carries.

Each risk's mitigation links to the concrete gate or decision that reduces it (clean-wheel sweep, extras
matrix, order-independence isolation, deprecation policy, backend support matrix, cross-version fixtures, …).
The top two are **live and specific to this release**:

- **R-01** — the done-but-unreviewed PR stack awaiting one reviewer;
- **R-02** — merge conflicts among PRs touching `tests.yml` / `pyproject.toml` / `conftest.py`,

each with a concrete merge-order mitigation. Sibling of the decision log (G0.2 / #341).

Acceptance (G0.5): ranked risks with probability, impact, mitigation, trigger, owner; every high risk has an
active mitigation — met.
