### PR TITLE
Distinguish LM inference-artifact persistence from training resume (worklist M11.3)

### DIFF
--- a/mixle/models/language_model.py
+++ b/mixle/models/language_model.py
@@ -111,12 +111,24 @@ class LM:
         return lm
 
     def save(self, path: str) -> None:
-        """Persist the trained LM to ``path`` via ``torch.save`` (hyperparameters + weights)."""
+        """Persist the LM's **inference artifact** to ``path`` via ``torch.save``: architecture config
+        (vocab/d_model/n_layer/n_head/block) + learned weights, nothing else.
+
+        This is **not** a training checkpoint. It deliberately does not store the optimizer, LR scheduler,
+        step count, RNG state, data-loader position, or gradient-scaler state, so :meth:`load` returns a
+        model ready for scoring and generation, not one you can resume training from without loss of state.
+        For resumable training use the checkpoint path in :mod:`mixle.utils.parallel.fault_tolerant_training`
+        / :mod:`mixle.utils.parallel.dcp_checkpoint`, which stores model + optimizer + data-loader position.
+        """
         _torch().save(self.to_dict(), path)
 
     @classmethod
     def load(cls, path: str) -> LM:
-        """Load an LM previously written by :meth:`save`."""
+        """Load an LM **inference artifact** written by :meth:`save` (config + weights).
+
+        Returns a model ready for scoring/generation; this is not a training-resume checkpoint (see
+        :meth:`save`), so optimizer/step/RNG/data-loader state is not restored.
+        """
         return cls.from_dict(_torch().load(path, weights_only=False))
 
     def fit(

--- a/mixle/tests/language_model_persistence_test.py
+++ b/mixle/tests/language_model_persistence_test.py
@@ -1,0 +1,73 @@
+"""LM.save persists an inference artifact, not a training checkpoint (worklist M11.3).
+
+Model persistence and training resume are different contracts with different guarantees. ``LM.save`` writes
+the *inference artifact* -- architecture config + learned weights -- so a loaded model can score and
+generate. It is deliberately NOT a training-resume checkpoint: it stores no optimizer, scheduler, step,
+RNG, data-loader position, or scaler state (that contract lives in
+``mixle.utils.parallel.fault_tolerant_training`` / ``dcp_checkpoint``). This test pins that boundary, so
+``LM.save`` cannot silently start being described or used as resumable training without the payload
+gaining the checkpoint fields -- which would fail here.
+"""
+
+import tempfile
+import unittest
+
+import pytest
+
+pytest.importorskip("torch")
+
+from mixle.models.language_model import LM  # noqa: E402
+
+# Fields that belong to a TRAINING checkpoint, never to the inference artifact.
+_TRAINING_ONLY_FIELDS = {
+    "optimizer",
+    "opt_state",
+    "optimizer_state",
+    "scheduler",
+    "lr_scheduler",
+    "step",
+    "global_step",
+    "epoch",
+    "rng",
+    "rng_state",
+    "loader",
+    "loader_state",
+    "data_loader",
+    "scaler",
+    "grad_scaler",
+    "distributed",
+    "health",
+}
+
+
+def _tiny_lm():
+    return LM(vocab=16, d_model=8, n_layer=1, n_head=2, block=4, device="cpu")
+
+
+class LMPersistenceContractTest(unittest.TestCase):
+    def test_to_dict_is_inference_artifact_only(self):
+        payload = _tiny_lm().to_dict()
+        # architecture config + weights, exactly
+        self.assertEqual(set(payload), {"vocab", "d_model", "n_layer", "n_head", "block", "device", "state_dict"})
+        # and nothing that belongs to a training-resume checkpoint
+        self.assertEqual(set(payload) & _TRAINING_ONLY_FIELDS, set())
+
+    def test_save_load_round_trips_a_scoring_ready_model(self):
+        import torch
+
+        lm = _tiny_lm()
+        x = torch.zeros(1, 4, dtype=torch.long)
+        with torch.no_grad():
+            before = lm.module(x)
+        with tempfile.TemporaryDirectory() as d:
+            path = f"{d}/lm.pt"
+            lm.save(path)
+            loaded = LM.load(path)
+        with torch.no_grad():
+            after = loaded.module(torch.zeros(1, 4, dtype=torch.long))
+        # a loaded artifact reproduces the model's outputs (scoring-ready), no training state needed
+        self.assertTrue(torch.allclose(before, after, atol=1e-6))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What (worklist M11.3)

Model persistence and training resume are different contracts with different guarantees. `LM.save` already
stored only architecture config + weights, but its docstring ("hyperparameters + weights") didn't say it is
**not** a training checkpoint — leaving room to mistake it for resumable training.

## Fix

`LM.save` / `LM.load` docstrings now state they persist the **inference artifact** (config + learned
weights, ready for scoring/generation) and deliberately store **no** optimizer, scheduler, step, RNG,
data-loader position, or scaler state — cross-referencing the actual resumable-training checkpoint path
(`mixle.utils.parallel.fault_tolerant_training` / `dcp_checkpoint`, which stores model + optimizer +
data-loader position).

## Test

`mixle/tests/language_model_persistence_test.py` (torch-gated):

- `to_dict()` contains **exactly** the architecture config + `state_dict` and **none** of the
  training-checkpoint fields (`optimizer`/`scheduler`/`step`/`rng`/`loader`/`scaler`/…);
- a save/load round-trip reproduces the model's outputs (scoring-ready).

So `LM.save` cannot silently become "resumable training" without the payload gaining checkpoint fields —
which fails this test.

## Evidence

2 tests pass; `ruff` clean.

Acceptance (M11.3): `LM.save` is not described as resumable training and does not store the checkpoint
contract — met, and pinned.
