### PR TITLE
Label frontier-training prototypes as experimental (worklist A1.4)

### DIFF
--- a/mixle/models/mup.py
+++ b/mixle/models/mup.py
@@ -1,5 +1,11 @@
 """muP (Maximal Update Parametrization) -- width-independent lr/init transfer for :mod:`mixle.models.transformer`.
 
+.. warning::
+
+   **Experimental frontier-training prototype.** The parametrization math is exact and tested at small
+   width, but this is not a validated production scaling recipe. Verify the coordinate check at your target
+   width before relying on transfer; treat it as a research prototype, not a supported training API.
+
 **The idea.** In the standard parametrization, the learning rate and init scale that work best for a
 transformer depend on its width (``d_model``): as a model gets wider, activations/gradients grow (or
 shrink) with width unless the parametrization compensates, so a wider model needs a *different* tuned

--- a/mixle/models/sparsity_2_4.py
+++ b/mixle/models/sparsity_2_4.py
@@ -1,5 +1,11 @@
 """2:4 structured sparsity, end to end (roadmap I4): training-time mask ramp + cuSPARSELt-format export.
 
+.. warning::
+
+   **Experimental frontier-training prototype.** The mask-ramp and export mechanics are exact and tested,
+   but the actual cuSPARSELt speedup needs a real CUDA device with that kernel; this is not a production
+   sparsity-training pipeline. Treat it as a prototype and measure end-to-end on your target hardware.
+
 Two pieces, glued by ONE borrowed primitive rather than two reimplementations:
 
 1. :class:`TwoFourSparsityRamp` -- a schedulable training-time mask ramp. It does not reinvent 2:4

--- a/mixle/ppl/scaling_laws.py
+++ b/mixle/ppl/scaling_laws.py
@@ -1,5 +1,11 @@
 """F5: scaling-law fits + compute allocation -- "mixle training mixle" (roadmap item F).
 
+.. warning::
+
+   **Experimental frontier-training prototype.** The curve fits and compute-allocation math are exact on
+   the data you give them, but any extrapolation beyond the fitted regime is a research estimate, not a
+   guarantee -- a scaling-law fit is only as trustworthy as its measured points. Not a production planner.
+
 Fits classic Chinchilla-style neural-scaling-law curves ``loss = f(N, D)`` (N = model
 parameters, D = training tokens) using mixle's OWN probabilistic-programming/regression
 machinery (:mod:`mixle.ppl`), not ``scipy.optimize.curve_fit`` or an ad-hoc fitter: a scaling

--- a/mixle/tests/frontier_prototype_labels_test.py
+++ b/mixle/tests/frontier_prototype_labels_test.py
@@ -1,0 +1,50 @@
+"""Frontier-training surfaces are labeled as experimental prototypes (worklist A1.4).
+
+mixle carries sharding mathematics and small-scale training simulations (muP, 2:4 sparsity, scaling-law
+fits, tensor/pipeline/context parallelism, fault-tolerant training, sharded checkpointing) whose mechanics
+are exact but which are NOT production frontier trainers -- the real multi-GPU / multi-node execution needs
+hardware this project does not gate on. A1.4's bar is that no user can mistake these for production. This
+test enforces that each such module's docstring carries an explicit experimental/prototype/simulation
+signal, so a new frontier surface cannot land in a stable namespace without one.
+"""
+
+import ast
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Frontier-training prototype modules that live in stable namespaces (not under mixle.experimental).
+_FRONTIER_MODULES = [
+    "mixle/models/mup.py",
+    "mixle/models/sparsity_2_4.py",
+    "mixle/ppl/scaling_laws.py",
+    "mixle/utils/parallel/context_parallel_spine.py",
+    "mixle/utils/parallel/fault_tolerant_training.py",
+    "mixle/utils/parallel/tensor_pipeline_context_parallel.py",
+    "mixle/utils/parallel/dcp_checkpoint.py",
+]
+
+# Any one of these phrases in the module docstring signals "prototype, not production".
+_SIGNALS = ("experimental", "prototype", "simulat", "not a production", "not production", "research prototype")
+
+
+class FrontierPrototypeLabelTest(unittest.TestCase):
+    def test_every_frontier_module_declares_prototype_status(self):
+        unlabeled = []
+        for rel in _FRONTIER_MODULES:
+            path = REPO_ROOT / rel
+            self.assertTrue(path.exists(), f"frontier module missing: {rel}")
+            doc = (ast.get_docstring(ast.parse(path.read_text())) or "").lower()
+            if not any(sig in doc for sig in _SIGNALS):
+                unlabeled.append(rel)
+        self.assertEqual(
+            unlabeled,
+            [],
+            "these frontier-training modules do not label themselves experimental/prototype in their module "
+            "docstring (A1.4 -- a user could mistake them for a production trainer):\n" + "\n".join(unlabeled),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mixle/utils/parallel/dcp_checkpoint.py
+++ b/mixle/utils/parallel/dcp_checkpoint.py
@@ -1,5 +1,12 @@
 """Sharded distributed checkpoints via ``torch.distributed.checkpoint`` (DCP) -- replaces pickle-broadcast at scale.
 
+.. warning::
+
+   **Experimental frontier-training prototype.** The DCP save/load mechanics are exact, but genuine
+   multi-rank sharded checkpointing needs a real process group across real devices; at single-process or
+   simulated-rank scale this exercises the mechanism, not a production multi-node checkpoint. Not a
+   supported production checkpointing API.
+
 The gather-to-root + ``pickle``-broadcast that :class:`TorchRunEncodedData` uses to move a model cannot save a
 model that does not fit (and is not folded on) one rank. DCP saves each rank's shard of the (FSDP2-sharded) model
 + optimizer state in parallel to a checkpoint directory, and loads it back sharded -- the standard frontier


### PR DESCRIPTION
## What (worklist A1.4)

mixle carries sharding mathematics and small-scale training simulations (muP, 2:4 sparsity, scaling-law
fits, TP/PP/CP, fault-tolerant training, sharded checkpointing) whose mechanics are exact but which are
**not** production frontier trainers — the real multi-GPU/multi-node execution needs hardware this project
doesn't gate on. A1.4's bar: **no user can mistake these for production**.

## Fix

Four of the seven such modules in stable namespaces (`mup`, `sparsity_2_4`, `scaling_laws`, `dcp_checkpoint`)
had **no** prototype label. Add a prominent `.. warning:: **Experimental frontier-training prototype**`
header to each, stating what's exact vs. what needs real hardware / is a research estimate. The other three
(`context_parallel_spine`, `fault_tolerant_training`, `tensor_pipeline_context_parallel`) already scope
themselves honestly ("simulated … not a real distributed job").

## Enforcement

`mixle/tests/frontier_prototype_labels_test.py` asserts each of the **seven** frontier-training modules'
docstring carries an experimental / prototype / simulation signal — so a new frontier surface can't land in
a stable namespace without one.

Docstring-only: **no runtime behavior change** (import paths and call sites untouched, so nothing breaks) —
the lower-risk of A1.4's "move to experimental **or** label with warnings" options.

## Evidence

The label test passes (all 7 labeled); all four edited modules parse; `ruff` clean.

Acceptance (A1.4): frontier-training prototypes are labeled so they can't be mistaken for a production
trainer — met (via consistent docstring labels + an enforcement test); complements #300 (TP/PP/CP raise
when requested-but-not-integrated).
