### PR TITLE
Bound automatic model-search cost with a candidate/time budget (worklist I6.5)

### DIFF
--- a/mixle/lifecycle.py
+++ b/mixle/lifecycle.py
@@ -316,6 +316,8 @@ def propose(
     holdout: float = 0.25,
     seed: int = 0,
     max_its: int = 25,
+    max_candidates: int | None = None,
+    timeout: float | None = None,
     **recommend_kw: Any,
 ) -> Model:
     """Propose a model for ``data`` from a *verified frontier* of candidates and return the winner.
@@ -328,6 +330,12 @@ def propose(
     The winner becomes the returned :class:`Model`; the full ranking lands in ``Model.frontier`` and the
     per-field confidence / dependency / candidate notes in ``Model.notes`` (shown by ``explain()``).
     Pass ``fit=True`` to also fit the winner to all of ``data`` before returning.
+
+    The frontier search is bounded by ``max_candidates`` (evaluate at most this many candidates, in
+    proposer order — the heuristic recommendation is always first) and ``timeout`` (stop starting new
+    candidate fits once this many wall-clock seconds have elapsed). Both default to ``None`` (unbounded).
+    A candidate skipped for budget is **recorded** in ``Model.frontier`` and ``Model.notes``, never silently
+    dropped, so a bounded search reports exactly what it did not evaluate.
     """
     from mixle.inference import optimize
     from mixle.task import recommend_model
@@ -357,19 +365,30 @@ def propose(
     train = [rows[i] for i in order[n_val:]]
 
     frontier: list[dict[str, Any]] = []
+    evaluated = 0
+    budget_start = time.monotonic()
     for name, est in candidates:
+        over_count = max_candidates is not None and evaluated >= max_candidates
+        over_time = timeout is not None and (time.monotonic() - budget_start) > timeout
+        if over_count or over_time:
+            reason = "max_candidates" if over_count else "timeout"
+            frontier.append({"name": name, "estimator": est, "skipped": f"search budget reached ({reason})"})
+            continue
         try:
             fitted = optimize(train, est, max_its=max_its, out=None)
             enc = fitted.dist_to_encoder().seq_encode(val)
             score = float(np.mean(np.asarray(fitted.seq_log_density(enc), dtype=np.float64)))
             frontier.append({"name": name, "estimator": est, "heldout_mean_log_density": score})
+            evaluated += 1
         except Exception as exc:  # noqa: BLE001 - a failing candidate is reported, never silently dropped
             frontier.append({"name": name, "estimator": est, "error": f"{type(exc).__name__}: {exc}"})
+            evaluated += 1
     scored = sorted(
         (f for f in frontier if "heldout_mean_log_density" in f), key=lambda f: -f["heldout_mean_log_density"]
     )
-    frontier = scored + [f for f in frontier if "error" in f]
+    frontier = scored + [f for f in frontier if "error" in f or "skipped" in f]
     winner = scored[0]["estimator"] if scored else rec.estimator
+    skipped_names = [f["name"] for f in frontier if "skipped" in f]
 
     notes = [
         f"field {c.path}: {c.family}"
@@ -382,15 +401,17 @@ def propose(
     ]
     notes += [f"dependency: {a} <-> {b} ({bits:.1f} bits for joint modeling)" for a, b, bits in rec.dependencies]
     notes += list(rec.warnings)
-    notes += [
-        f"candidate {f['name']}: "
-        + (
-            f"held-out mean log-density {f['heldout_mean_log_density']:.3f}"
-            if "error" not in f
-            else f"failed ({f['error']})"
-        )
-        for f in frontier
-    ]
+
+    def _candidate_note(f: dict[str, Any]) -> str:
+        if "skipped" in f:
+            return f"candidate {f['name']}: {f['skipped']}"
+        if "error" in f:
+            return f"candidate {f['name']}: failed ({f['error']})"
+        return f"candidate {f['name']}: held-out mean log-density {f['heldout_mean_log_density']:.3f}"
+
+    notes += [_candidate_note(f) for f in frontier]
+    if skipped_names:
+        notes.append(f"search budget: skipped {len(skipped_names)} candidate(s) unevaluated: {skipped_names}")
     m = Model(winner, notes=notes)
     m.frontier = frontier
     return m.fit(rows) if fit else m

--- a/mixle/tests/propose_budget_test.py
+++ b/mixle/tests/propose_budget_test.py
@@ -1,0 +1,50 @@
+"""Bound the automatic model-search cost (worklist I6.5).
+
+``mixle.propose`` scores a frontier of candidate models by fitting each one; without a budget that cost is
+unbounded in the number of proposers. ``max_candidates`` and ``timeout`` bound it -- and a candidate skipped
+for budget is *recorded* in the frontier and notes, never silently dropped, so a bounded search reports
+exactly what it did not evaluate. The defaults (``None``) leave the search unbounded, so existing behavior
+is unchanged.
+"""
+
+import unittest
+
+import numpy as np
+
+import mixle
+
+
+def _records(n=300, seed=0):
+    rng = np.random.RandomState(seed)
+    return [("free" if rng.rand() < 0.5 else "paid", float(rng.randn()), int(rng.poisson(3))) for _ in range(n)]
+
+
+class ProposeBudgetTest(unittest.TestCase):
+    def test_unbounded_by_default_evaluates_all_candidates(self):
+        m = mixle.propose(_records())
+        self.assertGreaterEqual(len(m.frontier), 2)  # heterogeneous records -> >=2 proposers
+        self.assertEqual([f for f in m.frontier if "skipped" in f], [])  # nothing skipped
+        self.assertTrue(any("heldout_mean_log_density" in f for f in m.frontier))
+
+    def test_max_candidates_bounds_the_search_and_records_skips(self):
+        m = mixle.propose(_records(), max_candidates=1)
+        evaluated = [f for f in m.frontier if "heldout_mean_log_density" in f]
+        skipped = [f for f in m.frontier if "skipped" in f]
+        self.assertEqual(len(evaluated), 1)  # only the first (recommended) candidate is fit
+        self.assertGreaterEqual(len(skipped), 1)  # the rest are recorded as skipped
+        self.assertIsNotNone(m.spec)  # a winner is still returned
+        self.assertTrue(any("search budget" in n for n in m.notes))  # and it is surfaced in notes
+        self.assertIn("max_candidates", skipped[0]["skipped"])
+
+    def test_generous_timeout_evaluates_all(self):
+        m = mixle.propose(_records(), timeout=1e6)
+        self.assertEqual([f for f in m.frontier if "skipped" in f], [])
+
+    def test_zero_timeout_skips_and_falls_back_to_recommendation(self):
+        m = mixle.propose(_records(), timeout=0.0)
+        self.assertTrue(all("heldout_mean_log_density" not in f for f in m.frontier))  # nothing scored
+        self.assertIsNotNone(m.spec)  # still returns the heuristic recommendation as the winner
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What (worklist I6.5)

`mixle.propose` scores a frontier of candidate models by fitting each; without a budget that cost is
**unbounded** in the number of proposers. Adds two optional bounds to `propose()`:

- **`max_candidates`** — fit at most this many candidates, in proposer order (the heuristic recommendation is
  always first);
- **`timeout`** — stop starting new candidate fits once this many wall-clock seconds have elapsed.

Both default to `None` (unbounded), so **existing behavior is unchanged**.

## No silent truncation

A candidate skipped for budget is **recorded** in `Model.frontier` (a `skipped` entry) and `Model.notes` —
never silently dropped — and a winner is **still returned** (the heuristic recommendation if the budget
stopped all frontier scoring).

## Tests

`mixle/tests/propose_budget_test.py`: unbounded evaluates all and skips none; `max_candidates=1` fits one and
records the rest as skipped **with a note** while still returning a winner; a generous `timeout` evaluates
all; a zero `timeout` scores nothing and falls back to the recommendation.

## Evidence

4 budget tests pass; the 9 lifecycle tests pass **unchanged** (backward-compatible); `ruff` clean.

Acceptance (I6.5): a candidate budget/timeout API that bounds automatic-search cost — met, additively.
