### PR TITLE
Add an external-reproduction protocol + receipt script (worklist E14)

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -201,6 +201,7 @@ reference under :doc:`api/modules` covers the broad public module surface;
 
    release-readiness
    validation
+   reproduction
    support-policy
    security-and-data
    stability-and-missing-data

--- a/docs/reproduction.rst
+++ b/docs/reproduction.rst
@@ -1,0 +1,55 @@
+External Reproduction
+=====================
+
+This page is the protocol for an independent reviewer to reproduce mixle's claims from a clean environment
+(worklist E14). It is deliberately runnable without insider knowledge: two commands, a captured environment,
+and deterministic outputs to compare.
+
+Why a receipt
+-------------
+
+A reproduction is only meaningful if two people can compare *the same thing*. mixle's claims are backed by
+seeded, deterministic computations, so an independent run on the same version must produce identical numbers.
+``scripts/reproduce.py`` captures the environment and those numbers as a JSON **receipt**; a difference in the
+``checks`` block is a real, environment-dependent discrepancy worth investigating, not noise.
+
+The protocol
+------------
+
+1. **Clean install.** In a fresh virtual environment, install the exact version under review::
+
+     python -m venv repro-env
+     repro-env/bin/pip install "mixle==<version>"        # or: pip install -e . from a clean clone
+
+2. **Emit a receipt.** Run the reproduction script and save its output::
+
+     repro-env/bin/python scripts/reproduce.py --out receipt.json
+
+   The receipt records the environment (Python, platform, machine, mixle / numpy / scipy versions, git
+   commit) and the deterministic claim checks -- a Gaussian fit recovering its parameters, scalar vs
+   vectorized score agreement, a serialization round-trip, automatic family recovery, and a seeded sample.
+
+3. **Compare.** The ``checks`` block must match a receipt produced from the same mixle version on any
+   platform. The ``environment`` block documents *where* the receipt was produced, so a platform-specific
+   difference (a BLAS build, a numpy version) is attributable rather than mysterious.
+
+4. **Full suite (optional, stronger).** For a complete reproduction, run the correctness gate against the
+   clean install::
+
+     repro-env/bin/python -m pytest -m "not optional and not benchmark"
+
+   and, with the optional backends installed, the optional and benchmark tiers. This is the same suite CI
+   runs; the release checklist records the exact commands and the result counts for the released commit.
+
+What a mismatch means
+---------------------
+
+* A **``checks`` difference on the same version** is a genuine reproducibility defect -- a nondeterminism, a
+  platform-dependent numeric path, or an unpinned dependency drift. Treat it as a bug and file it with both
+  receipts (the ``environment`` blocks localize the difference).
+* A **``checks`` difference across versions** is expected when a release intentionally changes behavior; it
+  must correspond to a changelog entry and a `release decision log <../release-checklists/0.8.0-decisions.md>`_
+  entry.
+
+The receipt's determinism is itself gated by ``mixle/tests/reproduce_receipt_test.py``, so the reproduction
+path cannot silently rot.

--- a/mixle/tests/reproduce_receipt_test.py
+++ b/mixle/tests/reproduce_receipt_test.py
@@ -1,0 +1,47 @@
+"""The reproduction script's claim checks are deterministic and correct (worklist E14).
+
+``scripts/reproduce.py`` emits a receipt an external reviewer runs to reproduce mixle's headline claims. Its
+value is only as good as its determinism: if the seeded checks drift between runs, the receipt cannot be
+compared. This pins that -- the checks reproduce exactly, and they hold (a Gaussian fit recovers its
+parameters, scalar/vectorized scores agree, serialization is score-preserving, automatic selection recovers
+the family) -- and that the environment capture has the fields a reviewer needs.
+"""
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+_GEN = Path(__file__).resolve().parents[2] / "scripts" / "reproduce.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("_reproduce", _GEN)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class ReproduceReceiptTest(unittest.TestCase):
+    def setUp(self):
+        self.mod = _load()
+
+    def test_claim_checks_are_deterministic(self):
+        self.assertEqual(self.mod.claim_checks(), self.mod.claim_checks())
+
+    def test_claim_checks_hold(self):
+        checks = self.mod.claim_checks()
+        self.assertTrue(checks["scalar_vectorized_agree"])
+        self.assertTrue(checks["serialization_score_equal"])
+        self.assertEqual(checks["auto_selects"], "GaussianEstimator")
+        # a Gaussian fit on N(3, 2) data recovers the parameters within sampling error.
+        self.assertAlmostEqual(checks["gaussian_fit_mu"], 3.0, delta=0.2)
+        self.assertAlmostEqual(checks["gaussian_fit_sigma"], 2.0, delta=0.2)
+
+    def test_environment_capture_has_required_fields(self):
+        env = self.mod.environment()
+        for field in ("python", "platform", "machine", "mixle", "numpy", "scipy", "git_commit"):
+            self.assertIn(field, env)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/reproduce.py
+++ b/scripts/reproduce.py
@@ -1,0 +1,107 @@
+"""Reproduce mixle's headline claims from a clean install and emit a receipt (worklist E14).
+
+External reproduction needs two things a reviewer can run without insider knowledge: a capture of the exact
+environment, and a set of *deterministic* checks whose numeric outputs an independent run must match. This
+script is both. It records the environment (Python, platform, mixle + core dependency versions, git commit
+if available) and runs seeded claim checks -- a Gaussian fit recovering known parameters, scalar/vectorized
+score agreement, a serialization round-trip, automatic family recovery, deterministic sampling -- printing a
+JSON receipt.
+
+Run ``python scripts/reproduce.py`` (add ``--out receipt.json`` to save it). Because every check is seeded,
+an independent reproduction on the same mixle version must produce the same ``checks`` values; a difference
+is a real environment-dependent discrepancy, not noise. See ``docs/reproduction.rst`` for the protocol.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import platform
+import subprocess
+import sys
+from importlib.metadata import PackageNotFoundError, version
+
+
+def _pkg_version(name: str) -> str:
+    try:
+        return version(name)
+    except PackageNotFoundError:
+        return "not installed"
+
+
+def _git_commit() -> str:
+    try:
+        out = subprocess.run(["git", "rev-parse", "--short", "HEAD"], capture_output=True, text=True, timeout=10)
+        return out.stdout.strip() if out.returncode == 0 else "unknown"
+    except (OSError, subprocess.SubprocessError):
+        return "unknown"
+
+
+def environment() -> dict:
+    return {
+        "python": platform.python_version(),
+        "platform": platform.platform(),
+        "machine": platform.machine(),
+        "mixle": _pkg_version("mixle"),
+        "numpy": _pkg_version("numpy"),
+        "scipy": _pkg_version("scipy"),
+        "git_commit": _git_commit(),
+    }
+
+
+def claim_checks() -> dict:
+    """Deterministic, seeded checks backing the headline claims. Values must reproduce across runs."""
+    import numpy as np
+
+    import mixle.stats as st
+    from mixle.inference.estimation import optimize
+    from mixle.utils.automatic import get_estimator
+    from mixle.utils.serialization import ensure_pysp_serialization_registry, from_serializable, to_serializable
+
+    ensure_pysp_serialization_registry()
+    checks: dict = {}
+
+    # 1. a Gaussian fit recovers the generating parameters (seeded data -> fixed rounded estimate).
+    data = np.random.RandomState(0).normal(3.0, 2.0, 2000).tolist()
+    fitted = optimize(data, st.GaussianEstimator(), max_its=20, out=None)
+    checks["gaussian_fit_mu"] = round(float(fitted.mu), 4)
+    checks["gaussian_fit_sigma"] = round(float(np.sqrt(fitted.sigma2)), 4)
+
+    # 2. scalar and vectorized scoring agree.
+    g = st.GaussianDistribution(1.0, 2.0)
+    xs = list(g.sampler(seed=0).sample(32))
+    seq = np.asarray(g.seq_log_density(g.dist_to_encoder().seq_encode(xs)), dtype=float)
+    scalar = np.array([float(g.log_density(x)) for x in xs])
+    checks["scalar_vectorized_agree"] = bool(np.allclose(seq, scalar, atol=1e-9))
+
+    # 3. serialization round-trips a model's score.
+    back = from_serializable(to_serializable(g))
+    checks["serialization_score_equal"] = round(float(back.log_density(0.5)), 6) == round(float(g.log_density(0.5)), 6)
+
+    # 4. automatic family recovery on seeded Gaussian data.
+    checks["auto_selects"] = type(get_estimator(np.random.RandomState(1).normal(0, 1, 1500).tolist())).__name__
+
+    # 5. deterministic seeded sampling.
+    checks["deterministic_sample"] = round(float(st.GammaDistribution(2.0, 1.5).sampler(seed=7).sample(1)[0]), 6)
+
+    return checks
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Reproduce mixle's headline claims and emit a receipt.")
+    parser.add_argument("--out", default=None, help="write the JSON receipt here (default: stdout)")
+    args = parser.parse_args(argv)
+
+    receipt = {"artifact": "mixle.reproduction_receipt/v1", "environment": environment(), "checks": claim_checks()}
+    text = json.dumps(receipt, indent=2, sort_keys=True)
+    if args.out:
+        with open(args.out, "w") as f:
+            f.write(text + "\n")
+        print(f"wrote {args.out}")
+    else:
+        print(text)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What (worklist E14)

External reproduction needs a reviewer to run something **without insider knowledge** and get outputs they
can **compare**. Adds:

- **`scripts/reproduce.py`** — captures the environment (Python, platform, machine, mixle/numpy/scipy
  versions, git commit) and runs **seeded, deterministic** claim checks (a Gaussian fit recovering N(3,2),
  scalar vs vectorized score agreement, a serialization round-trip, automatic family recovery, a seeded
  sample), emitting a JSON **receipt**. Because every check is seeded, an independent run on the same version
  must produce identical `checks` — a difference is a real environment-dependent discrepancy, not noise.
- **`docs/reproduction.rst`** — the protocol: clean install → `reproduce.py --out receipt.json` → compare the
  `checks` block (identical across platforms for a given version), with the `environment` block localizing
  any difference; plus the full-suite step and what a mismatch means (same-version diff = reproducibility
  bug; cross-version diff must map to a changelog + decision-log entry).
- **`mixle/tests/reproduce_receipt_test.py`** — gates the receipt's determinism and correctness so the
  reproduction path can't silently rot.

## Evidence

The receipt is byte-identical across two runs; 3 tests pass; the page parses as RST; `ruff` clean.

Acceptance (E14): a runnable external-reproduction path with an environment-captured, deterministic receipt —
met (the *execution* by an external reviewer is theirs; the artifact and protocol are here).
