### PR TITLE
Add the 0.8.0 release-candidate stage-gate runbook (worklist R15)

### DIFF
--- a/release-checklists/0.8.0-rc-stages.md
+++ b/release-checklists/0.8.0-rc-stages.md
@@ -1,0 +1,96 @@
+# 0.8.0 Release-Candidate Stage Gates
+
+The staged path to 0.8.0 (worklist **R15**): alpha → beta → rc → final, each stage a gate that must be
+green before the next begins. This runbook maps every stage requirement to the worklist ID that delivers it
+and the PR that implements it, so readiness is a checklist, not a memory. Legend:
+
+- **PR #n** — delivered by a shipped pull request (merge it to satisfy the gate on `release/0.8.0`).
+- **owner** — a scope/ownership/sign-off decision reserved to the release owner.
+- **hardware** — needs GPU / multi-node hardware to *execute* (the code/claim side is done where noted).
+
+The R15 process is staged, so a requirement can be "code-complete, execution-pending" (e.g. a benchmark
+harness exists but its designated-hardware rerun is the owner's).
+
+## Alpha 1 — boundary and artifact correctness
+
+*Can we identify and install the product we intend to stabilize?*
+
+| Requirement | Worklist | Delivered by |
+|---|---|---|
+| G0.1–G0.5 complete | G0.2 / G0.3 / G0.5 | #341, #297, #345 · G0.1/G0.4 scope+ownership: **owner** |
+| API / maturity inventory | A1.1 / A1.2 / A1.6 | #295, #329, #340 |
+| clean-wheel CI blocking | P2.1 | #304 |
+| base import sweep passing | P2.2 | #298 |
+| frontier / distributed claims corrected | A1.4 / N9.5 / D8.2 | #347, #300, #302 |
+| no new features merging (freeze) | G0.3 | #297 (PR template enforces the freeze) |
+
+## Alpha 2 — stable-core correctness
+
+*Does the supported core behave correctly at its boundaries?*
+
+| Requirement | Worklist | Delivered by |
+|---|---|---|
+| stable family invariant suite | Q5.1 | #349 |
+| automatic-modeling adversarial corpus | I6.4 | #348 (confusion matrix + ambiguity regions) |
+| warning ownership | T3.3 | #338 |
+| working stable-core type check | Y4.1 | #339 (blocking typed-core mypy) |
+| smoke / core / full test tiers | T3.1 / T3.2 | markers exist (#336, #342); tier **budgets**: owner |
+| serialization compatibility fixtures | M11.1 / M11.2 | #350, #313 |
+
+## Beta 1 — performance and backend evidence
+
+*Do speed and scale statements survive reproduction?*
+
+| Requirement | Worklist | Delivered by |
+|---|---|---|
+| tracked benchmark harness | B7.1 | #296 |
+| 0.8.0 benchmark rerun | B7.2 | harness ready (#296); rerun on designated **hardware** |
+| performance regression subset | B7.4 | **hardware** (harness in #296) |
+| backend support matrix | D8.1 | #307 |
+| real local-cluster / multi-process receipts | D8.3 / D8.5 | dask CI #315, MPI reconciled #352; cluster receipts: **hardware** |
+| GPU claims evidenced or downgraded | A1.4 | downgraded/labeled in #347; evidence: **hardware** |
+
+## Beta 2 — flagship workflows and documentation
+
+*Can target users succeed without private context from the maintainer?*
+
+| Requirement | Worklist | Delivered by |
+|---|---|---|
+| all three flagship workflows | F10.1 / F10.2 / F10.4 | #319, #320, #314 |
+| README / quickstart rewritten | X12.2 / D8.2 / N9.2 | #306, #302 |
+| claim-evidence ledger current | X12.4 | #305 |
+| example inventory pruned and executed | F10.x | flagships gated (#314/#319/#320); full sweep: **owner** |
+| complete migration notes | A1.5 | #324 (deprecation policy + message format) |
+
+## RC1 — freeze and independent review
+
+*Is there any evidence that would make a reasonable user interpret maturity incorrectly?*
+
+| Rule | Delivered by |
+|---|---|
+| only release-blocking fixes | **owner** (freeze enforced by #297) |
+| build immutable RC wheel | **owner** (release-metadata fingerprint: #318) |
+| run full supported matrix | CI (#310 min-versions, #312 macOS, #333/#334 gates) |
+| run 20× flake campaign | order-independence pinned (#335); repeated campaign: **owner** |
+| run benchmark suite on designated hardware | **hardware** (harness #296) |
+| run independent reproductions | reproduction protocol + receipt: #353 |
+| perform API and claim diffs | API drift gate #295, claim ledger #305 |
+
+## RC2 — final artifact rehearsal
+
+*Is the exact artifact we will publish the artifact we tested?*
+
+| Required | Delivered by |
+|---|---|
+| all RC1 blockers fixed | **owner** |
+| rebuild from clean tag candidate | **owner** (fingerprint #318 pins the exact artifact) |
+| repeat wheel / docs / examples / flagships / metadata checks | CI + #343 (post-publish verify) rehearsed pre-publish |
+| verify rollback / yank procedure | **owner** |
+| draft announcement from claim-ledger-approved statements only | ledger #305; drafting: **owner** |
+
+## Final release
+
+The publish sequence is the owner's (approve gate report → signed tag → trusted-CI build → GitHub + PyPI
+publish → install from public PyPI → post-publish smoke → publish docs + notes → monitor 72h → 0.8.1 only
+for regressions). The automatable post-publish smoke is the **post-publish-verify** workflow (#343); the
+decision log (#341) and risk register (#345) carry the sign-off evidence.


### PR DESCRIPTION
## What (worklist R15)

R15 is the **staged** path to 0.8.0 — alpha 1/2 → beta 1/2 → rc 1/2 → final — each a gate that must be green
before the next. `release-checklists/0.8.0-rc-stages.md` turns that abstract process into a **tracked
checklist**: every stage requirement is mapped to the worklist ID that delivers it and the **PR** that
implements it, each marked as:

- **PR #n** — delivered by a shipped PR (merge to satisfy);
- **owner** — a scope / ownership / sign-off decision reserved to the release owner;
- **hardware** — needs GPU / multi-node hardware to *execute* (code/claim side done where noted).

## Why it's useful

Readiness becomes inspectable at a glance — e.g. Alpha 2's *stable family invariant suite* → Q5.1 → #349,
*warning ownership* → T3.3 → #338, *stable-core type check* → Y4.1 → #339 — and it **honestly separates**
code-complete gates from the ones that genuinely need the owner (scope/ownership/sign-off) or hardware (the
benchmark rerun, real-cluster receipts, GPU evidence). The final publish sequence stays the owner's, with the
automatable post-publish smoke (#343), decision log (#341), and risk register (#345) named as its evidence.

Acceptance (R15): the staged RC gate process is defined and its gates traced to concrete work — met (the RC
*execution* — building, publishing, tagging, sign-off — remains the release owner's, by design).
