### PR TITLE
Define ownership, review boundaries, and the single-maintainer waiver (worklist G0.4)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,23 @@
+# Code ownership for mixle (worklist G0.4).
+#
+# mixle is a single-maintainer project: every stable namespace, release gate, and packaging/doc surface is
+# owned by the maintainer. There is no qualified second reviewer, so this file assigns ownership to the
+# maintainer everywhere and the review boundary is governed by the documented single-maintainer waiver in
+# release-checklists/0.8.0-ownership.md (the compensating controls -- heavy automated gates, a reduced
+# stable-claim surface, and external reproduction -- are described there).
+
+*                                   @gmboquet
+
+# Named subsystems (all the same owner today; listed so the map is explicit and a future co-owner can be
+# added per-area without changing the default).
+/mixle/stats/                       @gmboquet
+/mixle/inference/                   @gmboquet
+/mixle/ppl/                         @gmboquet
+/mixle/enumeration/                 @gmboquet
+/mixle/data/                        @gmboquet
+/mixle/models/                      @gmboquet
+/mixle/task/                        @gmboquet
+/mixle/utils/parallel/              @gmboquet
+/pyproject.toml                     @gmboquet
+/.github/                           @gmboquet
+/docs/                              @gmboquet

--- a/release-checklists/0.8.0-ownership.md
+++ b/release-checklists/0.8.0-ownership.md
@@ -1,0 +1,57 @@
+# 0.8.0 Ownership and Review Boundaries
+
+The ownership map for stable namespaces and release gates (worklist **G0.4**), and the single-maintainer
+waiver the review policy runs under. Machine-enforced ownership lives in `.github/CODEOWNERS`; this page is
+the human map and the waiver.
+
+## Ownership map
+
+| Area | Owner | Second reviewer |
+|---|---|---|
+| `mixle.stats` (distributions, combinators, mixtures, HMMs) | maintainer (@gmboquet) | none |
+| `mixle.inference` (`optimize`, EM, conjugate, structure) | maintainer | none |
+| `mixle.ppl` | maintainer | none |
+| `mixle.enumeration` / `mixle.ops` | maintainer | none |
+| `mixle.data` | maintainer | none |
+| `mixle.models` (neural leaves, GPs, grammars, ...) | maintainer | none |
+| `mixle.task` / `mixle.reason` | maintainer | none |
+| distributed code (`mixle.utils.parallel`, backends) | maintainer | none |
+| packaging (`pyproject.toml`, extras, CI) | maintainer | none |
+| documentation | maintainer | none |
+| release gates (CI workflows, manifests, checklists) | maintainer | none |
+
+Every area has **one owner and no qualified second reviewer**: mixle is a single-maintainer project.
+
+## Single-maintainer waiver
+
+G0.4's acceptance is that *every P0 change has a reviewer distinct from the author, **or** a documented
+single-maintainer waiver.* This is that waiver. There is no second maintainer qualified to review the
+numerical core, so P0 changes are authored and merged by the same person.
+
+Because that removes the human second-reviewer control, the release compensates with **automated and
+external controls** instead of pretending a second reviewer exists:
+
+* **Heavy blocking gates** stand in for a reviewer on the mechanical dimensions: ruff (format + lint + BLE),
+  a blocking typed-core mypy, the clean-wheel install + import sweep, the min-versions job, pip-audit, the
+  API / maturity / schema drift manifests, the repo-hygiene secret scan, and the numerical stress /
+  invariant / parity suites. A P0 change that breaks any of these fails without human judgment.
+* **A reduced stable-claim surface** (see [the stable surface](../docs/stable-surface.rst)) keeps the
+  single-reviewed *stable* promise small enough to test exhaustively; everything else is provisional or
+  experimental, which is the "reduced maturity claims where no second reviewer exists" G0.4 asks for.
+* **External reproduction** (see [reproduction](../docs/reproduction.rst)) lets an independent party
+  re-derive the claim-backing numbers, providing after-the-fact review the release cannot get before merge.
+* **A recorded decision trail** — the [decision log](0.8.0-decisions.md) and [risk register](0.8.0-risks.md)
+  — makes each single-maintainer P0 decision reviewable in the open (R-01 in the risk register is exactly
+  "single-maintainer review bottleneck", with its mitigation).
+
+## When to seek external review
+
+The waiver is not a blanket pass. Seek external review, or reduce the maturity claim, when a change:
+
+* alters a **stable** surface's numerical contract in a way the automated parity/invariant gates cannot fully
+  bound;
+* changes a **security**-relevant path (serialization, path handling, code loading);
+* changes a **published claim** or a benchmark methodology.
+
+Until a qualified second reviewer exists, such changes either get an external reviewer or the affected
+surface stays below `stable`.


### PR DESCRIPTION
## What (worklist G0.4)

- **`.github/CODEOWNERS`** — machine-enforced ownership: every namespace, release gate, and packaging/doc
  surface owned by the maintainer.
- **`release-checklists/0.8.0-ownership.md`** — the human ownership map + the **single-maintainer waiver**.

mixle is a single-maintainer project, so every stable namespace and release gate has one owner and **no
qualified second reviewer**. G0.4's acceptance explicitly allows *"a documented single-maintainer waiver"* in
place of a distinct reviewer — this is that waiver, and it's honest about the **compensating controls** that
stand in for the missing human review:

- heavy blocking gates (ruff/BLE, typed-core mypy, clean-wheel + import sweep, min-versions, pip-audit, the
  API/maturity/schema drift manifests, repo-hygiene secret scan, numerical stress/invariant/parity suites);
- the **reduced stable-claim surface** (A1.3 / #356);
- **external reproduction** (E14 / #353);
- the recorded **decision log** (#341) + **risk register** (#345), whose R-01 is exactly the single-maintainer
  bottleneck.

It also names **when external review is still required despite the waiver** — stable numerical-contract
changes the gates can't bound, security-relevant paths, and published-claim/benchmark changes.

Acceptance (G0.4): an ownership map for stable namespaces and release gates, with every P0 change covered by
a reviewer or a documented single-maintainer waiver — met.
