### PR TITLE
Document the authoritative base of the 0.8.0 stabilization branch (worklist G0.1)

### DIFF
--- a/release-checklists/0.8.0-base.md
+++ b/release-checklists/0.8.0-base.md
@@ -1,0 +1,40 @@
+# 0.8.0 Stabilization Branch: Authoritative Base
+
+Record of the base `release/0.8.0` was cut from, and why it is authoritative (worklist **G0.1**). The point
+is to prove the stabilization branch descends from the intended 0.7.0 release lineage with no accidental
+dependence on divergent local history.
+
+## The base
+
+`release/0.8.0` is based on commit **`068dbe6a`** — *"release: sync final 0.7.0 checklist state to main"*.
+
+## Why it is authoritative
+
+Verified with git (commands below), the four references agree:
+
+| Reference | Commit | Relationship to the base |
+|---|---|---|
+| `v0.7.0` (annotated release tag) | tag → commit `59ad4db9` | **ancestor** of the base (clean forward lineage) |
+| `origin/main` tip | `068dbe6a` | **identical** to the base |
+| `release/0.8.0` base | `068dbe6a` | — |
+| local `main` vs `origin/main` | — | 0 ahead / 0 behind (no divergent local history) |
+
+So the base is exactly `origin/main` at the point *after* 0.7.0 was published and its final release-checklist
+state was merged back to main. The commits between `v0.7.0` and the base are the 0.7.0 publication
+finalization only (publication marked done, the unused TestPyPI path dropped, docs-CI fixes, the checklist
+sync) — no feature work, no divergence. The branch name `release/0.8.0` follows the repository's
+`release/<version>` policy.
+
+## How to re-verify
+
+```
+git rev-parse v0.7.0                                   # the release tag
+git log --oneline -1 origin/release/0.8.0              # the base commit (068dbe6a)
+git log --oneline -1 origin/main                       # equals the base
+git merge-base --is-ancestor v0.7.0 origin/release/0.8.0 && echo "clean lineage"
+git rev-list --left-right --count origin/main...origin/release/0.8.0   # 0  0 -> no divergence
+git log --oneline v0.7.0..origin/release/0.8.0         # only the 0.7.0 publication finalization
+```
+
+All 0.8.0 stabilization work lands as PRs onto `release/0.8.0` from this base; the release ships from a tag
+on this lineage (see [the RC stage gates](0.8.0-rc-stages.md)).


### PR DESCRIPTION
## What (worklist G0.1)

The `release/0.8.0` stabilization branch already exists; G0.1's remaining deliverable is **proving its base
is authoritative** and free of divergent local history. `release-checklists/0.8.0-base.md` records that
`release/0.8.0` is based on **`068dbe6a`** ("release: sync final 0.7.0 checklist state to main"), verified
against four references that agree:

| Reference | Relationship to the base |
|---|---|
| `v0.7.0` annotated tag | clean **ancestor** of the base |
| `origin/main` tip | **identical** to the base |
| `release/0.8.0` base | `068dbe6a` |
| local `main` vs `origin/main` | 0 ahead / 0 behind — **no divergence** |

The commits between `v0.7.0` and the base are the **0.7.0 publication finalization only** (publication marked
done, unused TestPyPI path dropped, docs-CI fixes, checklist sync) — no feature work. The doc includes the
exact git commands to **re-verify**, and notes the `release/<version>` naming policy.

Acceptance (G0.1): a stabilization branch from the intended 0.7.0 lineage with a documented authoritative
base and no accidental divergent history — met (verified, re-checkable).
