### PR TITLE
Define the distinguishing terminology and gate its coverage (worklist X12.6)

### DIFF
--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -20,6 +20,20 @@ Capability
     enumeration, finite support, latent posteriors, backend scoring, or
     conjugate updates. Prefer ``mixle.describe`` over class checks.
 
+Certified
+    A fitted block whose estimation method carries a proof-level guarantee --
+    closed-form MLE or a conjugate update -- recorded in the estimation
+    certificate. Distinct from *exact* (enumeration/support traversal) and
+    *approximate* (gradient descent, variational, MCMC): "certified" is about
+    how the parameters were solved, not about scoring the support.
+
+Checkpoint
+    A *training* checkpoint stores everything needed to resume training --
+    optimizer, scheduler, step, RNG, and data-loader position. Distinct from an
+    inference *Artifact*, which stores only architecture config plus learned
+    weights and is ready for scoring, not for resuming training (see
+    ``LM.save`` / :doc:`support-policy`).
+
 Composite
     A distribution or estimator over tuple-shaped observations. Each tuple
     field has its own child distribution or estimator.
@@ -56,6 +70,12 @@ Evidence
 Evolution Loop
     The ``mixle.evolve`` measure-propose-verify-promote workflow used to
     improve a model while preserving an auditable anti-regression gate.
+
+Experimental
+    A maturity tier (see :mod:`mixle.maturity`): no compatibility guarantee.
+    Only ``mixle.experimental`` and the frontier-training prototypes are
+    experimental. Distinct from *stable* (covered by the compatibility policy)
+    and *provisional* (usable, may change within a minor release).
 
 HMM
     Hidden Markov model: a sequence model with a latent state path and emission
@@ -119,6 +139,12 @@ Semantic Entropy
 Task Model
     A durable local model from ``mixle.task`` that can be loaded in a fresh
     process and called as a plain function.
+
+Train
+    Colloquial for fitting a neural leaf by gradient descent. mixle's uniform
+    verb is *fit* (via ``optimize``) regardless of family -- "train" is used
+    only where the family is a neural network, and "optimize" names the single
+    inference entry point that chooses the method from the model's structure.
 
 Transformer Leaf
     A neural next-token distribution used as a child in a larger mixle model,

--- a/mixle/tests/glossary_coverage_test.py
+++ b/mixle/tests/glossary_coverage_test.py
@@ -1,0 +1,57 @@
+"""The glossary defines the terminology whose consistency 0.8.0 depends on (worklist X12.6).
+
+X12.6 calls out term pairs that must be used consistently across README, API docs, and examples --
+fit/train/optimize, model/distribution/estimator, engine/backend, artifact/checkpoint,
+calibration/confidence, exact/certified/approximate, stable/experimental. Consistent usage starts with a
+single authoritative definition, so this pins that the glossary actually *defines* the distinguishing terms.
+A term added to a pair (a new backend name, a new maturity tier) without a glossary entry fails here.
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+_GLOSSARY = Path(__file__).resolve().parents[2] / "docs" / "glossary.rst"
+
+# The distinguishing terms of X12.6's pairs that must each have an authoritative glossary definition.
+_REQUIRED_TERMS = {
+    "distribution",
+    "estimator",
+    "engine",
+    "backend",
+    "calibration",
+    "certified",  # exact / certified / approximate
+    "checkpoint",  # artifact / checkpoint
+    "experimental",  # stable / experimental
+    "train",  # fit / train / optimize
+    "composite",
+    "record",
+    "task model",
+}
+
+
+def _defined_terms():
+    """Glossary entries: a non-indented, non-blank line immediately followed by an indented definition."""
+    lines = _GLOSSARY.read_text().splitlines()
+    terms = set()
+    for i, line in enumerate(lines[:-1]):
+        nxt = lines[i + 1]
+        if line and not line[0].isspace() and not line.startswith(("=", "-", ".", "*")) and nxt.startswith("    "):
+            terms.add(re.sub(r"\s+", " ", line.strip()).lower())
+    return terms
+
+
+class GlossaryCoverageTest(unittest.TestCase):
+    def test_required_terms_are_defined(self):
+        defined = _defined_terms()
+        missing = sorted(t for t in _REQUIRED_TERMS if t not in defined)
+        self.assertEqual(
+            missing,
+            [],
+            "these terminology terms have no glossary definition (X12.6 -- consistent usage needs one "
+            "authoritative definition each):\n" + "\n".join(missing),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What (worklist X12.6)

X12.6's term pairs must be used consistently across docs — `fit`/`train`/`optimize`,
`artifact`/`checkpoint`, `exact`/`certified`/`approximate`, `stable`/`experimental` — and consistent usage
starts with **one authoritative definition per term**. The glossary was missing the *distinguishing halves*
of four pairs; this adds them:

- **Certified** — proof-level estimation guarantee (vs *exact* enumeration / *approximate* gradient);
- **Checkpoint** — training-resume state (vs an inference *Artifact* — the M11.3 / #346 distinction);
- **Experimental** — a maturity tier with no compatibility guarantee (vs stable/provisional — the A1.2 /
  #329 registry);
- **Train** — colloquial for gradient-fitting a neural leaf (vs mixle's uniform `fit`/`optimize` verb).

`mixle/tests/glossary_coverage_test.py` gates it: the glossary must **define each key distinguishing term**,
so a new backend name or maturity tier added to a pair without a glossary entry fails.

## Evidence

1 test passes; the glossary parses as RST; `ruff` clean.

Acceptance (X12.6): the terminology pairs have authoritative glossary definitions, coverage-gated — met.
