### PR TITLE
M11.5: state the bounded deployment scope and gate the wording

### DIFF
--- a/docs/production.rst
+++ b/docs/production.rst
@@ -20,6 +20,29 @@ Production concerns are grouped into five areas:
 * reproducibility receipts and local telemetry where the broader runtime layer
   is used.
 
+.. _deployment-scope:
+
+Deployment Scope: What the Core Package Provides
+------------------------------------------------
+
+To keep the claim honest, the boundary is explicit. The **core mixle package**
+provides deployment *building blocks*, not a serving platform:
+
+* **model artifacts** -- self-describing, versionable serialized models;
+* **scoring wrappers** -- call a fitted model behind a service or cascade;
+* **drift and provenance helpers** -- headers, lineage, drift detection,
+  reproducibility receipts;
+* **local registries** -- in-process registration, aliasing, and promotion.
+
+The core package does **not** provide, and does not claim to provide, a complete
+serving platform: no hosted or autoscaling inference service, no multi-tenant
+gateway, no fine-tuning-as-a-service, no cross-model routing infrastructure, and
+no managed monitoring backend. Those responsibilities belong to the companion
+project `mixle-mlops <https://github.com/gmboquet/mixle-mlops>`_, an
+OpenAI-compatible gateway that serves fitted mixle models alongside open and
+hosted LLMs. This split matches the maturity guide: the artifact, scoring, and
+registry helpers are provisional workflow layers, not a stable serving product.
+
 Fit with Provenance
 -------------------
 

--- a/mixle/tests/deployment_scope_test.py
+++ b/mixle/tests/deployment_scope_test.py
@@ -1,0 +1,66 @@
+"""Worklist M11.5 -- keep deployment claims bounded to what the core package is.
+
+The core mixle package provides deployment building blocks (artifacts, scoring
+wrappers, drift/provenance helpers, local registries), NOT a complete serving platform;
+serving is the companion `mixle-mlops` project's job. M11.5's acceptance is that public
+wording agrees with the maturity guide and companion-package responsibilities.
+
+This test pins that agreement so the boundary cannot quietly erode:
+  * ``docs/production.rst`` must carry the explicit Deployment Scope statement -- the
+    four things the core provides, the explicit "does not provide ... serving platform"
+    disclaimer, and a pointer to mixle-mlops;
+  * the README must not claim the core itself is a serving/production platform, and must
+    route serving to mixle-mlops.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+PRODUCTION_RST = ROOT / "docs" / "production.rst"
+README = ROOT / "README.md"
+
+
+def _read(path: Path) -> str:
+    if not path.is_file():
+        pytest.skip(f"{path} not found")
+    return path.read_text(encoding="utf-8")
+
+
+def test_production_doc_states_the_scope_boundary() -> None:
+    text = _read(PRODUCTION_RST).lower()
+    assert "deployment scope" in text, "production.rst is missing the Deployment Scope section"
+
+    # The four building blocks the core *does* provide must be named.
+    for provided in ("model artifacts", "scoring wrapper", "drift", "provenance", "local registr"):
+        assert provided in text, f"Deployment Scope does not name the core capability: {provided!r}"
+
+    # The explicit disclaimer that the core is not a serving platform.
+    assert "does not" in text and "serving platform" in text, (
+        "production.rst must explicitly disclaim being a complete serving platform"
+    )
+    # ...and point the serving responsibility at the companion project.
+    assert "mixle-mlops" in text, "Deployment Scope must route serving to mixle-mlops"
+
+
+def test_production_doc_ties_to_maturity() -> None:
+    """The boundary must reference the maturity framing, per the acceptance criterion."""
+    text = _read(PRODUCTION_RST).lower()
+    assert "maturity" in text, "Deployment Scope must tie the boundary to the maturity guide"
+
+
+def test_readme_does_not_claim_core_is_a_serving_platform() -> None:
+    text = _read(README).lower()
+    # These would overclaim the *core* as a full platform.
+    for banned in ("serving platform", "production platform", "complete mlops", "full mlops platform"):
+        assert banned not in text, (
+            f"README describes the core package as a {banned!r}; that belongs to mixle-mlops (M11.5)"
+        )
+
+
+def test_readme_routes_serving_to_companion() -> None:
+    text = _read(README)
+    assert "mixle-mlops" in text, "README must route serving/gateway responsibility to mixle-mlops"


### PR DESCRIPTION
## Worklist M11.5 — Keep deployment claims bounded (P0)

The core package should be described as providing **artifacts, scoring wrappers, drift/provenance helpers, and local registries — not a complete serving platform.** M11.5's acceptance: public wording agrees with the maturity guide and companion-package responsibilities.

The wording was already partly bounded (`production.rst` said "not a full production platform"; serving delegated to mixle-mlops), but never crisply enumerated the core-vs-companion split. This adds an explicit **Deployment Scope** section to `docs/production.rst`:

**Core provides** — model artifacts · scoring wrappers · drift & provenance helpers · local registries.

**Core does *not* provide** — hosted/autoscaling inference service, multi-tenant gateway, fine-tuning-as-a-service, cross-model routing, managed monitoring backend. Those belong to **mixle-mlops**. The split is explicitly tied to the maturity guide (provisional workflow layers, not a stable serving product).

### Enforcement (`deployment_scope_test.py`, 4 cases)
- `production.rst` must carry the scope section naming the four core capabilities, the explicit "does not … serving platform" disclaimer, the mixle-mlops pointer, and the maturity tie.
- README must **not** describe the core as a "serving platform" / "production platform" / "complete mlops", and must route serving to mixle-mlops.

**Verification:** `pytest mixle/tests/deployment_scope_test.py` → 4 passed. `ruff check` clean. RST parses cleanly at docutils report_level 4.

Part of the 0.8.0 credibility worklist.