### PR TITLE
X12.5: display package version + build commit so docs are version-aware

### DIFF
--- a/docs/_templates/sidebar/version-switcher.html
+++ b/docs/_templates/sidebar/version-switcher.html
@@ -4,9 +4,14 @@
    build data -- so it works the same for every version, including tags built before this file existed. #}
 <div id="version-switcher" class="version-switcher">
   <button type="button" class="version-switcher__button" aria-haspopup="listbox" aria-expanded="false">
-    <span>{{ version }}</span>
+    <span>{{ mixle_release|default(release) }}</span>
   </button>
   <ul class="version-switcher__menu" role="listbox" hidden></ul>
+  {% if mixle_commit and mixle_commit != "unknown" %}
+  <div class="version-switcher__commit" title="source revision these docs were built from">
+    build {{ mixle_commit }}
+  </div>
+  {% endif %}
 </div>
 <script>
 (function () {
@@ -74,4 +79,11 @@
   font-size: var(--sidebar-item-font-size);
 }
 .version-switcher__menu li a:hover { background: var(--color-sidebar-item-background--hover); }
+.version-switcher__commit {
+  margin: 0.25rem 0.1rem 0;
+  font-size: calc(var(--sidebar-item-font-size) * 0.85);
+  color: var(--color-sidebar-link-text);
+  opacity: 0.65;
+  font-variant-numeric: tabular-nums;
+}
 </style>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,6 +20,38 @@ pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text())
 release = pyproject["project"]["version"]
 version = ".".join(release.split(".")[:2])
 
+
+def _git_commit() -> str:
+    """Short commit the docs were built from, so a page can name its exact source.
+
+    Prefers a CI-provided SHA (GitHub Actions / Read the Docs) so the value is correct
+    even when the build runs from an exported tree with no ``.git``; falls back to a
+    local ``git`` call, then to ``"unknown"``. Never raises -- a docs build must not fail
+    because provenance is unavailable.
+    """
+    import os
+    import subprocess
+
+    for env_var in ("MIXLE_DOCS_COMMIT", "GITHUB_SHA", "READTHEDOCS_GIT_COMMIT_HASH"):
+        sha = os.environ.get(env_var)
+        if sha:
+            return sha[:12]
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(ROOT), "rev-parse", "--short=12", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if out.returncode == 0 and out.stdout.strip():
+            return out.stdout.strip()
+    except (OSError, subprocess.SubprocessError):
+        pass
+    return "unknown"
+
+
+commit = _git_commit()
+
 extensions = [
     "myst_parser",
     "sphinx.ext.autodoc",
@@ -137,6 +169,14 @@ html_theme_options = {
     },
 }
 html_css_files = ["mixle-docs.css"]
+
+# Make the exact version and build commit available to every template so a reader can
+# tell which release (and which source revision) they are looking at -- X12.5.
+html_context = {
+    "mixle_release": release,
+    "mixle_version": version,
+    "mixle_commit": commit,
+}
 
 # Furo ships no host-agnostic version switcher (its built-in one only activates under Read the Docs
 # hosting) -- this repo's own _templates/sidebar/version-switcher.html reads the version list from

--- a/mixle/tests/docs_version_aware_test.py
+++ b/mixle/tests/docs_version_aware_test.py
@@ -1,0 +1,84 @@
+"""Worklist X12.5 -- documentation is version-aware.
+
+A user arriving from PyPI must be able to tell which release (and which source
+revision) the docs they are reading correspond to. This test pins the machinery that
+makes that possible, without needing a full Sphinx build:
+
+  * ``docs/conf.py`` derives ``release`` from ``pyproject.toml`` (not a hardcoded literal
+    that can drift from the package);
+  * it captures the build commit, preferring a CI-provided SHA, with a safe fallback;
+  * it publishes ``release`` / ``version`` / ``commit`` into ``html_context`` so every
+    page can display them;
+  * the sidebar template actually renders the release and the commit stamp.
+"""
+
+from __future__ import annotations
+
+import os
+import runpy
+from pathlib import Path
+
+import pytest
+import tomllib
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+CONF = ROOT / "docs" / "conf.py"
+SWITCHER = ROOT / "docs" / "_templates" / "sidebar" / "version-switcher.html"
+
+
+def _load_conf(env: dict[str, str] | None = None) -> dict:
+    if not CONF.is_file():
+        pytest.skip(f"{CONF} not found")
+    saved = dict(os.environ)
+    try:
+        # Clear any ambient CI SHA so precedence tests are deterministic.
+        for var in ("MIXLE_DOCS_COMMIT", "GITHUB_SHA", "READTHEDOCS_GIT_COMMIT_HASH"):
+            os.environ.pop(var, None)
+        if env:
+            os.environ.update(env)
+        return runpy.run_path(str(CONF))
+    finally:
+        os.environ.clear()
+        os.environ.update(saved)
+
+
+def test_release_is_derived_from_pyproject() -> None:
+    ns = _load_conf()
+    pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    assert ns["release"] == pyproject["project"]["version"], (
+        "docs release must track the packaged version, not a hardcoded string"
+    )
+    # version is the major.minor prefix of release.
+    assert ns["version"] == ".".join(ns["release"].split(".")[:2])
+
+
+def test_commit_is_captured() -> None:
+    ns = _load_conf()
+    commit = ns["commit"]
+    assert isinstance(commit, str) and commit, "commit must be a non-empty string"
+    # Either a short hex SHA (local git) or the documented fallback.
+    assert commit == "unknown" or all(c in "0123456789abcdef" for c in commit), (
+        f"commit {commit!r} is neither a hex SHA nor the 'unknown' fallback"
+    )
+
+
+def test_ci_commit_env_takes_precedence() -> None:
+    """A CI-provided SHA must win, so an exported (.git-less) build is still stamped."""
+    ns = _load_conf(env={"MIXLE_DOCS_COMMIT": "abcdef1234567890"})
+    assert ns["commit"] == "abcdef123456", "MIXLE_DOCS_COMMIT should be used (truncated to 12)"
+
+
+def test_html_context_publishes_version_and_commit() -> None:
+    ns = _load_conf()
+    ctx = ns["html_context"]
+    assert ctx["mixle_release"] == ns["release"]
+    assert ctx["mixle_version"] == ns["version"]
+    assert ctx["mixle_commit"] == ns["commit"]
+
+
+def test_switcher_template_displays_release_and_commit() -> None:
+    if not SWITCHER.is_file():
+        pytest.skip(f"{SWITCHER} not found")
+    tpl = SWITCHER.read_text(encoding="utf-8")
+    assert "mixle_release" in tpl, "switcher must show the release from html_context"
+    assert "mixle_commit" in tpl, "switcher must show the build commit stamp"


### PR DESCRIPTION
## Worklist X12.5 — Make documentation version-aware (P1)

**Deliverable:** users can distinguish which release (and source revision) they are reading. **Acceptance:** a user arriving from PyPI reaches matching docs.

The multi-version switcher (sphinx-polyversion) already existed, and `conf.py` already read `release` from `pyproject.toml`. The gap was **display of the exact version and commit**. This closes it:

- **`conf.py`** — adds a `_git_commit()` capture that prefers a CI-provided SHA (`MIXLE_DOCS_COMMIT` / `GITHUB_SHA` / `READTHEDOCS_GIT_COMMIT_HASH`), falls back to a local `git` call, then `"unknown"`. It never raises — a docs build must not fail on missing provenance. Publishes `release` / `version` / `commit` into `html_context`.
- **`version-switcher.html`** — the button now shows the full `release` (e.g. `0.7.0`, not just `0.7`), and a subtle `build <sha>` stamp appears beneath it, so every page names its exact source revision. Sits alongside the existing dev/release version dropdown.

### Enforcement (`docs_version_aware_test.py`, 5 cases, no Sphinx build needed)
- `release` is derived from `pyproject.toml`, not hardcoded (can't drift from the package);
- the commit is captured (hex SHA or the documented `"unknown"` fallback);
- a CI-provided SHA takes precedence (so an exported, `.git`-less build is still stamped);
- `html_context` publishes release/version/commit;
- the switcher template actually renders release and the commit stamp.

**Verification:** `pytest mixle/tests/docs_version_aware_test.py` → 5 passed. `conf.py` executes cleanly (release=0.7.0, commit captured). `ruff check` clean.

Part of the 0.8.0 credibility worklist.