### PR TITLE
Y4.5: scan for copy-pasted bodies and gate against new ones

### DIFF
--- a/mixle/tests/duplicate_body_manifest.json
+++ b/mixle/tests/duplicate_body_manifest.json
@@ -1,0 +1,104 @@
+{
+  "_comment": "Worklist Y4.5 baseline of exact copy-pasted bodies in mixle/stats and mixle/models. A new entry means new copy-paste: dedupe it, or add it here with justification. Regenerate with python scripts/scan_duplicate_bodies.py --write.",
+  "min_stmts": 6,
+  "groups": [
+    {
+      "locations": [
+        "mixle/models/mixture_density.py::_module_class",
+        "mixle/models/neural_density.py::_module_class"
+      ],
+      "stmts": 11
+    },
+    {
+      "locations": [
+        "mixle/stats/combinator/composite.py::backend_stacked_sufficient_statistics_with_estimator",
+        "mixle/stats/combinator/record.py::backend_stacked_sufficient_statistics_with_estimator"
+      ],
+      "stmts": 8
+    },
+    {
+      "locations": [
+        "mixle/stats/graphs/hyperedge_replacement_grammar.py::__init__",
+        "mixle/stats/graphs/vertex_replacement_grammar.py::__init__"
+      ],
+      "stmts": 7
+    },
+    {
+      "locations": [
+        "mixle/stats/graphs/hyperedge_replacement_grammar.py::update",
+        "mixle/stats/graphs/vertex_replacement_grammar.py::update"
+      ],
+      "stmts": 9
+    },
+    {
+      "locations": [
+        "mixle/stats/latent/hidden_markov.py::combine",
+        "mixle/stats/latent/tree_hidden_markov_model.py::combine"
+      ],
+      "stmts": 8
+    },
+    {
+      "locations": [
+        "mixle/stats/latent/hidden_markov.py::from_value",
+        "mixle/stats/latent/tree_hidden_markov_model.py::from_value"
+      ],
+      "stmts": 9
+    },
+    {
+      "locations": [
+        "mixle/stats/latent/hidden_markov.py::key_merge",
+        "mixle/stats/latent/tree_hidden_markov_model.py::key_merge"
+      ],
+      "stmts": 7
+    },
+    {
+      "locations": [
+        "mixle/stats/latent/hidden_markov.py::key_replace",
+        "mixle/stats/latent/tree_hidden_markov_model.py::key_replace"
+      ],
+      "stmts": 7
+    },
+    {
+      "locations": [
+        "mixle/stats/latent/hidden_markov.py::scale",
+        "mixle/stats/latent/tree_hidden_markov_model.py::scale"
+      ],
+      "stmts": 7
+    },
+    {
+      "locations": [
+        "mixle/stats/univariate/continuous/exgaussian.py::_merge",
+        "mixle/stats/univariate/continuous/skew_normal.py::_merge"
+      ],
+      "stmts": 9
+    },
+    {
+      "locations": [
+        "mixle/stats/univariate/continuous/gaussian.py::_model_fisher",
+        "mixle/stats/univariate/continuous/log_gaussian.py::_model_fisher"
+      ],
+      "stmts": 12
+    },
+    {
+      "locations": [
+        "mixle/stats/univariate/continuous/gaussian.py::backend_stacked_sufficient_statistics",
+        "mixle/stats/univariate/continuous/log_gaussian.py::backend_stacked_sufficient_statistics"
+      ],
+      "stmts": 7
+    },
+    {
+      "locations": [
+        "mixle/stats/univariate/discrete/integer_categorical.py::seq_update",
+        "mixle/stats/univariate/discrete/integer_uniform_spike.py::seq_update"
+      ],
+      "stmts": 8
+    },
+    {
+      "locations": [
+        "mixle/stats/univariate/discrete/integer_categorical.py::seq_update_engine",
+        "mixle/stats/univariate/discrete/integer_uniform_spike.py::seq_update_engine"
+      ],
+      "stmts": 11
+    }
+  ]
+}

--- a/mixle/tests/duplicate_body_scan_test.py
+++ b/mixle/tests/duplicate_body_scan_test.py
@@ -1,0 +1,85 @@
+"""Worklist Y4.5 -- gate against new copy-pasted bodies (the sibling-bug prevention).
+
+``scripts/scan_duplicate_bodies.py`` finds functions in ``mixle/stats`` and
+``mixle/models`` that share an identical (non-trivial) body -- copy-paste that will bite
+when a fix lands on one copy and not the other. This test is the shared prevention
+mechanism: it re-runs the scan and fails if a duplicate group appears that is not in the
+reviewed manifest.
+
+When it fails, the fix is one of:
+  * de-duplicate the logic (preferred, when behavior must stay identical), or
+  * if the duplication is deliberate and justified, regenerate the manifest with
+    ``python scripts/scan_duplicate_bodies.py --write`` and explain why in review.
+
+The manifest is a ratchet: the current set of duplicates must be a subset of it, so the
+count can only go down without an explicit, reviewed manifest update.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_SCANNER = Path(__file__).resolve().parent.parent.parent / "scripts" / "scan_duplicate_bodies.py"
+
+
+def _load_scanner():
+    if not _SCANNER.is_file():
+        pytest.skip(f"scanner not found at {_SCANNER}")
+    spec = importlib.util.spec_from_file_location("scan_duplicate_bodies", _SCANNER)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_no_new_duplicate_bodies() -> None:
+    scanner = _load_scanner()
+    current = scanner.group_signatures(scanner.scan())
+    baseline = scanner.group_signatures(scanner.load_manifest())
+
+    new = current - baseline
+    assert not new, (
+        "new copy-pasted function bodies detected in mixle/stats or mixle/models "
+        "(Y4.5 sibling-bug risk). De-duplicate them, or if intentional, run "
+        "`python scripts/scan_duplicate_bodies.py --write` and justify in review.\n"
+        + "\n".join("  - " + " == ".join(sig) for sig in sorted(new))
+    )
+
+
+def test_manifest_is_not_stale() -> None:
+    """Every manifest entry should still be a real duplicate (keeps the baseline honest)."""
+    scanner = _load_scanner()
+    current = scanner.group_signatures(scanner.scan())
+    baseline = scanner.group_signatures(scanner.load_manifest())
+
+    resolved = baseline - current
+    assert not resolved, (
+        "the manifest lists duplicates that no longer exist -- prune them with "
+        "`python scripts/scan_duplicate_bodies.py --write`:\n"
+        + "\n".join("  - " + " == ".join(sig) for sig in sorted(resolved))
+    )
+
+
+def test_scanner_finds_a_planted_duplicate(tmp_path: Path) -> None:
+    """Negative control: two identical non-trivial bodies in a fake tree are detected."""
+    scanner = _load_scanner()
+    body = (
+        "        a = 1\n"
+        "        b = a + 1\n"
+        "        c = b + 1\n"
+        "        d = c + 1\n"
+        "        e = d + 1\n"
+        "        f = e + 1\n"
+        "        return f\n"
+    )
+    pkg = tmp_path / "mixle" / "stats"
+    pkg.mkdir(parents=True)
+    (tmp_path / "mixle" / "models").mkdir(parents=True)
+    (pkg / "a.py").write_text(f"def foo():\n{body}", encoding="utf-8")
+    (pkg / "b.py").write_text(f"def bar():\n{body}", encoding="utf-8")
+
+    groups = scanner.scan(root=tmp_path)
+    assert any(len(g["locations"]) == 2 for g in groups), "planted duplicate was not detected"

--- a/scripts/scan_duplicate_bodies.py
+++ b/scripts/scan_duplicate_bodies.py
@@ -1,0 +1,144 @@
+"""Worklist Y4.5 -- find copy-pasted method/function bodies before they cause sibling bugs.
+
+Duplicated logic is a sibling-bug factory: a fix applied to one copy silently leaves the
+other broken. This scanner walks the distribution-family and neural-leaf source trees,
+normalizes each function body (docstring stripped, structure compared via ``ast.dump``),
+and reports groups where the *same* non-trivial body appears in two or more different
+functions.
+
+It is intentionally exact-match (true copy-paste), not fuzzy: exact duplicates are the
+high-signal subset worth gating, and the gate must have near-zero false positives to be
+trusted. Bodies shorter than ``MIN_STMTS`` statements are ignored so trivial one-liners
+(``return self._x``) do not flood the report.
+
+Used two ways:
+* ``python scripts/scan_duplicate_bodies.py`` -- print the current duplicate groups;
+* ``python scripts/scan_duplicate_bodies.py --write`` -- (re)generate the reviewed
+  manifest that the drift-gate test compares against.
+
+The test in ``mixle/tests/duplicate_body_scan_test.py`` fails when a *new* duplicate
+appears -- the shared prevention mechanism Y4.5 asks for.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+from collections import defaultdict
+from pathlib import Path
+
+# Directories the worklist names: distribution families and neural leaves.
+TARGET_DIRS = ("mixle/stats", "mixle/models")
+MIN_STMTS = 6  # ignore trivial bodies
+
+_HERE = Path(__file__).resolve().parent
+ROOT = _HERE.parent
+MANIFEST = ROOT / "mixle" / "tests" / "duplicate_body_manifest.json"
+
+
+def _repo_root() -> Path:
+    return ROOT
+
+
+def _normalized_body(fn: ast.FunctionDef | ast.AsyncFunctionDef) -> str | None:
+    """Structural signature of a function body, or None if it is too short to gate."""
+    body = list(fn.body)
+    if (
+        body
+        and isinstance(body[0], ast.Expr)
+        and isinstance(getattr(body[0], "value", None), ast.Constant)
+        and isinstance(body[0].value.value, str)
+    ):
+        body = body[1:]  # drop the docstring
+    if len(body) < MIN_STMTS:
+        return None
+    return "\n".join(ast.dump(stmt) for stmt in body)
+
+
+def scan(root: Path | None = None) -> list[dict]:
+    """Return duplicate-body groups as a sorted, JSON-serializable list.
+
+    Each group: ``{"locations": ["relpath::func", ...], "stmts": <int>}`` where
+    ``locations`` is the sorted set of distinct functions sharing one body.
+    """
+    root = root or _repo_root()
+    by_signature: dict[str, set[tuple[str, str]]] = defaultdict(set)
+    stmts_of: dict[str, int] = {}
+
+    for target in TARGET_DIRS:
+        for path in sorted((root / target).rglob("*.py")):
+            try:
+                tree = ast.parse(path.read_text(encoding="utf-8"))
+            except (SyntaxError, UnicodeDecodeError):
+                continue
+            rel = path.relative_to(root).as_posix()
+            for node in ast.walk(tree):
+                if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    sig = _normalized_body(node)
+                    if sig is None:
+                        continue
+                    by_signature[sig].add((rel, node.name))
+                    stmts_of[sig] = len(node.body)
+
+    groups = []
+    for sig, locs in by_signature.items():
+        if len(locs) < 2:
+            continue
+        groups.append(
+            {
+                "locations": sorted(f"{rel}::{name}" for rel, name in locs),
+                "stmts": stmts_of[sig],
+            }
+        )
+    # Stable order: by first location, so the manifest diff is readable.
+    groups.sort(key=lambda g: g["locations"])
+    return groups
+
+
+def group_signatures(groups: list[dict]) -> set[tuple[str, ...]]:
+    """A hashable identity per group -- its set of locations -- for set comparison."""
+    return {tuple(g["locations"]) for g in groups}
+
+
+def load_manifest() -> list[dict]:
+    if not MANIFEST.is_file():
+        return []
+    return json.loads(MANIFEST.read_text(encoding="utf-8"))["groups"]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--write", action="store_true", help="(re)write the reviewed manifest")
+    args = parser.parse_args()
+
+    groups = scan()
+    if args.write:
+        MANIFEST.write_text(
+            json.dumps(
+                {
+                    "_comment": (
+                        "Worklist Y4.5 baseline of exact copy-pasted bodies in "
+                        "mixle/stats and mixle/models. A new entry means new copy-paste: "
+                        "dedupe it, or add it here with justification. Regenerate with "
+                        "python scripts/scan_duplicate_bodies.py --write."
+                    ),
+                    "min_stmts": MIN_STMTS,
+                    "groups": groups,
+                },
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        print(f"wrote {MANIFEST} with {len(groups)} duplicate groups")
+        return 0
+
+    print(f"{len(groups)} duplicate-body groups (>= {MIN_STMTS} stmts):")
+    for g in groups:
+        print(f"  [{g['stmts']} stmts] {g['locations']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Worklist Y4.5 — Reduce generated-code and copy/paste risk (P1)

**Deliverable:** duplicate logic is found before it produces sibling bugs. **Acceptance:** repeated bug classes have one shared prevention mechanism.

Duplicated logic is a sibling-bug factory — a fix on one copy silently leaves the other broken. This adds a **scanner + reviewed manifest + drift gate**, rather than a refactor (the worklist explicitly says *"do not create abstractions solely to reduce line count"*).

### Scanner (`scripts/scan_duplicate_bodies.py`)
Walks `mixle/stats` and `mixle/models` (the families and neural leaves the worklist names), normalizes each function body (docstring stripped, structure compared via `ast.dump`), and reports groups where the same non-trivial (≥ 6 statement) body appears in two or more functions. **Exact-match** by design — true copy-paste, near-zero false positives, so the gate is trustworthy.

### Baseline (`duplicate_body_manifest.json`, 14 groups)
Real copy-paste pairs found today, e.g.:
- `combine` / `from_value` / `scale` shared between `hidden_markov.py` and `tree_hidden_markov_model.py`;
- grammar `__init__` / `update` between the hyperedge and vertex replacement grammars;
- `backend_stacked_sufficient_statistics_with_estimator` between `composite.py` and `record.py`.

Recorded as a reviewed baseline, not silently refactored.

### Gate (`duplicate_body_scan_test.py`, 3 cases — the shared prevention mechanism)
- **No new duplicates** — current groups must stay a subset of the manifest, so new copy-paste fails CI (fix: dedupe, or `--write` the manifest with justification).
- **Manifest not stale** — a duplicate that gets resolved must be pruned, keeping the baseline honest.
- **Negative control** — a planted identical body in a fake tree is detected.

**Verification:** `pytest mixle/tests/duplicate_body_scan_test.py` → 3 passed. `ruff check` clean.

Part of the 0.8.0 credibility worklist.