### PR TITLE
E14.2: add the adversarial statistical-review protocol

### DIFF
--- a/mixle/tests/statistical_review_protocol_test.py
+++ b/mixle/tests/statistical_review_protocol_test.py
@@ -1,0 +1,63 @@
+"""Worklist E14.2 -- the adversarial statistical-review protocol is complete and honest.
+
+E14.2 requires an adversarial review of automatic selection, calibration, uncertainty,
+and latent-model claims, structured around five specific questions, executed by someone
+other than the implementer. This test guards the *instrument* for that review: the
+protocol must cover all five required questions, carry a findings table for the reviewer
+to fill in, and stay honestly labeled as a protocol -- not misrepresented as a completed
+external review.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+DOC = Path(__file__).resolve().parent.parent.parent / "release-checklists" / "0.8.0-statistical-review.md"
+
+# The five E14.2 questions, by a distinctive phrase each.
+REQUIRED_QUESTIONS = (
+    "estimand",  # Q1
+    "leakage",  # Q2
+    "calibration guarantees",  # Q3
+    "approximate routes",  # Q4
+    "scientific validity",  # Q5
+)
+
+
+def _doc() -> str:
+    if not DOC.is_file():
+        pytest.skip(f"{DOC} not found")
+    return DOC.read_text(encoding="utf-8")
+
+
+def test_all_five_questions_are_covered() -> None:
+    text = _doc().lower()
+    missing = [q for q in REQUIRED_QUESTIONS if q not in text]
+    assert not missing, f"statistical-review protocol is missing required questions: {missing}"
+
+
+def test_protocol_has_a_findings_table() -> None:
+    text = _doc()
+    assert "## Findings" in text, "protocol must include a Findings table for the reviewer"
+    assert "Severity" in text, "findings table must track severity (acceptance keys on high-severity)"
+    assert "Resolution" in text, "findings table must link the resolving PR"
+
+
+def test_protocol_is_honestly_labeled_not_a_completed_review() -> None:
+    """It must not misrepresent itself as an already-done independent review."""
+    text = _doc().lower()
+    assert "protocol, not a completed review" in text or "protocol, not a" in text, (
+        "the doc must state it is a protocol to be executed, not a finished external review"
+    )
+    assert "other than the implementer" in text, (
+        "the protocol must require execution by someone other than the implementer (E14.2)"
+    )
+
+
+def test_protocol_ties_acceptance_to_rc1() -> None:
+    text = _doc().lower()
+    assert "rc1" in text and ("resolved" in text or "reduced" in text), (
+        "protocol must tie high-severity resolution to the RC1 independent-review gate"
+    )

--- a/release-checklists/0.8.0-statistical-review.md
+++ b/release-checklists/0.8.0-statistical-review.md
@@ -1,0 +1,98 @@
+# 0.8.0 Adversarial Statistical Review — Protocol (Worklist E14.2)
+
+**Status: protocol, not a completed review.** This document is the *instrument* an
+independent statistical reviewer uses to adversarially challenge mixle's statistical
+claims. It is written to be executed by **someone other than the implementer**
+(E14.2's requirement). Each section states the question, the concrete checks that
+answer it, where the current claim and its evidence live, and the maintainer's
+starting position — which the reviewer is invited to falsify, not to accept.
+
+**Acceptance (E14.2):** high-severity findings are resolved, or the corresponding
+claim is reduced. Record findings in the table at the end and link the resolving PR.
+
+---
+
+## Q1. Is the estimand clear?
+
+For every headline claim, the *thing being estimated* must be stated before any number.
+
+**Checks.**
+- For each flagship (heterogeneous / temporal / cascade), name the estimand: what
+  quantity, over what population, under what sampling assumption?
+- Does `optimize(data)` document what "a fitted model" means — a maximum-likelihood
+  point estimate, a posterior, a calibrated decision rule? (See `explain_fit()` and
+  the route-explainability test.)
+- Are "accuracy", "agreement", and "selective risk" each defined against a named
+  reference, not left as bare percentages?
+
+**Maintainer starting position.** Routes are named and observable
+(`explain_fit()` reports conjugate / em / map / laplace / vi / mcmc / nuts, gated by
+`route_explainability_test.py`). The reviewer should still challenge whether the
+*flagship reports* state their estimand as precisely as the route layer does.
+
+## Q2. Is validation leakage prevented?
+
+**Checks.**
+- Confirm the held-out / calibration / test separation is *official* where the dataset
+  provides one (Banking77, Adult, sunspots), and that calibration touches only the
+  calibration split.
+- Confirm automatic model selection scores candidates on a **held-out frontier**, not
+  on training data (`propose(..., holdout=...)`, model-selection benchmark test).
+- Confirm conformal calibration's exchangeability assumption is stated and not violated
+  by the split (e.g. temporal order for the HMM flagship).
+
+**Maintainer starting position.** The model-selection benchmark and the calibration
+tests use held-out data; the reviewer should probe the *temporal* flagship hardest,
+where naive shuffling would leak.
+
+## Q3. Are calibration guarantees stated with their assumptions?
+
+**Checks.**
+- Every conformal / selective-risk guarantee must name its assumption (exchangeability,
+  finite-sample coverage level) and its failure mode when the assumption breaks.
+- Is the difference between *marginal* and *conditional* coverage stated?
+- Does the doc avoid implying calibration proves accuracy? (The README now says
+  calibration is a per-deployment property, not a library guarantee — X12.1.)
+
+**Maintainer starting position.** Coverage is finite-sample under exchangeability; the
+reviewer should check that every place a coverage number appears also carries the
+assumption, not just the headline page.
+
+## Q4. Are approximate routes labeled?
+
+**Checks.**
+- Non-decomposable enumeration (mixtures, HMMs) must return a certified estimate or a
+  bound, never a silent approximation (enumeration doc + tests).
+- Laplace / VI are approximate posteriors; are they labeled as such next to their
+  numbers, distinct from exact conjugate or asymptotically-exact MCMC?
+- Are Monte-Carlo estimates reported with a standard error / exact-vs-approximate flag?
+
+**Maintainer starting position.** The enumeration layer distinguishes exact from
+certified-estimate explicitly; the reviewer should check the *posterior* routes carry
+the same discipline in the flagship reports.
+
+## Q5. Do examples distinguish model fit from scientific validity?
+
+**Checks.**
+- Does an example that *fits* data avoid implying the fit is *true*? (A reproducible
+  low-quality model is still low-quality — provenance ≠ correctness, gated by
+  `provenance_replay_test.py`.)
+- Do the aspirational examples disclose synthetic / stand-in data prominently
+  (F10.5 classification)?
+- Does any example present a good log-likelihood as evidence of a correct causal or
+  scientific conclusion?
+
+**Maintainer starting position.** Aspirational examples now carry a `Classification:`
+tag and provenance is explicitly separated from correctness; the reviewer should look
+for any remaining example whose narrative overstates what a fit establishes.
+
+---
+
+## Findings
+
+| # | Severity | Question | Finding | Resolution (PR) | Status |
+|---|----------|----------|---------|-----------------|--------|
+| _(reviewer fills in)_ | | | | | |
+
+High-severity findings must be resolved or the claim reduced before RC1
+(see `0.8.0-rc-stages.md`, stage RC1 "freeze and independent review").


### PR DESCRIPTION
## Worklist E14.2 — Conduct adversarial statistical review (P1)

The *external execution* of an adversarial statistical review requires an independent reviewer. The **maintainer-side deliverable** — the instrument that review runs on — is fully shippable, and this provides it: `release-checklists/0.8.0-statistical-review.md`.

**Honestly framed.** The doc states up front it is *"a protocol, not a completed review,"* to be executed by *"someone other than the implementer."* It does not claim an external review has happened.

It operationalizes E14.2's five required questions into concrete, adversarial checks:
1. **Is the estimand clear?** — name the quantity/population/assumption behind every headline number.
2. **Is validation leakage prevented?** — official splits, held-out model selection, exchangeability for the temporal flagship.
3. **Are calibration guarantees stated with assumptions?** — exchangeability, finite-sample coverage, marginal vs conditional.
4. **Are approximate routes labeled?** — certified-vs-exact enumeration, Laplace/VI as approximate, MC standard errors.
5. **Do examples distinguish model fit from scientific validity?** — provenance ≠ correctness; synthetic stand-ins disclosed.

Each carries a pointer to where the current claim and its evidence live (route-explainability, model-selection benchmark, provenance-replay, F10.5 classification) and a maintainer starting position the reviewer is invited to falsify. Ends with a findings table (severity + resolving PR) tied to the RC1 independent-review gate.

### Enforcement (`statistical_review_protocol_test.py`, 4 cases)
All five questions covered; findings table with severity/resolution present; honest "protocol, not a completed review / other than the implementer" framing; RC1 tie.

**Verification:** `pytest` → 4 passed. `ruff` clean.

Part of the 0.8.0 credibility worklist (external-review readiness).