### PR TITLE
E14.1: add the independent-tester onboarding + report template

### DIFF
--- a/mixle/tests/tester_report_template_test.py
+++ b/mixle/tests/tester_report_template_test.py
@@ -1,0 +1,55 @@
+"""Worklist E14.1 -- the independent-tester report template is complete.
+
+E14.1 requires two independent testers to reproduce installation and a flagship workflow
+and submit written reports that include commands, failures, confusing points, and final
+status. The maintainer-side deliverable is the report template those testers fill in.
+This test guards that the template actually asks for every element the acceptance
+criterion names, and is honestly labeled as a template (not a fabricated report).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+DOC = Path(__file__).resolve().parent.parent.parent / "release-checklists" / "0.8.0-tester-report-template.md"
+
+# The acceptance criterion: reports include commands, failures, confusing points, status.
+REQUIRED_SECTIONS = ("command", "failure", "confusing", "final status")
+# And the diversity + independence requirements.
+REQUIRED_CONTEXT = ("independent", "statistician", "engineer", "linux", "macos")
+
+
+def _doc() -> str:
+    if not DOC.is_file():
+        pytest.skip(f"{DOC} not found")
+    return DOC.read_text(encoding="utf-8")
+
+
+def test_template_asks_for_every_required_element() -> None:
+    text = _doc().lower()
+    missing = [s for s in REQUIRED_SECTIONS if s not in text]
+    assert not missing, f"tester report template is missing required sections: {missing}"
+
+
+def test_template_states_diversity_and_independence() -> None:
+    text = _doc().lower()
+    missing = [c for c in REQUIRED_CONTEXT if c not in text]
+    assert not missing, f"template omits diversity/independence requirements: {missing}"
+
+
+def test_template_uses_the_published_artifact_not_a_checkout() -> None:
+    """Testers must install from the artifact, per E14 reproduction discipline."""
+    text = _doc().lower()
+    assert "pip install mixle" in text or "wheel" in text, (
+        "template must direct testers to install from the published artifact, not a source checkout"
+    )
+    assert "fresh environment" in text or "fresh" in text
+
+
+def test_template_is_labeled_a_template() -> None:
+    text = _doc().lower()
+    assert "status: template" in text or "template." in text, (
+        "the file must be labeled a template so it is not mistaken for a real submitted report"
+    )

--- a/release-checklists/0.8.0-tester-report-template.md
+++ b/release-checklists/0.8.0-tester-report-template.md
@@ -1,0 +1,85 @@
+# 0.8.0 Independent Release Tester — Onboarding + Report Template (Worklist E14.1)
+
+**Status: template.** This is the artifact an **independent release tester** — someone
+not involved in primary development — fills in. E14.1 asks for **two** such testers, in
+diverse environments and roles. Copy this file to
+`release-checklists/0.8.0-tester-report-<name>.md`, complete every section, and submit it
+as the written report the acceptance criterion requires.
+
+## Who we are looking for (diversity targets)
+
+- **Tester A** — a statistician / data scientist focused on *model semantics*: does the
+  fitted model mean what the docs say, and are the uncertainty claims usable?
+- **Tester B** — an ML / software engineer focused on *packaging, API, and runtime*: does
+  it install cleanly, import fast, and behave under a realistic environment?
+- **Platforms:** Linux and macOS if at all possible (one each).
+
+You do **not** need to have seen the codebase before. That is the point.
+
+## What to do
+
+1. **Install from the published artifact**, not a source checkout, in a fresh
+   environment.
+2. **Run one flagship workflow** end to end (pick from `examples/` — e.g. the
+   heterogeneous real-data flagship, the temporal flagship, or the Banking77 cascade).
+3. **Record everything below**, including the things that confused you. Confusing points
+   are findings, not user error.
+
+---
+
+## Report
+
+### 1. Environment
+
+| Field | Value |
+|-------|-------|
+| Tester name / role | |
+| OS + version | |
+| Python version | |
+| Install method (`pip install mixle` / `mixle[all]` / wheel) | |
+| Date | |
+| mixle version reported by `python -c "import mixle; print(mixle.__version__)"` | |
+
+### 2. Installation
+
+- Exact commands run:
+  ```
+  (paste commands)
+  ```
+- Result: ☐ clean ☐ warnings ☐ errors
+- Time to install:
+- Any dependency or resolver surprises:
+
+### 3. Flagship workflow
+
+- Which flagship / example:
+- Exact commands run:
+  ```
+  (paste commands)
+  ```
+- Result: ☐ ran to completion ☐ partial ☐ failed
+- Output / receipt summary (paste the key numbers):
+- Wall-clock time:
+
+### 4. Failures encountered
+
+For each: what you did, what you expected, what happened, and the traceback if any.
+
+### 5. Confusing points
+
+Where did the docs, error messages, or API mislead or slow you down? Be specific — this
+is the highest-value section.
+
+### 6. Final status
+
+- Overall: ☐ GO ☐ GO with caveats ☐ NO-GO
+- Top three things to fix before release:
+  1.
+  2.
+  3.
+- Would you use this again for your own work? Why / why not:
+
+---
+
+Submitted reports are tracked in the RC1 gate (`0.8.0-rc-stages.md`, "independent
+review"). Two complete reports (diverse environments) are required to clear E14.1.


### PR DESCRIPTION
## Worklist E14.1 — Recruit two independent release testers (P0)

The *recruitment* of two external testers is an owner action. The **maintainer-side deliverable** — the report template those testers fill in, so their reports are complete and comparable — is fully shippable, and this provides it: `release-checklists/0.8.0-tester-report-template.md`.

**Honestly framed** as a template (copy to `0.8.0-tester-report-<name>.md` and complete), not a fabricated report.

Captures exactly what the acceptance criterion requires — reports must include **commands, failures, confusing points, and final status**:
- **Environment** — OS, Python, install method, reported `mixle.__version__`.
- **Installation** — exact commands, clean/warnings/errors, resolver surprises.
- **Flagship workflow** — which one, exact commands, result, receipt numbers, wall-clock.
- **Failures** — what/expected/actual/traceback.
- **Confusing points** — explicitly framed as findings, not user error (highest-value section).
- **Final status** — GO / GO-with-caveats / NO-GO + top-three fixes.

Plus the diversity targets (statistician focused on model semantics vs engineer focused on packaging/runtime; Linux and macOS) and the discipline of installing from the **published artifact in a fresh environment**, not a source checkout.

### Enforcement (`tester_report_template_test.py`, 4 cases)
Template asks for every required element; states independence/diversity; directs artifact install in a fresh env; stays labeled a template.

**Verification:** `pytest` → 4 passed. `ruff` clean.

Part of the 0.8.0 credibility worklist (external-review readiness).