### PR TITLE
E14.3: add the adversarial systems-review protocol

### DIFF
--- a/mixle/tests/systems_review_protocol_test.py
+++ b/mixle/tests/systems_review_protocol_test.py
@@ -1,0 +1,49 @@
+"""Worklist E14.3 -- the adversarial systems-review protocol is complete and honest.
+
+E14.3 requires an independent review of packaging, distributed execution, checkpointing,
+and benchmark methodology, with the acceptance that the reviewer reproduces at least one
+backend and one benchmark from a clean clone. This test guards the protocol instrument:
+it must cover all four areas, name the clean-clone reproduction of a backend and a
+benchmark, carry a findings table, and stay honestly labeled as a protocol.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+DOC = Path(__file__).resolve().parent.parent.parent / "release-checklists" / "0.8.0-systems-review.md"
+
+REQUIRED_AREAS = ("packaging", "distributed execution", "checkpointing", "benchmark methodology")
+
+
+def _doc() -> str:
+    if not DOC.is_file():
+        pytest.skip(f"{DOC} not found")
+    return DOC.read_text(encoding="utf-8")
+
+
+def test_all_four_areas_covered() -> None:
+    text = _doc().lower()
+    missing = [a for a in REQUIRED_AREAS if a not in text]
+    assert not missing, f"systems-review protocol is missing areas: {missing}"
+
+
+def test_requires_clean_clone_reproduction_of_backend_and_benchmark() -> None:
+    text = _doc().lower()
+    assert "clean clone" in text, "protocol must require reproduction from a clean clone"
+    assert "one backend" in text or "≥1 backend" in text or "one distributed backend" in text
+    assert "one benchmark" in text or "≥1 benchmark" in text
+
+
+def test_has_findings_table_and_rc1_tie() -> None:
+    text = _doc()
+    assert "## Findings" in text and "Severity" in text
+    assert "rc1" in text.lower() or "RC1" in text
+
+
+def test_is_labeled_a_protocol() -> None:
+    text = _doc().lower()
+    assert "protocol, not a completed review" in text or "protocol, not a" in text
+    assert "other than the implementer" in text

--- a/release-checklists/0.8.0-systems-review.md
+++ b/release-checklists/0.8.0-systems-review.md
@@ -1,0 +1,75 @@
+# 0.8.0 Adversarial Systems Review — Protocol (Worklist E14.3)
+
+**Status: protocol, not a completed review.** This is the instrument an independent
+**systems** reviewer uses to challenge mixle's packaging, distributed execution,
+checkpointing, and benchmark methodology. Execute it from a **clean clone** in a fresh
+environment, as someone other than the implementer.
+
+**Acceptance (E14.3):** the reviewer reproduces **at least one backend** and **at least
+one benchmark** from a clean clone. Record outcomes in the findings table.
+
+---
+
+## 1. Packaging
+
+**Checks.**
+- `pip install mixle` in a fresh venv (base install, no extras). Does it import? Time
+  `python -c "import mixle"` (the import-latency budget is gated separately).
+- Install each extra group you can (`mixle[torch]`, `mixle[dask]`, ...). Does the
+  resolver succeed on your platform? Note any platform-gated extras (e.g. TBB on arm64).
+- Confirm the base install pulls no optional heavy dependency (torch, spark, ...).
+
+**Reviewer question:** does the dependency floor match what the code actually uses, or
+is it optimistic?
+
+## 2. Distributed execution (reproduce ≥1 backend)
+
+**Checks.**
+- Run `python examples/scaling_example.py` — it fits the same model under `local`, `mp`,
+  and (where a launcher is present) `dask` / `mpi` / `spark`, and should agree.
+- Reproduce **one** distributed backend end to end from the clean clone. `mp` needs no
+  launcher; `dask` needs `pip install mixle[dask]`; `mpi` needs `mpirun`.
+- Confirm the distributed fit agrees with the local fit to tolerance (the MPI route
+  equivalence and backend-matrix tests are the reference).
+
+**Reviewer question:** does "scale with a flag" hold on your machine, and does the
+backend agree with local numerically?
+
+## 3. Checkpointing
+
+**Checks.**
+- Run `python examples/production_example.py` — it fits with provenance, registers a
+  model, promotes an alias, and checks a drift report.
+- Interrupt a long fit that uses `registry.checkpointer(...)` and confirm the chain
+  verifies (`registry.verify_chain(...)`).
+- Confirm a promoted alias resolves to a specific version, and that promotion is separate
+  from registration.
+
+**Reviewer question:** can you recover a fit from a checkpoint, and is the lineage honest
+about what it does and does not record?
+
+## 4. Benchmark methodology (reproduce ≥1 benchmark)
+
+**Checks.**
+- Reproduce **one** benchmark or measured report from the reproducibility bundle
+  (`0.8.0-repro-bundle.json`) — run its command, compare your numbers to the reported
+  ones, and note the direction of any gap.
+- Confirm performance claims state whether they are throughput, latency, or capability
+  (see the performance-crossover page), and that losses (where a specialized package
+  wins) are reported alongside wins.
+- Confirm no headline number is carried over from a pre-0.8.0 artifact.
+
+**Reviewer question:** are the benchmark numbers reproducible on your hardware within a
+stated tolerance, and is the methodology honest about what it does not measure?
+
+---
+
+## Findings
+
+| # | Severity | Area | Finding | Reproduced from clean clone? | Resolution (PR) |
+|---|----------|------|---------|------------------------------|-----------------|
+| _(reviewer fills in)_ | | | | | |
+
+The acceptance is met when the reviewer has reproduced at least one backend (section 2)
+and one benchmark (section 4) from a clean clone, and high-severity findings are resolved
+or the claim reduced before RC1 (`0.8.0-rc-stages.md`).


### PR DESCRIPTION
## Worklist E14.3 — Conduct adversarial systems review (P1)

The maintainer-side deliverable — the instrument an independent **systems** reviewer runs from a clean clone. `release-checklists/0.8.0-systems-review.md`, honestly labeled a protocol (not a completed review), to be executed by someone other than the implementer.

Covers all four required areas with concrete checks, exact reproduction commands, and an adversarial question each:
1. **Packaging** — fresh-venv base install + extras resolution; does the dependency floor match what the code uses?
2. **Distributed execution** — reproduce **one backend** end to end (`scaling_example.py`: local/mp/dask/mpi/spark), confirm it agrees with local.
3. **Checkpointing** — `production_example.py`: provenance, registry, alias promotion, drift; recover a fit from a checkpoint chain.
4. **Benchmark methodology** — reproduce **one benchmark** from the reproducibility bundle; confirm throughput/latency/capability labeling, losses reported alongside wins, no pre-0.8.0 carryover.

**Acceptance:** reviewer reproduces ≥1 backend and ≥1 benchmark from a clean clone. Findings table tracks whether each finding reproduced, tied to the RC1 gate.

### Enforcement (`systems_review_protocol_test.py`, 4 cases)
All four areas covered; clean-clone backend + benchmark reproduction required; findings table + RC1 tie; honest protocol framing.

**Verification:** `pytest` → 4 passed. `ruff` clean.

Part of the 0.8.0 credibility worklist (external-review readiness). Companion to #377 (E14.2), #378 (E14.1), #379 (E14.5).