### PR TITLE
B7.5: add the performance-change policy (measured bottlenecks + parity gate)

### DIFF
--- a/mixle/tests/performance_change_policy_test.py
+++ b/mixle/tests/performance_change_policy_test.py
@@ -1,0 +1,51 @@
+"""Worklist B7.5 -- the performance-change policy states the full required workflow.
+
+B7.5's acceptance: no performance PR without a before/after result and a correctness
+gate. This test guards the policy document so the required workflow cannot be quietly
+weakened: it must name every step (profile, hypothesis, patch, parity, benchmark, memory,
+receipt), require both a before/after result and a correctness/parity gate, and keep the
+"only fix measured bottlenecks / no abstraction just to cut lines" discipline.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+DOC = Path(__file__).resolve().parent.parent.parent / "release-checklists" / "0.8.0-performance-change-policy.md"
+
+REQUIRED_STEPS = ("profile", "hypothesis", "patch", "parity", "benchmark", "memory", "receipt")
+
+
+def _doc() -> str:
+    if not DOC.is_file():
+        pytest.skip(f"{DOC} not found")
+    return DOC.read_text(encoding="utf-8")
+
+
+def test_all_workflow_steps_present() -> None:
+    text = _doc().lower()
+    missing = [s for s in REQUIRED_STEPS if s not in text]
+    assert not missing, f"performance policy is missing workflow steps: {missing}"
+
+
+def test_requires_before_after_and_correctness_gate() -> None:
+    text = _doc().lower()
+    assert "before/after" in text or ("before" in text and "after" in text), "policy must require a before/after result"
+    assert "correctness gate" in text or "parity" in text, (
+        "policy must require a correctness/parity gate (B7.5 acceptance)"
+    )
+
+
+def test_keeps_measured_bottleneck_discipline() -> None:
+    text = _doc().lower()
+    assert "measured bottleneck" in text or "only fix measured" in text or "not optimize on intuition" in text
+    assert "line count" in text, "policy must keep the 'no abstraction just to cut lines' rule"
+
+
+def test_has_a_receipt_template() -> None:
+    text = _doc().lower()
+    assert "receipt template" in text or "performance change receipt" in text, (
+        "policy must include a retained-receipt template so claims are auditable"
+    )

--- a/release-checklists/0.8.0-performance-change-policy.md
+++ b/release-checklists/0.8.0-performance-change-policy.md
@@ -1,0 +1,59 @@
+# 0.8.0 Performance-Change Policy (Worklist B7.5)
+
+**Rule: no performance PR merges without a before/after result and a passing
+correctness gate.** Speed changes are the easiest place to introduce a silent
+regression in the *numbers* while improving the *timings*. This policy makes the
+trade-off explicit and auditable.
+
+It applies to any change whose justification is speed or memory: kernel rewrites,
+vectorization, caching, lazy imports, reduced allocations, backend/reduction changes.
+
+## Only fix measured bottlenecks
+
+Do **not** optimize on intuition. A performance PR must start from a profile that shows
+the target is actually a bottleneck on a stable path. Candidate hot spots worth profiling
+first (from the 0.8.0 audit):
+
+- generic mixture responsibility accumulation;
+- terminal and segmental HMM loops;
+- repeated encoder construction;
+- automatic candidate refits;
+- import-time eager module loading;
+- distributed serialization / reduction overhead.
+
+Do **not** add an abstraction whose only purpose is to reduce line count.
+
+## Required workflow (every optimization)
+
+1. **Profile** — show the hot spot with a profiler on a representative input. Attach the
+   profile (or its summary) to the PR.
+2. **Hypothesis** — state *why* it is slow and *what* you expect to change.
+3. **Patch** — the smallest change that tests the hypothesis.
+4. **Parity test** — prove the fitted numbers are unchanged (or changed only within a
+   stated tolerance). A speed win that moves the parameters is a bug, not a win.
+5. **Benchmark** — before/after timing on the same machine and input. Report the ratio,
+   not just the faster number.
+6. **Memory check** — confirm the change did not trade time for a peak-memory regression.
+7. **Retained receipt** — commit the before/after result so the claim is auditable later.
+
+## Receipt template
+
+```
+### Performance change receipt
+- Target / hot spot:
+- Profile evidence (what showed it was a bottleneck):
+- Hypothesis:
+- Parity: <test name> -- parameters unchanged within <tol>
+- Benchmark (same machine + input):
+    before: <time / mem>
+    after:  <time / mem>
+    ratio:  <after/before>
+- Memory peak: before <> / after <>
+- Correctness gate: <CI job / test that must stay green>
+```
+
+## Acceptance
+
+A performance PR is complete only when it carries a before/after result **and** a
+correctness gate (a parity or family contract test) is green. A PR that shows a speedup
+but no parity evidence is rejected, however good the number looks.


### PR DESCRIPTION
## Worklist B7.5 — Profile and fix only measured stable-path bottlenecks (P1)

**Acceptance:** no performance PR without a before/after result and a correctness gate.

The *fixes* require measured bottlenecks to exist; the durable, shippable deliverable is the **policy that governs every future performance PR**, so a speed change can't silently move the numbers while improving the timings. `release-checklists/0.8.0-performance-change-policy.md`.

- **Only fix measured bottlenecks** — start from a profile; do not optimize on intuition; no abstraction whose only purpose is to cut lines. Lists the 0.8.0 candidate hot spots (mixture responsibility accumulation, HMM loops, repeated encoder construction, automatic candidate refits, eager imports, reduction overhead).
- **Required workflow** — profile → hypothesis → patch → **parity test** → benchmark (report the ratio) → memory check → **retained receipt**.
- **Receipt template** — target, profile evidence, hypothesis, parity (params unchanged within tol), before/after timing + ratio, memory peak, correctness gate.
- **Acceptance** — a PR showing a speedup but no parity evidence is rejected, however good the number looks.

### Enforcement (`performance_change_policy_test.py`, 4 cases)
All seven workflow steps present; before/after + correctness-gate required; measured-bottleneck + no-abstraction-to-cut-lines discipline kept; receipt template present.

**Verification:** `pytest` → 4 passed. `ruff` clean.

Part of the 0.8.0 credibility worklist.