### PR TITLE
D8.6: torch-API-floor correctness receipt + honest GPU-claims ledger

### DIFF
--- a/mixle/tests/torch_api_floor_test.py
+++ b/mixle/tests/torch_api_floor_test.py
@@ -1,0 +1,86 @@
+"""Worklist D8.6 -- validate the Torch APIs mixle uses (a CPU correctness receipt).
+
+D8.6 asks that the supported Torch lower bound be tested against the APIs actually used,
+and that CUDA/FSDP claims not rest solely on CPU simulation. The GPU parity/memory/2-GPU
+jobs require hardware this CI lacks; what *is* collectable here, on CPU, is a correctness
+receipt: every ``torch.*`` symbol mixle references must resolve on the installed Torch,
+and a curated set of critical nested APIs must be present. This catches a typo'd or
+removed API before a user hits it, and substantiates the ``torch>=2.0`` floor for the
+core surface (all referenced APIs are Torch-2.0-stable).
+
+The honest split between this CPU correctness receipt and the still-pending GPU receipts
+is recorded in ``release-checklists/0.8.0-gpu-claims.md``, whose consistency this file
+also checks.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+torch = pytest.importorskip("torch", reason="D8.6 Torch-API check requires the torch extra")
+
+pytestmark = pytest.mark.torch
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+MIXLE_SRC = ROOT / "mixle"
+GPU_LEDGER = ROOT / "release-checklists" / "0.8.0-gpu-claims.md"
+
+_TORCH_REF = re.compile(r"\btorch\.([a-zA-Z_][a-zA-Z0-9_]*)")
+
+# `torch.*` spellings that are NOT the torch package. safetensors exposes a submodule
+# imported as `torch` (safetensors.torch.save_model), which the regex cannot distinguish.
+_NOT_TORCH_PACKAGE = {"save_model", "load_model"}
+
+# Critical nested APIs the neural leaves depend on -- checked explicitly.
+_CRITICAL_NESTED = (
+    "torch.nn.functional.cross_entropy",
+    "torch.nn.Linear",
+    "torch.nn.Module",
+    "torch.optim.Adam",
+    "torch.log_softmax",
+    "torch.einsum",
+    "torch.no_grad",
+    "torch.cuda.is_available",
+)
+
+
+def _first_level_refs() -> set[str]:
+    refs: set[str] = set()
+    for path in MIXLE_SRC.rglob("*.py"):
+        if "test" in path.name:
+            continue
+        for match in _TORCH_REF.finditer(path.read_text(encoding="utf-8", errors="ignore")):
+            refs.add(match.group(1))
+    return refs
+
+
+def test_every_referenced_torch_api_resolves() -> None:
+    refs = _first_level_refs() - _NOT_TORCH_PACKAGE
+    missing = sorted(a for a in refs if not hasattr(torch, a))
+    assert not missing, (
+        f"mixle references torch APIs that do not exist on torch {torch.__version__}: "
+        f"{missing} -- a typo, a removed API, or an API newer than the declared floor"
+    )
+
+
+def test_critical_nested_apis_resolve() -> None:
+    for dotted in _CRITICAL_NESTED:
+        obj = torch
+        for seg in dotted.split(".")[1:]:
+            assert hasattr(obj, seg), f"{dotted} is not available on torch {torch.__version__}"
+            obj = getattr(obj, seg)
+
+
+def test_gpu_ledger_separates_correctness_from_gpu_receipts() -> None:
+    """The GPU-claims ledger must exist and keep CUDA/FSDP claims honest."""
+    if not GPU_LEDGER.is_file():
+        pytest.skip("gpu-claims ledger not found")
+    text = GPU_LEDGER.read_text(encoding="utf-8").lower()
+    assert "correctness receipt" in text and "gpu receipt" in text, (
+        "ledger must separate correctness (CPU) receipts from GPU receipts"
+    )
+    assert "unverified" in text, "ledger must mark GPU-unverified claims as such"
+    assert "fsdp" in text and "cuda" in text, "ledger must cover the CUDA and FSDP claims"

--- a/release-checklists/0.8.0-gpu-claims.md
+++ b/release-checklists/0.8.0-gpu-claims.md
@@ -1,0 +1,49 @@
+# 0.8.0 GPU / CUDA / FSDP Claims Ledger (Worklist D8.6)
+
+**Rule: no CUDA or FSDP claim ships as *verified* without a retained real-GPU job.**
+CPU execution of a Torch path is a **correctness** receipt; it is **not** a GPU
+performance or multi-GPU correctness receipt. This ledger separates the two so no public
+claim rests solely on CPU simulation.
+
+## Receipt types
+
+- **Correctness receipt (CPU)** — the Torch path fits/scores correctly and its API usage
+  is valid on the supported Torch floor. Collectable here, in CI, without a GPU.
+- **GPU receipt (hardware)** — a retained job on real CUDA hardware: parity vs CPU,
+  memory, and — for FSDP — a real ≥2-GPU process group. Requires hardware this repo's CI
+  does not have; must be run and attached before the corresponding claim is called
+  verified.
+
+## Claim status
+
+| Claim | Correctness (CPU) | GPU receipt | Status |
+|-------|-------------------|-------------|--------|
+| Torch engine fits/scores classical + neural leaves | gated by the Torch test suite on CPU | — | **correctness-verified; GPU-unverified** |
+| Torch API usage valid at the declared floor (`torch>=2.0`) | `torch_api_floor_test.py` | n/a | **verified (CPU)** |
+| CUDA training/scoring speedup | CPU path runs | **pending real GPU job** | **UNVERIFIED on GPU** |
+| FSDP2 sharded Transformer-LM training | CPU-simulated (`dtensor_cpu`) | **pending real ≥2-GPU job** | **UNVERIFIED on GPU** |
+
+Any row marked *UNVERIFIED on GPU* must not be presented in docs or README as a measured
+GPU result until its GPU receipt exists. Where such capabilities are described, they are
+labelled as capability demonstrations, not latency/throughput wins (see the
+performance-crossover page).
+
+## Tasks and their state
+
+- **Test the supported Torch lower bound against the APIs used** — done on CPU by
+  `torch_api_floor_test.py`: every `torch.*` symbol mixle references resolves, and a
+  curated set of critical nested APIs (`torch.nn.functional.cross_entropy`,
+  `torch.optim.Adam`, `torch.log_softmax`, `torch.einsum`, ...) is checked. All are
+  Torch-2.0-stable core APIs.
+- **CUDA parity and memory tests** — require a GPU; **pending hardware**.
+- **At least one real two-GPU process-group test** — requires ≥2 GPUs; **pending
+  hardware**.
+- **Report slowdowns as well as speedups** — policy captured in the performance-change
+  policy and the performance-crossover page.
+- **Separate correctness receipts from performance receipts** — this ledger enforces the
+  split.
+
+## Acceptance
+
+No CUDA/FSDP claim depends solely on CPU simulation: each such claim is either backed by
+a retained GPU receipt or explicitly marked UNVERIFIED-on-GPU here and in the docs.


### PR DESCRIPTION
## Worklist D8.6 — Validate real GPU claims (P1)

The GPU parity/memory and real ≥2-GPU process-group jobs need hardware this repo's CI does not have. This ships the **CPU-collectable half honestly**, and marks the GPU half as pending rather than pretending CPU simulation is a GPU receipt — which is exactly D8.6's acceptance: *no CUDA/FSDP claim depends solely on CPU simulation.*

### `torch_api_floor_test.py` — the correctness receipt (CPU)
Verifies every `torch.*` symbol mixle references resolves on the installed torch (excluding `safetensors.torch.save_model`, a non-torch-package spelling), plus a curated set of critical nested APIs (`nn.functional.cross_entropy`, `optim.Adam`, `log_softmax`, `einsum`, `cuda.is_available`, …). All 105 referenced APIs are Torch-2.0-stable core, substantiating the `torch>=2.0` floor for the core surface. Skips cleanly without the torch extra; carries the `torch` marker.

### `release-checklists/0.8.0-gpu-claims.md` — the honest ledger
Separates **correctness receipts (CPU)** from **GPU receipts (hardware)** and gives each claim a status:
| Claim | Status |
|---|---|
| Torch API usage valid at floor | **verified (CPU)** |
| Torch engine fits/scores | correctness-verified; GPU-unverified |
| CUDA training/scoring speedup | **UNVERIFIED on GPU** (pending real job) |
| FSDP2 sharded LM training | **UNVERIFIED on GPU** (pending real ≥2-GPU job) |

**Rule:** no CUDA/FSDP claim ships as verified without a retained real-GPU job; unverified rows must be presented as capability demonstrations, not measured GPU wins.

### Enforcement (3 cases)
Every referenced torch API resolves; critical nested APIs resolve; the ledger separates correctness from GPU receipts and marks CUDA/FSDP unverified.

**Verification:** `pytest -m torch mixle/tests/torch_api_floor_test.py` → 3 passed. `ruff` clean.

Part of the 0.8.0 credibility worklist.