### PR TITLE
E14.4: add the external use-case intake template

### DIFF
--- a/mixle/tests/external_use_case_template_test.py
+++ b/mixle/tests/external_use_case_template_test.py
@@ -1,0 +1,61 @@
+"""Worklist E14.4 -- the external use-case intake asks for everything, honestly.
+
+E14.4 requires one real external use case, with evidence covering the problem statement,
+data shape, chosen model, failure points, runtime, and whether mixle reduced or increased
+work -- and the acceptance that findings feed docs/bug fixes and marketing does not
+cherry-pick only successes. This test guards the intake template so it keeps asking for
+every element, including the honest "did mixle increase work?" question.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+DOC = Path(__file__).resolve().parent.parent.parent / "release-checklists" / "0.8.0-external-use-case-template.md"
+
+REQUIRED = (
+    "problem statement",
+    "data shape",
+    "chosen model",
+    "failure points",
+    "runtime",
+    "reduce or increase",  # the honest both-outcomes question
+)
+
+
+def _doc() -> str:
+    if not DOC.is_file():
+        pytest.skip(f"{DOC} not found")
+    return DOC.read_text(encoding="utf-8")
+
+
+def test_intake_asks_for_every_required_element() -> None:
+    text = _doc().lower()
+    missing = [r for r in REQUIRED if r not in text]
+    assert not missing, f"use-case intake is missing required elements: {missing}"
+
+
+def test_intake_forbids_cherry_picking() -> None:
+    text = _doc().lower()
+    assert "cherry-pick" in text or "cherry pick" in text, (
+        "the template must state marketing does not cherry-pick only successes (E14.4)"
+    )
+    assert "increase" in text and "reduce" in text, (
+        "the template must record both increased-work and reduced-work outcomes"
+    )
+
+
+def test_intake_feeds_docs_and_bugs() -> None:
+    text = _doc().lower()
+    assert "docs to fix" in text or "docs" in text
+    assert "bug" in text, "findings must feed bug fixes"
+
+
+def test_is_labeled_a_template() -> None:
+    text = _doc().lower()
+    assert "status: template" in text or "template." in text
+    assert "external" in text and "not design" in text, (
+        "the use case must be on data the maintainer did not design (external)"
+    )

--- a/release-checklists/0.8.0-external-use-case-template.md
+++ b/release-checklists/0.8.0-external-use-case-template.md
@@ -1,0 +1,60 @@
+# 0.8.0 External Use-Case Intake (Worklist E14.4)
+
+**Status: template.** E14.4 asks for **one real external use case**: a user applies the
+0.8.0 RC to data the maintainer did not design. This is the intake the user (or the
+maintainer, on their behalf) fills in. Copy to
+`release-checklists/0.8.0-use-case-<name>.md` and complete it.
+
+**Honesty rule (acceptance):** findings feed docs and bug fixes, and **marketing must not
+cherry-pick only the successes**. A use case where mixle *increased* work is as valuable a
+finding as one where it reduced it, and must be recorded with the same prominence.
+
+---
+
+## Intake
+
+### 1. Problem statement
+
+- What is the user actually trying to do (in their words, not mixle's)?
+- Why did they reach for a probabilistic-modeling library?
+
+### 2. Data shape
+
+- Rows / size:
+- Field types (numeric, category, boolean, text, temporal, missing, ...):
+- Anything unusual (heavy tails, high cardinality, imbalance, leakage risk):
+
+### 3. Chosen model
+
+- What model / estimator did they end up with, and how did they arrive at it
+  (`optimize(data)` auto, a prototype, `propose`, manual)?
+- Did `explain_fit()` / the docs help them understand the route?
+
+### 4. Failure points
+
+- Where did it break, confuse, or fight them? Include tracebacks and the exact step.
+- Did any error message mislead?
+
+### 5. Runtime
+
+- Wall-clock for the fit(s), machine, install method.
+- Did it fit in memory? Any surprises?
+
+### 6. Did mixle reduce or increase work? (both outcomes recorded honestly)
+
+- Compared to what they would otherwise have done (bespoke code, scikit-learn, a
+  notebook), did mixle **reduce** or **increase** the total work?
+- Be specific about *where* time went (modeling, debugging, reading docs, fighting the
+  API).
+
+### 7. What this feeds
+
+- Docs to fix:
+- Bugs to file (link issues):
+- Claims to reduce (if the use case contradicts a headline claim):
+
+---
+
+The completed use case is tracked in the RC gate (`0.8.0-rc-stages.md`). If it surfaces a
+high-severity problem, that must be resolved or the claim reduced before final release —
+and the writeup, including negative findings, is retained, not filtered.


### PR DESCRIPTION
## Worklist E14.4 — Collect one real external use case (P1)

The *use case itself* is an external user's output. The **maintainer-side deliverable** — the intake that captures it completely and honestly — is shippable: `release-checklists/0.8.0-external-use-case-template.md`, labeled a template (not a fabricated case).

Captures every element the acceptance requires:
- **Problem statement** — in the user's words, why they reached for a PPL.
- **Data shape** — size, field types, unusual properties.
- **Chosen model** — how they arrived at it; did `explain_fit()`/docs help.
- **Failure points** — where it broke/confused, with tracebacks.
- **Runtime** — wall-clock, machine, memory.
- **Did mixle reduce or increase work?** — both outcomes recorded at equal prominence.
- **What this feeds** — docs to fix, bugs to file, claims to reduce.

**Honesty rule (acceptance):** findings feed docs/bug fixes and **marketing does not cherry-pick only successes** — a use case where mixle *increased* work is as valuable and must be retained with the same prominence.

### Enforcement (`external_use_case_template_test.py`, 4 cases)
Every required element present; no-cherry-picking rule + both-outcomes question present; findings feed docs/bugs; honest external-data framing.

**Verification:** `pytest` → 4 passed. `ruff` clean.

Part of the 0.8.0 credibility worklist (external-review readiness).