### PR TITLE
B7.3: stamp benchmark results with their producing version; gate stale artifacts

### DIFF
--- a/mixle/tests/benchmark_provenance_test.py
+++ b/mixle/tests/benchmark_provenance_test.py
@@ -1,0 +1,80 @@
+"""Worklist B7.3 -- no headline benchmark number may come from a stale artifact.
+
+B7.3 requires that 0.8.0's published measurements are produced on 0.8.0, not carried over
+from 0.5.x/0.6.x. The enforcement is provenance: ``scripts/benchmark_provenance.py``
+stamps every result with the mixle version/minor/commit that produced it, and this test
+proves the stamping + staleness detection works, and scans any benchmark results files in
+the repo to ensure none carry a stale (different major.minor) or missing stamp.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+PROVENANCE = ROOT / "scripts" / "benchmark_provenance.py"
+BENCH_DIR = ROOT / "benchmarks"
+
+
+def _mod():
+    if not PROVENANCE.is_file():
+        pytest.skip(f"{PROVENANCE} not found")
+    spec = importlib.util.spec_from_file_location("benchmark_provenance", PROVENANCE)
+    assert spec and spec.loader
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return m
+
+
+def test_stamp_marks_the_current_version() -> None:
+    prov = _mod()
+    stamped = prov.stamp_result({"benchmark": "gmm_fit", "seconds": 0.1})
+    assert stamped["mixle_version"], "stamp must record the mixle version"
+    assert stamped["mixle_minor"], "stamp must record the major.minor line"
+    assert prov.is_current(stamped), "a freshly-stamped result must read as current"
+
+
+def test_stale_and_unstamped_results_are_detected() -> None:
+    prov = _mod()
+    current = prov.stamp_result({"benchmark": "x"})
+    stale = {"benchmark": "x", "mixle_version": "0.6.2", "mixle_minor": "0.6"}
+    unstamped = {"benchmark": "x", "seconds": 0.1}
+    bad = prov.stale_results([current, stale, unstamped])
+    assert stale in bad and unstamped in bad, "stale and unstamped results must be flagged"
+    assert current not in bad, "the current-version result must not be flagged"
+
+
+def test_minor_extraction() -> None:
+    prov = _mod()
+    assert prov.minor_of("0.8.0.dev1") == "0.8"
+    assert prov.minor_of("0.6.2") == "0.6"
+
+
+def test_no_committed_benchmark_result_is_stale() -> None:
+    """Any results file in the repo must be stamped with the current release line."""
+    prov = _mod()
+    if not BENCH_DIR.is_dir():
+        pytest.skip("no benchmarks/ directory in this checkout (harness lands separately)")
+    result_files = [p for p in BENCH_DIR.rglob("*.json") if "result" in p.name.lower()]
+    if not result_files:
+        pytest.skip("no benchmark results files present yet")
+    offenders = []
+    for path in result_files:
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            continue
+        records = data if isinstance(data, list) else data.get("results", [data])
+        if not isinstance(records, list):
+            continue
+        for rec in records:
+            if isinstance(rec, dict) and rec.get("seconds") is not None and not prov.is_current(rec):
+                offenders.append(f"{path.name}: {rec.get('benchmark', rec)}")
+    assert not offenders, (
+        "benchmark results carry a stale or missing version stamp (B7.3 -- no headline "
+        "number from old artifacts):\n" + "\n".join(offenders)
+    )

--- a/scripts/benchmark_provenance.py
+++ b/scripts/benchmark_provenance.py
@@ -1,0 +1,84 @@
+"""Worklist B7.3 -- stamp benchmark results with the version that produced them.
+
+B7.3's deliverable is that no headline performance number comes from a stale (0.5.x /
+0.6.x) artifact. The mechanism: every published benchmark result carries the mixle
+version and commit it was produced on, and a gate rejects results whose version does not
+match the release being prepared. Re-running the panels on 0.8.0 then means: produce
+results whose stamp says 0.8.
+
+This module is the stamping helper and the staleness check. The benchmark harness (see
+``benchmarks/``) calls ``stamp_result`` when it writes a result; the gate test
+(``benchmark_provenance_test.py``) calls ``is_current`` over any results files present.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def _package_version() -> str:
+    import mixle
+
+    return getattr(mixle, "__version__", "0.0.0")
+
+
+def minor_of(version: str) -> str:
+    """The major.minor prefix -- the granularity a release's headline numbers are tied to."""
+    return ".".join(version.split(".")[:2])
+
+
+def _git_commit() -> str:
+    for env_var in ("MIXLE_BENCH_COMMIT", "GITHUB_SHA"):
+        sha = os.environ.get(env_var)
+        if sha:
+            return sha[:12]
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(ROOT), "rev-parse", "--short=12", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if out.returncode == 0 and out.stdout.strip():
+            return out.stdout.strip()
+    except (OSError, subprocess.SubprocessError):
+        pass
+    return "unknown"
+
+
+def stamp_result(result: dict[str, Any]) -> dict[str, Any]:
+    """Return ``result`` with mixle version/minor/commit provenance attached."""
+    version = _package_version()
+    return {
+        **result,
+        "mixle_version": version,
+        "mixle_minor": minor_of(version),
+        "mixle_commit": _git_commit(),
+    }
+
+
+def is_current(result: dict[str, Any], *, current_version: str | None = None) -> bool:
+    """Whether ``result`` was produced by the current release line (major.minor match)."""
+    current = minor_of(current_version or _package_version())
+    stamped = result.get("mixle_minor")
+    if stamped is None:
+        version = result.get("mixle_version")
+        stamped = minor_of(version) if version else None
+    return stamped == current
+
+
+def stale_results(results: list[dict[str, Any]], *, current_version: str | None = None) -> list[dict[str, Any]]:
+    """Results that are unstamped or stamped with a different release line."""
+    return [r for r in results if not is_current(r, current_version=current_version)]
+
+
+if __name__ == "__main__":
+    import json
+
+    demo = stamp_result({"benchmark": "gmm_fit", "n": 100000, "seconds": 0.098})
+    print(json.dumps(demo, indent=2))


### PR DESCRIPTION
## Worklist B7.3 — Re-run all published measurements on 0.8.0 (P0)

**Deliverable:** no headline performance number comes from 0.5.x/0.6.x artifacts.

The canonical-machine re-run needs the benchmark harness (B7.1, separate) and fixed hardware. The **enforceable core** — the thing that *guarantees* "no stale numbers" and makes "re-run on 0.8.0" verifiable — is provenance stamping, shipped here.

### `scripts/benchmark_provenance.py`
- `stamp_result(result)` attaches `mixle_version` / `mixle_minor` / `mixle_commit` to every benchmark result.
- `is_current(result)` / `stale_results(results)` flag results whose major.minor doesn't match the release being prepared, or that carry no stamp.

"Re-run on 0.8.0" becomes concrete: produce results whose stamp reads `0.8`; any result stamped `0.6` fails the gate.

### `benchmark_provenance_test.py` (4 cases)
- a freshly-stamped result reads as current;
- a stale `0.6.2` result and an unstamped result are both flagged;
- major.minor extraction (`0.8.0.dev1` → `0.8`);
- **repo scan** — any `benchmarks/**/*result*.json` with a `seconds` field must carry a current-line stamp; skips cleanly until the harness + results land, then rejects carried-over numbers automatically.

**Verification:** `pytest` → 3 passed, 1 skipped (no results files on base yet). `ruff` clean. Demo stamp output confirmed.

Part of the 0.8.0 credibility worklist.