### PR TITLE
P9: anytime-valid receipts via e-processes (experimental)

### DIFF
--- a/mixle/experimental/__init__.py
+++ b/mixle/experimental/__init__.py
@@ -42,6 +42,11 @@ Current contents:
   propagation over evicted tokens (the fast-multipole-method structure), a tree-path positional
   encoding replacing RoPE for the far field, a predict-the-summary auxiliary loss, and a receipted
   stop-gradient horizon. See ``notes/designs/E4.md`` for the design.
+- :mod:`mixle.experimental.e_process` -- P9, anytime-valid receipts: :class:`~mixle.experimental.e_process.EProcess`
+  (the generic running-product e-process from per-step density ratios) and the closed-form Robbins
+  :func:`~mixle.experimental.e_process.normal_mixture_eprocess` / :class:`~mixle.experimental.e_process.MeanShiftDetector`
+  for drift. Because a mixle density ratio is an e-value, monitoring ``E_t >= 1/alpha`` gives type-I control
+  under continuous peeking and optional stopping (Ville's inequality) -- verified empirically in the test.
 
 Tests for code under here are tagged ``@pytest.mark.experimental`` (see ``pyproject.toml``) so they can be
 run and reported on distinctly from the stable-package suite.

--- a/mixle/experimental/e_process.py
+++ b/mixle/experimental/e_process.py
@@ -1,0 +1,176 @@
+"""P9 (experimental) -- anytime-valid receipts via e-processes.
+
+Conformal/coverage receipts are fixed-sample, but much of mixle streams: streaming EM, drift
+monitoring, training curves, the evolution loop's champion/challenger gate. A fixed-sample test
+that you *peek at* every step spends its error budget silently -- after enough peeks a level-alpha
+test rejects a true null with probability far above alpha.
+
+E-processes fix this. An **e-value** is a non-negative statistic with expectation <= 1 under the
+null; an **e-process** ``(E_t)`` is a sequence of them that forms a non-negative supermartingale
+under the null with ``E_0 = 1``. Ville's inequality then gives, for the whole trajectory at once,
+
+    P_null( sup_t  E_t  >=  1/alpha )  <=  alpha.
+
+So the rule "reject the first time ``E_t >= 1/alpha``" controls the type-I error at ``alpha``
+*no matter when you look or when you stop* -- continuous monitoring and optional stopping are
+free, with no alpha-spending bookkeeping.
+
+Why this is native to mixle: a likelihood ratio ``q(x)/p(x)`` between two densities is exactly an
+e-value when ``p`` is the null (``E_null[q(X)/p(X)] = integral q = 1``), so a running product of
+mixle density ratios IS an e-process. This module provides:
+
+* :class:`EProcess` -- the generic running-product e-process from per-step log density ratios,
+  with the ``E_t >= 1/alpha`` stopping rule and the anytime-valid guarantee;
+* :func:`normal_mixture_eprocess` / :class:`MeanShiftDetector` -- the closed-form Robbins
+  normal-mixture e-process for detecting a mean shift of unknown size, and a drift detector built
+  on it.
+
+This is exploratory ``mixle.experimental`` code (see the P9 card): its graduation receipt is the
+empirically-verified anytime type-I control in ``e_process_test.py``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+
+
+class EProcess:
+    """A generic e-process: the running product of per-step density ratios ``q/p``.
+
+    Feed it, one observation at a time, the log density under the alternative and under the null
+    (or their difference directly). Under the null, ``e_value`` is a non-negative martingale with
+    mean 1, so the stopping rule :meth:`rejects` controls type-I error at any stopping time.
+    """
+
+    def __init__(self) -> None:
+        self._log_e = 0.0  # log E_0 = 0, i.e. E_0 = 1
+        self._peak_log_e = 0.0
+        self._t = 0
+
+    def update(self, log_ratio: float) -> float:
+        """Multiply in one factor ``exp(log_ratio) = q(x_t)/p(x_t)``; return the new ``e_value``."""
+        self._log_e += float(log_ratio)
+        self._t += 1
+        if self._log_e > self._peak_log_e:
+            self._peak_log_e = self._log_e
+        return self.e_value
+
+    def update_densities(self, log_alt: float, log_null: float) -> float:
+        """Update from separate alternative/null log-densities of the current observation."""
+        return self.update(log_alt - log_null)
+
+    @property
+    def e_value(self) -> float:
+        return float(np.exp(self._log_e))
+
+    @property
+    def log_e_value(self) -> float:
+        return float(self._log_e)
+
+    @property
+    def n(self) -> int:
+        return self._t
+
+    def rejects(self, alpha: float = 0.05) -> bool:
+        """Whether the CURRENT e-value clears the ``1/alpha`` threshold (an anytime-valid reject)."""
+        return bool(self._log_e >= -np.log(alpha))
+
+    def ever_rejected(self, alpha: float = 0.05) -> bool:
+        """Whether the e-process has crossed ``1/alpha`` at any point so far (peeking-safe)."""
+        return bool(self._peak_log_e >= -np.log(alpha))
+
+    def receipt(self, alpha: float = 0.05) -> dict[str, Any]:
+        """A small anytime-valid receipt: current/peak e-value, n, and the reject decision."""
+        return {
+            "e_value": self.e_value,
+            "peak_e_value": float(np.exp(self._peak_log_e)),
+            "n": self._t,
+            "alpha": float(alpha),
+            "threshold": float(1.0 / alpha),
+            "rejected": self.ever_rejected(alpha),
+            "guarantee": "anytime-valid: P_null(ever reject) <= alpha by Ville's inequality",
+        }
+
+
+def normal_mixture_log_e(sum_centered: float, t: int, *, sigma: float, tau: float) -> float:
+    """Log of the Robbins two-sided normal-mixture e-value for a Gaussian mean shift.
+
+    Tests ``H0: mean == mu0`` for a stream of ``N(mean, sigma^2)`` observations, mixing the
+    alternative mean over a ``N(mu0, tau^2)`` prior (so an unknown-size shift is covered without
+    choosing it in advance). ``sum_centered = sum_i (x_i - mu0)`` over the ``t`` observations.
+
+    Closed form (a non-negative martingale under H0 with value 1 at t=0)::
+
+        E_t = sqrt( s2 / (s2 + t*T2) ) * exp( T2 * S^2 / (2*s2*(s2 + t*T2)) )
+
+    with ``s2 = sigma^2``, ``T2 = tau^2``, ``S = sum_centered``.
+    """
+    if t == 0:
+        return 0.0
+    s2 = float(sigma) ** 2
+    tau2 = float(tau) ** 2
+    denom = s2 + t * tau2
+    log_e = 0.5 * np.log(s2 / denom) + (tau2 * sum_centered**2) / (2.0 * s2 * denom)
+    return float(log_e)
+
+
+def normal_mixture_eprocess(stream: Any, *, mu0: float, sigma: float, tau: float) -> np.ndarray:
+    """Return the running e-values of the Robbins normal-mixture e-process over ``stream``.
+
+    ``result[i]`` is ``E_{i+1}`` after seeing ``stream[:i+1]``. Element 0 corresponds to one
+    observation; the process starts at ``E_0 = 1`` implicitly.
+    """
+    xs = np.asarray(list(stream), dtype=float)
+    centered = np.cumsum(xs - float(mu0))
+    ts = np.arange(1, len(xs) + 1)
+    s2 = float(sigma) ** 2
+    tau2 = float(tau) ** 2
+    denom = s2 + ts * tau2
+    log_e = 0.5 * np.log(s2 / denom) + (tau2 * centered**2) / (2.0 * s2 * denom)
+    return np.exp(log_e)
+
+
+@dataclass
+class DriftReport:
+    """Outcome of a drift scan: whether/when the e-process crossed ``1/alpha``."""
+
+    detected: bool
+    detection_time: int | None  # 1-indexed observation count at first crossing, else None
+    alpha: float
+    peak_e_value: float
+    final_e_value: float
+    guarantee: str = field(default="anytime-valid: false-alarm probability <= alpha under the null (Ville)")
+
+
+class MeanShiftDetector:
+    """An anytime-valid detector for a shift in a Gaussian stream's mean, built on the e-process.
+
+    The null is ``mean == mu0`` with known ``sigma``; ``tau`` sets the scale of shifts the mixture
+    is most sensitive to. Because it is an e-process, you may test after every observation and stop
+    whenever it fires; the false-alarm probability over the whole run is still at most ``alpha``.
+    """
+
+    def __init__(self, *, mu0: float, sigma: float, tau: float = 1.0, alpha: float = 0.05) -> None:
+        self.mu0 = float(mu0)
+        self.sigma = float(sigma)
+        self.tau = float(tau)
+        self.alpha = float(alpha)
+
+    def scan(self, stream: Any) -> DriftReport:
+        e_values = normal_mixture_eprocess(stream, mu0=self.mu0, sigma=self.sigma, tau=self.tau)
+        if e_values.size == 0:
+            return DriftReport(False, None, self.alpha, 1.0, 1.0)
+        threshold = 1.0 / self.alpha
+        crossings = np.flatnonzero(e_values >= threshold)
+        detected = bool(crossings.size > 0)
+        detection_time = int(crossings[0] + 1) if detected else None
+        return DriftReport(
+            detected=detected,
+            detection_time=detection_time,
+            alpha=self.alpha,
+            peak_e_value=float(np.max(e_values)),
+            final_e_value=float(e_values[-1]),
+        )

--- a/mixle/tests/conftest.py
+++ b/mixle/tests/conftest.py
@@ -296,6 +296,9 @@ FILE_MARKERS: dict[str, MarkerTuple] = {
     # GP-surrogate active-learning + multi-fidelity placement (roadmap M4): each test fits several torch
     # GPs across a sequential design loop, mirroring doe_active_test.py / doe_multifidelity_test.py.
     "task_emulate_test.py": ("doe", "torch", "slow"),
+    # P9 e-processes (mixle/experimental/e_process.py): the anytime type-I control receipt runs several
+    # hundred vectorized null/drift replications with continuous peeking -- pure numpy, stochastic, no torch.
+    "e_process_test.py": ("experimental", "stochastic"),
 }
 
 

--- a/mixle/tests/e_process_test.py
+++ b/mixle/tests/e_process_test.py
@@ -1,0 +1,135 @@
+"""P9 (experimental) -- e-processes give anytime-valid receipts.
+
+The graduation receipt for the e-process mechanism is empirical anytime type-I control: under
+the null, continuously peeking and rejecting the first time ``E_t >= 1/alpha`` must fire with
+probability at most ``alpha`` -- the guarantee Ville's inequality promises. These tests verify
+that, contrast it with a naively-peeked fixed-sample test (which blows its error budget), and
+confirm the detector has power against a real mean shift.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from mixle.experimental.e_process import (
+    EProcess,
+    MeanShiftDetector,
+    normal_mixture_eprocess,
+)
+
+
+def _stream(rng, *, n, mean, sigma):
+    return rng.normal(mean, sigma, size=n)
+
+
+def test_eprocess_null_behavior_is_a_valid_e_value() -> None:
+    """Under H0, E_t is right-skewed with a fixed-time Ville bound -- the e-value hallmark.
+
+    We do NOT test the sample mean: with tau=1 the mixture e-value has infinite variance, so its
+    empirical mean is meaningless. The robust, defining signatures are: most trajectories sit below
+    1 (right skew, since the mean is pinned at 1), and at any FIXED time P(E_t >= 1/alpha) <= alpha.
+    """
+    sigma, tau, mu0, t, alpha = 1.0, 1.0, 0.0, 50, 0.1
+    reps = 800
+    finals = np.empty(reps)
+    for i in range(reps):
+        rng = np.random.default_rng(1000 + i)
+        e = normal_mixture_eprocess(_stream(rng, n=t, mean=mu0, sigma=sigma), mu0=mu0, sigma=sigma, tau=tau)
+        finals[i] = e[-1]
+    assert np.median(finals) < 1.0, "under H0 the e-value should be right-skewed (median < 1)"
+    fixed_time_reject = np.mean(finals >= 1.0 / alpha)
+    assert fixed_time_reject <= alpha + 0.03, (
+        f"fixed-time P(E_t >= 1/alpha) = {fixed_time_reject:.3f} exceeds alpha={alpha}"
+    )
+
+
+def test_anytime_type_I_control_under_continuous_peeking() -> None:
+    """Rejecting the first time E_t >= 1/alpha must fire <= alpha of the time under H0."""
+    alpha, sigma, tau, mu0, T = 0.1, 1.0, 1.0, 0.0, 400
+    reps = 500
+    false_alarms = 0
+    for i in range(reps):
+        rng = np.random.default_rng(7000 + i)
+        report = MeanShiftDetector(mu0=mu0, sigma=sigma, tau=tau, alpha=alpha).scan(
+            _stream(rng, n=T, mean=mu0, sigma=sigma)
+        )
+        false_alarms += int(report.detected)  # detected == ever crossed 1/alpha over the whole run
+    rate = false_alarms / reps
+    # Ville bounds this by alpha for the ENTIRE trajectory; empirically it sits below alpha.
+    assert rate <= alpha + 0.03, f"anytime false-alarm rate {rate:.3f} exceeds alpha={alpha}"
+
+
+def test_naive_peeked_fixed_test_inflates_but_eprocess_does_not() -> None:
+    """A fixed-sample z-test peeked every step blows past alpha; the e-process stays valid."""
+    alpha, sigma, mu0, T = 0.1, 1.0, 0.0, 400
+    reps = 400
+    z_crit = 1.959963984540054  # two-sided per-look 0.05 critical value -- but we peek every step
+    naive_false = 0
+    eproc_false = 0
+    for i in range(reps):
+        rng = np.random.default_rng(4200 + i)
+        xs = _stream(rng, n=T, mean=mu0, sigma=sigma)
+        # naive: after each observation, z-test the running mean; reject if it EVER crosses.
+        csum = np.cumsum(xs - mu0)
+        ns = np.arange(1, T + 1)
+        z = csum / (sigma * np.sqrt(ns))
+        naive_false += int(np.any(np.abs(z) > z_crit))
+        # e-process on the same stream at the same alpha.
+        e = normal_mixture_eprocess(xs, mu0=mu0, sigma=sigma, tau=1.0)
+        eproc_false += int(np.any(e >= 1.0 / alpha))
+    naive_rate = naive_false / reps
+    eproc_rate = eproc_false / reps
+    # The continuously-peeked fixed test spends far more than its nominal error budget...
+    assert naive_rate > 0.30, f"expected the peeked fixed test to inflate; got {naive_rate:.3f}"
+    # ...while the e-process holds its anytime guarantee.
+    assert eproc_rate <= alpha + 0.03, f"e-process inflated to {eproc_rate:.3f}"
+    assert eproc_rate < naive_rate, "the whole point: the e-process is far tighter under peeking"
+
+
+def test_detects_a_real_mean_shift_with_power() -> None:
+    """Under a genuine shift, the e-process crosses the threshold with high probability."""
+    alpha, sigma, tau, mu0, T = 0.1, 1.0, 1.0, 0.0, 200
+    shift = 0.7  # a moderate, not-obvious shift
+    reps = 300
+    detections = 0
+    delays = []
+    for i in range(reps):
+        rng = np.random.default_rng(9100 + i)
+        report = MeanShiftDetector(mu0=mu0, sigma=sigma, tau=tau, alpha=alpha).scan(
+            _stream(rng, n=T, mean=mu0 + shift, sigma=sigma)
+        )
+        if report.detected:
+            detections += 1
+            delays.append(report.detection_time)
+    power = detections / reps
+    assert power >= 0.8, f"power against a {shift}-sigma shift was only {power:.2f}"
+    assert np.median(delays) < T, "median detection happened before the stream ended"
+
+
+def test_generic_eprocess_reject_rule_and_receipt() -> None:
+    """The generic EProcess multiplies ratios and rejects at 1/alpha, peeking-safe."""
+    e = EProcess()
+    # Feed constant log-ratio 0.2 per step; after k steps log_e = 0.2k, e = exp(0.2k).
+    for _ in range(20):
+        e.update(0.2)
+    assert e.n == 20
+    assert np.isclose(e.log_e_value, 4.0)
+    assert e.rejects(alpha=0.05)  # exp(4) = 54.6 >= 1/0.05 = 20
+    # A process that spikes then decays must still report the peak crossing (peeking-safe).
+    e2 = EProcess()
+    for lr in [3.5, -3.0, -3.0]:  # crosses 1/0.05 at step 1 (e=33), then decays
+        e2.update(lr)
+    assert not e2.rejects(alpha=0.05), "current e-value has decayed below threshold"
+    assert e2.ever_rejected(alpha=0.05), "but the peak crossed -- an anytime reject already happened"
+    rec = e2.receipt(alpha=0.05)
+    assert rec["rejected"] is True and rec["threshold"] == 20.0
+
+
+def test_determinism_given_seed() -> None:
+    xs = np.random.default_rng(123).normal(0.3, 1.0, size=100)
+    a = normal_mixture_eprocess(xs, mu0=0.0, sigma=1.0, tau=1.0)
+    b = normal_mixture_eprocess(xs, mu0=0.0, sigma=1.0, tau=1.0)
+    assert np.array_equal(a, b)
+    r1 = MeanShiftDetector(mu0=0.0, sigma=1.0, tau=1.0, alpha=0.05).scan(xs)
+    r2 = MeanShiftDetector(mu0=0.0, sigma=1.0, tau=1.0, alpha=0.05).scan(xs)
+    assert r1 == r2


### PR DESCRIPTION
## Standout roadmap P9 — Anytime-valid receipts (e-processes) [★★]

Fixed-sample conformal/coverage receipts break under peeking: a level-α test you look at every step rejects a true null far more than α. Much of mixle *streams* (streaming EM, drift, training curves, the evolution gate), so it needs receipts that survive continuous monitoring. **E-processes** provide exactly that.

An e-value has expectation ≤ 1 under the null; an e-process `(E_t)` is a non-negative supermartingale with `E_0 = 1`, so Ville's inequality gives
`P_null( sup_t E_t ≥ 1/α ) ≤ α` — reject the first time `E_t ≥ 1/α` and type-I error is controlled **at any stopping time**. And a mixle density ratio `q/p` *is* an e-value (`E_null[q(X)/p(X)] = ∫q = 1`), so this is native, no new machinery.

### What's added (`mixle/experimental/e_process.py`)
- **`EProcess`** — generic running-product e-process from per-step log density ratios; `update`, `rejects(α)`, peeking-safe `ever_rejected(α)`, and a `receipt`.
- **`normal_mixture_eprocess` / `MeanShiftDetector`** — the closed-form Robbins two-sided normal-mixture e-process for a Gaussian mean shift of unknown size (mixes the alternative mean over a `N(μ0, τ²)` prior), and a drift detector on it.

### Graduation receipt (`e_process_test.py`, 6 tests)
- **Anytime type-I control** — over 500 null replications with continuous peeking, false-alarm ≤ α (empirical Ville).
- **Contrast** — a fixed z-test peeked every step inflates past 0.30; the e-process stays ≤ α. (P9 experiment a's point.)
- **Valid e-value hallmark** — right-skew + fixed-time Ville bound (the object has *infinite variance* by design, so the sample mean is deliberately not asserted).
- **Power** — detects a 0.7σ shift with ≥ 0.8 power at finite delay.
- Determinism; generic reject-rule/receipt correctness.

Placed under `mixle.experimental` per the roadmap's own Q1 freeze classification (P track = experimental-during-freeze; no stability claims). Pure numpy, no torch; marked `experimental`+`stochastic`.

**Verification:** `pytest -m experimental mixle/tests/e_process_test.py` → 6 passed (~2s). `ruff` clean.