### PR TITLE
test: restore the fast gate (36m38s -> 3m14s, zero tests deleted)

### DIFF
--- a/mixle/tests/checkpoint_family_ladder_test.py
+++ b/mixle/tests/checkpoint_family_ladder_test.py
@@ -23,8 +23,6 @@ from mixle.models.eval_harness import markov_transition_matrix
 from mixle.models.transformer import build_causal_lm
 from mixle.task.checkpoint_family_ladder import RungSpec, build_checkpoint_family, count_params
 
-pytestmark = pytest.mark.fast
-
 
 def _train_headline_model(
     seed: int, vocab: int, d_model: int, n_layer: int, n_head: int, block: int, steps: int = 8000

--- a/mixle/tests/coarsening_test.py
+++ b/mixle/tests/coarsening_test.py
@@ -27,8 +27,6 @@ from mixle.models.coarsening import (
 from mixle.models.moment_propagation import GaussianLaw
 from mixle.models.transformer import build_causal_lm
 
-pytestmark = pytest.mark.fast
-
 
 def _random_law(rng: np.random.Generator, d: int, scale: float = 0.5) -> GaussianLaw:
     mu = rng.normal(size=d) * 0.1

--- a/mixle/tests/compress_test.py
+++ b/mixle/tests/compress_test.py
@@ -21,8 +21,6 @@ torch = pytest.importorskip("torch")
 from mixle.models.compress import METHODS, compress
 from mixle.models.transformer import build_causal_lm
 
-pytestmark = pytest.mark.fast
-
 
 def _scale_weights_(model, factor: float) -> None:
     """In-place scale every Block's weight (not bias/embedding) parameters -- used to synthesize

--- a/mixle/tests/conftest.py
+++ b/mixle/tests/conftest.py
@@ -91,7 +91,7 @@ FILE_MARKERS: dict[str, MarkerTuple] = {
     "ppl_inference_test.py": ("ppl", "stochastic", "slow"),
     "ppl_new_distributions_test.py": ("ppl", "stochastic"),
     "ppl_predictive_test.py": ("ppl", "stochastic"),
-    "ppl_survival_test.py": ("ppl", "stochastic"),
+    "ppl_survival_test.py": ("ppl", "stochastic", "slow"),  # +slow 2026-07-11: 16s censored-Weibull recovery
     "ppl_summarize_test.py": ("ppl", "stochastic"),
     "ppl_leaf_families_test.py": ("ppl", "stochastic", "slow"),
     "ppl_vector_params_test.py": ("ppl", "stochastic", "slow"),
@@ -159,7 +159,7 @@ FILE_MARKERS: dict[str, MarkerTuple] = {
     "lookback_lag0_test.py": ("hmm",),
     "marginal_seek_test.py": ("enumeration",),
     "model_helpers_test.py": ("latent", "graph", "pomdp", "knowledge_graph", "causal", "grammar"),
-    "mcmc_test.py": ("stochastic",),
+    "mcmc_test.py": ("stochastic", "slow"),  # +slow 2026-07-11: 9s HMC-vs-MH posterior agreement
     "responsibility_attention_test.py": ("distribution", "latent", "stochastic"),
     "chained_attention_test.py": ("distribution", "latent", "stochastic", "slow"),
     "variational_multihop_attention_test.py": ("distribution", "latent", "stochastic", "slow"),
@@ -205,8 +205,9 @@ FILE_MARKERS: dict[str, MarkerTuple] = {
     "parallel_test.py": ("parallel", "integration", "slow"),
     "placement_test.py": ("parallel", "planner"),
     "model_decomposition_test.py": ("parallel", "planner"),
-    "model_parallel_test.py": ("parallel", "planner"),
-    "ppl_separation_test.py": ("ppl",),
+    # +slow 2026-07-11: two MPI data+model-parallel composition tests at ~42-44s each were in the fast gate.
+    "model_parallel_test.py": ("parallel", "planner", "slow"),
+    "ppl_separation_test.py": ("ppl", "slow"),  # +slow 2026-07-11: 14s import-graph walk
     "random_graph_models_test.py": ("graph",),
     "quantized_hmm_test.py": ("hmm", "integration", "slow"),
     "quantized_triangular_hmm_test.py": ("hmm", "enumeration", "integration", "slow"),
@@ -345,6 +346,71 @@ FILE_MARKERS: dict[str, MarkerTuple] = {
     # P9 e-processes (mixle/experimental/e_process.py): the anytime type-I control receipt runs several
     # hundred vectorized null/drift replications with continuous peeking -- pure numpy, stochastic, no torch.
     "e_process_test.py": ("experimental", "stochastic"),
+    # Roadmap acceptance-receipt files landed untriaged (profiled 2026-07-11 via `pytest -m fast
+    # --durations=60`: the fast gate had regressed to 36m38s wall; single calls up to 870s and one
+    # 1027s setUpClass). Each trains real models / runs real chaos-recovery or measured-speedup
+    # receipts -- legitimately heavy, so they move to the full gate rather than being shrunk.
+    "balance_test.py": ("parallel", "integration", "slow"),
+    "checkpoint_family_ladder_test.py": ("torch", "integration", "slow"),
+    "condition_test.py": ("stochastic", "slow"),
+    "conditional_jit_controller_test.py": ("torch", "integration", "slow"),
+    "deploy_family_test.py": ("integration", "slow"),
+    "deprecation_test.py": ("integration", "slow"),
+    "doe_stability2_test.py": ("doe", "stochastic", "slow"),
+    "energy_test.py": ("torch", "stochastic", "slow"),
+    "eval_harness_test.py": ("torch", "integration", "slow"),
+    "heterogeneous_executor_test.py": ("parallel", "integration", "slow"),
+    "hvis_goals_test.py": ("hvis", "integration", "slow"),
+    "inverse_test.py": ("stochastic", "slow"),
+    "kv_cache_quant_test.py": ("torch", "integration", "slow"),
+    "language_model_dense_fit_test.py": ("torch", "integration", "slow"),
+    "memory_efficient_training_test.py": ("torch", "integration", "slow"),
+    "mixture_density_test.py": ("torch", "integration", "slow"),
+    "mpi_route_equivalence_test.py": ("parallel", "integration", "slow"),
+    "mup_test.py": ("torch", "integration", "slow"),
+    "neural_density_test.py": ("torch", "integration", "slow"),
+    "ppl_density_test.py": ("ppl", "stochastic", "slow"),
+    "projection_leaf_test.py": ("torch", "integration", "slow"),
+    "provenance_replay_test.py": ("serialization", "integration", "slow"),
+    "qat_test.py": ("torch", "integration", "slow"),
+    "repro_bundle_test.py": ("integration", "slow"),
+    "resilient_em_test.py": ("parallel", "integration", "slow"),
+    "route_explainability_test.py": ("stochastic", "slow"),
+    "rvine_copula_test.py": ("distribution", "stochastic", "slow"),
+    "scaled_embedding_test.py": ("torch", "slow"),
+    "scaling_laws_test.py": ("doe", "stochastic", "slow"),
+    "scenario_test.py": ("stochastic", "slow"),
+    "sdc_audit_test.py": ("parallel", "integration", "slow"),
+    "self_distillation_test.py": ("torch", "integration", "slow"),
+    "sparsity_2_4_test.py": ("torch", "integration", "slow"),
+    "structure_edit_schedule_test.py": ("integration", "slow"),
+    "task_solve_test.py": ("integration", "slow"),
+    "torch_parity_test.py": ("torch", "integration", "slow"),
+    # Second retriage pass (same 2026-07-11 profiling, after the first pass cut the gate 36m38s ->
+    # 5m34s): the remaining >=5s-per-call files, plus the heavy files that had been self-marked
+    # `fast` at module level (now stripped -- see the policy note in pytest_collection_modifyitems).
+    "automatic_copula_structure_test.py": ("automatic", "distribution", "slow"),
+    "automatic_vine_core_test.py": ("automatic", "distribution", "slow"),
+    "compress_test.py": ("integration", "slow"),
+    "distill_methods_test.py": ("torch", "integration", "slow"),
+    "doe_amplify_test.py": ("doe", "stochastic", "slow"),
+    "duplicate_body_scan_test.py": ("integration", "slow"),
+    "frontier_family_showcase_smoke_test.py": ("torch", "integration", "slow"),
+    "geoscience_inversion_report_test.py": ("integration", "slow"),
+    "hmm_steady_state_test.py": ("hmm", "slow"),
+    "moe_test.py": ("torch", "integration", "slow"),
+    "multi_field_test.py": ("integration", "slow"),
+    "neural_composition_grid_test.py": ("torch", "integration", "slow"),
+    "ppl_model_comparison_test.py": ("ppl", "stochastic", "slow"),
+    "ppl_regression_test.py": ("ppl", "stochastic", "slow"),
+    "product_energy_net_test.py": ("torch", "slow"),
+    "quantization_test.py": ("integration", "slow"),
+    "random_forest_leaf_test.py": ("integration", "slow"),
+    "ranking_lazy_enumerator_test.py": ("enumeration", "slow"),
+    "real_receipt_banking77_smoke_test.py": ("integration", "slow"),
+    "reproduce_receipt_test.py": ("integration", "slow"),
+    "sorted_profile_quantizer_test.py": ("integration", "slow"),
+    "task_quantize_test.py": ("integration", "slow"),
 }
 
 
@@ -362,6 +428,24 @@ NODEID_MARKERS: tuple[tuple[str, MarkerTuple], ...] = (
     # proxy) to get an honest, independent perplexity number -- multiple real training runs are the point,
     # so it's slow by construction; the rest of sigma_weighted_projection_test.py stays in the fast gate.
     ("DataFreeSigmaBeatsPlainSvdTest", ("slow",)),
+    # grad_leaf_test.py's minibatch-vs-full-batch optimum comparison runs two real fits (~28s); the rest
+    # of the file is subsecond unit coverage of the torch bridge and stays in the fast gate. (File-scoped
+    # token: a bare "MinibatchTest" would also catch NeuralCategoricalMinibatchTest by substring.)
+    ("grad_leaf_test.py::MinibatchTest", ("slow",)),
+    # data_layer_test.py's cold-import timing checks re-launch a fresh interpreter (~8s each); the rest
+    # of the file is subsecond and stays in the fast gate.
+    ("data_layer_test.py::ColdImportTest", ("slow",)),
+)
+
+
+# Classes whose setUpClass trains for minutes: under xdist's default `load` distribution their tests
+# scatter across workers and EACH worker re-runs the whole setup (unittest caches setUpClass per
+# process, not per suite). Pinning each class to one xdist group -- honored by `--dist loadgroup` in
+# addopts -- makes the expensive setup run once per suite instead of once per worker; ungrouped tests
+# keep the default load-balancing behavior.
+XDIST_GROUPS: tuple[tuple[str, str], ...] = (
+    ("qat_test.py::QATBeatsPTQTest", "qat-beats-ptq-setup"),  # ~17 min QAT-vs-PTQ training setup
+    ("deploy_family_test.py::DeployFamilyEndToEndTest", "deploy-family-setup"),  # ~95 s family build
 )
 
 
@@ -388,7 +472,18 @@ def pytest_collection_modifyitems(items) -> None:
             if token in item.nodeid:
                 _add_markers(item, marker_names, assigned)
 
-        if not {"slow", "optional", "benchmark"} & assigned:
+        for token, group in XDIST_GROUPS:
+            if token in item.nodeid:
+                item.add_marker(pytest.mark.xdist_group(name=group))
+
+        # Respect marks the test carries on its own (module pytestmark / decorators): a file that
+        # declares itself slow/optional must not be auto-promoted into the fast gate. The converse
+        # also holds as policy: files do NOT self-mark `fast` -- this registry is the single triage
+        # authority (a self-applied fast mark would defeat retriage: the item ends up with BOTH
+        # marks and `-m fast` still selects it, which is exactly how 20 heavy roadmap files kept a
+        # regressed 36-minute fast gate pinned in place).
+        existing = {mark.name for mark in item.iter_markers()}
+        if not {"slow", "optional", "benchmark"} & (assigned | existing):
             _add_markers(item, ("fast",), assigned)
 
 

--- a/mixle/tests/deploy_family_test.py
+++ b/mixle/tests/deploy_family_test.py
@@ -33,9 +33,6 @@ from mixle.task.frontier_to_native import (  # noqa: E402
     measure_cascade_receipt,
 )
 
-pytestmark = pytest.mark.fast
-
-
 # --- a small real (not random-init) headline causal LM, trained on F10's own four eval axes at
 # reduced steps -- enough to be measurably above chance without J2's own full 8000-step budget. -----
 

--- a/mixle/tests/dpo_and_registry_hardening_test.py
+++ b/mixle/tests/dpo_and_registry_hardening_test.py
@@ -13,9 +13,6 @@ import tempfile
 import numpy as np
 import pytest
 
-pytestmark = pytest.mark.fast
-
-
 # --------------------------------------------------------------------------- DPO weights
 
 

--- a/mixle/tests/experimental_scaffold_test.py
+++ b/mixle/tests/experimental_scaffold_test.py
@@ -5,8 +5,6 @@ import pytest
 import mixle.experimental as experimental
 from mixle.experimental.graduation import REGISTRY, ExperimentalMechanism
 
-pytestmark = pytest.mark.fast
-
 
 def test_experimental_package_imports():
     assert experimental.__doc__

--- a/mixle/tests/frontier_family_showcase_smoke_test.py
+++ b/mixle/tests/frontier_family_showcase_smoke_test.py
@@ -25,8 +25,6 @@ from mixle.task.checkpoint_family_ladder import RungSpec, build_checkpoint_famil
 from mixle.task.deploy_family import deploy_family  # noqa: E402
 from mixle.task.economics import CostModel  # noqa: E402
 
-pytestmark = pytest.mark.fast
-
 
 class FrontierFamilyShowcaseSmokeTest(unittest.TestCase):
     def test_lifecycle_receipt_at_reduced_scale(self):

--- a/mixle/tests/growth_operators_test.py
+++ b/mixle/tests/growth_operators_test.py
@@ -31,8 +31,6 @@ from mixle.experimental.growth_operators import (  # noqa: E402
 )
 from mixle.models.transformer import Block, build_causal_lm
 
-pytestmark = pytest.mark.fast
-
 
 class Net2NetWideningExactnessTest(unittest.TestCase):
     """Acceptance criterion: the real Net2Net duplication rule preserves the composed function exactly,

--- a/mixle/tests/moe_test.py
+++ b/mixle/tests/moe_test.py
@@ -106,7 +106,6 @@ class MatchedFlopsLossWinTest:
         )
 
 
-@pytest.mark.fast
 class ExpertCollapseReceiptTest:
     def _forced_merged_history(self, n_experts=4, rounds=6, n_tokens=64, seed=0):
         """Deliberately collapsed routing: nearly all mass on expert 0 every round (load-balance loss
@@ -178,7 +177,6 @@ class ExpertCollapseReceiptTest:
         assert receipt["merged"] is False, receipt["diagnosis"]
 
 
-@pytest.mark.fast
 class UpcyclingReceiptTest:
     def _trained_looking_dense(self, d_model=32, n_head=4, seed=0):
         torch.manual_seed(seed)

--- a/mixle/tests/moment_propagation_test.py
+++ b/mixle/tests/moment_propagation_test.py
@@ -28,8 +28,6 @@ from mixle.models.moment_propagation import (
 )
 from mixle.models.transformer import build_causal_lm
 
-pytestmark = pytest.mark.fast
-
 
 def _law(mu, covar) -> GaussianLaw:
     return GaussianLaw(mu=np.asarray(mu, dtype=float), covar=np.asarray(covar, dtype=float))

--- a/mixle/tests/mup_test.py
+++ b/mixle/tests/mup_test.py
@@ -130,7 +130,6 @@ def _bo_tune_log_lr(
 # --- 3. hand-checkable unit tests of the abc-parametrization formulas themselves -----------------
 
 
-@pytest.mark.fast
 def test_init_std_multiplier_matches_published_mup_formula():
     # input role: Theta(1), never rescaled.
     assert init_std_multiplier("input", width_mult=1.0) == pytest.approx(1.0)
@@ -145,7 +144,6 @@ def test_init_std_multiplier_matches_published_mup_formula():
     assert init_std_multiplier("output", width_mult=16.0) == pytest.approx(1.0 / 16.0)
 
 
-@pytest.mark.fast
 def test_lr_multiplier_matches_published_mup_formula():
     # input role: constant lr, never rescaled.
     assert lr_multiplier("input", width_mult=8.0) == pytest.approx(1.0)
@@ -155,13 +153,11 @@ def test_lr_multiplier_matches_published_mup_formula():
     assert lr_multiplier("output", width_mult=8.0) == pytest.approx(0.125)
 
 
-@pytest.mark.fast
 def test_output_forward_multiplier_matches_hidden_and_output_lr_scaling():
     assert output_forward_multiplier(width_mult=1.0) == pytest.approx(1.0)
     assert output_forward_multiplier(width_mult=4.0) == pytest.approx(0.25)
 
 
-@pytest.mark.fast
 def test_transfer_lr_and_transfer_init_std_apply_the_role_multiplier():
     # width doubles -> hidden lr predicted to halve; base_width==target_width -> identity.
     assert transfer_lr(1e-3, base_width=32, target_width=64) == pytest.approx(5e-4)
@@ -169,7 +165,6 @@ def test_transfer_lr_and_transfer_init_std_apply_the_role_multiplier():
     assert transfer_lr(1e-3, base_width=32, target_width=32, role="input") == pytest.approx(1e-3)
 
 
-@pytest.mark.fast
 def test_unknown_role_raises():
     with pytest.raises(ValueError):
         init_std_multiplier("bogus", width_mult=2.0)  # type: ignore[arg-type]
@@ -180,7 +175,6 @@ def test_unknown_role_raises():
 # --- classification / param-group unit tests (fast, no training) ---------------------------------
 
 
-@pytest.mark.fast
 def test_classify_causal_lm_params_assigns_expected_roles():
     model = build_causal_lm(vocab=VOCAB, d_model=16, n_layer=2, n_head=2, block=BLOCK)
     roles = classify_causal_lm_params(model)
@@ -200,7 +194,6 @@ def test_classify_causal_lm_params_assigns_expected_roles():
     assert model.head.weight is model.tok.weight
 
 
-@pytest.mark.fast
 def test_mup_param_groups_scale_lr_by_role():
     model = build_causal_lm(vocab=VOCAB, d_model=64, n_layer=2, n_head=2, block=BLOCK)
     groups = mup_param_groups(model, base_width=32, lr=1e-2)  # width_mult = 64/32 = 2
@@ -213,7 +206,6 @@ def test_mup_param_groups_scale_lr_by_role():
     assert len(grouped) == len(list(model.parameters()))
 
 
-@pytest.mark.fast
 def test_apply_mup_init_rescales_hidden_weight_std_with_width():
     torch.manual_seed(0)
     small = build_causal_lm(vocab=VOCAB, d_model=32, n_layer=2, n_head=2, block=BLOCK)

--- a/mixle/tests/neural_composition_grid_test.py
+++ b/mixle/tests/neural_composition_grid_test.py
@@ -32,8 +32,6 @@ from mixle.stats import (
 )
 from mixle.utils.serialization import from_json, to_json
 
-pytestmark = pytest.mark.fast
-
 
 def _unconditional_seqs(dim=2, n=30, seed=0):
     init = HiddenMarkovModelDistribution(

--- a/mixle/tests/neural_families_test.py
+++ b/mixle/tests/neural_families_test.py
@@ -22,8 +22,6 @@ from mixle.models import (
 from mixle.stats import MixtureDistribution, MultivariateGaussianDistribution
 from mixle.utils.serialization import from_json, to_json
 
-pytestmark = pytest.mark.fast
-
 
 def _data(n=64, d=4, seed=0):
     rng = np.random.RandomState(seed)

--- a/mixle/tests/reason_modality_test.py
+++ b/mixle/tests/reason_modality_test.py
@@ -6,13 +6,10 @@ reported as a measured accuracy gap, not assumed.
 """
 
 import numpy as np
-import pytest
 
 from mixle.inference import optimize
 from mixle.reason.modality import ModalityGraph, ModalityView
 from mixle.stats import CategoricalEstimator, GaussianDistribution, GaussianEstimator
-
-pytestmark = pytest.mark.fast
 
 N_CATS = 16
 _CONFUSE_P = 0.15  # a noisy report names a neighboring category instead of the true one

--- a/mixle/tests/self_distillation_test.py
+++ b/mixle/tests/self_distillation_test.py
@@ -29,9 +29,6 @@ from mixle.models.self_distillation import (
 )
 from mixle.models.transformer import build_causal_lm
 
-pytestmark = pytest.mark.fast
-
-
 # --------------------------------------------------------------------------------------------------------
 # shared synthetic-data helper: a small Markov-ish token stream, so there is real structure to learn
 # --------------------------------------------------------------------------------------------------------

--- a/mixle/tests/sparsity_2_4_test.py
+++ b/mixle/tests/sparsity_2_4_test.py
@@ -39,9 +39,6 @@ from mixle.models.sparsity_2_4 import (  # noqa: E402
 )
 from mixle.models.transformer import build_causal_lm  # noqa: E402
 
-pytestmark = pytest.mark.fast
-
-
 # --------------------------------------------------------------------------------------------------------
 # 1. mask ramp correctness
 # --------------------------------------------------------------------------------------------------------

--- a/mixle/tests/streaming_transformer_weights_test.py
+++ b/mixle/tests/streaming_transformer_weights_test.py
@@ -15,8 +15,6 @@ torch = pytest.importorskip("torch")
 from mixle.models.streaming_transformer_leaf import StreamingTransformerAccumulatorFactory
 from mixle.models.transformer import build_causal_lm
 
-pytestmark = pytest.mark.fast
-
 
 def _batch(V=12, block=8, n=6, seed=0):
     rng = np.random.RandomState(seed)

--- a/mixle/tests/structure_clone_isolation_test.py
+++ b/mixle/tests/structure_clone_isolation_test.py
@@ -11,8 +11,6 @@ import pytest
 
 from mixle.inference.structure import _clone
 
-pytestmark = pytest.mark.fast
-
 
 def test_clone_returns_an_independent_object_not_the_same_template():
     import mixle.stats as st

--- a/mixle/tests/tying_discovery_test.py
+++ b/mixle/tests/tying_discovery_test.py
@@ -20,8 +20,6 @@ from mixle.experimental.tying_discovery import (
 )
 from mixle.models.transformer import build_causal_lm
 
-pytestmark = pytest.mark.fast
-
 
 def test_profile_of_permuted_tensor_is_identical():
     """Sorting removes the arrangement: a permutation of a tensor has an IDENTICAL profile."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,13 +113,17 @@ testpaths = ["mixle/tests"]
 python_files = ["*_test.py"]
 python_classes = ["*Test", "*TestCase"]
 python_functions = ["test_*"]
-# Fast + parallel by default: plain `pytest` runs the `fast` gate under `-n auto` in ~25 s (vs ~2.5 min
-# for the whole suite). The heavy integration / PDE-inversion / stochastic-recovery tests are tagged
-# `slow` in conftest and excluded here; they still run in CI's full gate. A later `-m` on the command
-# line overrides this default, so the CI gates keep working:
+# Fast + parallel by default: plain `pytest` runs the `fast` gate under `-n auto` in a few minutes on a
+# laptop (re-measured 2026-07-11: ~3 min for ~4.8k tests; it had silently regressed to 36+ min before
+# the conftest registry retriage). Heavy integration / training / stochastic-recovery tests are tagged
+# `slow` in conftest and excluded here; they still run in CI's full gate. Files must NOT self-mark
+# `fast` -- the conftest registry is the single triage authority (see pytest_collection_modifyitems).
+# A later `-m` on the command line overrides this default, so the CI gates keep working:
 #   full correctness run : pytest -m "not optional and not benchmark"   (everything incl. slow)
 #   single file, serial  : pytest path/to/file_test.py -n0 -m ""        (-m "" clears the fast filter)
-addopts = "-ra --strict-markers -n auto -m fast"
+# --dist loadgroup honors the xdist_group marks conftest puts on minute-scale setUpClass classes
+# (the setup runs once per suite instead of once per worker); ungrouped tests keep plain load-balancing.
+addopts = "-ra --strict-markers -n auto --dist loadgroup -m fast"
 # Warning ownership (T3.3): a DeprecationWarning issued by mixle's OWN code during tests is promoted to an
 # error. A deprecation MUST be asserted with pytest.warns / assertWarns (which consumes it before this
 # filter sees it); a leaked one is a defect -- a deprecated path used somewhere it should not be, or a


### PR DESCRIPTION
## What this is

The fast gate (`pytest -m fast` — the default local run and CI's per-push feedback loop on
three OS jobs, none of which carry a timeout) had silently regressed from its designed
~1s/test budget to **36m38s** wall (measured `-n auto`, 12-core laptop, 2026-07-11). This PR
restores it to **3m14s** on the same machine with the same flags — **11.3×** — while running
**exactly the same set of tests overall**: 6,421 test methods before and after, zero deleted;
everything retriaged out of the fast gate still runs in CI's full gate (verified by
collect-only under the full-gate expression).

## Three interacting causes, three fixes

**1. Registry drift (data).** Dozens of roadmap acceptance-receipt files (QAT-vs-PTQ,
ConditionalJIT controller, checkpoint family ladder, muP transfer, SDC audit, resilient EM,
scaling laws, 2:4 sparsity, KV-cache quant, M0 conditioning, …) landed untriaged and defaulted
into the fast gate — single calls up to 870s and one 1027s `setUpClass`. ~60 files retriaged to
`slow` across two profiled passes (durations tables in the conftest comments' style: profiled,
then tagged). These tests train real models and run real chaos/measured-speedup receipts —
they are deliberately *not* shrunk, just moved to the lane built for them.

**2. Self-marking bypassed triage (mechanism).** 20 files carried their own
`pytestmark = pytest.mark.fast` (or per-test decorators). An item then ends up with **both**
`fast` and `slow` marks and `-m fast` selects it no matter what the registry says — which is
exactly how the first retriage pass appeared to "miss" four files. All self-applied `fast`
marks are removed and the policy is now written into the conftest: **the registry is the
single triage authority.** The auto-fast guard also now respects marks a file carries on its
own — previously a self-declared `optional` file could be auto-promoted into the gate
(`mpi_executor_test`'s 22s MPI test was riding along that way).

**3. Worker-duplicated setups (scheduling).** `unittest` caches `setUpClass` per *process*;
under xdist's default `load` distribution a minute-scale setup re-ran on every worker that
received one of the class's tests. A new `XDIST_GROUPS` table pins such classes to one worker
via `xdist_group` marks, honored by `--dist loadgroup` in addopts (ungrouped tests keep plain
load-balancing). `qat_test`'s ~17min setup and `deploy_family_test`'s ~95s setup now run once
per suite instead of once per worker.

## On "remove redundant tests"

An AST-level scan of all 6,421 test methods (exact-structure hashing, docstrings stripped,
plus an identifier-normalized clone pass) found **no removable redundancy**: the 9 groups of
textually identical tests are per-fixture template methods across different classes
(`TorchExtBase` pattern) — identical bodies, different distribution/engine under test.
Deleting any of them would drop real coverage (the full lane enforces `--cov-fail-under=45`).
Nothing was deleted on redundancy grounds; the scan is the receipt that the question was
asked and answered rather than skipped.

## Measurements

| state | fast-gate wall | tests in gate |
|-------|---------------:|--------------:|
| before | 36m38s | 5,327 (+3,863 subtests) |
| after pass 1 (registry) | 5m34s | 5,059 |
| after pass 2 (registry + self-mark removal + guard) | **3m14s** | 4,792 (+3,859 subtests) |

Same machine, same flags, similar background load. Worst remaining test: 10.5s. CI effect:
3 OS jobs × every push × ~33 saved minutes each, plus the coverage lane stops paying
worker-duplicated monster setups.

## Not done (deliberately)

- The remaining 5–10s stragglers (`backend_respecialization_test`,
  `automatic_modality_routing_test`, flagship smoke files — the latter also run as dedicated
  CI steps) — diminishing returns; listed for a follow-up pass.
- No shrinking of receipt tests (seed counts, training lengths): those sizes are the claims.
  Any future size reduction should argue per-claim that statistical power is preserved.
- The stale "~25s" promise in pyproject is replaced with the measured budget rather than
  re-promised.

## Worklist alignment

Test-infrastructure hygiene during the freeze (no product code touched): supports Q5.2's
stress-panel cadence (a usable fast gate) and G0.2's decisions-in-repo discipline (triage
policy now documented in conftest, not tribal knowledge).
