### PR TITLE
fix(hmm): normalize use_numba defaults to numba-when-installed (3.7x, bit-identical)

### DIFF
--- a/mixle/stats/latent/hidden_markov.py
+++ b/mixle/stats/latent/hidden_markov.py
@@ -2333,7 +2333,7 @@ class HiddenMarkovAccumulator(SequenceEncodableStatisticAccumulator):
         self,
         accumulators: Sequence[SequenceEncodableStatisticAccumulator],
         len_accumulator: SequenceEncodableStatisticAccumulator | None = NullAccumulator(),
-        use_numba: bool | None = False,
+        use_numba: bool | None = None,
         keys: tuple[str | None, str | None, str | None] = (None, None, None),
         name: str | None = None,
     ) -> None:
@@ -2372,7 +2372,7 @@ class HiddenMarkovAccumulator(SequenceEncodableStatisticAccumulator):
         self.trans_key = keys[1]
         self.state_key = keys[2]
 
-        self.use_numba = use_numba
+        self.use_numba = HAS_NUMBA if use_numba is None else use_numba
         self.name = name
 
         # Cached once (not per EM iteration); see HiddenMarkovModelDistribution.__init__.
@@ -3211,7 +3211,7 @@ class HiddenMarkovAccumulatorFactory(StatisticAccumulatorFactory):
         self,
         factories: Sequence[StatisticAccumulatorFactory],
         len_factory: StatisticAccumulatorFactory = NullAccumulatorFactory(),
-        use_numba: bool = False,
+        use_numba: bool | None = None,
         keys: tuple[str | None, str | None, str | None] | None = (None, None, None),
         name: str | None = None,
     ) -> None:
@@ -3228,7 +3228,7 @@ class HiddenMarkovAccumulatorFactory(StatisticAccumulatorFactory):
             name: Optional diagnostic name shared by generated accumulators.
         """
         self.factories = factories
-        self.use_numba = use_numba
+        self.use_numba = HAS_NUMBA if use_numba is None else use_numba
         self.keys = keys if keys is not None else (None, None, None)
         self.len_factory = len_factory
         self.name = name
@@ -3475,7 +3475,7 @@ class HiddenMarkovDataEncoder(DataSequenceEncoder):
         self,
         emission_encoder: DataSequenceEncoder,
         len_encoder: DataSequenceEncoder | None = NullDataEncoder(),
-        use_numba: bool = False,
+        use_numba: bool | None = None,
     ) -> None:
         """Create an encoder for HMM sequence observations and sequence lengths.
 
@@ -3493,7 +3493,7 @@ class HiddenMarkovDataEncoder(DataSequenceEncoder):
         """
         self.emission_encoder = emission_encoder
         self.len_encoder = len_encoder if len_encoder is not None else NullDataEncoder()
-        self.use_numba = use_numba
+        self.use_numba = HAS_NUMBA if use_numba is None else use_numba
 
     def __str__(self) -> str:
         """Return a readable encoder summary."""

--- a/mixle/stats/latent/integer_hidden_association.py
+++ b/mixle/stats/latent/integer_hidden_association.py
@@ -70,7 +70,7 @@ class IntegerHiddenAssociationDistribution(SequenceEncodableProbabilityDistribut
         len_dist: SequenceEncodableProbabilityDistribution | None = NullDistribution(),
         name: str | None = None,
         keys: tuple[str | None, str | None] = (None, None),
-        use_numba: bool = False,
+        use_numba: bool | None = None,
     ) -> None:
         """Create an integer hidden association distribution.
 
@@ -112,7 +112,7 @@ class IntegerHiddenAssociationDistribution(SequenceEncodableProbabilityDistribut
         self.name = name
         self.keys = keys
         self.init_prob_vec = np.empty(0, dtype=np.float64)
-        self.use_numba = use_numba
+        self.use_numba = HAS_NUMBA if use_numba is None else use_numba
 
     def compute_capabilities(self):
         """Return backend capability metadata for this concrete integer association model."""
@@ -527,7 +527,7 @@ class IntegerHiddenAssociationAccumulator(SequenceEncodableStatisticAccumulator)
         num_states: int,
         prev_acc: SequenceEncodableStatisticAccumulator | None = NullAccumulator(),
         size_acc: SequenceEncodableStatisticAccumulator | None = NullAccumulator(),
-        use_numba: bool = False,
+        use_numba: bool | None = None,
         keys: tuple[str | None, str | None] | None = (None, None),
     ) -> None:
         """Create an accumulator for integer hidden-association sufficient statistics.
@@ -538,7 +538,8 @@ class IntegerHiddenAssociationAccumulator(SequenceEncodableStatisticAccumulator)
             num_states (int): Number of hidden states.
             prev_acc (Optional[SequenceEncodableStatisticAccumulator]): Accumulator for the previous word set.
             size_acc (Optional[SequenceEncodableStatisticAccumulator]): Accumulator for the emission count.
-            use_numba (bool): If True, numba encodings are used for vectorized updates.
+            use_numba (Optional[bool]): Whether numba encodings are used for vectorized updates.
+                ``None`` (default) selects the compiled path when numba is installed.
             keys (Optional[Tuple[Optional[str], Optional[str]]]): Keys for the weight and state counts.
 
         Attributes:
@@ -550,7 +551,8 @@ class IntegerHiddenAssociationAccumulator(SequenceEncodableStatisticAccumulator)
             num_vals1 (int): Number of words in S1.
             num_vals2 (int): Number of words in S2.
             num_states (int): Number of hidden states.
-            use_numba (bool): If True, numba encodings are used for vectorized updates.
+            use_numba (Optional[bool]): Whether numba encodings are used for vectorized updates.
+                ``None`` (default) selects the compiled path when numba is installed.
             weight_key (Optional[str]): Key for merging weight counts.
             state_key (Optional[str]): Key for merging state counts.
 
@@ -563,7 +565,7 @@ class IntegerHiddenAssociationAccumulator(SequenceEncodableStatisticAccumulator)
         self.num_vals1 = num_vals1
         self.num_vals2 = num_vals2
         self.num_states = num_states
-        self.use_numba = use_numba
+        self.use_numba = HAS_NUMBA if use_numba is None else use_numba
         self.weight_key, self.state_key = keys if keys is not None else (None, None)
 
         # Data log-likelihood accumulated as a byproduct of the E-step (the per-observation log_density),
@@ -994,7 +996,7 @@ class IntegerHiddenAssociationAccumulatorFactory(StatisticAccumulatorFactory):
         num_states: int,
         prev_factory: StatisticAccumulatorFactory | None = NullAccumulatorFactory(),
         len_factory: StatisticAccumulatorFactory | None = NullAccumulatorFactory(),
-        use_numba: bool = False,
+        use_numba: bool | None = None,
         keys: tuple[str | None, str | None] = (None, None),
     ) -> None:
         """Create an accumulator factory.
@@ -1021,7 +1023,7 @@ class IntegerHiddenAssociationAccumulatorFactory(StatisticAccumulatorFactory):
         self.len_factory = len_factory if len_factory is not None else NullAccumulatorFactory()
         self.prev_factory = prev_factory if prev_factory is not None else NullAccumulatorFactory()
         self.keys = keys
-        self.use_numba = use_numba
+        self.use_numba = HAS_NUMBA if use_numba is None else use_numba
         self.num_vals1 = num_vals1
         self.num_vals2 = num_vals2
         self.num_states = num_states

--- a/mixle/stats/latent/quantized_hidden_markov_model.py
+++ b/mixle/stats/latent/quantized_hidden_markov_model.py
@@ -431,7 +431,7 @@ class QuantizedHiddenMarkovModelDistribution(HiddenMarkovModelDistribution):
         len_dist: SequenceEncodableProbabilityDistribution | None = NullDistribution(),
         name: str | None = None,
         terminal_values: set | None = None,
-        use_numba: bool = False,
+        use_numba: bool | None = None,
         terminal_states: set[int] | Sequence[int] | None = None,
     ) -> None:
         """QuantizedHiddenMarkovModelDistribution: an HMM whose probabilities are powers of theta.
@@ -459,7 +459,8 @@ class QuantizedHiddenMarkovModelDistribution(HiddenMarkovModelDistribution):
                 on non-negative integers for the sequence lengths.
             name (Optional[str]): Optional distribution name.
             terminal_values (Optional[set]): Define terminating emission outputs of the HMM.
-            use_numba (bool): If True, use numba package for encoding and vectorized operations.
+            use_numba (Optional[bool]): Whether to use the numba encoding and vectorized operations.
+                ``None`` (default) selects the compiled path when numba is installed.
 
         Attributes:
             theta (float): Shared base.

--- a/mixle/stats/latent/semi_supervised_hidden_markov_model.py
+++ b/mixle/stats/latent/semi_supervised_hidden_markov_model.py
@@ -64,7 +64,7 @@ class SemiSupervisedHiddenMarkovModelDistribution(SequenceEncodableProbabilityDi
 
         return DistributionCapabilities(engine_ready=("numpy",), kernel_status="legacy_numpy")
 
-    def __init__(self, topics, transitions, len_dist=None, name=None, keys=None, use_numba=False, terminal_states=None):
+    def __init__(self, topics, transitions, len_dist=None, name=None, keys=None, use_numba=None, terminal_states=None):
         """SemiSupervisedHiddenMarkovModelDistribution.
 
         Args:
@@ -73,7 +73,7 @@ class SemiSupervisedHiddenMarkovModelDistribution(SequenceEncodableProbabilityDi
             len_dist (Optional[SequenceEncodableProbabilityDistribution]): optional sequence-length distribution.
             name (Optional[str]): optional name.
             keys (Optional[Tuple[Optional[str], Optional[str]]]): optional (transition, emission) keys for tying.
-            use_numba (bool): accepted for backward compatibility; this model is numpy-only.
+            use_numba (Optional[bool]): accepted for backward compatibility and ignored; this model is numpy-only.
         """
         self.topics = list(topics)
         self.nStates = len(self.topics)
@@ -85,6 +85,9 @@ class SemiSupervisedHiddenMarkovModelDistribution(SequenceEncodableProbabilityDi
         if keys is None:
             keys = (None, None)
         self.keys = keys
+        # Deliberately hard False (not a tunable default): the semi-supervised forward/backward is a
+        # custom per-sequence implementation with no numba kernel, and its encoder must emit the
+        # matching per-sequence layout. Mirrors the terminal-state force-off in hidden_markov.py.
         self.use_numba = False
         self.terminal_states = None if terminal_states is None else set(int(s) for s in terminal_states)
         if self.terminal_states is not None:

--- a/mixle/stats/latent/tree_hidden_markov_model.py
+++ b/mixle/stats/latent/tree_hidden_markov_model.py
@@ -45,7 +45,7 @@ from mixle.stats.compute.pdist import (
     StatisticAccumulatorFactory,
 )
 from mixle.utils.aliasing import MISSING, coalesce_alias, require
-from mixle.utils.optional_deps import numba
+from mixle.utils.optional_deps import HAS_NUMBA, numba
 
 D = tuple[int, int | None]
 T = TypeVar("T")  # Type for emissions
@@ -153,7 +153,7 @@ class TreeHiddenMarkovModelDistribution(SequenceEncodableProbabilityDistribution
         len_dist: SequenceEncodableProbabilityDistribution | None = NullDistribution(),
         terminal_level: int = 10,
         name: str | None = None,
-        use_numba: bool = False,
+        use_numba: bool | None = None,
         weights: Sequence[float] | np.ndarray = MISSING,
     ) -> None:
         """TreeHiddenMarkovModelDistribution for specifying an HMM on a rooted tree.
@@ -210,7 +210,7 @@ class TreeHiddenMarkovModelDistribution(SequenceEncodableProbabilityDistribution
             self.name = name
             self.len_dist = len_dist if len_dist is not None else NullDistribution()
             self.terminal_level = terminal_level
-            self.use_numba = use_numba
+            self.use_numba = HAS_NUMBA if use_numba is None else use_numba
 
         # Cache for the parameter-only per-level marginal state probabilities
         # (init_prob @ transitions^k). Keyed by the (w, transitions) identities so it
@@ -919,7 +919,7 @@ class TreeHiddenMarkovAccumulator(SequenceEncodableStatisticAccumulator):
         len_accumulator: SequenceEncodableStatisticAccumulator | None = NullAccumulator(),
         keys: tuple[str | None, str | None, str | None] = (None, None, None),
         name: str | None = None,
-        use_numba: bool = True,
+        use_numba: bool | None = None,
     ) -> None:
         """Create an accumulator for tree-HMM sufficient statistics.
 
@@ -959,7 +959,7 @@ class TreeHiddenMarkovAccumulator(SequenceEncodableStatisticAccumulator):
         self.state_key = keys[2]
 
         self.name = name
-        self.use_numba = use_numba
+        self.use_numba = HAS_NUMBA if use_numba is None else use_numba
 
         # When _track_ll is enabled, seq_update accumulates the per-tree data
         # log-likelihood into _seq_ll. Used by the fused-EM fast path in
@@ -1606,7 +1606,7 @@ class TreeHiddenMarkovAccumulatorFactory(StatisticAccumulatorFactory):
         len_factory: StatisticAccumulatorFactory = NullAccumulatorFactory(),
         keys: tuple[str | None, str | None, str | None] | None = (None, None, None),
         name: str | None = None,
-        use_numba: bool = True,
+        use_numba: bool | None = None,
     ) -> None:
         """Create a factory for tree hidden Markov accumulators.
 
@@ -1625,7 +1625,7 @@ class TreeHiddenMarkovAccumulatorFactory(StatisticAccumulatorFactory):
         self.keys = keys if keys is not None else (None, None, None)
         self.len_factory = len_factory
         self.name = name
-        self.use_numba = use_numba
+        self.use_numba = HAS_NUMBA if use_numba is None else use_numba
 
     def make(self) -> "TreeHiddenMarkovAccumulator":
         """Return a new tree hidden Markov accumulator."""
@@ -1649,7 +1649,7 @@ class TreeHiddenMarkovEstimator(ParameterEstimator):
         pseudo_count: tuple[float | None, float | None] | None = (None, None),
         name: str | None = None,
         keys: tuple[str | None, str | None, str | None] | None = (None, None, None),
-        use_numba: bool = True,
+        use_numba: bool | None = None,
     ) -> None:
         """Create an estimator for a tree hidden Markov model.
 
@@ -1663,7 +1663,8 @@ class TreeHiddenMarkovEstimator(ParameterEstimator):
             name (Optional[str]): Optional name assigned to estimated distributions.
             keys (Optional[Tuple[Optional[str], Optional[str], Optional[str]]]): Keys for merging the
                 initial state counts, transition counts, and state (emission) accumulators respectively.
-            use_numba (bool): If True, the estimated distribution and accumulators use the numba encoding.
+            use_numba (Optional[bool]): Whether the estimated distribution and accumulators use the numba
+                encoding. ``None`` (default) selects the compiled path when numba is installed.
 
         """
         self.num_states = len(estimators)
@@ -1672,7 +1673,7 @@ class TreeHiddenMarkovEstimator(ParameterEstimator):
         self.keys = keys if keys is not None else (None, None, None)
         self.len_estimator = len_estimator if len_estimator is not None else NullEstimator()
         self.name = name
-        self.use_numba = use_numba
+        self.use_numba = HAS_NUMBA if use_numba is None else use_numba
 
     def accumulator_factory(self) -> TreeHiddenMarkovAccumulatorFactory:
         """Return an accumulator factory configured from this estimator."""
@@ -1744,7 +1745,7 @@ class TreeHiddenMarkovDataEncoder(DataSequenceEncoder):
         self,
         emission_encoder: DataSequenceEncoder,
         len_encoder: DataSequenceEncoder | None = NullDataEncoder(),
-        use_numba: bool = True,
+        use_numba: bool | None = None,
     ) -> None:
         """Create an encoder for tree HMM observations.
 
@@ -1758,7 +1759,7 @@ class TreeHiddenMarkovDataEncoder(DataSequenceEncoder):
         """
         self.emission_encoder = emission_encoder
         self.len_encoder = len_encoder if len_encoder is not None else NullDataEncoder()
-        self.use_numba = use_numba
+        self.use_numba = HAS_NUMBA if use_numba is None else use_numba
 
     def __str__(self) -> str:
         """Return a constructor-style representation of the encoder."""

--- a/mixle/tests/hmm_numba_default_contract_test.py
+++ b/mixle/tests/hmm_numba_default_contract_test.py
@@ -1,0 +1,92 @@
+"""Contract: every ``use_numba`` parameter in the latent family defaults to ``None``.
+
+``None`` resolves to ``HAS_NUMBA`` at construction (the pattern established by
+``HiddenMarkovModelDistribution``), so numba engages exactly when it is installed. A hardcoded
+``False`` default silently forces the ~6x-slower numpy Baum-Welch even with numba present (the
+recurring bug this test exists to kill); a hardcoded ``True`` silently runs numba-shaped kernels
+in pure Python when numba is absent. Deliberate force-offs (terminal-state layouts, the
+semi-supervised custom updater) assign ``self.use_numba = False`` in the body, never through a
+parameter default, so they pass this scan by construction.
+"""
+
+import ast
+import unittest
+from pathlib import Path
+
+import mixle.stats.latent as latent_pkg
+from mixle.utils.optional_deps import HAS_NUMBA
+
+LATENT_DIR = Path(latent_pkg.__file__).parent
+
+
+def _bad_defaults():
+    """Return every (file, function, default) where a use_numba parameter defaults to non-None."""
+    offenders = []
+    for path in sorted(LATENT_DIR.glob("*.py")):
+        tree = ast.parse(path.read_text())
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            args = node.args
+            params = args.posonlyargs + args.args + args.kwonlyargs
+            defaults = [None] * (len(args.posonlyargs) + len(args.args) - len(args.defaults))
+            defaults += list(args.defaults) + list(args.kw_defaults)
+            for param, default in zip(params, defaults):
+                if param.arg != "use_numba" or default is None:
+                    continue
+                if not (isinstance(default, ast.Constant) and default.value is None):
+                    offenders.append((path.name, node.name, ast.unparse(default)))
+    return offenders
+
+
+class UseNumbaDefaultContractTest(unittest.TestCase):
+    def test_every_use_numba_parameter_defaults_to_none(self):
+        offenders = _bad_defaults()
+        self.assertEqual(
+            offenders,
+            [],
+            "use_numba parameter defaults must be None (resolved to HAS_NUMBA at construction); "
+            "hardcoded defaults silently pin the slow or the broken path: %r" % (offenders,),
+        )
+
+    def test_entry_points_resolve_none_to_has_numba(self):
+        from mixle.stats import GaussianDistribution
+        from mixle.stats.latent.hidden_markov import HiddenMarkovModelDistribution
+        from mixle.stats.latent.tree_hidden_markov_model import TreeHiddenMarkovEstimator
+
+        hmm = HiddenMarkovModelDistribution(
+            topics=[GaussianDistribution(0.0, 1.0), GaussianDistribution(3.0, 1.0)],
+            w=[0.5, 0.5],
+            transitions=[[0.9, 0.1], [0.1, 0.9]],
+        )
+        self.assertEqual(hmm.use_numba, HAS_NUMBA)
+
+        from mixle.stats import GaussianEstimator
+        from mixle.stats.latent.hidden_markov import HiddenMarkovEstimator
+
+        est = HiddenMarkovEstimator([GaussianEstimator(), GaussianEstimator()])
+        self.assertEqual(est.use_numba, HAS_NUMBA)
+        # the resolved value must propagate unchanged through the accumulator pipeline
+        factory = est.accumulator_factory()
+        self.assertEqual(factory.use_numba, HAS_NUMBA)
+        self.assertEqual(factory.make().use_numba, HAS_NUMBA)
+        self.assertEqual(hmm.dist_to_encoder().use_numba, HAS_NUMBA)
+
+        tree_est = TreeHiddenMarkovEstimator([GaussianEstimator(), GaussianEstimator()])
+        self.assertEqual(tree_est.use_numba, HAS_NUMBA)
+
+    def test_terminal_states_still_force_the_per_sequence_layout(self):
+        from mixle.stats import GaussianDistribution
+        from mixle.stats.latent.hidden_markov import HiddenMarkovModelDistribution
+
+        hmm = HiddenMarkovModelDistribution(
+            topics=[GaussianDistribution(0.0, 1.0), GaussianDistribution(3.0, 1.0)],
+            w=[0.5, 0.5],
+            transitions=[[0.9, 0.1], [0.1, 0.9]],
+            terminal_states=[1],
+        )
+        self.assertFalse(hmm.use_numba)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
fix(hmm): normalize every use_numba default to None -> numba-when-installed

The flagship HiddenMarkovModelDistribution resolves `use_numba=None` to
HAS_NUMBA, next to a comment documenting why: a hardcoded False default
"silently forced the ~6x-slower numpy Baum-Welch even when the estimator
wanted numba." Twelve other signatures across the latent family still
hardcoded False (or True, which silently runs numba-shaped kernels in pure
Python when numba is absent):

- QuantizedHiddenMarkovModelDistribution defaulted False while its own
  estimator resolved HAS_NUMBA -- the estimator encodes through the
  distribution's encoder, which is exactly the documented bug shape.
- TreeHiddenMarkovModelDistribution defaulted False while the same file's
  estimator/accumulator/factory/encoder hardcoded True.
- HiddenMarkovAccumulator was half-fixed (`bool | None = False`);
  HiddenMarkovAccumulatorFactory and HiddenMarkovDataEncoder defaulted False.
- IntegerHiddenAssociation distribution/accumulator/factory defaulted False
  while the estimator resolved HAS_NUMBA.

All now use `use_numba: bool | None = None` resolved to HAS_NUMBA at
construction, so every default-constructed piece of the pipeline agrees on
the encoded-data layout in any environment. The three deliberate force-offs
are untouched and now all documented: the terminal-state forward/backward
(per-sequence layout, both sites already commented) and the semi-supervised
model (numpy-only custom updater; comment added, its backward-compat dead
parameter now also defaults None).

Receipts:
- speed: a default-constructed HiddenMarkovEstimator Baum-Welch fit runs
  3.7x faster than the old effective default, with bitwise-identical
  log-likelihood (delta exactly 0.0).
- regression gate: hmm_numba_default_contract_test.py AST-scans the latent
  family and fails on any use_numba parameter default other than None (this
  keeps the bug from returning file by file, which is how it accumulated),
  and asserts entry points resolve to HAS_NUMBA, propagation through
  estimator -> factory -> accumulator -> encoder preserves the resolved
  value, and terminal_states still forces the per-sequence layout.
- 191 tests + 38 subtests across the full HMM family (tree, quantized,
  scheduled, lookback, segmental, semi-supervised, structured, steady-state,
  fused-EM, sampler batching, hidden-association) pass with the new
  defaults.
