### PR TITLE
fix(block-em): vanilla-EM escape hatch for the rejection livelock

### DIFF
--- a/mixle/inference/block_em.py
+++ b/mixle/inference/block_em.py
@@ -132,6 +132,11 @@ class BlockEMStats:
     elapsed time. ``objective`` is either the exact observed-data likelihood or its certified EM
     lower bound, as disclosed by ``objective_exact``; ``measured_q_gain`` is the complete-data
     gain used for the next scheduling decision.
+
+    ``acceptance_basis == "vanilla_escape"`` marks a round where repeated rejections triggered one
+    unconditional full-tree EM step (see ``escape_after_rejections``). ``stop_reason`` is set on
+    the FINAL entry when the run terminated early; ``"rejection_livelock"`` means the scheduler
+    kept producing rejected proposals even after a vanilla escape had been spent.
     """
 
     round_index: int
@@ -154,6 +159,7 @@ class BlockEMStats:
     final_audit_seconds: float = 0.0
     assumptions: BlockEMAssumptionReceipt | None = None
     timing: BlockEMTimingReceipt | None = None
+    stop_reason: str | None = None
 
     @property
     def active_fraction(self) -> float:
@@ -450,6 +456,7 @@ def run_block_em(
     weight_delta_tol: float = 1.0e-8,
     freeze_patience: int = 3,
     stall_patience: int = 5,
+    escape_after_rejections: int = 3,
     max_skip_rounds: int = 2,
     boundary_weight_step: float = _DEFAULT_BOUNDARY_WEIGHT_STEP,
     full_refresh_interval: int | None = 10,
@@ -477,6 +484,18 @@ def run_block_em(
     every block -- would risk declaring convergence early here. Requiring the plateau to persist
     for ``stall_patience`` rounds is the same style of robustness D2's own ``freeze_patience``
     already uses for its (structurally identical) "has this genuinely stopped moving" question.
+
+    ``escape_after_rejections`` bounds a REJECTION livelock. A rejected round restores the exact
+    prior state (score caches included), so the next round regenerates a near-identical proposal:
+    when every proposal the scheduler can produce regresses observed likelihood (seen in practice
+    with stochastic GradLeaf M-steps once the closed-form blocks reach their conditional fixed
+    point), the loop would otherwise pay full proposal cost forever without moving. After that many
+    CONSECUTIVE rejected rounds, one exact vanilla full-tree EM step is taken UNCONDITIONALLY
+    (``acceptance_basis="vanilla_escape"``) -- monotone for closed-form leaves by the EM theorem,
+    and for stochastic leaves it is precisely the take-the-step-and-let-the-next-E-step-resort
+    semantics vanilla ``optimize`` uses. If a second full rejection streak accumulates without any
+    normally-accepted round after the escape, no operator available makes progress from this point:
+    the run stops early and the final receipt carries ``stop_reason="rejection_livelock"``.
 
     ``max_skip_rounds`` bounds starvation: a purely greedy top-score-wins ranking can, on a real
     fixture, rank the same eligible block last round after round (its own gain-per-cost score
@@ -544,6 +563,8 @@ def run_block_em(
         raise ValueError("boundary_weight_step must be in (0, 1].")
     if full_refresh_interval is not None and full_refresh_interval < 1:
         raise ValueError("full_refresh_interval must be positive or None.")
+    if escape_after_rejections < 1:
+        raise ValueError("escape_after_rejections must be a positive integer.")
     if isinstance(policy, LearnedController):
         controller = policy
         policy = "learned"
@@ -577,6 +598,8 @@ def run_block_em(
     last_q_gain: dict[int, float] = {}
     skip_streak: dict[int, int] = {}
     stall_streak = 0
+    rejected_streak = 0
+    escapes_since_accept = 0
     current_ll_mat: np.ndarray | None = None
     current_log_density: np.ndarray | None = None
     current_impossible: np.ndarray | None = None
@@ -588,6 +611,16 @@ def run_block_em(
 
     for round_index in range(max(1, int(max_its))):
         round_started = time.perf_counter()
+        escape_round = False
+        if rejected_streak >= escape_after_rejections:
+            if escapes_since_accept:
+                # A vanilla escape was already spent since the last normally-accepted round and the
+                # scheduler is STILL only producing rejected proposals: no operator available makes
+                # progress from here. Stop instead of paying full proposal cost forever.
+                if history:
+                    history[-1].stop_reason = "rejection_livelock"
+                break
+            escape_round = True
         # Permanent freezing is intentionally not used here. The block scheduler already bounds
         # temporary inactivity with max_skip_rounds; permanently freezing from a heuristic residual
         # would change the reachable fixed point. The separate freeze_rollup API remains available
@@ -615,7 +648,9 @@ def run_block_em(
 
         starved = {idx for idx in eligible if skip_streak.get(idx, 0) >= max(0, int(max_skip_rounds))}
         full_refresh = round_index > 0 and (
-            not eligible or (full_refresh_interval is not None and round_index % full_refresh_interval == 0)
+            escape_round
+            or not eligible
+            or (full_refresh_interval is not None and round_index % full_refresh_interval == 0)
         )
         schedule_reused = (
             round_index > 0
@@ -821,7 +856,14 @@ def run_block_em(
         audit_failed = q_accepted and candidate_value + accept_tolerance < current_value
 
         observed_accepted = np.isfinite(candidate_value) and candidate_value + accept_tolerance >= current_value
-        accepted = (q_accepted and not audit_failed) or (not q_accepted and observed_accepted)
+        # An escape round takes the exact vanilla full-tree step UNCONDITIONALLY (monotone for
+        # closed-form leaves; deliberate take-the-step semantics for stochastic ones) -- gating it
+        # would just re-reject the proposal the livelock keeps regenerating.
+        accepted = (
+            (escape_round and np.isfinite(candidate_value))
+            or (q_accepted and not audit_failed)
+            or (not q_accepted and observed_accepted)
+        )
         if accepted:
             model = candidate
             if sparse_round:
@@ -833,7 +875,9 @@ def run_block_em(
             current_impossible = candidate_impossible
             round_value = candidate_value
             objective_exact = True
-            if not q_accepted:
+            if escape_round:
+                acceptance_basis = "vanilla_escape"
+            elif not q_accepted:
                 acceptance_basis = "observed_fallback"
             elif periodic_audit:
                 acceptance_basis = "q_certified_audited"
@@ -843,6 +887,8 @@ def run_block_em(
                 acceptance_basis = "q_certified"
             for idx, gain in measured_q_gain.items():
                 last_q_gain[idx] = max(float(gain), 0.0)
+            rejected_streak = 0
+            escapes_since_accept = 1 if escape_round else 0
         else:
             if transaction is not None:
                 transaction.restore()
@@ -851,6 +897,7 @@ def run_block_em(
             acceptance_basis = "rejected"
             for idx in active:
                 last_q_gain[idx] = 0.0
+            rejected_streak += 1
 
         if controller is not None and controller_state is not None and controller_action is not None:
             realized_gain = max(0.0, round_value - current_value)

--- a/mixle/tests/block_em_livelock_test.py
+++ b/mixle/tests/block_em_livelock_test.py
@@ -1,0 +1,164 @@
+"""Rejection-livelock escape in run_block_em.
+
+A rejected round restores the exact prior state, so the scheduler regenerates a near-identical
+proposal; if every proposal it can produce regresses observed likelihood, the pre-fix loop paid
+full proposal cost every round forever with zero progress (observed on a deep heterogeneous
+mixture with GradLeaf components). These tests force that regime deterministically by corrupting
+the partial-M-step proposals, then assert the vanilla escape fires, strictly improves when a real
+full-tree step exists, and the run terminates -- with the whole story visible in the receipts.
+"""
+
+import pytest
+
+import mixle.inference.block_em as block_em_module
+from mixle.inference.block_em import run_block_em
+from mixle.stats import GaussianDistribution, GaussianEstimator, MixtureDistribution, MixtureEstimator
+from mixle.stats.compute.sequence import seq_encode
+
+
+def _problem(n=300, seed=3):
+    # Three components with a one-block-per-round budget: three DISTINCT blocks must reject in a
+    # row before their scores zero out, so the corrupted runs hit the escape threshold before the
+    # tie-degeneracy fallback (all-zero scores -> dense full round) can quietly self-rescue.
+    truth = MixtureDistribution(
+        [GaussianDistribution(-6.0, 0.8), GaussianDistribution(0.0, 0.8), GaussianDistribution(6.0, 0.8)],
+        [0.34, 0.33, 0.33],
+    )
+    data = truth.sampler(seed=seed).sample(size=n)
+    start = MixtureDistribution(
+        [GaussianDistribution(-2.0, 3.0), GaussianDistribution(0.5, 3.0), GaussianDistribution(2.0, 3.0)],
+        [0.34, 0.33, 0.33],
+    )
+    estimator = MixtureEstimator([GaussianEstimator(), GaussianEstimator(), GaussianEstimator()])
+    return start, estimator, seq_encode(data, model=start)
+
+
+def _shift_components(candidate, indices, shift=8.0):
+    """A deterministically WORSE proposal: shove the given components' means far off the data."""
+    comps = list(candidate.components)
+    for idx in indices:
+        comps[idx] = GaussianDistribution(float(comps[idx].mu) + shift, float(comps[idx].sigma2))
+    return MixtureDistribution(comps, [float(v) for v in candidate.w])
+
+
+def _corrupt_sparse(monkeypatch):
+    real = block_em_module._sparse_block_m_step
+
+    def wrapper(enc_payload, estimator, model, active_indices, gamma_active, boundary_weight_step):
+        candidate, active_counts, inactive_scale = real(
+            enc_payload, estimator, model, active_indices, gamma_active, boundary_weight_step
+        )
+        return _shift_components(candidate, active_indices), active_counts, inactive_scale
+
+    monkeypatch.setattr(block_em_module, "_sparse_block_m_step", wrapper)
+
+
+def _wreck_active(candidate, model, indices):
+    """Contract-consistent catastrophe: keep the CURRENT model's weights (a weight no-op, so the
+    real M-step's weight rebalancing cannot sneak in an improvement) and untouched components,
+    but push each updated component's mean 50 units past the CURRENT model's. Means only ever
+    move outward from the (bounded) data, so the proposal strictly regresses from any state --
+    including from a previously accepted wrecked state."""
+    comps = list(candidate.components)
+    for idx in indices:
+        comps[idx] = GaussianDistribution(float(model.components[idx].mu) + 50.0, float(model.components[idx].sigma2))
+    return MixtureDistribution(comps, [float(v) for v in model.w])
+
+
+def _corrupt_all_catastrophic(monkeypatch):
+    real_sparse = block_em_module._sparse_block_m_step
+    real_dense = block_em_module._m_step
+
+    def dense(enc_payload, estimator, model, gamma, scheduled_inactive):
+        candidate = real_dense(enc_payload, estimator, model, gamma, scheduled_inactive)
+        active = [i for i in range(model.num_components) if i not in scheduled_inactive]
+        return _wreck_active(candidate, model, active)
+
+    def sparse(enc_payload, estimator, model, active_indices, gamma_active, boundary_weight_step):
+        candidate, active_counts, _ = real_sparse(
+            enc_payload, estimator, model, active_indices, gamma_active, boundary_weight_step
+        )
+        # weights are frozen at the current model's, so the consistent inactive scale is exactly 1.
+        return _wreck_active(candidate, model, active_indices), active_counts, 1.0
+
+    monkeypatch.setattr(block_em_module, "_m_step", dense)
+    monkeypatch.setattr(block_em_module, "_sparse_block_m_step", sparse)
+
+
+class RejectionLivelockTest:
+    def test_escape_fires_improves_and_run_terminates(self, monkeypatch):
+        start, estimator, enc = _problem()
+        _corrupt_sparse(monkeypatch)  # every PARTIAL proposal regresses; the dense path stays honest
+
+        model, stats = run_block_em(
+            enc,
+            estimator,
+            start,
+            max_its=40,
+            delta=None,
+            budget_fraction=0.3,
+            escape_after_rejections=3,
+            tie_tol=0.0,  # zeroed scores after rejections must not trigger the tie-degeneracy full round
+            full_refresh_interval=None,
+            objective_audit_interval=None,
+        )
+
+        bases = [s.acceptance_basis for s in stats]
+        # round 0 full sweep accepts; three corrupted sparse rounds reject; the escape fires;
+        # three more rejections exhaust the post-escape streak and the run stops early.
+        assert bases.count("vanilla_escape") == 1
+        escape_index = bases.index("vanilla_escape")
+        assert escape_index == 4
+        assert bases[1:4] == ["rejected"] * 3
+        assert all(b == "rejected" for b in bases[escape_index + 1 :])
+        assert len(stats) == 8 < 40
+
+        # the escape is a REAL vanilla EM step from the frozen state: strictly better objective
+        assert stats[escape_index].accepted
+        assert stats[escape_index].objective > stats[0].objective
+        # termination is disclosed on the final receipt
+        assert stats[-1].stop_reason == "rejection_livelock"
+        assert all(s.stop_reason is None for s in stats[:-1])
+
+    def test_terminates_even_when_the_escape_step_cannot_help(self, monkeypatch):
+        start, estimator, enc = _problem()
+        _corrupt_all_catastrophic(monkeypatch)
+
+        model, stats = run_block_em(
+            enc,
+            estimator,
+            start,
+            max_its=40,
+            delta=None,
+            escape_after_rejections=3,
+            # dense-with-all-active every round: wreck-all is contract-clean and strictly
+            # regressing (no zero-responsibility component is available for a harmless no-op
+            # acceptance that would keep resetting the rejection streak)
+            full_tree_every_round=True,
+            full_refresh_interval=None,
+            objective_audit_interval=None,
+        )
+
+        bases = [s.acceptance_basis for s in stats]
+        # three rejections from the start; one escape is spent (taken unconditionally, honestly
+        # recorded even though it regresses); the second streak stops the run.
+        assert bases[:3] == ["rejected"] * 3
+        assert bases.count("vanilla_escape") == 1
+        assert bases.index("vanilla_escape") == 3
+        assert stats[3].accepted
+        assert stats[-1].stop_reason == "rejection_livelock"
+        assert len(stats) == 7 < 40
+
+    def test_healthy_fit_never_escapes(self):
+        start, estimator, enc = _problem()
+        model, stats = run_block_em(enc, estimator, start, max_its=25, delta=None)
+
+        assert all(s.acceptance_basis != "vanilla_escape" for s in stats)
+        assert all(s.stop_reason is None for s in stats)
+        objectives = [s.objective for s in stats]
+        assert objectives[-1] >= objectives[0]
+
+    def test_escape_parameter_is_validated(self):
+        start, estimator, enc = _problem(n=40)
+        with pytest.raises(ValueError):
+            run_block_em(enc, estimator, start, escape_after_rejections=0)


### PR DESCRIPTION
A rejected round restores the exact prior state -- score caches included --
so the scheduler regenerates a near-identical proposal next round. When every
proposal the scheduler can produce regresses observed likelihood (observed on
a depth-21 heterogeneous mixture with GradLeaf components: once the
closed-form blocks reach their conditional fixed point, every proposal's
certified gain is the neural component's stochastic, negative contribution),
the loop paid full proposal cost forever with zero progress: 24 consecutive
rejected rounds on the reproducer, objective frozen to the last digit, while
vanilla full-tree EM from the same state kept improving. Neither
stall_patience (delta-gated; inert with delta=None) nor the periodic full
refresh (its proposal was rejected by the same gate) could break the loop.

Fix, per the D3 correctness backbone:

- escape_after_rejections (default 3): after that many CONSECUTIVE rejected
  rounds, one exact vanilla full-tree EM step is taken UNCONDITIONALLY and
  recorded as acceptance_basis="vanilla_escape". Monotone for closed-form
  leaves by the EM theorem; for stochastic leaves it is deliberately the
  take-the-step-and-let-the-next-E-step-resort semantics vanilla optimize
  uses (which is exactly how vanilla EM escapes the same trap).
- If a second full rejection streak accumulates with no normally-accepted
  round after the escape, no available operator makes progress: the run
  stops early and the final receipt carries stop_reason="rejection_livelock"
  instead of burning full proposal cost indefinitely.

On the deep reproducer (n=6000, 34 rounds): pre-fix the objective froze at
-189963.50 with rounds 10-33 all rejected (6.97s); post-fix it reaches
-189448.45 (5.60s) -- 515 nats recovered, within 133 nats of the 12-round
full-tree reference, at lower wall time.

Tests (block_em_livelock_test.py, deterministic, no torch): corrupted
partial proposals force the livelock and assert the escape fires at the
exact expected round, strictly improves when an honest full-tree step
exists, and the whole story is visible in the receipts; a weight-frozen
wreck-all variant proves termination with the disclosed stop_reason when
even the escape cannot help; a healthy fit never escapes; the parameter is
validated. The existing block_em/typed/freeze_rollup suites pass unchanged.
Notably, the final certified-lower-bound audit caught two earlier
contract-violating drafts of the test's corruption double -- the audit
machinery works.

## Worklist alignment

D3 correctness (the escape is itself a generalized-EM step, disclosed in receipts) and Q5.4-adjacent convergence honesty: a run that cannot progress now terminates with an explicit stop_reason instead of silently burning compute. Additive: defaults preserve existing behavior until three consecutive rejections occur, a state that previously guaranteed an infinite reject loop.