### PR TITLE
fix(grad-leaf): snapshot-restore guard for diverging neural M-steps

### DIFF
--- a/mixle/models/grad_leaf.py
+++ b/mixle/models/grad_leaf.py
@@ -324,6 +324,9 @@ class GradEstimator(ParameterEstimator):
         self.name = name
         self.loss = loss
         self.optimizer = optimizer
+        # Cumulative count of divergence recoveries across this estimator's M-steps (one optimize()
+        # run shares one estimator tree, so this accumulates over EM rounds; see estimate()).
+        self.nonfinite_recoveries = 0
 
     def _leaf(self) -> GradLeaf:
         return GradLeaf(
@@ -360,6 +363,15 @@ class GradEstimator(ParameterEstimator):
         opt = self.optimizer(params) if self.optimizer is not None else torch.optim.Adam(params, lr=self.lr)
         autocast_dev = "cuda" if str(dev).startswith("cuda") else "cpu"
         use_bf16 = self.precision == "bf16"
+        # Divergence guard: an aggressive step can drive parameters non-finite, after which the
+        # module's own log_density may RAISE (e.g. a torch.distributions constraint check) from
+        # inside this M-step -- before the outer EM loop's non-finite acceptance gate or its
+        # transaction restore can act, crashing the fit and leaving the shared module poisoned.
+        # Snapshot the module state up front; on a non-finite loss/parameter or a raising module,
+        # restore the snapshot and stop stepping. The round degrades to a no-op proposal the outer
+        # loop gates normally, and the recovery is disclosed in the fit receipt.
+        pre_step_state = {key: value.detach().clone() for key, value in self.module.state_dict().items()}
+        recovered = False
         optimizer_steps = 0
         epochs_completed = 0
         stop = False
@@ -370,23 +382,39 @@ class GradEstimator(ParameterEstimator):
                 xb = tuple(xt[idx].to(dev) for xt in xs)
                 wb = w[idx].to(dev)
                 opt.zero_grad()
-                with torch.autocast(device_type=autocast_dev, dtype=torch.bfloat16, enabled=use_bf16):
-                    if self.loss is not None:
-                        loss = self.loss(self.module, *xb, wb)
+                step_healthy = True
+                try:
+                    with torch.autocast(device_type=autocast_dev, dtype=torch.bfloat16, enabled=use_bf16):
+                        if self.loss is not None:
+                            loss = self.loss(self.module, *xb, wb)
+                        else:
+                            # tuple default: log_density(*fields) -- a single field unpacks to log_density(x),
+                            # identical to before; a conditional bare module's log_density(x, y, ...) just works.
+                            loss = -(wb * self.module.log_density(*xb)).sum()
+                            # ``w`` is normalized over the full M-step data. A uniform minibatch's raw
+                            # weighted sum is smaller by E[batch_size / n]; rescale it so every optimizer
+                            # step is an unbiased estimate of the same full responsibility-weighted Q
+                            # objective. This stabilizes gradient scale across batch sizes without claiming
+                            # identical Adam trajectories (their noise and moment estimates still differ).
+                            if len(idx) < n:
+                                loss = loss * (float(n) / float(len(idx)))
+                    if not bool(torch.isfinite(loss)):
+                        step_healthy = False
                     else:
-                        # tuple default: log_density(*fields) -- a single field unpacks to log_density(x),
-                        # identical to before; a conditional bare module's log_density(x, y, ...) just works.
-                        loss = -(wb * self.module.log_density(*xb)).sum()
-                        # ``w`` is normalized over the full M-step data. A uniform minibatch's raw
-                        # weighted sum is smaller by E[batch_size / n]; rescale it so every optimizer
-                        # step is an unbiased estimate of the same full responsibility-weighted Q
-                        # objective. This stabilizes gradient scale across batch sizes without claiming
-                        # identical Adam trajectories (their noise and moment estimates still differ).
-                        if len(idx) < n:
-                            loss = loss * (float(n) / float(len(idx)))
-                loss.backward()
-                opt.step()
-                optimizer_steps += 1
+                        loss.backward()
+                        opt.step()
+                        optimizer_steps += 1
+                        if not all(bool(torch.isfinite(p).all()) for p in params):
+                            step_healthy = False
+                except (ValueError, RuntimeError):
+                    step_healthy = False
+                if not step_healthy:
+                    with torch.no_grad():
+                        self.module.load_state_dict(pre_step_state)
+                    self.nonfinite_recoveries += 1
+                    recovered = True
+                    stop = True
+                    break
                 if self.max_optimizer_steps is not None and optimizer_steps >= self.max_optimizer_steps:
                     stop = True
                     break
@@ -402,6 +430,8 @@ class GradEstimator(ParameterEstimator):
             "optimizer_steps": int(optimizer_steps),
             "max_optimizer_steps": self.max_optimizer_steps,
             "gradient_estimator": "unbiased_full_weighted_objective" if self.loss is None else "custom_loss",
+            "nonfinite_recovery": bool(recovered),
+            "nonfinite_recoveries_total": int(self.nonfinite_recoveries),
         }
         return leaf
 

--- a/mixle/tests/grad_leaf_test.py
+++ b/mixle/tests/grad_leaf_test.py
@@ -316,5 +316,42 @@ class TupleDefaultLossTest(unittest.TestCase):
         self.assertAlmostEqual(float(fitted.module.b.detach()[0]), 1.0, delta=0.2)
 
 
+class DivergenceRecoveryTest(unittest.TestCase):
+    def _bimodal(self, n=150):
+        rng = np.random.RandomState(0)
+        return [float(v) for v in np.concatenate([rng.normal(-4.0, 1.0, n), rng.normal(4.0, 1.0, n)])]
+
+    def test_diverging_neural_step_recovers_instead_of_crashing(self):
+        # lr=25 drives DiagGauss to NaN within a few steps; the module then RAISES from inside
+        # log_density (torch.distributions constraint check). Pre-guard this crashed optimize()
+        # mid-M-step and left the shared module poisoned; now the round restores the pre-step
+        # state, the fit completes, and the recovery is disclosed in the fit receipt.
+        torch.manual_seed(0)
+        proto = MixtureDistribution(
+            [GradLeaf(DiagGauss(1, mu0=0.5), m_steps=40, lr=25.0), GaussianDistribution(-1.0, 3.0)],
+            [0.5, 0.5],
+        )
+        data = self._bimodal()
+        fitted = optimize(data, proto.estimator(), prev_estimate=proto, max_its=8, out=None)
+
+        enc = fitted.dist_to_encoder().seq_encode(data)
+        self.assertTrue(np.isfinite(float(np.sum(fitted.seq_log_density(enc)))))
+        for p in fitted.components[0].module.parameters():
+            self.assertTrue(bool(torch.isfinite(p).all()))
+        receipt = fitted.components[0].fit_receipt
+        self.assertGreaterEqual(receipt["nonfinite_recoveries_total"], 1)
+
+    def test_healthy_fit_records_zero_recoveries(self):
+        torch.manual_seed(0)
+        proto = MixtureDistribution(
+            [GradLeaf(DiagGauss(1, mu0=0.5), m_steps=25, lr=0.05), GaussianDistribution(-1.0, 3.0)],
+            [0.5, 0.5],
+        )
+        fitted = optimize(self._bimodal(), proto.estimator(), prev_estimate=proto, max_its=8, out=None)
+        receipt = fitted.components[0].fit_receipt
+        self.assertFalse(receipt["nonfinite_recovery"])
+        self.assertEqual(receipt["nonfinite_recoveries_total"], 0)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
A diverging optimizer step (e.g. an aggressive learning rate) drives module
parameters non-finite, after which the module's own log_density can RAISE
from inside the M-step (e.g. a torch.distributions constraint check on a NaN
scale). The exception fired before the outer EM loop's non-finite acceptance
gate or its MutableStateSnapshot restore could act: the fit crashed with an
unhandled ValueError AND the shared module was left poisoned with NaN
parameters.

estimate() now snapshots the module state before stepping and, on a
non-finite loss, a non-finite post-step parameter, or a ValueError/
RuntimeError raised by the module mid-step, restores the snapshot and stops
stepping. The round degrades to a no-op proposal the outer loop gates
normally (the leaf freezes at its pre-divergence state while other nodes
keep optimizing), and the event is disclosed: fit_receipt gains
nonfinite_recovery (this round) and nonfinite_recoveries_total (cumulative
across the estimator's rounds), with the counter also readable on the
estimator.

Receipts: the lr=25 reproducer that previously crashed mid-fit now completes
40/40 EM rounds with a finite objective, best-iterate selection intact, and
finite module parameters; the healthy-path equivalence check is unchanged
(EM<->Adam hopping still lands 0.0028 nats / 0.0001% from the exact-EM
optimum with identical recovered parameters). New tests cover the
divergence-recovery fixture and assert a healthy fit records zero
recoveries; the full grad_leaf/torch_parity/neural_density suites pass
unchanged (36 tests).

## Worklist alignment

Q5.1 (invariants for stable families): a fit must not crash with poisoned shared state on a recoverable numerical event; divergence now degrades to a receipted no-op round. Additive-only -- healthy-path trajectories are unchanged (verified against the exact-EM equivalence check).