### PR TITLE
feat(em): convergence contract (Q5.4) + SAEM-window lr schedule for neural M-steps

### DIFF
--- a/mixle/inference/estimation.py
+++ b/mixle/inference/estimation.py
@@ -832,6 +832,15 @@ def optimize(
             steps may be traversed, but the returned model (including mutable module parameters) is
             restored to the best selected-objective value observed. Pass ``True`` to reject the
             first decreasing step, or ``False`` to permit a non-monotone trajectory explicitly.
+
+            Convergence contract (worklist Q5.4; pinned by ``em_convergence_contract_test``): under
+            strict acceptance the accepted-round objectives are non-decreasing within tolerance and
+            -- bounded above by the estimator variance floors -- the objective sequence converges;
+            limit-point stationarity is the classical EM/GEM theory per family. Under best-seen
+            selection the guarantee is the best visited iterate; a neural leaf fit with
+            ``lr_decay`` in ``(0.5, 1]`` additionally follows a Robbins--Monro step schedule (the
+            condition stochastic-approximation EM analyses require). A non-finite objective is
+            never accepted and never becomes the convergence reference.
         track_best (Optional[bool]): Whether to restore the best outer-objective state seen. ``None``
             (default) does so except when an estimator explicitly declares a surrogate fitting
             objective, such as NCE; observed density is not a valid selector until such a model is

--- a/mixle/models/grad_leaf.py
+++ b/mixle/models/grad_leaf.py
@@ -324,6 +324,9 @@ class GradEstimator(ParameterEstimator):
         self.name = name
         self.loss = loss
         self.optimizer = optimizer
+        # Cumulative count of divergence recoveries across this estimator's M-steps (one optimize()
+        # run shares one estimator tree, so this accumulates over EM rounds; see estimate()).
+        self.nonfinite_recoveries = 0
 
     def _leaf(self) -> GradLeaf:
         return GradLeaf(
@@ -360,6 +363,15 @@ class GradEstimator(ParameterEstimator):
         opt = self.optimizer(params) if self.optimizer is not None else torch.optim.Adam(params, lr=self.lr)
         autocast_dev = "cuda" if str(dev).startswith("cuda") else "cpu"
         use_bf16 = self.precision == "bf16"
+        # Divergence guard: an aggressive step can drive parameters non-finite, after which the
+        # module's own log_density may RAISE (e.g. a torch.distributions constraint check) from
+        # inside this M-step -- before the outer EM loop's non-finite acceptance gate or its
+        # transaction restore can act, crashing the fit and leaving the shared module poisoned.
+        # Snapshot the module state up front; on a non-finite loss/parameter or a raising module,
+        # restore the snapshot and stop stepping. The round degrades to a no-op proposal the outer
+        # loop gates normally, and the recovery is disclosed in the fit receipt.
+        pre_step_state = {key: value.detach().clone() for key, value in self.module.state_dict().items()}
+        recovered = False
         optimizer_steps = 0
         epochs_completed = 0
         stop = False
@@ -370,23 +382,39 @@ class GradEstimator(ParameterEstimator):
                 xb = tuple(xt[idx].to(dev) for xt in xs)
                 wb = w[idx].to(dev)
                 opt.zero_grad()
-                with torch.autocast(device_type=autocast_dev, dtype=torch.bfloat16, enabled=use_bf16):
-                    if self.loss is not None:
-                        loss = self.loss(self.module, *xb, wb)
+                step_healthy = True
+                try:
+                    with torch.autocast(device_type=autocast_dev, dtype=torch.bfloat16, enabled=use_bf16):
+                        if self.loss is not None:
+                            loss = self.loss(self.module, *xb, wb)
+                        else:
+                            # tuple default: log_density(*fields) -- a single field unpacks to log_density(x),
+                            # identical to before; a conditional bare module's log_density(x, y, ...) just works.
+                            loss = -(wb * self.module.log_density(*xb)).sum()
+                            # ``w`` is normalized over the full M-step data. A uniform minibatch's raw
+                            # weighted sum is smaller by E[batch_size / n]; rescale it so every optimizer
+                            # step is an unbiased estimate of the same full responsibility-weighted Q
+                            # objective. This stabilizes gradient scale across batch sizes without claiming
+                            # identical Adam trajectories (their noise and moment estimates still differ).
+                            if len(idx) < n:
+                                loss = loss * (float(n) / float(len(idx)))
+                    if not bool(torch.isfinite(loss)):
+                        step_healthy = False
                     else:
-                        # tuple default: log_density(*fields) -- a single field unpacks to log_density(x),
-                        # identical to before; a conditional bare module's log_density(x, y, ...) just works.
-                        loss = -(wb * self.module.log_density(*xb)).sum()
-                        # ``w`` is normalized over the full M-step data. A uniform minibatch's raw
-                        # weighted sum is smaller by E[batch_size / n]; rescale it so every optimizer
-                        # step is an unbiased estimate of the same full responsibility-weighted Q
-                        # objective. This stabilizes gradient scale across batch sizes without claiming
-                        # identical Adam trajectories (their noise and moment estimates still differ).
-                        if len(idx) < n:
-                            loss = loss * (float(n) / float(len(idx)))
-                loss.backward()
-                opt.step()
-                optimizer_steps += 1
+                        loss.backward()
+                        opt.step()
+                        optimizer_steps += 1
+                        if not all(bool(torch.isfinite(p).all()) for p in params):
+                            step_healthy = False
+                except (ValueError, RuntimeError):
+                    step_healthy = False
+                if not step_healthy:
+                    with torch.no_grad():
+                        self.module.load_state_dict(pre_step_state)
+                    self.nonfinite_recoveries += 1
+                    recovered = True
+                    stop = True
+                    break
                 if self.max_optimizer_steps is not None and optimizer_steps >= self.max_optimizer_steps:
                     stop = True
                     break
@@ -402,6 +430,8 @@ class GradEstimator(ParameterEstimator):
             "optimizer_steps": int(optimizer_steps),
             "max_optimizer_steps": self.max_optimizer_steps,
             "gradient_estimator": "unbiased_full_weighted_objective" if self.loss is None else "custom_loss",
+            "nonfinite_recovery": bool(recovered),
+            "nonfinite_recoveries_total": int(self.nonfinite_recoveries),
         }
         return leaf
 

--- a/mixle/models/grad_leaf.py
+++ b/mixle/models/grad_leaf.py
@@ -104,6 +104,7 @@ class GradLeaf(SequenceEncodableProbabilityDistribution):
         name: str | None = None,
         loss: Any = None,
         optimizer: Any = None,
+        lr_decay: float | None = None,
     ) -> None:
         self.module = module
         self.m_steps = int(m_steps)
@@ -119,6 +120,13 @@ class GradLeaf(SequenceEncodableProbabilityDistribution):
         self.name = name
         self.loss = loss
         self.optimizer = optimizer
+        self.lr_decay = None if lr_decay is None else float(lr_decay)
+        if self.lr_decay is not None and not 0.0 < self.lr_decay <= 1.0:
+            raise ValueError("lr_decay must lie in (0, 1] when supplied.")
+        if self.lr_decay is not None and optimizer is not None:
+            raise ValueError(
+                "lr_decay applies to the built-in Adam schedule; it cannot be combined with a custom optimizer hook."
+            )
         self.outer_objective_compatible = loss is None
 
     def __str__(self) -> str:
@@ -163,6 +171,7 @@ class GradLeaf(SequenceEncodableProbabilityDistribution):
             name=self.name,
             loss=self.loss,
             optimizer=self.optimizer,
+            lr_decay=self.lr_decay,
         )
 
     def dist_to_encoder(self) -> GradLeafEncoder:
@@ -309,6 +318,7 @@ class GradEstimator(ParameterEstimator):
         name: str | None = None,
         loss: Any = None,
         optimizer: Any = None,
+        lr_decay: float | None = None,
     ) -> None:
         self.module = module
         self.m_steps = int(m_steps)
@@ -324,9 +334,18 @@ class GradEstimator(ParameterEstimator):
         self.name = name
         self.loss = loss
         self.optimizer = optimizer
+        self.lr_decay = None if lr_decay is None else float(lr_decay)
+        if self.lr_decay is not None and not 0.0 < self.lr_decay <= 1.0:
+            raise ValueError("lr_decay must lie in (0, 1] when supplied.")
+        if self.lr_decay is not None and optimizer is not None:
+            raise ValueError(
+                "lr_decay applies to the built-in Adam schedule; it cannot be combined with a custom optimizer hook."
+            )
         # Cumulative count of divergence recoveries across this estimator's M-steps (one optimize()
         # run shares one estimator tree, so this accumulates over EM rounds; see estimate()).
         self.nonfinite_recoveries = 0
+        # 1-based count of M-step rounds this estimator has run; drives the lr_decay schedule.
+        self._fit_rounds = 0
 
     def _leaf(self) -> GradLeaf:
         return GradLeaf(
@@ -340,6 +359,7 @@ class GradEstimator(ParameterEstimator):
             name=self.name,
             loss=self.loss,
             optimizer=self.optimizer,
+            lr_decay=self.lr_decay,
         )
 
     def accumulator_factory(self) -> DataBufferAccumulatorFactory:
@@ -360,7 +380,14 @@ class GradEstimator(ParameterEstimator):
         n = xs[0].shape[0]
         bs = self.batch_size or n
         self.module.to(dev).train()
-        opt = self.optimizer(params) if self.optimizer is not None else torch.optim.Adam(params, lr=self.lr)
+        self._fit_rounds += 1
+        # SAEM window: a per-round Robbins--Monro schedule lr / t**a with a in (0.5, 1] satisfies
+        # sum(step)=inf and sum(step^2)<inf -- the step-size conditions stochastic-approximation EM
+        # analyses (SAEM, gradient-EM) require for almost-sure convergence to stationary points.
+        # Constant lr (lr_decay=None, the default) keeps today's behavior and the weaker
+        # best-visited-iterate guarantee provided by the outer loop.
+        effective_lr = self.lr if self.lr_decay is None else self.lr / (self._fit_rounds**self.lr_decay)
+        opt = self.optimizer(params) if self.optimizer is not None else torch.optim.Adam(params, lr=effective_lr)
         autocast_dev = "cuda" if str(dev).startswith("cuda") else "cpu"
         use_bf16 = self.precision == "bf16"
         # Divergence guard: an aggressive step can drive parameters non-finite, after which the
@@ -430,6 +457,10 @@ class GradEstimator(ParameterEstimator):
             "optimizer_steps": int(optimizer_steps),
             "max_optimizer_steps": self.max_optimizer_steps,
             "gradient_estimator": "unbiased_full_weighted_objective" if self.loss is None else "custom_loss",
+            "fit_round": int(self._fit_rounds),
+            "lr_effective": float(effective_lr),
+            "lr_decay": self.lr_decay,
+            "saem_schedule": bool(self.lr_decay is not None and self.lr_decay > 0.5),
             "nonfinite_recovery": bool(recovered),
             "nonfinite_recoveries_total": int(self.nonfinite_recoveries),
         }

--- a/mixle/tests/em_convergence_contract_test.py
+++ b/mixle/tests/em_convergence_contract_test.py
@@ -1,0 +1,212 @@
+"""The EM convergence contract (worklist Q5.4): trustworthy fit histories, as tests.
+
+Tolerance-aware monotonicity rules, enforced by mixle's outer loop and pinned here:
+
+- CLOSED-FORM trees (mixtures, HMMs, nested composites): every accepted round's observed
+  log-likelihood is non-decreasing within the loop's acceptance tolerance (1e-12 of magnitude);
+  the objective SEQUENCE therefore converges (it is bounded above by the estimator variance
+  floors). ``monotone`` resolves to True automatically for these trees.
+- MUTABLE (neural) trees: the loop auto-switches to best-visited selection; a round may decline
+  (a stochastic M-step is not a Q-maximizer) but the RETURNED model's objective equals the best
+  accepted round's. A failed M-step (non-finite objective, or a diverging module recovered by the
+  GradLeaf guard) is never accepted and never poisons the convergence reference.
+- ``lr_decay`` places the neural M-step schedule inside the Robbins-Monro window used by
+  stochastic-approximation EM analyses (sum of steps infinite, sum of squares finite for
+  exponents in (0.5, 1]); the schedule is disclosed per round in the fit receipt.
+- Default console output is silent: iteration reporting happens only when ``out`` is supplied.
+
+Weighted-fit trustworthiness (weighted == integer-replicated statistics) is Q5.3's contract and
+lives in weighted_estimation_test.py; this file covers the remaining Q5.4 model classes.
+"""
+
+import io
+import unittest
+from contextlib import redirect_stdout
+
+import numpy as np
+
+from mixle.inference.estimation import optimize
+from mixle.stats import (
+    CategoricalDistribution,
+    CompositeDistribution,
+    GaussianDistribution,
+    IntegerCategoricalDistribution,
+    MixtureDistribution,
+)
+from mixle.stats.latent.hidden_markov import HiddenMarkovModelDistribution
+
+try:
+    import torch
+
+    _HAS_TORCH = True
+except ImportError:
+    _HAS_TORCH = False
+
+
+def _trace_fit(proto, data, **kwargs):
+    trace = []
+    fitted = optimize(
+        data,
+        proto.estimator(),
+        prev_estimate=proto,
+        print_iter=0,
+        on_step=lambda s: trace.append(s.log_density),
+        **kwargs,
+    )
+    return fitted, trace
+
+
+def _ll(model, data):
+    return float(np.sum(model.seq_log_density(model.dist_to_encoder().seq_encode(data))))
+
+
+def _assert_monotone(test, trace):
+    for a, b in zip(trace, trace[1:]):
+        test.assertGreaterEqual(b, a - 1e-9 * max(1.0, abs(a)))
+
+
+class ClosedFormMonotonicityTest(unittest.TestCase):
+    """Closed-form trees: accepted-round objectives never decline beyond tolerance."""
+
+    def test_mixture_trace_is_monotone_and_quiet_by_default(self):
+        rng = np.random.RandomState(0)
+        data = np.concatenate([rng.normal(m, 1.0, 250) for m in (-5.0, 0.0, 5.0)])
+        proto = MixtureDistribution([GaussianDistribution(float(m), 2.0) for m in (-2.0, 0.5, 2.0)], [1 / 3] * 3)
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            fitted, trace = _trace_fit(proto, data, max_its=25, delta=None)
+        self.assertEqual(buf.getvalue(), "")  # no unsolicited iteration output
+        self.assertGreaterEqual(len(trace), 5)
+        _assert_monotone(self, trace)
+        self.assertTrue(np.isfinite(_ll(fitted, data)))
+
+    def test_hmm_trace_is_monotone(self):
+        rng = np.random.RandomState(1)
+        data = [list(rng.normal(-3.0 if rng.rand() < 0.5 else 3.0, 1.0, rng.randint(3, 7))) for _ in range(150)]
+        proto = HiddenMarkovModelDistribution(
+            topics=[GaussianDistribution(-1.0, 2.0), GaussianDistribution(1.0, 2.0)],
+            w=[0.5, 0.5],
+            transitions=[[0.8, 0.2], [0.2, 0.8]],
+            len_dist=IntegerCategoricalDistribution(3, [0.25, 0.25, 0.25, 0.25]),
+        )
+        _, trace = _trace_fit(proto, data, max_its=15, delta=None)
+        _assert_monotone(self, trace)
+
+    def test_nested_composite_trace_is_monotone(self):
+        rng = np.random.RandomState(2)
+        values = np.concatenate([rng.normal(-4.0, 1.0, 300), rng.normal(4.0, 1.0, 300)])
+        data = [(float(v), "a" if v < 0 else "b") for v in values]
+        proto = MixtureDistribution(
+            [
+                CompositeDistribution(
+                    (GaussianDistribution(float(m), 2.0), CategoricalDistribution({"a": 0.5, "b": 0.5}))
+                )
+                for m in (-1.0, 1.0)
+            ],
+            [0.5, 0.5],
+        )
+        _, trace = _trace_fit(proto, data, max_its=15, delta=None)
+        _assert_monotone(self, trace)
+
+    def test_delta_convergence_stops_early_with_small_final_gain(self):
+        rng = np.random.RandomState(3)
+        data = np.concatenate([rng.normal(-4.0, 1.0, 300), rng.normal(4.0, 1.0, 300)])
+        proto = MixtureDistribution([GaussianDistribution(-2.0, 2.0), GaussianDistribution(2.0, 2.0)], [0.5, 0.5])
+        _, trace = _trace_fit(proto, data, max_its=300, delta=1e-8)
+        self.assertLess(len(trace), 300)  # converged, not exhausted
+        self.assertLess(trace[-1] - trace[-2], 1e-6)
+
+
+@unittest.skipUnless(_HAS_TORCH, "torch not installed")
+class MutableModeContractTest(unittest.TestCase):
+    """Neural trees: best-visited selection, disclosed failures, and the SAEM schedule."""
+
+    class DiagGauss(torch.nn.Module if _HAS_TORCH else object):
+        def __init__(self, mu0=0.0):
+            super().__init__()
+            self.mu = torch.nn.Parameter(torch.tensor([float(mu0)]))
+            self.log_sigma = torch.nn.Parameter(torch.zeros(1))
+
+        def log_density(self, x):
+            d = torch.distributions.Normal(self.mu, torch.exp(self.log_sigma))
+            return d.log_prob(x if x.dim() > 1 else x.unsqueeze(-1)).sum(-1)
+
+    def _bimodal(self, n=200, seed=0):
+        rng = np.random.RandomState(seed)
+        return [float(v) for v in np.concatenate([rng.normal(-4, 1, n), rng.normal(4, 1, n)])]
+
+    def _proto(self, lr=0.05, lr_decay=None, m_steps=25):
+        from mixle.models import GradLeaf
+
+        torch.manual_seed(0)
+        return MixtureDistribution(
+            [
+                GradLeaf(self.DiagGauss(0.5), m_steps=m_steps, lr=lr, lr_decay=lr_decay),
+                GaussianDistribution(-1.0, 3.0),
+            ],
+            [0.5, 0.5],
+        )
+
+    def test_returned_model_is_best_visited(self):
+        data = self._bimodal()
+        fitted, trace = _trace_fit(self._proto(), data, max_its=12, delta=None)
+        self.assertGreaterEqual(_ll(fitted, data), max(trace) - 1e-6)
+
+    def test_failed_m_step_is_disclosed_not_accepted(self):
+        # lr=25 diverges; the GradLeaf guard recovers and the receipt says so, while the fit's
+        # objective stays finite -- a failed M-step is distinguishable from a true decline.
+        data = self._bimodal()
+        fitted, trace = _trace_fit(self._proto(lr=25.0, m_steps=40), data, max_its=8, delta=None)
+        self.assertTrue(all(np.isfinite(v) for v in trace))
+        self.assertTrue(np.isfinite(_ll(fitted, data)))
+        self.assertGreaterEqual(fitted.components[0].fit_receipt["nonfinite_recoveries_total"], 1)
+
+    def test_monotone_override_audits_the_trajectory(self):
+        data = self._bimodal()
+        _, trace = _trace_fit(self._proto(), data, max_its=12, delta=None, monotone=True)
+        _assert_monotone(self, trace)  # with the strict gate, every accepted round is monotone
+
+    def test_lr_decay_follows_the_declared_schedule_and_is_receipted(self):
+        from mixle.models import GradLeaf
+
+        data = self._bimodal()
+        torch.manual_seed(0)
+        proto = GradLeaf(self.DiagGauss(0.0), m_steps=10, lr=0.08, lr_decay=0.75)
+        receipts = []
+        optimize(
+            data,
+            proto.estimator(),
+            prev_estimate=proto,
+            max_its=6,
+            delta=None,
+            print_iter=0,
+            on_step=lambda s: receipts.append(dict(s.model.fit_receipt)),
+        )
+        self.assertGreaterEqual(len(receipts), 3)
+        for r in receipts:
+            t = r["fit_round"]
+            self.assertAlmostEqual(r["lr_effective"], 0.08 / (t**0.75), places=12)
+            self.assertTrue(r["saem_schedule"])
+        rounds = [r["fit_round"] for r in receipts]
+        self.assertEqual(rounds, sorted(rounds))
+
+    def test_constant_lr_is_disclosed_as_outside_the_saem_window(self):
+        data = self._bimodal()
+        fitted, _ = _trace_fit(self._proto(), data, max_its=4, delta=None)
+        receipt = fitted.components[0].fit_receipt
+        self.assertIsNone(receipt["lr_decay"])
+        self.assertFalse(receipt["saem_schedule"])
+
+    def test_lr_decay_validation(self):
+        from mixle.models import GradLeaf
+
+        with self.assertRaises(ValueError):
+            GradLeaf(self.DiagGauss(), lr_decay=0.0)
+        with self.assertRaises(ValueError):
+            GradLeaf(self.DiagGauss(), lr_decay=1.5)
+        with self.assertRaises(ValueError):
+            GradLeaf(self.DiagGauss(), lr_decay=0.75, optimizer=lambda params: None)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mixle/tests/grad_leaf_test.py
+++ b/mixle/tests/grad_leaf_test.py
@@ -316,5 +316,42 @@ class TupleDefaultLossTest(unittest.TestCase):
         self.assertAlmostEqual(float(fitted.module.b.detach()[0]), 1.0, delta=0.2)
 
 
+class DivergenceRecoveryTest(unittest.TestCase):
+    def _bimodal(self, n=150):
+        rng = np.random.RandomState(0)
+        return [float(v) for v in np.concatenate([rng.normal(-4.0, 1.0, n), rng.normal(4.0, 1.0, n)])]
+
+    def test_diverging_neural_step_recovers_instead_of_crashing(self):
+        # lr=25 drives DiagGauss to NaN within a few steps; the module then RAISES from inside
+        # log_density (torch.distributions constraint check). Pre-guard this crashed optimize()
+        # mid-M-step and left the shared module poisoned; now the round restores the pre-step
+        # state, the fit completes, and the recovery is disclosed in the fit receipt.
+        torch.manual_seed(0)
+        proto = MixtureDistribution(
+            [GradLeaf(DiagGauss(1, mu0=0.5), m_steps=40, lr=25.0), GaussianDistribution(-1.0, 3.0)],
+            [0.5, 0.5],
+        )
+        data = self._bimodal()
+        fitted = optimize(data, proto.estimator(), prev_estimate=proto, max_its=8, out=None)
+
+        enc = fitted.dist_to_encoder().seq_encode(data)
+        self.assertTrue(np.isfinite(float(np.sum(fitted.seq_log_density(enc)))))
+        for p in fitted.components[0].module.parameters():
+            self.assertTrue(bool(torch.isfinite(p).all()))
+        receipt = fitted.components[0].fit_receipt
+        self.assertGreaterEqual(receipt["nonfinite_recoveries_total"], 1)
+
+    def test_healthy_fit_records_zero_recoveries(self):
+        torch.manual_seed(0)
+        proto = MixtureDistribution(
+            [GradLeaf(DiagGauss(1, mu0=0.5), m_steps=25, lr=0.05), GaussianDistribution(-1.0, 3.0)],
+            [0.5, 0.5],
+        )
+        fitted = optimize(self._bimodal(), proto.estimator(), prev_estimate=proto, max_its=8, out=None)
+        receipt = fitted.components[0].fit_receipt
+        self.assertFalse(receipt["nonfinite_recovery"])
+        self.assertEqual(receipt["nonfinite_recoveries_total"], 0)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Makes the convergence story a tested, documented contract instead of folklore.

1. em_convergence_contract_test.py -- the Q5.4 deliverable, pinned as tests:
   - tolerance-aware monotonicity: accepted-round objectives are non-decreasing
     within the loop's acceptance tolerance for closed-form trees, verified on
     mixtures, HMMs, and nested composites (weighted-fit trustworthiness is
     Q5.3's contract in weighted_estimation_test.py);
   - the three declines are distinguishable: numerical noise (within-tolerance,
     accepted), a failed M-step (non-finite or diverging -- never accepted,
     never poisons the convergence reference, disclosed via the GradLeaf
     recovery receipt), and a true stochastic decline (traversed only in
     best-visited mode, where the returned model provably equals the best
     accepted round);
   - monotone=True audits a mutable tree with the strict gate;
   - delta convergence stops early with a small final gain;
   - default console output is verified silent (no unsolicited iteration spam).

2. GradLeaf lr_decay: an optional per-round Robbins-Monro step schedule
   (lr / round**a, a in (0, 1]). Exponents in (0.5, 1] satisfy the step-size
   conditions (sum infinite, sum of squares finite) that stochastic-
   approximation EM analyses (SAEM, gradient-EM) require for almost-sure
   convergence to stationary points -- placing the neural tier inside a real
   convergence theory instead of outside it. The schedule is disclosed per
   round in fit_receipt (fit_round, lr_effective, lr_decay, saem_schedule);
   constant lr (the default, unchanged) is flagged saem_schedule=False.
   lr_decay conflicts with a custom optimizer hook and is validated.

3. optimize()'s docstring now states the guarantee tiers explicitly: enforced
   monotonicity + variance-floor boundedness => objective-sequence convergence
   for gated paths; classical per-family stationarity theory; best-visited for
   the mutable tier, upgraded by the SAEM window.

Stacked on the grad-leaf divergence guard (its recovery receipt is what makes
the failed-M-step arm of the contract testable). 46 tests pass across the new
contract file and the grad_leaf / torch_parity / neural_density suites.

## Worklist alignment

**Q5.4 (P0), implemented to its task list**: tolerance-aware monotonicity rules defined and tested; numerical noise / failed M-step / true decline distinguished (each with its own test arm); non-finite objectives shown never-accepted; mixtures, HMMs, and nested composites covered (weighted fits: Q5.3's existing contract); quiet-by-default console verified. Also touches Q5.1 (the schedule and its theory window are receipted, not implicit).

## Note on stacking

This branch includes PR #406 (grad-leaf divergence guard) -- its recovery receipt is what the failed-M-step contract arm asserts against. Merge #406 first and this PR rebases to just the contract + schedule; or merge this one directly and it subsumes #406.