### PR TITLE
fix(precision): plan precision=minimal against the initialized model on cold starts

### DIFF
--- a/mixle/inference/estimation.py
+++ b/mixle/inference/estimation.py
@@ -704,6 +704,18 @@ def _resolve_track_best(track_best: bool | None, estimator: ParameterEstimator) 
 
 
 # --- public estimation drivers (optimize / fit / best_of) -------------------
+def _record_precision_plan(estimator: Any, plan: Any, out: IO | None) -> None:
+    """Disclose the ``precision="minimal"`` allocation: on the estimator (which survives the fit;
+    fitted models may round-trip custom serializers) and on the requested reporting stream. A
+    silent float64 fallback is a receipts violation -- the decision must be observable."""
+    try:
+        estimator.last_precision_plan = plan
+    except (AttributeError, TypeError):  # a slotted/frozen estimator: the stream still discloses
+        pass
+    if out is not None:
+        out.write("precision=minimal: %s (%s)\n" % (np.dtype(plan.compute_dtype).name, plan.rationale))
+
+
 def optimize(
     data: Sequence[T] | None,
     estimator: ParameterEstimator | ProbabilityDistribution | None = None,
@@ -891,16 +903,25 @@ def optimize(
     if init_estimator is not None:
         init_estimator = _coerce_estimator(init_estimator, data)
     rng = RandomState(0) if rng is None else rng  # fixed default: an un-seeded fit is deterministic
+    minimal_precision_pending = False
     if precision == "minimal":
         # Data-aware allocation: inspect the data + model and run the reduced-precision fused kernel only
         # where it is verified safe; else stay float64. The accumulation is float64 either way.
-        from mixle.inference.precision_plan import recommend_compute_precision
+        # A warm start has a model to inspect NOW; a cold start defers planning until seq_initialize
+        # has produced one -- planning against ``prev_estimate=None`` silently allocated float64 to
+        # every cold-start fit (the common case). The deferred decision lands immediately after the
+        # model materializes, before any engine consumer runs.
+        if prev_estimate is not None:
+            from mixle.inference.precision_plan import recommend_compute_precision
 
-        plan = recommend_compute_precision(prev_estimate, data)
-        if plan.reduced() and engine is None:
-            from mixle.engines import NumpyEngine
+            plan = recommend_compute_precision(prev_estimate, data)
+            _record_precision_plan(estimator, plan, out)
+            if plan.reduced() and engine is None:
+                from mixle.engines import NumpyEngine
 
-            engine = NumpyEngine(dtype=plan.compute_dtype, prefer_fused=True)
+                engine = NumpyEngine(dtype=plan.compute_dtype, prefer_fused=True)
+        else:
+            minimal_precision_pending = True
         precision = None  # carried by the explicit engine (or the default float64 host path)
     elif precision == "auto":
         from mixle.engines import auto_precision
@@ -968,6 +989,23 @@ def optimize(
             mm = seq_initialize(enc_data=enc_data, estimator=est, rng=rng, p=p)
         else:
             mm = prev_estimate
+
+        if minimal_precision_pending:
+            # Deferred cold-start leg of precision="minimal" (see the block above). Parallel
+            # backends already built their encoded handles engine-free, so they keep the
+            # conservative float64 rather than switching dtype mid-flight.
+            from mixle.inference.precision_plan import PrecisionPlan, recommend_compute_precision
+
+            local_path = resources is None and placement is None and backend_name == "local"
+            if engine is None and data is not None and local_path:
+                plan = recommend_compute_precision(mm, data)
+            else:
+                plan = PrecisionPlan(np.float64, "minimal: non-local backend or engine already supplied -> float64")
+            _record_precision_plan(estimator, plan, out)
+            if plan.reduced() and engine is None:
+                from mixle.engines import NumpyEngine
+
+                engine = NumpyEngine(dtype=plan.compute_dtype, prefer_fused=True)
 
         if enc_vdata is None and vdata is not None:
             vdata_for_encoding = _data_records_for_encoding(vdata, fields, est, mm)

--- a/mixle/tests/auto_precision_test.py
+++ b/mixle/tests/auto_precision_test.py
@@ -134,6 +134,12 @@ if __name__ == "__main__":
     unittest.main()
 
 
+try:
+    from mixle.utils.optional_deps import HAS_NUMBA
+except ImportError:  # pragma: no cover
+    HAS_NUMBA = False
+
+
 class MinimalPrecisionColdStartTestCase(unittest.TestCase):
     """optimize(precision="minimal") must plan against a REAL model on cold starts.
 
@@ -152,6 +158,7 @@ class MinimalPrecisionColdStartTestCase(unittest.TestCase):
         estimator = MixtureEstimator([GaussianEstimator() for _ in range(4)])
         return data, estimator
 
+    @unittest.skipUnless(HAS_NUMBA, "the fp32 plan requires the fused numba kernel")
     def test_cold_start_selects_float32_on_a_safe_mixture(self):
         from mixle.inference.estimation import optimize
 
@@ -174,6 +181,7 @@ class MinimalPrecisionColdStartTestCase(unittest.TestCase):
         self.assertEqual(np.dtype(plan.compute_dtype), np.dtype(np.float64))
         self.assertFalse(plan.reduced())
 
+    @unittest.skipUnless(HAS_NUMBA, "the fp32 plan requires the fused numba kernel")
     def test_warm_start_records_the_plan_too(self):
         from mixle.inference.estimation import optimize
         from mixle.stats import GaussianDistribution, MixtureDistribution
@@ -185,6 +193,7 @@ class MinimalPrecisionColdStartTestCase(unittest.TestCase):
         plan = estimator.last_precision_plan
         self.assertEqual(np.dtype(plan.compute_dtype), np.dtype(np.float32))
 
+    @unittest.skipUnless(HAS_NUMBA, "the fp32 plan requires the fused numba kernel")
     def test_out_stream_discloses_the_allocation(self):
         import io
 

--- a/mixle/tests/auto_precision_test.py
+++ b/mixle/tests/auto_precision_test.py
@@ -132,3 +132,65 @@ class PrecisionNameHygieneTestCase(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class MinimalPrecisionColdStartTestCase(unittest.TestCase):
+    """optimize(precision="minimal") must plan against a REAL model on cold starts.
+
+    Planning used to run against ``prev_estimate`` before initialization, so every cold-start fit
+    hit the planner's no-model branch and silently allocated float64; the fix defers planning until
+    the initialized model exists, and the decision is disclosed on the estimator and the ``out``
+    stream either way.
+    """
+
+    def _fixture(self, offset=0.0, n=4000):
+        from mixle.stats import GaussianEstimator, MixtureEstimator
+
+        rng = np.random.RandomState(0)
+        data = np.concatenate([rng.normal(offset + 6.0 * c, 1.0, n // 4) for c in range(4)])
+        rng.shuffle(data)
+        estimator = MixtureEstimator([GaussianEstimator() for _ in range(4)])
+        return data, estimator
+
+    def test_cold_start_selects_float32_on_a_safe_mixture(self):
+        from mixle.inference.estimation import optimize
+
+        data, estimator = self._fixture()
+        fitted = optimize(data, estimator, precision="minimal", max_its=4, print_iter=0, delta=None)
+
+        plan = estimator.last_precision_plan
+        self.assertEqual(np.dtype(plan.compute_dtype), np.dtype(np.float32))
+        self.assertTrue(plan.reduced())
+        enc = fitted.dist_to_encoder().seq_encode(data)
+        self.assertTrue(np.isfinite(float(np.sum(fitted.seq_log_density(enc)))))
+
+    def test_danger_zone_magnitude_stays_float64(self):
+        from mixle.inference.estimation import optimize
+
+        data, estimator = self._fixture(offset=2.0e6)  # |x| > 1e6: outside the validated fp32 band
+        optimize(data, estimator, precision="minimal", max_its=2, print_iter=0, delta=None)
+
+        plan = estimator.last_precision_plan
+        self.assertEqual(np.dtype(plan.compute_dtype), np.dtype(np.float64))
+        self.assertFalse(plan.reduced())
+
+    def test_warm_start_records_the_plan_too(self):
+        from mixle.inference.estimation import optimize
+        from mixle.stats import GaussianDistribution, MixtureDistribution
+
+        data, estimator = self._fixture()
+        proto = MixtureDistribution([GaussianDistribution(6.0 * c, 2.0) for c in range(4)], [0.25] * 4)
+        optimize(data, estimator, precision="minimal", prev_estimate=proto, max_its=2, print_iter=0, delta=None)
+
+        plan = estimator.last_precision_plan
+        self.assertEqual(np.dtype(plan.compute_dtype), np.dtype(np.float32))
+
+    def test_out_stream_discloses_the_allocation(self):
+        import io
+
+        from mixle.inference.estimation import optimize
+
+        data, estimator = self._fixture()
+        buf = io.StringIO()
+        optimize(data, estimator, precision="minimal", max_its=2, print_iter=0, delta=None, out=buf)
+        self.assertIn("precision=minimal: float32", buf.getvalue())


### PR DESCRIPTION
optimize(precision="minimal") computed its precision plan from prev_estimate
BEFORE the model was initialized, so every cold-start fit (prev_estimate=None,
the common case) hit the planner's "no model to inspect" branch and silently
ran float64. The feature only ever engaged on warm starts.

Warm starts still plan immediately; cold starts now defer planning until
seq_initialize has produced the model, immediately before any engine consumer
runs. Parallel backends keep the conservative float64 (their encoded handles
are built engine-free before the model exists) with that decision disclosed
rather than implicit.

The allocation is now observable either way (a silent fallback is a receipts
violation): the plan lands on the estimator as last_precision_plan, and the
out stream reports "precision=minimal: <dtype> (<rationale>)" when reporting
is requested.

Measured on a 500k-observation 8-component Gaussian mixture (cold start,
15 rounds): default fused float64 0.45s; precision="minimal" now 0.23s with
plan=float32 -- 1.96x, with summed-LL drift 6e-4 absolute / 3e-10 relative,
inside the fused float32 kernel's validated <1e-6 relative band. Before the
fix the same call ran 0.44s at float64 with a silent fallback.

Tests (auto_precision_test.py): a cold-start minimal fit on an fp32-safe
mixture selects float32 (asserted via the recorded plan) and returns a finite
objective; a magnitude-2e6 danger-zone fixture stays float64; warm starts
record the plan too; the out stream discloses the allocation. The
optimize-adjacent suites (convergence contract, fused EM, torch parity,
block EM) pass unchanged: 54 tests + 5 subtests.

## Worklist alignment

Q5.2 (numerical stress panels) / K-track precision allocation: the auto-precision control loop now actually runs on the common path, its danger-zone guardrails are regression-tested, and the allocation decision is disclosed on the estimator and the reporting stream instead of silently falling back.