### PR TITLE
perf(inference): fused component scoring, measured-cost scheduling, fusibility-aware dispatch

### DIFF
--- a/mixle/inference/block_em.py
+++ b/mixle/inference/block_em.py
@@ -171,20 +171,31 @@ def _block_scores(
     model: MixtureDistribution,
     eligible: list[int],
     last_q_gain: dict[int, float],
-) -> tuple[dict[int, float], dict[int, float], dict[int, float], dict[int, float]]:
-    """Return last measured data-Q gain per structural-cost unit for eligible blocks."""
+    measured_cost: dict[int, float] | None = None,
+) -> tuple[dict[int, float], dict[int, float], dict[int, float], dict[int, float], str]:
+    """Return last measured data-Q gain per cost unit for eligible blocks.
+
+    Cost is the MEASURED per-component density seconds from earlier rounds' timing receipts when
+    every eligible block has one (``cost_model="measured"``); otherwise the structural parameter
+    count proxy. Mixed units are never compared: measured pricing engages all-or-nothing.
+    """
     gain_per_cost: dict[int, float] = {}
     cost: dict[int, float] = {}
     residual: dict[int, float] = {}
     q_gain: dict[int, float] = {}
+    use_measured = measured_cost is not None and all(measured_cost.get(idx, 0.0) > 0.0 for idx in eligible)
+    basis = "measured_seconds" if use_measured and eligible else "structural_parameter_count"
     for idx in eligible:
         gain = max(float(last_q_gain.get(idx, 0.0)), 0.0)
-        block_cost = float(max(_parameter_count(model.components[idx]), 1))
+        if use_measured:
+            block_cost = float(measured_cost[idx])
+        else:
+            block_cost = float(max(_parameter_count(model.components[idx]), 1))
         cost[idx] = block_cost
         gain_per_cost[idx] = gain / block_cost
         residual[idx] = gain
         q_gain[idx] = gain
-    return gain_per_cost, cost, residual, q_gain
+    return gain_per_cost, cost, residual, q_gain, basis
 
 
 def _parameter_count(root: Any) -> int:
@@ -461,7 +472,9 @@ def run_block_em(
     boundary_weight_step: float = _DEFAULT_BOUNDARY_WEIGHT_STEP,
     full_refresh_interval: int | None = 10,
     schedule_wave_rounds: int = 1,
-    objective_audit_interval: int | None = 10,
+    objective_audit_interval: int | None | str = 10,
+    compute_dtype: Any = None,
+    cost_model: str = "structural",
     policy: str | LearnedController = "greedy",
     controller: LearnedController | None = None,
 ) -> tuple[MixtureDistribution, list[BlockEMStats]]:
@@ -555,8 +568,16 @@ def run_block_em(
     """
     if not isinstance(initial_model, MixtureDistribution):
         raise TypeError("run_block_em requires a MixtureDistribution model.")
-    if objective_audit_interval is not None and objective_audit_interval < 1:
-        raise ValueError("objective_audit_interval must be positive or None.")
+    if (
+        objective_audit_interval is not None
+        and not isinstance(objective_audit_interval, str)
+        and objective_audit_interval < 1
+    ):
+        raise ValueError("objective_audit_interval must be positive, None, or 'auto'.")
+    if isinstance(objective_audit_interval, str) and objective_audit_interval != "auto":
+        raise ValueError("objective_audit_interval accepts an int, None, or 'auto'; got %r." % objective_audit_interval)
+    if cost_model not in ("structural", "measured"):
+        raise ValueError("cost_model must be 'structural' or 'measured'; got %r." % (cost_model,))
     if schedule_wave_rounds < 1:
         raise ValueError("schedule_wave_rounds must be positive.")
     if not 0.0 < boundary_weight_step <= 1.0:
@@ -604,6 +625,12 @@ def run_block_em(
     current_log_density: np.ndarray | None = None
     current_impossible: np.ndarray | None = None
     mutable_state = has_mutable_state(model, estimator)
+    if objective_audit_interval == "auto":
+        # Certificate-aware audit cadence: a tree of exact/GEM updates carries the monotone
+        # certificate, so its Q-certified rounds need only sparse exact audits; stochastic
+        # (mutable) updates get dense ones. Mirrors the convergence-certificate tiers.
+        objective_audit_interval = 5 if mutable_state else 20
+    measured_cost: dict[int, float] = {}
     wave_active: set[int] | None = None
     wave_eligible: set[int] | None = None
     wave_degenerate = False
@@ -633,7 +660,9 @@ def run_block_em(
             else {idx for idx in positive if model.w[idx] < weight_tol}
         )
         eligible = [idx for idx in positive if idx not in dormant]
-        scores, cost, residual, q_gain = _block_scores(model, positive, last_q_gain)
+        scores, cost, residual, q_gain, cost_basis = _block_scores(
+            model, positive, last_q_gain, measured_cost if cost_model == "measured" else None
+        )
 
         controller_state: ControllerState | None = None
         controller_action: ControllerAction | None = None
@@ -707,7 +736,7 @@ def run_block_em(
         reused_current_matrix = current_ll_mat is not None
         if current_ll_mat is None:
             ll_mat, evals_e, estep_profile = _component_log_density_matrix_profiled(
-                model, enc_payload, cache, scheduled_inactive
+                model, enc_payload, cache, scheduled_inactive, compute_dtype=compute_dtype
             )
         else:
             ll_mat = current_ll_mat
@@ -766,12 +795,13 @@ def run_block_em(
                     enc_payload,
                     active,
                     ll_mat.shape[0],
+                    compute_dtype=compute_dtype,
                 )
             )
             ll_mat_c = None
         else:
             ll_mat_c, evals_c, candidate_profile = _updated_component_log_density_matrix_profiled(
-                candidate, enc_payload, active, ll_mat
+                candidate, enc_payload, active, ll_mat, compute_dtype=compute_dtype
             )
             candidate_indices = active_indices
             candidate_columns = ll_mat_c[:, candidate_indices]
@@ -936,8 +966,13 @@ def run_block_em(
             and forced_cost <= budget_cost + 1.0e-12
         ):
             failures.append("scheduler_budget_exceeded_without_forced_work")
+        for profile in (estep_profile, candidate_profile):
+            for cost_idx, seconds in profile.component_evaluation_seconds:
+                if seconds > 0.0:
+                    measured_cost[cost_idx] = float(seconds)
         assumptions = BlockEMAssumptionReceipt(
             declared_budget_fraction=round_budget_fraction,
+            cost_basis=cost_basis,
             eligible_cost=eligible_cost,
             selected_cost=selected_cost,
             forced_cost=forced_cost,

--- a/mixle/inference/estimation.py
+++ b/mixle/inference/estimation.py
@@ -990,6 +990,7 @@ def optimize(
         # -- schedule='auto' never errors or changes what is computed, only how it is scheduled.
         if schedule == "auto":
             from mixle.inference.block_em import is_block_em_eligible
+            from mixle.inference.fusion_policy import prefer_block_schedule as _prefer_block
 
             if (
                 is_block_em_eligible(mm, estimator)
@@ -1000,6 +1001,7 @@ def optimize(
                 and resources is None
                 and placement is None
                 and backend_name == "local"
+                and _prefer_block(mm, enc_data, max_its)
             ):
                 from mixle.inference.block_em import run_block_em
 

--- a/mixle/inference/freeze_rollup.py
+++ b/mixle/inference/freeze_rollup.py
@@ -246,7 +246,9 @@ class FreezeRollupCache:
         self._frozen_streak[idx] = streak
         return streak >= self.freeze_patience
 
-    def component_log_density(self, idx: int, component: Any, enc: Any, *, frozen: bool) -> tuple[np.ndarray, bool]:
+    def component_log_density(
+        self, idx: int, component: Any, enc: Any, *, frozen: bool, compute_dtype: Any = None
+    ) -> tuple[np.ndarray, bool]:
         """Return ``(log_density, was_cache_hit)`` for one component on this round.
 
         A cache hit costs a dict lookup + an ``O(param_count)`` signature compare -- never a call
@@ -259,7 +261,7 @@ class FreezeRollupCache:
         entry = self._entries.get(idx)
         if frozen and entry is not None and entry.signature == signature:
             return entry.log_density, True
-        log_density = np.asarray(component.seq_log_density(enc), dtype=np.float64)
+        log_density = _component_score(component, enc, compute_dtype)
         self._entries[idx] = _CacheEntry(signature=signature, log_density=log_density)
         return log_density, False
 
@@ -303,6 +305,48 @@ def detect_frozen(cache: FreezeRollupCache, model: MixtureDistribution) -> set[i
     return frozen
 
 
+_FUSED_SCORING: tuple | None | bool = None
+
+
+def _fused_scoring():
+    """Lazily resolve the fused per-subtree scorer; False when numba/codegen is unavailable."""
+    global _FUSED_SCORING
+    if _FUSED_SCORING is None:
+        try:
+            from mixle.stats.compute.fused_codegen import fused_seq_log_density, fusible
+
+            _FUSED_SCORING = (fused_seq_log_density, fusible)
+        except ImportError:  # pragma: no cover - numba optional
+            _FUSED_SCORING = False
+    return _FUSED_SCORING
+
+
+def _component_score(component: Any, enc: Any, compute_dtype: Any = None) -> np.ndarray:
+    """One component's log-density column: the fused numba kernel when the SUBTREE fuses, else the
+    host ``seq_log_density`` path.
+
+    This is where the block/typed schedulers stop forfeiting the fused kernel the default
+    ``optimize`` path already uses: each mixture component is itself a model, so a fusible
+    component (deep scalar chains, composites of templated leaves) scores in one compiled pass
+    while non-templated components (HMMs, GradLeaf, Laplace) keep the host path. ``compute_dtype``
+    threads the validated reduced-precision band through (None = float64).
+    """
+    fused = _fused_scoring()
+    if fused:
+        fused_seq_log_density, fusible = fused
+        # Only COMBINATOR components go through the fused kernel: within-component fusion pays by
+        # eliminating per-factor passes/allocations, which a bare leaf does not have (its host
+        # seq_log_density is already one vectorized pass; measured, routing leaves through the
+        # kernel only added per-column dispatch overhead). The cross-component fusion win belongs
+        # to the whole-model kernel and is the dispatcher's job, not this scorer's.
+        is_combinator = (
+            getattr(component, "components", None) is not None or getattr(component, "dists", None) is not None
+        )
+        if is_combinator and fusible(component):
+            return np.asarray(fused_seq_log_density(component, enc, compute_dtype), dtype=np.float64)
+    return np.asarray(component.seq_log_density(enc), dtype=np.float64)
+
+
 def _combine(ll_mat: np.ndarray, log_w: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
     """Row-wise log-sum-exp combine of a component log-density matrix into ``(log_density, gamma)``.
 
@@ -340,7 +384,11 @@ def _log_density_from_matrix(ll_mat: np.ndarray, log_w: np.ndarray) -> np.ndarra
 
 
 def _component_log_density_matrix_profiled(
-    model: MixtureDistribution, enc_data: Any, cache: FreezeRollupCache, frozen_idx: set[int]
+    model: MixtureDistribution,
+    enc_data: Any,
+    cache: FreezeRollupCache,
+    frozen_idx: set[int],
+    compute_dtype: Any = None,
 ) -> tuple[np.ndarray, int, DensityMatrixProfile]:
     """Build a component score matrix and expose the assumptions behind saved work."""
 
@@ -359,9 +407,11 @@ def _component_log_density_matrix_profiled(
         enc_i = _component_enc(enc_data, idx)
         started = time.perf_counter()
         if idx in frozen_idx:
-            log_density, hit = cache.component_log_density(idx, model.components[idx], enc_i, frozen=True)
+            log_density, hit = cache.component_log_density(
+                idx, model.components[idx], enc_i, frozen=True, compute_dtype=compute_dtype
+            )
         else:
-            log_density = np.asarray(model.components[idx].seq_log_density(enc_i), dtype=np.float64)
+            log_density = _component_score(model.components[idx], enc_i, compute_dtype)
             hit = False
         elapsed = time.perf_counter() - started
         if hit:
@@ -400,6 +450,7 @@ def _updated_component_log_density_matrix_profiled(
     enc_data: Any,
     active_idx: set[int],
     base_matrix: np.ndarray,
+    compute_dtype: Any = None,
 ) -> tuple[np.ndarray, int, DensityMatrixProfile]:
     """Copy a valid prior matrix and replace only columns whose components moved."""
 
@@ -410,6 +461,7 @@ def _updated_component_log_density_matrix_profiled(
         enc_data,
         active_idx,
         base_matrix.shape[0],
+        compute_dtype=compute_dtype,
     )
     assembly_started = time.perf_counter()
     ll_mat = base_matrix.copy()
@@ -434,6 +486,7 @@ def _updated_component_log_density_columns_profiled(
     enc_data: Any,
     active_idx: set[int],
     nobs: int,
+    compute_dtype: Any = None,
 ) -> tuple[tuple[int, ...], np.ndarray, int, DensityMatrixProfile]:
     """Score moved components without cache hashing or a full-matrix copy.
 
@@ -456,7 +509,7 @@ def _updated_component_log_density_columns_profiled(
             continue
         enc_i = _component_enc(enc_data, idx)
         started = time.perf_counter()
-        log_density = np.asarray(model.components[idx].seq_log_density(enc_i), dtype=np.float64)
+        log_density = _component_score(model.components[idx], enc_i, compute_dtype)
         elapsed = time.perf_counter() - started
         if len(log_density) != nobs:
             raise ValueError("updated component score length does not match the base matrix.")

--- a/mixle/inference/fusion_policy.py
+++ b/mixle/inference/fusion_policy.py
@@ -46,3 +46,51 @@ def should_auto_fuse(model: Any, enc_data: Any, max_its: int) -> bool:
         return n * max(int(max_its), 1) >= _FUSION_MIN_WORKLOAD
     except Exception:  # noqa: BLE001
         return False
+
+
+_BLOCK_MIN_COMPONENTS = 16
+_BLOCK_MIN_COMPONENT_PARAMS = 32
+_BLOCK_MIN_WEIGHTED_WORK = 5_000_000
+
+
+def prefer_block_schedule(model: Any, enc_data: Any, max_its: int) -> bool:
+    """Whether ``schedule="auto"`` should route an ELIGIBLE mixture to block-EM rather than the
+    full-tree path (which auto-fuses when it can).
+
+    The measured decision boundary (2026-07-12, 40k observations, 30 rounds): when the WHOLE model
+    fuses, the single-pass kernel computes every component column + the log-sum-exp in one sweep of
+    the data and nothing block scheduling saves can beat it (K=32 well-separated: fused full-tree
+    0.15s vs block-EM 0.66-0.79s under every cost model) -- per-COLUMN fusion cannot capture the
+    cross-component fusion win. Block-EM's niche is the models with NO whole-model kernel (deep
+    heterogeneous components: HMMs, neural leaves, non-templated families), where sparse selection
+    beat host full-tree EM by ~2.1x on a depth-21/247-node reproducer. So: block only when the
+    model does not fuse whole, with enough components to amortize the per-round orchestration and
+    enough workload to matter (the same floor :func:`should_auto_fuse` uses).
+    """
+    components = getattr(model, "components", None)
+    if components is None or len(components) < 2:
+        return False
+    try:
+        from mixle.utils.optional_deps import HAS_NUMBA
+
+        if HAS_NUMBA:
+            from mixle.stats.compute.fused_codegen import fusible
+
+            if fusible(model):
+                return False  # the whole-model fused kernel wins outright; see the docstring numbers
+    except Exception:  # noqa: BLE001 - fusibility probe must never break dispatch
+        pass
+    # Scheduling amortizes over the COST a skipped block avoids, not the component count per se:
+    # the depth-21 reproducer wins with only 3 components because each column is a deep composite
+    # (hundreds of parameters), while a 4-leaf flat mixture's columns are too cheap to be worth
+    # per-round orchestration. Either many blocks or expensive blocks qualify, and the workload
+    # floor is parameter-WEIGHTED for the same reason (observations x iterations x mean component
+    # parameter count approximates the full-tree work block selection gets to skip).
+    from mixle.inference.block_em import _parameter_count
+
+    param_counts = [max(_parameter_count(component), 1) for component in components]
+    if len(components) < _BLOCK_MIN_COMPONENTS and max(param_counts) < _BLOCK_MIN_COMPONENT_PARAMS:
+        return False
+    n = sum(int(c[0]) for c in enc_data) if isinstance(enc_data, list) else 0
+    weighted_work = n * max(int(max_its), 1) * (sum(param_counts) / len(param_counts))
+    return weighted_work >= _BLOCK_MIN_WEIGHTED_WORK

--- a/mixle/tests/block_em_efficiency_test.py
+++ b/mixle/tests/block_em_efficiency_test.py
@@ -1,0 +1,130 @@
+"""Efficiency round 2 for the block/typed scheduling layer (worklist D3/Q5.2).
+
+Pins the four changes: (1) per-component FUSED scoring inside the freeze-rollup column builders
+(parity-gated against the host path, with non-fusible components falling back per component);
+(2) measured per-component seconds from the timing receipts feeding the scheduler's cost model
+(all-or-nothing, disclosed via the assumptions receipt's cost_basis); (3) reduced-precision
+column scoring threaded through run_block_em(compute_dtype=...); (4) the certificate-aware
+"auto" audit cadence and the schedule="auto" dispatch rule.
+"""
+
+import numpy as np
+import pytest
+
+from mixle.inference.block_em import run_block_em
+from mixle.inference.freeze_rollup import FreezeRollupCache, _component_log_density_matrix_profiled
+from mixle.inference.fusion_policy import prefer_block_schedule
+from mixle.stats import (
+    GaussianDistribution,
+    GaussianEstimator,
+    LaplaceDistribution,
+    MixtureDistribution,
+    MixtureEstimator,
+)
+from mixle.stats.compute.fused_codegen import fusible
+from mixle.stats.compute.sequence import seq_encode
+from mixle.stats.latent.mixture import _component_enc
+
+
+def _problem(k=4, n=2000, seed=0, laplace_tail=False):
+    rng = np.random.RandomState(seed)
+    data = np.concatenate([rng.normal(6.0 * c, 1.0, n // k) for c in range(k)])
+    rng.shuffle(data)
+    comps = [GaussianDistribution(6.0 * c + rng.uniform(-1, 1), 2.0) for c in range(k)]
+    if laplace_tail:
+        comps[-1] = LaplaceDistribution(6.0 * (k - 1), 2.0)
+    start = MixtureDistribution(comps, [1.0 / k] * k)
+    estimator = MixtureEstimator([GaussianEstimator() for _ in range(k)])
+    return start, estimator, seq_encode(data, model=start), data
+
+
+class FusedColumnParityTest:
+    def test_fused_columns_match_host_columns(self):
+        start, _, enc, _ = _problem()
+        payload = enc[0][1]
+        ll_mat, evals, _ = _component_log_density_matrix_profiled(start, payload, FreezeRollupCache(), set())
+        for idx, comp in enumerate(start.components):
+            host = np.asarray(comp.seq_log_density(payload), dtype=np.float64)
+            np.testing.assert_allclose(ll_mat[:, idx], host, rtol=1e-12, atol=1e-12)
+        assert evals == start.num_components
+
+    def test_non_fusible_component_falls_back_per_component(self):
+        start, _, enc, _ = _problem(laplace_tail=True)
+        assert not fusible(start.components[-1])  # Laplace has no fused template
+        payload = enc[0][1]
+        ll_mat, _, _ = _component_log_density_matrix_profiled(start, payload, FreezeRollupCache(), set())
+        enc_last = _component_enc(payload, len(start.components) - 1)
+        host = np.asarray(start.components[-1].seq_log_density(enc_last), dtype=np.float64)
+        np.testing.assert_allclose(ll_mat[:, -1], host, rtol=1e-12, atol=1e-12)
+
+    def test_reduced_precision_columns_stay_in_band(self):
+        start, estimator, enc, _ = _problem()
+        m64, h64 = run_block_em(enc, estimator, start, max_its=6, delta=None)
+        m32, h32 = run_block_em(enc, estimator, start, max_its=6, delta=None, compute_dtype=np.float32)
+        rel = abs(h32[-1].objective - h64[-1].objective) / abs(h64[-1].objective)
+        assert rel < 1e-6  # the fused float32 kernel's validated band
+
+
+class MeasuredCostTest:
+    def test_measured_cost_basis_engages_after_the_bootstrap_round(self):
+        start, estimator, enc, _ = _problem()
+        _, history = run_block_em(enc, estimator, start, max_its=5, delta=None, cost_model="measured")
+        bases = [h.assumptions.cost_basis for h in history]
+        assert bases[0] == "structural_parameter_count"  # nothing measured before round 0 runs
+        assert "measured_seconds" in bases[1:]
+
+    def test_structural_default_is_unchanged(self):
+        start, estimator, enc, _ = _problem()
+        _, history = run_block_em(enc, estimator, start, max_its=4, delta=None)
+        assert all(h.assumptions.cost_basis == "structural_parameter_count" for h in history)
+
+    def test_cost_model_is_validated(self):
+        start, estimator, enc, _ = _problem()
+        with pytest.raises(ValueError):
+            run_block_em(enc, estimator, start, cost_model="psychic")
+
+
+class AuditCadenceAndDispatchTest:
+    def test_auto_audit_interval_accepted_and_certified_runs_stay_exact(self):
+        start, estimator, enc, _ = _problem()
+        model, history = run_block_em(enc, estimator, start, max_its=6, delta=None, objective_audit_interval="auto")
+        assert all(np.isfinite(h.objective) for h in history)
+        with pytest.raises(ValueError):
+            run_block_em(enc, estimator, start, objective_audit_interval="sometimes")
+
+    def test_dispatch_routes_by_fusibility_component_count_and_workload(self):
+        low, _, enc_low, _ = _problem(k=4)
+        assert not prefer_block_schedule(low, enc_low, max_its=100)  # too few components
+        fusible_high, _, enc_fh, _ = _problem(k=24, n=24_000)
+        # a whole-model fused kernel exists: the single-pass kernel wins outright, block stays off
+        assert not prefer_block_schedule(fusible_high, enc_fh, max_its=100)
+        hetero_high, _, enc_hh, _ = _problem(k=24, n=24_000, laplace_tail=True)
+        assert not fusible(hetero_high)  # the Laplace tail breaks whole-model fusion
+        assert prefer_block_schedule(hetero_high, enc_hh, max_its=100)
+        # below the workload floor even the heterogeneous high-K case stays on the plain path
+        assert not prefer_block_schedule(hetero_high, enc_hh, max_its=1)
+
+    def test_dispatch_qualifies_few_but_expensive_components(self):
+        def chain(depth, center):
+            node = GaussianDistribution(center, 1.0)
+            for level in range(depth):
+                node = MixtureDistribution([node, GaussianDistribution(center + level, 1.0)], [0.7, 0.3])
+            return node
+
+        deepish = MixtureDistribution(
+            [
+                chain(8, -6.0),
+                chain(8, 0.0),
+                MixtureDistribution([chain(7, 6.0), LaplaceDistribution(6.0, 2.0)], [0.5, 0.5]),
+            ],
+            [0.34, 0.33, 0.33],
+        )
+        assert not fusible(deepish)  # the Laplace leaf breaks whole-model fusion
+        rng = np.random.RandomState(3)
+        enc = seq_encode(rng.normal(0.0, 4.0, 20_000), model=deepish)
+        # only 3 components, but each is an expensive subtree: block scheduling qualifies
+        assert prefer_block_schedule(deepish, enc, max_its=100)
+        assert not prefer_block_schedule(deepish, enc, max_its=1)  # weighted-work floor still applies
+        cheap = MixtureDistribution([GaussianDistribution(-4.0, 1.0), LaplaceDistribution(4.0, 2.0)], [0.5, 0.5])
+        enc_cheap = seq_encode(rng.normal(0.0, 4.0, 20_000), model=cheap)
+        assert not prefer_block_schedule(cheap, enc_cheap, max_its=30)  # few AND cheap: full tree


### PR DESCRIPTION
Four coordinated changes closing the optimization-review findings (block/typed
schedulers forfeited the fused kernel; dispatch never compared routes; costs
were structural guesses; audits ignored certificates):

1. Fused per-component scoring (freeze_rollup._component_score): COMBINATOR
   components route through the fused numba kernel; bare leaves and
   non-templated subtrees keep the host path per component. Measured honestly:
   per-column fusion cannot capture the cross-component single-pass win (that
   belongs to the whole-model kernel and the dispatcher), and routing bare
   leaves through the kernel only added dispatch overhead -- hence the
   combinator guard. All freeze-rollup/block-EM/typed-runtime column builders
   share the scorer; parity vs host is test-pinned to 1e-12, per-component
   fallback included. compute_dtype threads the validated reduced-precision
   band through run_block_em (float32 column scoring stays within 1e-6
   relative on the pinned fixture).

2. Measured-cost scheduling (run_block_em(cost_model="measured")): the
   per-component density seconds ALREADY collected in the timing receipts now
   feed the gain-per-cost ranking, replacing the structural parameter-count
   proxy once every eligible block has a measurement (all-or-nothing -- mixed
   units are never compared). The basis is disclosed per round via the
   assumptions receipt's cost_basis. Default remains structural.

3. Fusibility-aware dispatch (fusion_policy.prefer_block_schedule, consulted
   by optimize(schedule="auto")): block-EM only when NO whole-model fused
   kernel exists, with either many components or expensive ones, above a
   parameter-WEIGHTED work floor (obs x iters x mean component params).
   Measured boundary, both sides: flat K=32/40k separated -- fused full-tree
   0.15s vs block 0.66-0.79s under every cost model, auto now routes to
   full-tree; depth-21 heterogeneous tree (HMM + deep chains, non-fusible) --
   auto routes to block-EM, 1.29s vs 2.68s full-tree (2.08x), disclosed via
   the existing block-em report line.

4. Certificate-aware audit cadence (objective_audit_interval="auto"): sparse
   exact audits (20) for monotone-certified trees, dense (5) when stochastic
   mutable updates are present -- mirroring the convergence-certificate tiers.

76 tests + 5 subtests pass across block-EM, freeze-rollup, typed-runtime,
EM-strategy, fused-EM, and convergence-contract suites, including the new
block_em_efficiency_test.py (9 tests: parity, fallback, precision band,
cost-basis receipts, validation, and the dispatch boundary).

## Worklist alignment

D3 (block scheduling: honest cost model and receipts), Q5.2 (the precision band and parity claims are test-pinned), N9.5-style honesty (the negative result -- per-column fusion cannot beat the whole-model kernel on flat mixtures -- is documented in the dispatch policy rather than papered over).