### PR TITLE
feat(typed-runtime): compute-band axis on the update-graph IR

### DIFF
--- a/mixle/experimental/typed_runtime/compiler.py
+++ b/mixle/experimental/typed_runtime/compiler.py
@@ -10,6 +10,7 @@ import numpy as np
 
 from mixle.experimental.typed_runtime.contracts import (
     ArtifactKind,
+    ComputeBand,
     ConsistencyRequirement,
     ConvergenceCertificate,
     CostEstimate,
@@ -331,6 +332,25 @@ def _decomposition(model: Any) -> tuple[tuple[str, ...], bool]:
         return (), True
 
 
+def _compute_band(model: Any) -> ComputeBand:
+    """Float32 eligibility of this node's scoring subtree: it must fuse (the validated
+    reduced-precision path is the fused kernel's) and every leaf family must be in the
+    runtime planner's validated set. Data-side safety stays a runtime decision."""
+    try:
+        from mixle.inference.precision_plan import FP32_SAFE_FAMILIES, _leaf_components
+        from mixle.stats.compute.fused_codegen import fusible
+        from mixle.utils.optional_deps import HAS_NUMBA
+
+        if not HAS_NUMBA or model is None or not fusible(model):
+            return ComputeBand.FLOAT64
+        for leaf in _leaf_components(model):
+            if type(leaf).__name__ not in FP32_SAFE_FAMILIES:
+                return ComputeBand.FLOAT64
+        return ComputeBand.FLOAT32_ELIGIBLE
+    except Exception:  # noqa: BLE001 - eligibility probing must never break compilation
+        return ComputeBand.FLOAT64
+
+
 def _convergence_certificate(
     update_kind: UpdateKind, exact_update: bool, estimator: Any | None
 ) -> ConvergenceCertificate:
@@ -388,6 +408,7 @@ def infer_update_contract(model: Any, estimator: Any | None) -> UpdateContract:
         reads=frozenset(reads),
         writes=frozenset(writes),
         convergence_certificate=_convergence_certificate(update, exact_update, estimator),
+        compute_band=_compute_band(model),
         outer_objective_compatible=compatible,
         exact=exact_update and exact_decomposition and compatible,
         declared_by="structural_inference",

--- a/mixle/experimental/typed_runtime/contracts.py
+++ b/mixle/experimental/typed_runtime/contracts.py
@@ -80,6 +80,31 @@ _CERTIFICATE_STRENGTH = {
 }
 
 
+class ComputeBand(StrEnum):
+    """Model-side compute-precision eligibility of a node's scoring subtree.
+
+    ``float32_eligible`` means the subtree fuses AND every leaf family is in the validated
+    reduced-precision set (``mixle.inference.precision_plan.FP32_SAFE_FAMILIES``) -- the fused
+    float32 kernel's summed-log-likelihood error is verified < ~1e-6 relative there. The DATA-side
+    conditions (bounded magnitude, non-degenerate variances) remain a runtime decision
+    (``optimize(precision="minimal")``); this axis declares what the model structure permits.
+    Composition is weakest-link: one ineligible node keeps the tree at ``float64``.
+    """
+
+    FLOAT32_ELIGIBLE = "float32_eligible"
+    FLOAT64 = "float64"
+
+
+def weakest_band(bands: Any) -> ComputeBand:
+    """FLOAT32_ELIGIBLE only when every node is eligible; FLOAT64 otherwise (or when empty)."""
+    result: ComputeBand | None = None
+    for band in bands:
+        if band is ComputeBand.FLOAT64:
+            return ComputeBand.FLOAT64
+        result = band
+    return result if result is not None else ComputeBand.FLOAT64
+
+
 def weakest_certificate(certificates: Any) -> ConvergenceCertificate:
     """The minimum certificate over an iterable (the tree-level guarantee); UNKNOWN when empty."""
     result: ConvergenceCertificate | None = None
@@ -209,6 +234,7 @@ class UpdateContract:
     outer_objective_compatible: bool = True
     exact: bool = True
     convergence_certificate: ConvergenceCertificate = ConvergenceCertificate.UNKNOWN
+    compute_band: ComputeBand = ComputeBand.FLOAT64
     declared_by: str = "compiler_default"
     notes: tuple[str, ...] = ()
 
@@ -250,6 +276,7 @@ class UpdateContract:
             "outer_objective_compatible": self.outer_objective_compatible,
             "exact": self.exact,
             "convergence_certificate": self.convergence_certificate.value,
+            "compute_band": self.compute_band.value,
             "declared_by": self.declared_by,
             "notes": list(self.notes),
         }

--- a/mixle/experimental/typed_runtime/graph.py
+++ b/mixle/experimental/typed_runtime/graph.py
@@ -157,6 +157,13 @@ class UpdateGraph:
         }
 
     @property
+    def compute_band(self):
+        """Tree-level precision eligibility: float32 only when every node's subtree qualifies."""
+        from mixle.experimental.typed_runtime.contracts import weakest_band
+
+        return weakest_band(node.contract.compute_band for node in self.nodes)
+
+    @property
     def convergence_certificate(self):
         """Tree-level guarantee: the weakest node certificate (guarantees compose by minimum)."""
         from mixle.experimental.typed_runtime.contracts import weakest_certificate
@@ -170,6 +177,7 @@ class UpdateGraph:
             "Statistically typed update graph",
             "root=%s nodes=%d dependencies=%d" % (self.root_node, len(self.nodes), len(self.edges)),
             "convergence certificate (weakest link): %s" % self.convergence_certificate.value,
+            "compute band (weakest link): %s" % self.compute_band.value,
         ]
         by_id = {node.node_id: node for node in self.nodes}
         for node_id in self.topological_order():
@@ -178,7 +186,7 @@ class UpdateGraph:
             axes = ",".join(contract.decomposition_axes) or "replicated"
             state = ",".join(sorted(item.value for item in contract.state_semantics))
             lines.append(
-                "- %s %s: %s/%s merge=%s state=%s axes=%s cost=%s cert=%s"
+                "- %s %s: %s/%s merge=%s state=%s axes=%s cost=%s cert=%s band=%s"
                 % (
                     node.node_id,
                     node.path,
@@ -189,6 +197,7 @@ class UpdateGraph:
                     axes,
                     node.cost.source,
                     contract.convergence_certificate.value,
+                    contract.compute_band.value,
                 )
             )
         if self.edges:

--- a/mixle/inference/precision_plan.py
+++ b/mixle/inference/precision_plan.py
@@ -61,6 +61,11 @@ def _leaf_components(model: Any) -> list[Any]:
     return [model]
 
 
+# Public alias: the typed-runtime compiler declares per-node float32 eligibility from the same
+# validated family set the runtime planner uses, so the two can never drift apart.
+FP32_SAFE_FAMILIES = _FP32_SAFE
+
+
 def recommend_compute_precision(
     model: Any,
     data: Any,

--- a/mixle/tests/typed_compute_band_test.py
+++ b/mixle/tests/typed_compute_band_test.py
@@ -8,6 +8,10 @@ validated reduced-precision kernel," not "should this fit."
 
 import pytest
 
+# float32 eligibility exists only where the fused numba kernel does; without numba every band is
+# correctly float64 and the discriminating assertions below would be vacuous.
+pytest.importorskip("numba")
+
 from mixle.experimental.typed_runtime import compile_update_graph
 from mixle.experimental.typed_runtime.contracts import ComputeBand, weakest_band
 from mixle.stats import GaussianDistribution, LaplaceDistribution, MixtureDistribution

--- a/mixle/tests/typed_compute_band_test.py
+++ b/mixle/tests/typed_compute_band_test.py
@@ -1,0 +1,67 @@
+"""Compute-band axis of the typed update graph: what precision the model STRUCTURE permits.
+
+Float32 eligibility is declared from the same validated family set the runtime planner uses
+(single source of truth), the tree-level band composes by weakest link, and the data-side
+safety checks remain a runtime decision -- this axis answers "could this subtree ever take the
+validated reduced-precision kernel," not "should this fit."
+"""
+
+import pytest
+
+from mixle.experimental.typed_runtime import compile_update_graph
+from mixle.experimental.typed_runtime.contracts import ComputeBand, weakest_band
+from mixle.stats import GaussianDistribution, LaplaceDistribution, MixtureDistribution
+
+
+def _graph(model):
+    return compile_update_graph(model, model.estimator(), nobs=500)
+
+
+class ComputeBandTest:
+    def test_fp32_safe_classical_tree_is_eligible_end_to_end(self):
+        model = MixtureDistribution([GaussianDistribution(float(m), 1.0) for m in (-4.0, 0.0, 4.0)], [1 / 3] * 3)
+        graph = _graph(model)
+        assert graph.compute_band is ComputeBand.FLOAT32_ELIGIBLE
+        assert all(n.contract.compute_band is ComputeBand.FLOAT32_ELIGIBLE for n in graph.nodes)
+
+    def test_one_unvalidated_family_drops_the_tree_to_float64(self):
+        model = MixtureDistribution([GaussianDistribution(-4.0, 1.0), LaplaceDistribution(4.0, 2.0)], [0.5, 0.5])
+        graph = _graph(model)
+        bands = {n.node_id: n.contract.compute_band for n in graph.nodes}
+        assert ComputeBand.FLOAT32_ELIGIBLE in bands.values()  # the Gaussian sibling stays eligible
+        assert graph.compute_band is ComputeBand.FLOAT64
+
+    def test_neural_leaf_is_float64(self):
+        torch = pytest.importorskip("torch")
+        from mixle.models import GradLeaf
+
+        class DiagGauss(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.mu = torch.nn.Parameter(torch.zeros(1))
+                self.log_sigma = torch.nn.Parameter(torch.zeros(1))
+
+            def log_density(self, x):
+                d = torch.distributions.Normal(self.mu, torch.exp(self.log_sigma))
+                return d.log_prob(x if x.dim() > 1 else x.unsqueeze(-1)).sum(-1)
+
+        torch.manual_seed(0)
+        model = MixtureDistribution(
+            [GradLeaf(DiagGauss(), m_steps=5, lr=0.05), GaussianDistribution(1.0, 1.0)], [0.5, 0.5]
+        )
+        graph = _graph(model)
+        assert graph.compute_band is ComputeBand.FLOAT64
+
+    def test_explain_and_as_dict_carry_the_band(self):
+        model = MixtureDistribution([GaussianDistribution(-4.0, 1.0), GaussianDistribution(4.0, 1.0)], [0.5, 0.5])
+        graph = _graph(model)
+        text = graph.explain()
+        assert "compute band (weakest link): float32_eligible" in text
+        assert "band=float32_eligible" in text
+        assert all(n.contract.as_dict()["compute_band"] == "float32_eligible" for n in graph.nodes)
+
+    def test_weakest_band_composition(self):
+        b = ComputeBand
+        assert weakest_band([b.FLOAT32_ELIGIBLE, b.FLOAT32_ELIGIBLE]) is b.FLOAT32_ELIGIBLE
+        assert weakest_band([b.FLOAT32_ELIGIBLE, b.FLOAT64]) is b.FLOAT64
+        assert weakest_band([]) is b.FLOAT64


### PR DESCRIPTION
The IR carried update mechanics and (as of #408) convergence certificates,
but not what precision a node's scoring subtree structurally permits.
UpdateContract gains compute_band:

- float32_eligible: the subtree fuses AND every leaf family is in the
  validated reduced-precision set -- declared from the SAME family list the
  runtime planner uses (precision_plan.FP32_SAFE_FAMILIES, now exported as
  the single source of truth, so compiler and runtime can never drift);
- float64: everything else (non-fusible subtrees, neural leaves,
  non-templated families).

Data-side safety (bounded magnitude, non-degenerate variances) remains the
runtime planner's decision; this axis answers "could this subtree ever take
the validated reduced-precision kernel," per node and -- by weakest link --
per tree. UpdateGraph.compute_band, explain() ("compute band (weakest
link): ..." plus per-node band=... tags), and as_dict() all carry it, so a
scheduler or the mlops layer can see at compile time which subtrees the
float32 kernel may score and which pin the fit to float64.

Tests: an fp32-safe classical tree is eligible end to end; one unvalidated
family (Laplace) drops the tree to float64 while its Gaussian sibling stays
eligible; a GradLeaf is float64; explain()/as_dict carry the band;
weakest-link composition incl. the empty case. The 148-model compiler
catalog, the certificate suite, and the runtime precision tests pass
unchanged (39 tests).

## Worklist alignment

Q5.2 / K-track precision allocation: the model-side precision verdict is now a compile-time, per-node declaration sharing one source of truth with the runtime planner. Experimental namespace throughout (freeze rule 5) except the one-line public alias in precision_plan and the test file.