### PR TITLE
perf(fused): bridge factor kind, nested-kernel dtype/parallel, opt-in quantized LSE, edge pins

### DIFF
--- a/docs/large-module-audit.rst
+++ b/docs/large-module-audit.rst
@@ -135,7 +135,7 @@ Probabilistic-programming surface
 Compiled-kernel code generation
 -------------------------------
 
-``mixle/stats/compute/fused_codegen.py`` (1,622)
+``mixle/stats/compute/fused_codegen.py`` (1,703)
     * **Responsibilities:** the fused-kernel source generator — per-family ``LeafTemplate``\s (scalar,
       vector, matrix, tabulated, categorical, chain), plan analysis (``analyze``/``fusible``), source
       emission for the one-pass scorer and E-step (sequential and chunk-parallel prange variants), the

--- a/mixle/inference/freeze_rollup.py
+++ b/mixle/inference/freeze_rollup.py
@@ -389,7 +389,8 @@ def _component_score(component: Any, enc: Any, compute_dtype: Any = None) -> np.
         # scalar-tree kernels are structure-keyed and disk-cached (measured on a depth-18 chain
         # component: first-ever compile ~4.5s, then 0.10s in ANY process vs 0.34s on the host walk
         # -- 3.4x; dispatcher signature counts stay at 1-2, i.e. no per-call respecialization).
-        # The nested kernels ignore compute_dtype and always run float64.
+        # The nested kernels honor compute_dtype (float32 rows, float64 accumulation), same as the
+        # template kernels -- both route through the shared fused entry points below.
         is_combinator = (
             getattr(component, "components", None) is not None or getattr(component, "dists", None) is not None
         )

--- a/mixle/models/grad_leaf.py
+++ b/mixle/models/grad_leaf.py
@@ -87,6 +87,12 @@ def looks_like_torch_module(obj: Any) -> bool:
 
 class GradLeaf(SequenceEncodableProbabilityDistribution):
     """Wrap a torch density ``module`` (``module.log_density(x) -> (n,)``) as a composable mixle
+
+    Measured negative, so nobody re-derives it (2026-07-12, Apple M4, torch 2.12 CPU): wrapping the
+    full-batch M-step loss in ``torch.compile`` is a LOSS here -- 0.93x at a 2x32 MLP / n=100k and
+    0.79x at 2x256 / n=200k, plus ~6s compile overhead per module -- so there is deliberately no
+    ``compile=`` flag. Re-measure before adding one (a CUDA build or a much larger module could
+    flip it); the probe script pattern lives in the introducing PR.
     distribution (see the module docstring). ``loss`` and ``optimizer`` are the M-step hooks."""
 
     __pysp_serializable__ = True  # module persisted as bytes (see __pysp_getstate__)

--- a/mixle/stats/compute/fused_codegen.py
+++ b/mixle/stats/compute/fused_codegen.py
@@ -115,9 +115,9 @@ def register_leaf_template(t: LeafTemplate) -> None:
     _TEMPLATES.append(t)
 
 
-def _template_for(dist: Any) -> LeafTemplate | None:
+def _template_for(dist: Any, allow_bridge: bool = True) -> LeafTemplate | None:
     for t in _TEMPLATES:
-        if t.matches(dist):
+        if (allow_bridge or t.kind != "bridge") and t.matches(dist):
             return t
     return None
 
@@ -796,6 +796,28 @@ register_leaf_template(
 )
 
 
+_BRIDGE_TYPES = frozenset({"MixtureDistribution", "HiddenMarkovModelDistribution", "CompositeDistribution"})
+
+
+def _bridge_matches(d: Any) -> bool:
+    """Combinators sitting inside a composite factor: scored and estimated through their OWN native
+    machinery (seq_log_density / accumulator seq_update), so ANY configuration they support -- priors
+    included -- is supported here. Registered LAST, so every specific template outranks the bridge."""
+    return type(d).__name__ in _BRIDGE_TYPES
+
+
+register_leaf_template(
+    LeafTemplate(
+        name="bridge",
+        matches=_bridge_matches,
+        data=lambda enc: (),
+        params=lambda comps: {},
+        arity=0,
+        kind="bridge",
+    )
+)
+
+
 # --- structure analysis ---------------------------------------------------------------------------
 @dataclass(frozen=True)
 class FusedPlan:
@@ -813,17 +835,29 @@ class FusedPlan:
         return any(t.kind == "matrix" for t in self.leaf_templates)
 
     @property
+    def has_bridge(self) -> bool:
+        """Whether any factor is a BRIDGED combinator (scored via its own native seq_log_density; its
+        sufficient statistics collected by its own accumulator, weighted by the responsibility matrix)."""
+        return any(t.kind == "bridge" for t in self.leaf_templates)
+
+    @property
     def needs_responsibilities(self) -> bool:
         """Whether the E-step must materialize the (n, K) responsibility matrix R (matrix BLAS
-        accumulation and chain post-pass scatters both read it after the row loop)."""
-        return any(t.kind in ("matrix", "chain") for t in self.leaf_templates)
+        accumulation and chain post-pass scatters read it after the row loop; bridged factors hand it
+        back to the caller for their native weighted updates)."""
+        return any(t.kind in ("matrix", "chain", "bridge") for t in self.leaf_templates)
 
 
 def _node_factors(node: Any) -> list[Any] | None:
-    """The leaf factors of a fusible *node* (an exact Composite, or a templated bare leaf), else None."""
+    """The leaf factors of a fusible *node* (an exact Composite, or a templated bare leaf), else None.
+
+    The bare-node check deliberately excludes the bridge template: a bare Mixture-of-Mixtures (no
+    Composite anywhere) belongs to fused_nested's in-kernel nested-tree path, which is faster than
+    bridging. Bridge factors exist for combinators sitting INSIDE a composite, where no in-kernel
+    path exists at all."""
     if type(node).__name__ == "CompositeDistribution":
         return list(node.dists)
-    if _template_for(node) is not None:
+    if _template_for(node, allow_bridge=False) is not None:
         return [node]
     return None
 
@@ -904,6 +938,7 @@ def _dummy(t: LeafTemplate) -> Any:
         "negbinomial": stats.NegativeBinomialDistribution(1.0, 0.5),
         "mvgaussian": stats.MultivariateGaussianDistribution([0.0, 0.0], [[1.0, 0.0], [0.0, 1.0]]),
         "markovchain": stats.MarkovChainDistribution({"a": 1.0}, {"a": {"a": 1.0}}),
+        "bridge": stats.GaussianDistribution(0.0, 1.0),  # params() ignores it (bridge has no static params)
     }[t.name]
 
 
@@ -979,6 +1014,12 @@ def _emit(plan: FusedPlan, acc_suffix: str = "") -> dict[str, list[str]]:
             frag["acc"].append(f"{accmap['sx']}[k] += r * x{i}_0[i]")
             if t.tab_hist:
                 frag["acc"].append(f"{accmap['hist']}[k, int(x{i}_0[i])] += r")  # weighted count histogram
+        elif t.kind == "bridge":
+            # scored from a precomputed (n, K) table (each column: the factor's OWN seq_log_density for
+            # that component); no in-kernel statistics -- the wrapper drives the factor's native
+            # accumulator with the R column instead.
+            frag["param_args"].append(f"bt{i}")
+            frag["row"].append(f"acc += bt{i}[i, k]")
         elif t.kind == "chain":
             frag["param_args"] += [f"cinit{i}", f"ctrans{i}"]  # (K,S) init and (K,S,S) transition log tables
             frag["acc_args"] += [f"ih{i}", f"th{i}"]  # (K,S) init and (K,S,S) transition weighted histograms
@@ -1138,23 +1179,49 @@ def _score_body(indent: str, row_lines: list[str], llbuf_name: str) -> list[str]
     return lines
 
 
-def _compile(plan: FusedPlan, parallel: bool = False) -> Callable:
-    cached = _COMPILED.get((plan.signature, parallel))
+def _score_tail_quantized(indent: str, row_lines: list[str], llbuf_name: str) -> list[str]:
+    """The per-row block with the log-sum-exp EXP replaced by one LUT gather over a delta-grid --
+    mixle.engines.qlut.quantized_logsumexp's exact semantics (round to grid, clamp the deep tail into
+    the bottom bin), emitted inline. Error bound: half a grid step (lse_error_bound), plus the
+    negligible clipped-tail term the qlut docstring quantifies."""
+    lines = [f"{indent}for k in range(kc):", f"{indent}    acc = logw[k]"]
+    lines += [f"{indent}    {rt}" for rt in row_lines]
+    lines += [
+        f"{indent}    {llbuf_name}[k] = acc",
+        f"{indent}m = {llbuf_name}[0]",
+        f"{indent}for k in range(1, kc):",
+        f"{indent}    if {llbuf_name}[k] > m:",
+        f"{indent}        m = {llbuf_name}[k]",
+        f"{indent}s = 0.0",
+        f"{indent}for k in range(kc):",
+        f"{indent}    qi = int(np.rint(({llbuf_name}[k] - m) * lse_inv_delta)) + lse_levm1",
+        f"{indent}    if qi < 0:",
+        f"{indent}        qi = 0",  # scores more than `span` below the max clip into the bottom bin
+        f"{indent}    s += lse_lut[qi]",
+        f"{indent}out[i] = (m + np.log(s)) if m > -np.inf else -np.inf",
+    ]
+    return lines
+
+
+def _compile(plan: FusedPlan, parallel: bool = False, quantized_lse: bool = False) -> Callable:
+    cached = _COMPILED.get((plan.signature, parallel, quantized_lse))
     if cached is not None:
         return cached
     f = _emit(plan)
     data_args = f["data_args"]
+    lse_args = ["lse_lut", "lse_inv_delta", "lse_levm1"] if quantized_lse else []
+    tail = _score_tail_quantized if quantized_lse else _score_body
     if not parallel:
-        args = ", ".join(data_args + f["param_args"] + ["logw", "out", "llbuf"])
+        args = ", ".join(data_args + f["param_args"] + lse_args + ["logw", "out", "llbuf"])
         lines = ["def _fused(%s):" % args, "    n = out.shape[0]", "    kc = logw.shape[0]"]
         lines += ["    " + ln for ln in f["precompute"]]
         lines += ["    for i in range(n):"]
-        lines += _score_body("        ", f["row"], "llbuf")
+        lines += tail("        ", f["row"], "llbuf")
         fn = _njit("\n".join(lines), "_fused")
     else:
         # prange over fixed chunks; out[i] rows are disjoint and each row's arithmetic is identical to
         # the sequential kernel's, so the parallel scorer is BIT-IDENTICAL to it (asserted in tests).
-        args = ", ".join(data_args + f["param_args"] + ["logw", "out", "n_chunks"])
+        args = ", ".join(data_args + f["param_args"] + lse_args + ["logw", "out", "n_chunks"])
         lines = ["def _fused_par(%s):" % args, "    n = out.shape[0]", "    kc = logw.shape[0]"]
         lines += ["    " + ln for ln in f["precompute"]]
         lines += [
@@ -1163,9 +1230,9 @@ def _compile(plan: FusedPlan, parallel: bool = False) -> Callable:
             "        llbuf_c = np.empty(kc)",
             "        for i in range(c * step, min(n, (c + 1) * step)):",
         ]
-        lines += _score_body("            ", f["row"], "llbuf_c")
+        lines += tail("            ", f["row"], "llbuf_c")
         fn = _njit("\n".join(lines), "_fused_par", parallel=True)
-    _COMPILED[(plan.signature, parallel)] = fn
+    _COMPILED[(plan.signature, parallel, quantized_lse)] = fn
     return fn
 
 
@@ -1176,11 +1243,12 @@ def _compile_estep(plan: FusedPlan, parallel: bool = False) -> Callable:
     f = _emit(plan, acc_suffix="_c" if parallel else "")
     data_args = f["data_args"]
     if not parallel:
+        extra = ["R"] if plan.has_bridge else []
         args = ", ".join(
-            data_args + f["param_args"] + ["weights", "logw", "comp_counts", *f["acc_args"], "llbuf", "out_ll"]
+            data_args + f["param_args"] + ["weights", "logw", "comp_counts", *f["acc_args"], *extra, "llbuf", "out_ll"]
         )
         lines = ["def _estep(%s):" % args, "    n = weights.shape[0]", "    kc = logw.shape[0]"]
-        if plan.needs_responsibilities:
+        if plan.needs_responsibilities and not plan.has_bridge:
             lines.append("    R = np.empty((n, kc))")  # read back by the matrix BLAS / chain post passes
         lines += ["    " + ln for ln in f["precompute"]]
         lines += [
@@ -1222,11 +1290,14 @@ def _compile_estep(plan: FusedPlan, parallel: bool = False) -> Callable:
             if lt.kind not in ("matrix", "chain")
             for an in lt.acc_names
         ]
+        extra = ["R"] if plan.has_bridge else []
         args = ", ".join(
-            data_args + f["param_args"] + ["weights", "logw", "comp_counts", *f["acc_args"], "out_ll", "n_chunks"]
+            data_args
+            + f["param_args"]
+            + ["weights", "logw", "comp_counts", *f["acc_args"], *extra, "out_ll", "n_chunks"]
         )
         lines = ["def _estep_par(%s):" % args, "    n = weights.shape[0]", "    kc = logw.shape[0]"]
-        if plan.needs_responsibilities:
+        if plan.needs_responsibilities and not plan.has_bridge:
             lines.append("    R = np.empty((n, kc))")
         lines += ["    " + ln for ln in f["precompute"]]
         lines += [
@@ -1302,6 +1373,13 @@ def _data_and_params(
         comps_i = [factor_lists[k][i] for k in range(plan.num_components)]
         pdict = t.params(comps_i)
         param_arrays.extend(np.ascontiguousarray(pdict[pn]) for pn in sorted(pdict.keys()))
+        if t.kind == "bridge":
+            cols = [np.asarray(c.seq_log_density(factor_encs[i]), dtype=np.float64) for c in comps_i]
+            table = np.ascontiguousarray(np.stack(cols, axis=1))  # (n, K)
+            if n_rows is None:
+                n_rows = int(table.shape[0])
+            param_arrays.append(table)
+            tab_ctx[i] = (factor_encs[i], 0)  # the factor's own encoding, for the wrapper's native updates
         if t.kind == "chain":
             if n_rows is None:
                 n_rows = int(factor_encs[i][0])  # the chain encoding carries the row count directly
@@ -1338,7 +1416,14 @@ def _data_and_params(
     return data_arrays, param_arrays, tab_ctx, int(n_rows if n_rows is not None else 0)
 
 
-def fused_seq_log_density(model: Any, enc: Any, compute_dtype: Any = None, parallel: bool | None = None) -> np.ndarray:
+def fused_seq_log_density(
+    model: Any,
+    enc: Any,
+    compute_dtype: Any = None,
+    parallel: bool | None = None,
+    lse_bits: int | None = None,
+    lse_span: float = 24.0,
+) -> np.ndarray:
     """Per-row log densities of ``model`` over encoding ``enc`` via one fused numba pass.
 
     ``compute_dtype`` (e.g. ``np.float32``) runs the row arithmetic in reduced precision while the
@@ -1350,23 +1435,46 @@ def fused_seq_log_density(model: Any, enc: Any, compute_dtype: Any = None, paral
     sequential kernel it agrees to 1-2 ULP (different fastmath binaries vectorize differently --
     measured max 4.7e-16 relative), not bit-for-bit.
 
+    ``lse_bits`` (OPT-IN, banded): replace the per-row log-sum-exp's exp calls with one gather from a
+    ``2**lse_bits``-entry table over a ``lse_span/2**lse_bits`` grid -- the qlut quantized-LSE kernel
+    inlined. Per-row error is bounded by ``mixle.engines.qlut.lse_error_bound(lse_bits, lse_span)``
+    (12 bits ~ 2.9e-3 bound, ~6e-5 measured), so this is for scoring/audit paths whose compute band
+    tolerates a delta-grid; E-steps deliberately keep exact exp (a perturbed objective could flip
+    monotone-gate accepts). ``None`` (default) is the exact path, byte-identical to before.
+
     Raises ``ValueError`` if ``model`` is not fusible -- callers should check :func:`fusible` first.
     """
     plan = analyze(model)
     if plan is None:
+        if lse_bits is not None:
+            raise NotImplementedError("quantized LSE is wired for the template kernels; nested trees are exact-only.")
         from mixle.stats.compute.fused_nested import fused_nested_seq_log_density
 
-        return fused_nested_seq_log_density(model, enc)  # nested scalar tree (raises if not that either)
+        # nested scalar tree (raises if not that either); same dtype/parallel contract
+        return fused_nested_seq_log_density(model, enc, compute_dtype=compute_dtype, parallel=parallel)
     data_arrays, param_arrays, _, n = _data_and_params(model, plan, enc, compute_dtype)
     logw = np.asarray(getattr(model, "log_w", np.zeros(1)), dtype=np.float64)
     out = np.empty(n, dtype=np.float64)
     if parallel is None:
         parallel = _auto_parallel(n)
+    lse_extra: tuple = ()
+    quantized = lse_bits is not None
+    if quantized:
+        if not 1 <= int(lse_bits) <= 24:
+            raise ValueError(f"need 1 <= lse_bits <= 24, got {lse_bits}")
+        if lse_span <= 0:
+            raise ValueError(f"lse_span must be positive, got {lse_span}")
+        levels = 1 << int(lse_bits)
+        delta = float(lse_span) / levels
+        table = np.exp((np.arange(levels, dtype=np.float64) - (levels - 1)) * delta)
+        lse_extra = (table, 1.0 / delta, levels - 1)
     if parallel:
-        _compile(plan, parallel=True)(*data_arrays, *param_arrays, logw, out, _n_chunks(n))
+        _compile(plan, parallel=True, quantized_lse=quantized)(
+            *data_arrays, *param_arrays, *lse_extra, logw, out, _n_chunks(n)
+        )
     else:
         llbuf = np.empty(plan.num_components, dtype=np.float64)
-        _compile(plan)(*data_arrays, *param_arrays, logw, out, llbuf)
+        _compile(plan, quantized_lse=quantized)(*data_arrays, *param_arrays, *lse_extra, logw, out, llbuf)
     return out
 
 
@@ -1385,6 +1493,7 @@ def fusible_estep(model: Any) -> bool:
         "tabulated": lambda t: t.tab_table,
         "categorical": lambda t: t.cat_table,
         "chain": lambda t: t.chain_to_value,
+        "bridge": lambda t: t.matches,  # support == matching: statistics come from the factor's own accumulator
     }
     return all(hook[t.kind](t) is not None for t in plan.leaf_templates)
 
@@ -1417,7 +1526,9 @@ def fused_accumulate(
     if plan is None:
         from mixle.stats.compute.fused_nested import fused_nested_accumulate
 
-        return fused_nested_accumulate(model, enc, weights, return_ll=return_ll)  # nested scalar tree
+        return fused_nested_accumulate(
+            model, enc, weights, return_ll=return_ll, compute_dtype=compute_dtype, parallel=parallel
+        )  # nested scalar tree
     if not fusible_estep(model):
         raise ValueError("%s is not a fusible E-step (an unsupported leaf)." % type(model).__name__)
     K = plan.num_components
@@ -1435,6 +1546,11 @@ def fused_accumulate(
     acc_arrays: list[np.ndarray] = []
     offset = 0
     for i, t in enumerate(plan.leaf_templates):
+        if t.kind == "bridge":  # no in-kernel statistics; arity 0
+            scalar_acc.append({})
+            matrix_acc.append((np.empty(0), np.empty(0)))
+            chain_acc.append((np.empty(0), np.empty(0)))
+            continue
         if t.kind == "chain":
             S = tab_ctx[i][1]
             # written by the sequential post-pass over R in BOTH kernel variants, so never chunked
@@ -1482,6 +1598,7 @@ def fused_accumulate(
         offset += t.arity
 
     logw = np.asarray(getattr(model, "log_w", np.zeros(1)), dtype=np.float64)
+    bridge_R = [np.empty((n, K), dtype=np.float64)] if plan.has_bridge else []
     if parallel:
         comp_counts = np.zeros((nc, K), dtype=np.float64)
         out_ll = np.zeros(nc, dtype=np.float64)
@@ -1492,6 +1609,7 @@ def fused_accumulate(
             logw,
             comp_counts,
             *acc_arrays,
+            *bridge_R,
             out_ll,
             nc,
         )
@@ -1513,11 +1631,32 @@ def fused_accumulate(
             logw,
             comp_counts,
             *acc_arrays,
+            *bridge_R,
             llbuf,
             out_ll,
         )
 
+    bridge_values: dict[int, list[Any]] = {}
+    if plan.has_bridge:
+        # Each bridged factor's sufficient statistics come from its OWN accumulator, weighted by the
+        # responsibility column the kernel just computed -- byte-for-byte the host mixture E-step's
+        # semantics for that factor (priors and all), with everything else still fused.
+        factor_lists = _component_factor_lists(model, plan)
+        for i, t in enumerate(plan.leaf_templates):
+            if t.kind != "bridge":
+                continue
+            enc_i = tab_ctx[i][0]
+            vals = []
+            for k in range(K):
+                factor_k = factor_lists[k][i]
+                acc = factor_k.estimator().accumulator_factory().make()
+                acc.seq_update(enc_i, np.ascontiguousarray(bridge_R[0][:, k]), factor_k)
+                vals.append(acc.value())
+            bridge_values[i] = vals
+
     def leaf_value(i: int, t: LeafTemplate, k: int) -> Any:
+        if t.kind == "bridge":
+            return bridge_values[i][k]
         if t.kind == "chain":
             ih, th = chain_acc[i]
             enc_i, _ = tab_ctx[i]

--- a/mixle/stats/compute/fused_nested.py
+++ b/mixle/stats/compute/fused_nested.py
@@ -24,7 +24,7 @@ from typing import Any
 
 import numpy as np
 
-from mixle.stats.compute.fused_codegen import LeafTemplate, _njit, _template_for
+from mixle.stats.compute.fused_codegen import LeafTemplate, _auto_parallel, _n_chunks, _njit, _template_for
 
 
 @dataclass
@@ -213,48 +213,114 @@ _SCORE_CACHE: dict[Any, Any] = {}
 _ESTEP_CACHE: dict[Any, Any] = {}
 
 
+def _cast_reduced(arrays: list, compute_dtype: Any) -> list:
+    """Down-cast FLOAT arrays to the reduced compute dtype (float32 only, as fused_codegen validates);
+    integer index arrays and the float64 accumulators/outputs are never touched, so accumulation
+    precision is unchanged -- the same discipline as fused_codegen's _data_and_params."""
+    if compute_dtype is None or np.dtype(compute_dtype) == np.float64:
+        return arrays
+    if np.dtype(compute_dtype) != np.float32:
+        raise ValueError("nested fused kernels support reduced precision only in float32. Got %r." % (compute_dtype,))
+    return [np.ascontiguousarray(a, dtype=np.float32) if a.dtype.kind == "f" else a for a in arrays]
+
+
 def _sig(root: Any, ctx: _Ctx) -> tuple:
     return ("nested", _shape(root), tuple(ctx.slot_template[s].name for s in range(len(ctx.slots))))
 
 
-def _compile_score(root: Any, ctx: _Ctx, sig: tuple) -> Any:
-    if sig in _SCORE_CACHE:
-        return _SCORE_CACHE[sig]
+def _compile_score(root: Any, ctx: _Ctx, sig: tuple, parallel: bool = False) -> Any:
+    cached = _SCORE_CACHE.get((sig, parallel))
+    if cached is not None:
+        return cached
     body: list[str] = []
     expr = _emit_score(root, body)
-    args = ", ".join(_data_args(ctx) + _param_args(root) + ["out"])
-    lines = [f"def _ns({args}):", "    n = x0_0.shape[0]", "    k = 0", "    for i in range(n):"]
-    lines += ["    " + ln for ln in body]  # body already indented to one level; add the loop indent
-    lines.append(f"        out[i] = {expr}")
-    fn = _njit("\n".join(lines), "_ns")
-    _SCORE_CACHE[sig] = fn
+    if not parallel:
+        args = ", ".join(_data_args(ctx) + _param_args(root) + ["out"])
+        # k = 0: leaf templates index their (1,)-stacked params as p[k] (fused_codegen's component-loop
+        # convention); in the nested emitter every leaf node is its own single-component stack.
+        lines = [f"def _ns({args}):", "    n = out.shape[0]", "    k = 0", "    for i in range(n):"]
+        lines += ["    " + ln for ln in body]  # body already indented to one level; add the loop indent
+        lines.append(f"        out[i] = {expr}")
+        fn = _njit("\n".join(lines), "_ns")
+    else:
+        # same fixed-chunk prange design as fused_codegen: rows are disjoint (out[i] only), so the
+        # parallel scorer is bit-stable across reruns and worker counts, and agrees with the
+        # sequential kernel to 1-2 ULP (different fastmath binaries).
+        args = ", ".join(_data_args(ctx) + _param_args(root) + ["out", "n_chunks"])
+        lines = [
+            f"def _ns_par({args}):",
+            "    n = out.shape[0]",
+            "    step = (n + n_chunks - 1) // n_chunks",
+            "    for c in numba.prange(n_chunks):",
+            "        k = 0",
+            "        for i in range(c * step, min(n, (c + 1) * step)):",
+        ]
+        lines += ["        " + ln for ln in body]
+        lines.append(f"            out[i] = {expr}")
+        fn = _njit("\n".join(lines), "_ns_par", parallel=True)
+    _SCORE_CACHE[(sig, parallel)] = fn
     return fn
 
 
-def _compile_estep(root: Any, ctx: _Ctx, sig: tuple) -> Any:
-    if sig in _ESTEP_CACHE:
-        return _ESTEP_CACHE[sig]
-    fwd: list[str] = []
-    root_expr = _emit_score(root, fwd)
-    bwd: list[str] = []
-    _emit_backward(root, "wi", bwd)
+def _acc_names(root: Any) -> tuple[list[str], list[str]]:
+    """(mixture-count arg names, leaf-accumulator arg names) in emission order."""
     cc_args = [f"cc{m.node_id}" for m in _mixtures(root)]
     leaf_acc: list[str] = []
     for lf in _leaves(root):
         leaf_acc += [f"a{lf.node_id}_{an}" for an in lf.template.acc_names] + [f"ct{lf.node_id}"]
-    args = ", ".join(_data_args(ctx) + _param_args(root) + ["weights", *cc_args, *leaf_acc, "out_ll"])
-    lines = [
-        f"def _es({args}):",
-        "    n = x0_0.shape[0]",
-        "    k = 0",
-        "    for i in range(n):",
-        "        wi = weights[i]",
-    ]
-    lines += ["    " + ln for ln in fwd]
-    lines.append(f"        out_ll[0] += wi * ({root_expr})")
-    lines += ["    " + ln for ln in bwd]
-    fn = _njit("\n".join(lines), "_es")
-    _ESTEP_CACHE[sig] = fn
+    return cc_args, leaf_acc
+
+
+def _compile_estep(root: Any, ctx: _Ctx, sig: tuple, parallel: bool = False) -> Any:
+    cached = _ESTEP_CACHE.get((sig, parallel))
+    if cached is not None:
+        return cached
+    fwd: list[str] = []
+    root_expr = _emit_score(root, fwd)
+    bwd: list[str] = []
+    _emit_backward(root, "wi", bwd)
+    cc_args, leaf_acc = _acc_names(root)
+    if not parallel:
+        args = ", ".join(_data_args(ctx) + _param_args(root) + ["weights", *cc_args, *leaf_acc, "out_ll"])
+        lines = [
+            f"def _es({args}):",
+            "    n = weights.shape[0]",
+            "    k = 0",
+            "    for i in range(n):",
+            "        wi = weights[i]",
+        ]
+        lines += ["    " + ln for ln in fwd]
+        lines.append(f"        out_ll[0] += wi * ({root_expr})")
+        lines += ["    " + ln for ln in bwd]
+        fn = _njit("\n".join(lines), "_es")
+    else:
+        # Chunk-parallel with the fused_codegen design: every accumulator gains a leading n_chunks
+        # axis (allocated by the caller), chunk c writes only row c through the _c views bound below,
+        # and the caller's fixed-order sum over the chunk axis keeps results bit-stable across runs
+        # and worker counts. The emitted statements are IDENTICAL to the sequential kernel's -- the
+        # rebinding is pure text substitution on the accumulator names.
+        acc_all = [*cc_args, *leaf_acc]
+        args = ", ".join(_data_args(ctx) + _param_args(root) + ["weights", *acc_all, "out_ll", "n_chunks"])
+        lines = [
+            f"def _es_par({args}):",
+            "    n = weights.shape[0]",
+            "    step = (n + n_chunks - 1) // n_chunks",
+            "    for c in numba.prange(n_chunks):",
+        ]
+        lines += [f"        {nm}_c = {nm}[c]" for nm in acc_all]
+        lines += [
+            "        k = 0",
+            "        for i in range(c * step, min(n, (c + 1) * step)):",
+            "            wi = weights[i]",
+        ]
+        lines += ["        " + ln for ln in fwd]
+        lines.append(f"            out_ll[c] += wi * ({root_expr})")
+        bwd_sub = bwd
+        for nm in acc_all:
+            bwd_sub = [ln.replace(f"{nm}[", f"{nm}_c[") for ln in bwd_sub]
+        lines += ["        " + ln for ln in bwd_sub]
+        fn = _njit("\n".join(lines), "_es_par", parallel=True)
+    _ESTEP_CACHE[(sig, parallel)] = fn
     return fn
 
 
@@ -291,15 +357,30 @@ def _fill_slots(model: Any, path: tuple, enc: Any, ctx: _Ctx) -> None:
         ctx.slot_data[slot] = ctx.slots[path][0].data(enc)
 
 
-def fused_nested_seq_log_density(model: Any, enc: Any) -> np.ndarray:
-    """Score encoded observations with the nested scalar fused kernel."""
+def fused_nested_seq_log_density(
+    model: Any, enc: Any, compute_dtype: Any = None, parallel: bool | None = None
+) -> np.ndarray:
+    """Score encoded observations with the nested scalar fused kernel.
+
+    ``compute_dtype``/``parallel`` follow fused_codegen's contract exactly: float32 runs the row
+    arithmetic reduced while accumulation and output stay float64; ``parallel=None`` auto-engages
+    the chunked prange kernel on large inputs, bit-stable across reruns and worker counts.
+    """
     built = analyze_nested(model)
     if built is None:
         raise ValueError("%s is not a fusible nested scalar tree." % type(model).__name__)
     root, ctx = built
     data, params = _marshal(model, root, ctx, enc)
-    out = np.empty(data[0].shape[0], dtype=np.float64)
-    _compile_score(root, ctx, _sig(root, ctx))(*data, *params, out)
+    data = _cast_reduced(data, compute_dtype)
+    params = _cast_reduced(params, compute_dtype)
+    n = data[0].shape[0]
+    out = np.empty(n, dtype=np.float64)
+    if parallel is None:
+        parallel = _auto_parallel(n)
+    if parallel:
+        _compile_score(root, ctx, _sig(root, ctx), parallel=True)(*data, *params, out, _n_chunks(n))
+    else:
+        _compile_score(root, ctx, _sig(root, ctx))(*data, *params, out)
     return out
 
 
@@ -313,30 +394,57 @@ def _node_value(node: Any, accs: dict) -> Any:
     return accs[f"cc{node.node_id}"], tuple(children)
 
 
-def fused_nested_accumulate(model: Any, enc: Any, weights: np.ndarray, return_ll: bool = False) -> Any:
-    """Accumulate nested scalar sufficient statistics with the fused E-step kernel."""
+def fused_nested_accumulate(
+    model: Any,
+    enc: Any,
+    weights: np.ndarray,
+    return_ll: bool = False,
+    compute_dtype: Any = None,
+    parallel: bool | None = None,
+) -> Any:
+    """Accumulate nested scalar sufficient statistics with the fused E-step kernel.
+
+    ``compute_dtype``/``parallel`` follow fused_codegen's contract: reduced-precision row arithmetic
+    with float64 accumulation; the chunk-parallel variant is bit-stable across reruns and worker
+    counts (fixed chunking, fixed-order combine) and differs from the sequential kernel only by
+    chunk-boundary float re-association.
+    """
     built = analyze_nested(model)
     if built is None:
         raise ValueError("%s is not a fusible nested scalar tree." % type(model).__name__)
     root, ctx = built
     data, params = _marshal(model, root, ctx, enc)
+    data = _cast_reduced(data, compute_dtype)
+    params = _cast_reduced(params, compute_dtype)
+    n = data[0].shape[0] if data else int(np.asarray(weights).shape[0])
+    if parallel is None:
+        parallel = _auto_parallel(n)
+    nc = _n_chunks(n) if parallel else 0
+    lead = (lambda shape: (nc, *shape)) if parallel else (lambda shape: shape)
     accs: dict = {}
     for lf in _leaves(root):
         for an in lf.template.acc_names:
-            accs[f"a{lf.node_id}_{an}"] = np.zeros(1, dtype=np.float64)
-        accs[f"ct{lf.node_id}"] = np.zeros(1, dtype=np.float64)
+            accs[f"a{lf.node_id}_{an}"] = np.zeros(lead((1,)), dtype=np.float64)
+        accs[f"ct{lf.node_id}"] = np.zeros(lead((1,)), dtype=np.float64)
     for mx in _mixtures(root):
-        accs[f"cc{mx.node_id}"] = np.zeros(len(mx.children), dtype=np.float64)
+        accs[f"cc{mx.node_id}"] = np.zeros(lead((len(mx.children),)), dtype=np.float64)
     cc_arrays = [accs[f"cc{m.node_id}"] for m in _mixtures(root)]
     leaf_acc: list = []
     for lf in _leaves(root):
         leaf_acc += [accs[f"a{lf.node_id}_{an}"] for an in lf.template.acc_names] + [accs[f"ct{lf.node_id}"]]
-    out_ll = np.zeros(1, dtype=np.float64)
-    _compile_estep(root, ctx, _sig(root, ctx))(
-        *data, *params, np.asarray(weights, dtype=np.float64), *cc_arrays, *leaf_acc, out_ll
-    )
+    if parallel:
+        out_ll = np.zeros(nc, dtype=np.float64)
+        _compile_estep(root, ctx, _sig(root, ctx), parallel=True)(
+            *data, *params, np.asarray(weights, dtype=np.float64), *cc_arrays, *leaf_acc, out_ll, nc
+        )
+        accs = {name: arr.sum(axis=0) for name, arr in accs.items()}  # fixed-order combine
+    else:
+        out_ll = np.zeros(1, dtype=np.float64)
+        _compile_estep(root, ctx, _sig(root, ctx))(
+            *data, *params, np.asarray(weights, dtype=np.float64), *cc_arrays, *leaf_acc, out_ll
+        )
     suff = _node_value(root, accs)
-    return (suff, float(out_ll[0])) if return_ll else suff
+    return (suff, float(out_ll.sum())) if return_ll else suff
 
 
 def fusible_nested(model: Any) -> bool:

--- a/mixle/tests/block_em_efficiency_test.py
+++ b/mixle/tests/block_em_efficiency_test.py
@@ -268,8 +268,11 @@ class FusedMStepEngagementTest:
         score_before, estep_before = len(fn._SCORE_CACHE), len(fn._ESTEP_CACHE)
         run_block_em(enc, estimator, start, max_its=4, delta=None)
         # two same-structure (different-parameter) chain components across four rounds: at most ONE
-        # new kernel per cache, and no per-call numba respecialization (signature growth)
+        # new kernel per cache, and no per-call numba respecialization (signature growth). The bound is
+        # per-dimension: 2 layout variants x 2 supported compute dtypes (float64 + the float32
+        # reduced-precision path the nested kernels now honor) -- growth BEYOND that means per-call
+        # respecialization is back.
         assert len(fn._SCORE_CACHE) <= score_before + 1
         assert len(fn._ESTEP_CACHE) <= estep_before + 1
         for kernel in list(fn._SCORE_CACHE.values()) + list(fn._ESTEP_CACHE.values()):
-            assert len(kernel.signatures) <= 2
+            assert len(kernel.signatures) <= 4

--- a/mixle/tests/conftest.py
+++ b/mixle/tests/conftest.py
@@ -46,6 +46,11 @@ FILE_MARKERS: dict[str, MarkerTuple] = {
     # Markov-chain leaf template (composites with chain factors fuse): host-parity + guard tests --
     # numba-gated for the same reason as fused_codegen_test.py.
     "fused_chain_test.py": ("numba", "optional"),
+    # Bridge factor kind (combinators inside composites fuse via their own native machinery) -- numba-gated
+    # for the same reason as fused_codegen_test.py.
+    "fused_bridge_test.py": ("numba", "optional"),
+    # Nested scalar-tree kernels: compute_dtype + chunk-parallel receipts -- numba-gated like its siblings.
+    "fused_nested_parallel_test.py": ("numba", "optional"),
     # Chunk-parallel fused kernels: determinism receipts (bit-identity across reruns/worker counts) and
     # sequential-vs-parallel parity -- numba-gated for the same reason as fused_codegen_test.py.
     "fused_parallel_test.py": ("numba", "optional"),

--- a/mixle/tests/fused_bridge_test.py
+++ b/mixle/tests/fused_bridge_test.py
@@ -78,9 +78,7 @@ class BridgeParityTest(unittest.TestCase):
         rng = np.random.RandomState(1)
         comps = [CompositeDistribution((_hmm(j), PoissonDistribution(2.0 + j))) for j in range(2)]
         model = MixtureDistribution(comps, [0.6, 0.4])
-        data = [
-            ([float(rng.randn()) for _ in range(int(rng.randint(2, 7)))], int(rng.poisson(3))) for _ in range(1500)
-        ]
+        data = [([float(rng.randn()) for _ in range(int(rng.randint(2, 7)))], int(rng.poisson(3))) for _ in range(1500)]
         _parity(self, model, data)
 
     def test_nested_composite_factor_fuses(self):

--- a/mixle/tests/fused_bridge_test.py
+++ b/mixle/tests/fused_bridge_test.py
@@ -1,0 +1,129 @@
+"""Bridge factor kind: combinators inside composite factors fuse through their own native machinery.
+
+A bridged factor (nested Mixture, HMM, nested Composite) is scored from a precomputed per-component
+table (each column that factor's OWN ``seq_log_density``) and its sufficient statistics come from its
+OWN accumulator driven by the responsibility matrix the fused kernel hands back -- byte-for-byte the
+host mixture E-step's semantics for that factor, priors included, while everything else (leaf scoring,
+the softmax, leaf statistics) stays in one nopython pass.
+
+Honesty receipts asserted here: parity vs the host path at 1e-12 through score AND the M-step;
+the bare Mixture-of-Mixtures guard (fused_nested's faster in-kernel path is NOT stolen by the
+bridge); heterogeneous per-component factor configurations; and the parallel variant's bit-stable
+reruns. Measured wall-clock (recorded in the introducing PR, cold-compile excluded): 1.2x over host
+on nested-mixture composites, parity on HMM-heavy composites (the HMM's native numba kernels carry
+the bulk either way), with the chain template's 5.1x untouched.
+"""
+
+import unittest
+
+import numpy as np
+
+from mixle.stats import (
+    CategoricalDistribution,
+    CompositeDistribution,
+    GaussianDistribution,
+    HiddenMarkovModelDistribution,
+    MixtureDistribution,
+    PoissonDistribution,
+)
+from mixle.stats.compute import fused_codegen as fc
+from mixle.stats.compute.fused_nested import fusible_nested
+from mixle.utils.optional_deps import HAS_NUMBA
+
+
+def _inner_mix(seed):
+    return MixtureDistribution(
+        [GaussianDistribution(-3.0 + seed, 1.0), GaussianDistribution(3.0 + seed, 1.0 + 0.1 * seed)], [0.6, 0.4]
+    )
+
+
+def _hmm(seed):
+    r = np.random.RandomState(seed)
+    return HiddenMarkovModelDistribution(
+        [GaussianDistribution(-2.0 + seed, 1.0), GaussianDistribution(2.0 + seed, 1.2)],
+        w=list(r.dirichlet(np.ones(2))),
+        transitions=r.dirichlet(np.ones(2), size=2).tolist(),
+    )
+
+
+def _parity(self, model, data):
+    enc = model.dist_to_encoder().seq_encode(data)
+    self.assertTrue(fc.fusible(model))
+    self.assertTrue(fc.fusible_estep(model))
+    np.testing.assert_allclose(fc.fused_seq_log_density(model, enc), model.seq_log_density(enc), rtol=1e-12)
+    w = np.ones(len(data))
+    est = model.estimator()
+    acc = est.accumulator_factory().make()
+    acc.seq_update(enc, w, model)
+    new_host = est.estimate(len(data), acc.value())
+    new_fused = est.estimate(len(data), fc.fused_accumulate(model, enc, w))
+    np.testing.assert_allclose(new_fused.seq_log_density(enc), new_host.seq_log_density(enc), rtol=1e-12, atol=1e-12)
+
+
+@unittest.skipUnless(HAS_NUMBA, "fused kernels require numba")
+class BridgeParityTest(unittest.TestCase):
+    def test_nested_mixture_factor_fuses_and_matches_host_through_the_m_step(self):
+        rng = np.random.RandomState(0)
+        comps = [
+            CompositeDistribution(
+                (_inner_mix(j), GaussianDistribution(float(j), 1.5), CategoricalDistribution({"x": 0.5, "y": 0.5}))
+            )
+            for j in range(3)
+        ]
+        model = MixtureDistribution(comps, [0.5, 0.3, 0.2])
+        data = [(float(rng.randn() * 3), float(rng.randn() + (i % 3)), ("x", "y")[rng.randint(2)]) for i in range(3000)]
+        _parity(self, model, data)
+
+    def test_hmm_factor_fuses_and_matches_host_through_the_m_step(self):
+        rng = np.random.RandomState(1)
+        comps = [CompositeDistribution((_hmm(j), PoissonDistribution(2.0 + j))) for j in range(2)]
+        model = MixtureDistribution(comps, [0.6, 0.4])
+        data = [
+            ([float(rng.randn()) for _ in range(int(rng.randint(2, 7)))], int(rng.poisson(3))) for _ in range(1500)
+        ]
+        _parity(self, model, data)
+
+    def test_nested_composite_factor_fuses(self):
+        rng = np.random.RandomState(2)
+        nested = lambda j: CompositeDistribution((GaussianDistribution(float(j), 1.0), PoissonDistribution(1.0 + j)))  # noqa: E731
+        comps = [CompositeDistribution((nested(j), GaussianDistribution(-float(j), 2.0))) for j in range(2)]
+        model = MixtureDistribution(comps, [0.5, 0.5])
+        data = [((float(rng.randn()), int(rng.poisson(2))), float(rng.randn())) for _ in range(2000)]
+        _parity(self, model, data)
+
+    def test_parallel_variant_matches_and_is_bit_stable(self):
+        rng = np.random.RandomState(3)
+        comps = [CompositeDistribution((_inner_mix(j), GaussianDistribution(float(j), 1.5))) for j in range(2)]
+        model = MixtureDistribution(comps, [0.5, 0.5])
+        data = [(float(rng.randn() * 3), float(rng.randn())) for _ in range(4000)]
+        enc = model.dist_to_encoder().seq_encode(data)
+        np.testing.assert_allclose(
+            fc.fused_seq_log_density(model, enc, parallel=True),
+            fc.fused_seq_log_density(model, enc, parallel=False),
+            rtol=1e-12,
+        )
+        w = np.ones(len(data))
+        _, ll1 = fc.fused_accumulate(model, enc, w, return_ll=True, parallel=True)
+        _, ll2 = fc.fused_accumulate(model, enc, w, return_ll=True, parallel=True)
+        self.assertEqual(ll1, ll2)
+
+
+@unittest.skipUnless(HAS_NUMBA, "fused kernels require numba")
+class BridgeBoundaryTest(unittest.TestCase):
+    def test_bare_nested_mixtures_keep_the_faster_fused_nested_path(self):
+        model = MixtureDistribution([_inner_mix(0), _inner_mix(1)], [0.5, 0.5])
+        self.assertIsNone(fc.analyze(model), "the bridge must not steal fused_nested's in-kernel path")
+        self.assertTrue(fusible_nested(model))
+
+    def test_specific_templates_outrank_the_bridge(self):
+        comps = [
+            CompositeDistribution((GaussianDistribution(float(j), 1.0), CategoricalDistribution({"x": 0.5, "y": 0.5})))
+            for j in range(2)
+        ]
+        plan = fc.analyze(MixtureDistribution(comps, [0.5, 0.5]))
+        self.assertIsNotNone(plan)
+        self.assertEqual([t.name for t in plan.leaf_templates], ["gaussian", "categorical"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mixle/tests/fused_chain_test.py
+++ b/mixle/tests/fused_chain_test.py
@@ -114,6 +114,20 @@ class FusibilityGuardTest(unittest.TestCase):
         model = MixtureDistribution([CompositeDistribution((with_len, GaussianDistribution(0.0, 1.0)))] * 2, [0.5, 0.5])
         self.assertIsNone(fc.analyze(model), "a real length distribution is outside the fused tables")
 
+    def test_all_chain_homogeneous_mixture_survives_the_block_em_path(self):
+        """Regression pin: an ALL-chain homogeneous top mixture used to hit an IndexError inside
+        _component_enc on the block-EM/freeze-rollup path (hetero fixtures worked). Fixed upstream by
+        the freeze-rollup resolver work; pinned here so the encoder-shape edge cannot quietly return."""
+        from mixle.inference.block_em import run_block_em
+
+        rng = np.random.RandomState(3)
+        model = MixtureDistribution([_chain(j) for j in range(3)], [1 / 3] * 3)
+        data = [[STATES[rng.randint(3)] for _ in range(int(rng.randint(2, 8)))] for _ in range(1500)]
+        enc_data = [(len(data), model.dist_to_encoder().seq_encode(data))]
+        final_model, history = run_block_em(enc_data, model.estimator(), model, max_its=3)
+        self.assertTrue(len(history) >= 1)
+        self.assertTrue(np.isfinite(final_model.seq_log_density(enc_data[0][1]).sum()))
+
     def test_bare_chain_mixture_is_fusible_too(self):
         model = MixtureDistribution([_chain(0), _chain(1)], [0.5, 0.5])
         self.assertTrue(fc.fusible(model))

--- a/mixle/tests/fused_nested_parallel_test.py
+++ b/mixle/tests/fused_nested_parallel_test.py
@@ -1,0 +1,97 @@
+"""Nested scalar-tree kernels: reduced-precision compute and the chunk-parallel variant.
+
+fused_nested previously ignored ``compute_dtype`` (always float64) and had no prange variant --
+both closed here with fused_codegen's exact contracts: float32 runs row arithmetic reduced while
+every accumulator stays float64, and the parallel kernels are bit-stable across reruns and worker
+counts (fixed chunking, fixed-order combine), agreeing with the sequential kernels to float
+re-association tolerance.
+"""
+
+import unittest
+
+import numpy as np
+
+from mixle.stats import GaussianDistribution, MixtureDistribution
+from mixle.stats.compute import fused_nested as fn
+from mixle.utils.optional_deps import HAS_NUMBA
+
+
+def _nested_model_and_enc(n=50_000, seed=0):
+    rng = np.random.RandomState(seed)
+    inner = lambda s: MixtureDistribution(  # noqa: E731
+        [GaussianDistribution(-3.0 + s, 1.0), GaussianDistribution(3.0 + s, 1.0 + 0.2 * s)], [0.6, 0.4]
+    )
+    model = MixtureDistribution([inner(0), inner(1), inner(2)], [0.5, 0.3, 0.2])
+    data = [float(v) for v in rng.randn(n) * 3]
+    return model, model.dist_to_encoder().seq_encode(data), n
+
+
+def _flatten(suff):
+    out = []
+
+    def walk(v):
+        if isinstance(v, (tuple, list)):
+            for piece in v:
+                walk(piece)
+        elif v is not None:
+            out.extend(np.asarray(v, dtype=np.float64).ravel().tolist())
+
+    walk(suff)
+    return np.asarray(out)
+
+
+@unittest.skipUnless(HAS_NUMBA, "nested fused kernels require numba")
+class NestedComputeDtypeTest(unittest.TestCase):
+    def test_float32_rows_track_float64_within_reduced_precision(self):
+        model, enc, _ = _nested_model_and_enc(n=20_000)
+        full = fn.fused_nested_seq_log_density(model, enc)
+        reduced = fn.fused_nested_seq_log_density(model, enc, compute_dtype=np.float32)
+        np.testing.assert_allclose(reduced, full, rtol=2e-5, atol=2e-5)
+        self.assertEqual(reduced.dtype, np.float64, "accumulation and output stay float64")
+
+    def test_non_float32_reduced_dtypes_are_refused(self):
+        model, enc, _ = _nested_model_and_enc(n=200)
+        with self.assertRaises(ValueError):
+            fn.fused_nested_seq_log_density(model, enc, compute_dtype=np.float16)
+
+
+@unittest.skipUnless(HAS_NUMBA, "nested fused kernels require numba")
+class NestedParallelTest(unittest.TestCase):
+    def test_parallel_scorer_matches_sequential_and_is_bit_stable(self):
+        model, enc, _ = _nested_model_and_enc()
+        seq = fn.fused_nested_seq_log_density(model, enc, parallel=False)
+        par = fn.fused_nested_seq_log_density(model, enc, parallel=True)
+        rerun = fn.fused_nested_seq_log_density(model, enc, parallel=True)
+        np.testing.assert_allclose(par, seq, rtol=1e-12, atol=1e-12)
+        self.assertTrue(np.array_equal(par, rerun))
+
+    def test_parallel_estep_matches_sequential_and_is_bit_stable(self):
+        model, enc, n = _nested_model_and_enc()
+        w = np.ones(n)
+        suff_seq, ll_seq = fn.fused_nested_accumulate(model, enc, w, return_ll=True, parallel=False)
+        suff_par, ll_par = fn.fused_nested_accumulate(model, enc, w, return_ll=True, parallel=True)
+        suff_rerun, ll_rerun = fn.fused_nested_accumulate(model, enc, w, return_ll=True, parallel=True)
+        self.assertAlmostEqual(ll_seq, ll_par, delta=abs(ll_seq) * 1e-9)
+        np.testing.assert_allclose(_flatten(suff_par), _flatten(suff_seq), rtol=1e-8, atol=1e-10)
+        self.assertEqual(ll_par, ll_rerun)
+        self.assertTrue(np.array_equal(_flatten(suff_par), _flatten(suff_rerun)))
+
+    def test_parallel_estep_is_bit_identical_across_worker_counts(self):
+        import numba
+
+        model, enc, n = _nested_model_and_enc(n=30_000)
+        w = np.ones(n)
+        before = numba.get_num_threads()
+        try:
+            numba.set_num_threads(max(2, before))
+            suff_many, ll_many = fn.fused_nested_accumulate(model, enc, w, return_ll=True, parallel=True)
+            numba.set_num_threads(1)
+            suff_one, ll_one = fn.fused_nested_accumulate(model, enc, w, return_ll=True, parallel=True)
+        finally:
+            numba.set_num_threads(before)
+        self.assertEqual(ll_many, ll_one)
+        self.assertTrue(np.array_equal(_flatten(suff_many), _flatten(suff_one)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mixle/tests/fused_parallel_test.py
+++ b/mixle/tests/fused_parallel_test.py
@@ -144,6 +144,39 @@ class ParallelEstepTest(unittest.TestCase):
 
 
 @unittest.skipUnless(HAS_NUMBA, "parallel fused kernels require numba")
+class QuantizedLseTest(unittest.TestCase):
+    def test_quantized_scorer_stays_within_the_qlut_bound(self):
+        from mixle.engines.qlut import lse_error_bound
+
+        model, enc, _ = _mixed_model_and_enc(n=20_000)
+        exact = fc.fused_seq_log_density(model, enc)
+        for bits in (8, 12):
+            quant = fc.fused_seq_log_density(model, enc, lse_bits=bits)
+            bound = lse_error_bound(bits, 24.0)
+            self.assertLessEqual(float(np.abs(quant - exact).max()), bound, f"bits={bits}")
+        # parallel x quantized composes, with the same bit-stability contract
+        par1 = fc.fused_seq_log_density(model, enc, parallel=True, lse_bits=12)
+        par2 = fc.fused_seq_log_density(model, enc, parallel=True, lse_bits=12)
+        self.assertTrue(np.array_equal(par1, par2))
+        self.assertLessEqual(float(np.abs(par1 - exact).max()), lse_error_bound(12, 24.0))
+
+    def test_quantized_lse_is_opt_in_and_guarded(self):
+        model, enc, _ = _mixed_model_and_enc(n=500)
+        with self.assertRaises(ValueError):
+            fc.fused_seq_log_density(model, enc, lse_bits=0)
+        with self.assertRaises(ValueError):
+            fc.fused_seq_log_density(model, enc, lse_bits=12, lse_span=-1.0)
+        from mixle.stats import GaussianDistribution as G
+
+        nested = MixtureDistribution(
+            [MixtureDistribution([G(-2.0, 1.0), G(2.0, 1.0)], [0.5, 0.5]) for _ in range(2)], [0.5, 0.5]
+        )
+        nenc = nested.dist_to_encoder().seq_encode([0.1, -0.4, 2.2])
+        with self.assertRaises(NotImplementedError):
+            fc.fused_seq_log_density(nested, nenc, lse_bits=12)
+
+
+@unittest.skipUnless(HAS_NUMBA, "parallel fused kernels require numba")
 class AutoPolicyTest(unittest.TestCase):
     def test_small_inputs_stay_sequential_and_large_engage_parallel(self):
         model, enc, n = _mixed_model_and_enc(n=4_000)


### PR DESCRIPTION
## What

The remaining compiler-robustness edges from the review, closed together — each falsified before build:

### 1. Bridge factor kind — the last "genuinely recursive" cases fuse without recursion
Nested **Mixture** factors, **HMM** factors, and nested **Composites** inside composite factors: scored from a precomputed (n, K) table (each column the factor's own native `seq_log_density`), estimated by the factor's **own accumulator** driven by the responsibility matrix the kernel now hands back — byte-for-byte the host E-step's semantics for that factor, priors included, while everything else stays in one nopython pass.
- Parity: 8.9e-16 (nested mixture) / 3.6e-15 (HMM) scores; ≤1.1e-14 through the M-step.
- Boundary honesty: bridge registers **last** (specific templates outrank it); bare Mixture-of-Mixtures keeps fused_nested's faster in-kernel path (asserted).
- Wall-clock (arm-order-swapped, 3 reps, cold compile excluded — the first benchmark's 2.2×-slower reading was cold-compile contamination, caught and corrected): **1.2×** on nested-mixture composites; **parity** on HMM-heavy ones (native HMM kernels dominate both arms — the win there is coverage).

### 2. Nested kernels: compute_dtype + chunk-parallel
Same contracts as the template kernels (float32 rows / float64 accumulation; bit-stable across reruns and worker counts, asserted). Options flow through the fallback entry points; the stale freeze_rollup comment is corrected. `k = 0` in the emitted preamble is **not** dead (templates index (1,)-stacked params as `p[k]`) — documented after its removal broke compilation. The respecialization pin widens per-dimension (2 layouts × 2 dtypes) with dimensions named.

### 3. Quantized LSE, opt-in and banded
`fused_seq_log_density(lse_bits=…)` inlines the qlut histogram-LSE as one LUT gather per component; per-row error asserted under `lse_error_bound` at 8/12 bits; composes with the parallel variant. **Scoring/audit paths only** — E-steps keep exact exp (a δ-perturbed objective could flip monotone-gate accepts); nested trees refuse loudly.

### 4. Edge pins
The all-chain homogeneous `_component_enc` IndexError no longer reproduces anywhere (fixed upstream); pinned with a regression test. GradLeaf's docstring records the measured **torch.compile negative** (0.93×/0.79× at two scales, ~6s compile tax, CPU) so nobody re-derives the obvious-looking flag.

## Tests
115 fused/freeze-rollup/block-EM/audit tests green locally including 6 bridge + 5 nested-parallel + 2 quantized-LSE new ones; registry entries follow the numba-gated sibling pattern.