### PR TITLE
perf(encode): vectorize Markov-chain encoding; C-speed composite row validation (1.9x end-to-end)

### DIFF
--- a/mixle/stats/combinator/composite.py
+++ b/mixle/stats/combinator/composite.py
@@ -1165,22 +1165,31 @@ class CompositeDataEncoder(DataSequenceEncoder):
                 "%s" % type(x).__name__,
                 "pass a list/tuple of observations, e.g. [(x0, x1, ...), ...].",
             )
-        for row_idx, u in enumerate(x):
-            if not isinstance(u, (tuple, list, np.ndarray)):
-                raise ContractError(
-                    "CompositeDistribution.dists (row %d)" % row_idx,
-                    "a tuple of %d fields (one per component distribution)" % count,
-                    "%s" % type(u).__name__,
-                    "wrap the observation in a %d-tuple matching the component distributions." % count,
-                )
-            if len(u) != count:
-                raise ContractError(
-                    "CompositeDistribution.dists (row %d)" % row_idx,
-                    "a tuple of length %d" % count,
-                    "a tuple of length %d" % len(u),
-                    "check row %d for a missing or extra field -- every row must have exactly %d "
-                    "entries, one per component distribution." % (row_idx, count),
-                )
+        # Validation in one C-speed pass (set(map(len, x)) -- the per-row python loop this replaces was
+        # the single largest encode cost at 1M rows); the loop below runs only on the ERROR path, so the
+        # per-row contract messages are byte-identical when something is actually wrong.
+        try:
+            row_lens = set(map(len, x))
+            row_types_ok = all(issubclass(tp, (tuple, list, np.ndarray)) for tp in set(map(type, x)))
+        except TypeError:
+            row_lens, row_types_ok = None, False
+        if row_lens is None or row_lens - {count} or not row_types_ok:
+            for row_idx, u in enumerate(x):
+                if not isinstance(u, (tuple, list, np.ndarray)):
+                    raise ContractError(
+                        "CompositeDistribution.dists (row %d)" % row_idx,
+                        "a tuple of %d fields (one per component distribution)" % count,
+                        "%s" % type(u).__name__,
+                        "wrap the observation in a %d-tuple matching the component distributions." % count,
+                    )
+                if len(u) != count:
+                    raise ContractError(
+                        "CompositeDistribution.dists (row %d)" % row_idx,
+                        "a tuple of length %d" % count,
+                        "a tuple of length %d" % len(u),
+                        "check row %d for a missing or extra field -- every row must have exactly %d "
+                        "entries, one per component distribution." % (row_idx, count),
+                    )
 
         enc_data = []
 

--- a/mixle/stats/sequences/markov_chain.py
+++ b/mixle/stats/sequences/markov_chain.py
@@ -1954,46 +1954,68 @@ class MarkovChainDataEncoder(DataSequenceEncoder):
 
         """
 
-        init_entries = []
-        pair_entries = []
-        entries_idx0 = []
-        entries_idx1 = []
-        obs_cnt = []
-        key_map = dict()
+        import itertools
 
-        for i in range(len(x)):
-            entry = x[i]
-            obs_cnt.append(len(entry))
+        obs_cnt = np.fromiter((len(entry) for entry in x), dtype=np.int64, count=len(x))
+        n_tokens = int(obs_cnt.sum())
+        flat = list(itertools.chain.from_iterable(x))
 
-            if len(entry) == 0:
-                continue
+        # State -> first-seen integer code. Fast path: a sortable homogeneous array lets np.unique
+        # produce the codes in one vectorized pass, remapped to FIRST-SEEN order so the encoding is
+        # byte-identical to the dict walk (inv_key_map order included). Any failure (mixed or
+        # unorderable state types -- dicts compare where sorts cannot) falls back to the dict walk.
+        codes_flat = None
+        _SAFE_STATE_TYPES = (str, int, float, bool, np.str_, np.bytes_, np.integer, np.floating, np.bool_)
+        if n_tokens:
+            # The fast path must not let np.asarray COERCE across python types: [1, "1"] becomes two
+            # equal strings under coercion while the dict walk keeps them distinct states. One cheap
+            # type-homogeneity scan gates it; anything else (tuples, custom objects, mixed types)
+            # takes the dict walk with the original semantics.
+            state_types = set(map(type, flat))
+            if len(state_types) == 1 and issubclass(next(iter(state_types)), _SAFE_STATE_TYPES):
+                try:
+                    arr = np.asarray(flat)
+                    if arr.dtype != object and arr.ndim == 1:
+                        uniq, first_pos, inverse = np.unique(arr, return_index=True, return_inverse=True)
+                        order = np.argsort(first_pos, kind="stable")
+                        remap = np.empty(len(uniq), dtype=np.int64)
+                        remap[order] = np.arange(len(uniq), dtype=np.int64)
+                        codes_flat = remap[inverse.reshape(-1)]
+                        inv_key_map = np.asarray([uniq[j] for j in order])
+                except (TypeError, ValueError):  # pathological values: take the dict walk below
+                    codes_flat = None
+        if codes_flat is None:
+            key_map: dict = {}
+            codes_flat = np.empty(n_tokens, dtype=np.int64)
+            pos = 0
+            for value in flat:
+                code = key_map.get(value)
+                if code is None:
+                    code = len(key_map)
+                    key_map[value] = code
+                codes_flat[pos] = code
+                pos += 1
+            inv_key_map = [None] * len(key_map)
+            for k, v in key_map.items():
+                inv_key_map[v] = k
+            # dtype=object for heterogeneous state types: a bare asarray COERCES [1, "1"] into two
+            # equal strings, silently merging states the dict walk (and every downstream key_map
+            # lookup) keeps distinct -- a pre-existing hazard of the original encoder, fixed here.
+            inv_key_map = np.asarray(inv_key_map, dtype=object if len(state_types) > 1 else None)
 
-            if entry[0] not in key_map:
-                key_map[entry[0]] = len(key_map)
+        # Structure arrays from offsets, fully vectorized: rows of length >= 1 contribute their first
+        # token to the init arrays; every within-row position >= 1 contributes a (prev, next) pair.
+        starts = np.concatenate(([0], np.cumsum(obs_cnt)[:-1])) if len(x) else np.zeros(0, dtype=np.int64)
+        nonempty = obs_cnt > 0
+        entries_idx0 = np.nonzero(nonempty)[0]
+        init_entries = codes_flat[starts[nonempty]] if n_tokens else np.zeros(0, dtype=np.int64)
 
-            prev_idx = key_map[entry[0]]
-            init_entries.append(prev_idx)
-            entries_idx0.append(i)
-
-            for j in range(1, len(entry)):
-                if entry[j] not in key_map:
-                    key_map[entry[j]] = len(key_map)
-                next_idx = key_map[entry[j]]
-
-                pair_entries.append([prev_idx, next_idx])
-                entries_idx1.append(i)
-                prev_idx = next_idx
-
-        obs_cnt = np.asarray(obs_cnt)
-        init_entries = np.asarray(init_entries)
-        pair_entries = np.asarray(pair_entries)
-        entries_idx0 = np.asarray(entries_idx0)
-        entries_idx1 = np.asarray(entries_idx1)
-
-        inv_key_map = [None] * len(key_map)
-        for k, v in key_map.items():
-            inv_key_map[v] = k
-        inv_key_map = np.asarray(inv_key_map)
+        row_ids = np.repeat(np.arange(len(x), dtype=np.int64), obs_cnt)
+        token_pos = np.arange(n_tokens, dtype=np.int64) - np.repeat(starts, obs_cnt)
+        trans_mask = token_pos >= 1
+        entries_idx1 = row_ids[trans_mask]
+        next_entries = codes_flat[trans_mask] if n_tokens else np.zeros(0, dtype=np.int64)
+        prev_entries = codes_flat[np.nonzero(trans_mask)[0] - 1] if n_tokens else np.zeros(0, dtype=np.int64)
 
         len_enc = self.len_encoder.seq_encode(obs_cnt)
 
@@ -2002,8 +2024,8 @@ class MarkovChainDataEncoder(DataSequenceEncoder):
             entries_idx0,
             entries_idx1,
             init_entries,
-            pair_entries[:, 0],
-            pair_entries[:, 1],
+            prev_entries,
+            next_entries,
             inv_key_map,
             len_enc,
         )

--- a/mixle/tests/markov_chain_encode_test.py
+++ b/mixle/tests/markov_chain_encode_test.py
@@ -1,0 +1,126 @@
+"""Vectorized Markov-chain encoding: byte-parity with the original dict walk, plus its fixed edges.
+
+The chain encoder was the single largest wall-clock sink on chain-bearing fits (a pure-Python
+per-token loop: ~86% of a 300k-sequence optimize call). The vectorized encoder must reproduce the
+dict walk EXACTLY -- including inv_key_map's first-seen state order, empty and length-1 sequences --
+via the sortable fast path and the dict fallback alike, and it must not let numpy's asarray COERCION
+merge states the dict kept distinct ([1, "1"] is two states, not one).
+"""
+
+import unittest
+
+import numpy as np
+
+from mixle.stats import CompositeDistribution, GaussianDistribution, MarkovChainDistribution, PoissonDistribution
+
+
+def _dict_walk_oracle(x):
+    """The original encoder's semantics, verbatim, as the parity oracle."""
+    init_entries, pair_entries, entries_idx0, entries_idx1 = [], [], [], []
+    key_map: dict = {}
+    for i, entry in enumerate(x):
+        if len(entry) == 0:
+            continue
+        if entry[0] not in key_map:
+            key_map[entry[0]] = len(key_map)
+        prev = key_map[entry[0]]
+        init_entries.append(prev)
+        entries_idx0.append(i)
+        for j in range(1, len(entry)):
+            if entry[j] not in key_map:
+                key_map[entry[j]] = len(key_map)
+            nxt = key_map[entry[j]]
+            pair_entries.append([prev, nxt])
+            entries_idx1.append(i)
+            prev = nxt
+    inv = [None] * len(key_map)
+    for k, v in key_map.items():
+        inv[v] = k
+    pairs = np.asarray(pair_entries) if pair_entries else np.zeros((0, 2), dtype=np.int64)
+    return (
+        np.asarray(entries_idx0),
+        np.asarray(entries_idx1),
+        np.asarray(init_entries),
+        pairs[:, 0],
+        pairs[:, 1],
+        list(inv),
+    )
+
+
+def _chain(states):
+    return MarkovChainDistribution(
+        {s: 1.0 / len(states) for s in states}, {s: {t: 1.0 / len(states) for t in states} for s in states}
+    )
+
+
+class ChainEncodeParityTest(unittest.TestCase):
+    def _assert_parity(self, states, data):
+        got = _chain(states).dist_to_encoder().seq_encode(data)
+        exp = _dict_walk_oracle(data)
+        for g, e, name in zip(got[1:7], exp, ("idx0", "idx1", "init", "prev", "next", "inv_key_map")):
+            self.assertEqual(
+                list(np.asarray(g).ravel().tolist()),
+                list(np.asarray(e, dtype=object).ravel().tolist())
+                if name == "inv_key_map"
+                else list(np.asarray(e).tolist()),
+                name,
+            )
+
+    def test_string_states_mixed_lengths_including_empty_and_len1(self):
+        rng = np.random.RandomState(0)
+        states = ["a", "b", "c", "d"]
+        data = [[states[rng.randint(4)] for _ in range(int(rng.randint(0, 6)))] for _ in range(3000)]
+        self._assert_parity(states, data)
+
+    def test_integer_states(self):
+        rng = np.random.RandomState(1)
+        data = [[int(v) for v in rng.randint(0, 9, int(rng.randint(1, 5)))] for _ in range(2000)]
+        self._assert_parity(list(range(9)), data)
+
+    def test_first_seen_order_is_preserved_not_sorted(self):
+        got = _chain(["z", "m", "a"]).dist_to_encoder().seq_encode([["z", "m"], ["a", "z"]])
+        self.assertEqual([str(v) for v in got[6].tolist()], ["z", "m", "a"], "inv_key_map must be first-seen order")
+
+    def test_all_length_one_sequences_have_no_transitions(self):
+        got = _chain(["a", "b"]).dist_to_encoder().seq_encode([["a"], ["b"], ["a"]])
+        self.assertEqual(len(got[2]), 0)  # idx1 empty
+        self.assertEqual(len(got[4]), 0)  # prev empty
+        self.assertEqual(list(got[1]), [0, 1, 2])  # every row contributes an init
+
+    def test_mixed_type_states_stay_distinct(self):
+        """np.asarray coercion must never merge int 1 with str \"1\" -- the dict walk keeps them
+        distinct, and so must both the fast path (which refuses mixed types) and the fallback's
+        object-dtype inv_key_map (a pre-existing coercion hazard, fixed alongside the fast path)."""
+        got = _chain(["a"]).dist_to_encoder().seq_encode([[1, "1", 1], ["1", 1]])
+        inv = got[6].tolist()
+        self.assertEqual(len(inv), 2)
+        self.assertEqual({type(v) for v in inv}, {int, str})
+
+    def test_scoring_parity_end_to_end(self):
+        rng = np.random.RandomState(2)
+        states = ["a", "b", "c"]
+        d = _chain(states)
+        data = [[states[rng.randint(3)] for _ in range(int(rng.randint(1, 7)))] for _ in range(500)]
+        enc = d.dist_to_encoder().seq_encode(data)
+        per_row = [d.log_density(seq) for seq in data]
+        np.testing.assert_allclose(d.seq_log_density(enc), per_row, rtol=1e-12)
+
+
+class CompositeValidationFastPathTest(unittest.TestCase):
+    def setUp(self):
+        self.enc = CompositeDistribution((GaussianDistribution(0.0, 1.0), PoissonDistribution(2.0))).dist_to_encoder()
+
+    def test_well_formed_rows_encode(self):
+        self.assertIsNotNone(self.enc.seq_encode([(1.0, 2), (0.5, 3)]))
+
+    def test_error_paths_keep_the_per_row_contract_messages(self):
+        # the C-speed validation pass must hand EVERY malformed shape to the original per-row loop,
+        # so the error still names the offending row
+        for bad in ([(1.0, 2), "ab"], [(1.0, 2), (1.0,)], [(1.0, 2), 5], [(1.0, 2), (1.0, 2, 3)]):
+            with self.assertRaises(Exception) as ctx:
+                self.enc.seq_encode(bad)
+            self.assertIn("row 1", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Round-2 profiling at the merged tip flipped the story: after the kernel work, **encoding dominates** — 82% of a flat 1M-row fit and 89% of a chain-bearing 300k fit, nearly all of it two pure-Python per-row loops. Both closed.

### MarkovChain encoding: 5.3× (860ms → 161ms at 300k sequences)
The per-token dict walk becomes one `np.unique` pass with codes remapped to **first-seen order** — the encoding, `inv_key_map` order included, is byte-identical to the dict walk (asserted against a verbatim oracle) — plus vectorized offset arithmetic for the init/transition arrays.

Two honesty catches from falsification:
- `np.asarray` **coerces across python types**: `[1, "1"]` would silently merge two states. The fast path is gated by a type-homogeneity scan; mixed/exotic state types take the dict walk (tested).
- The original dict walk's own `inv_key_map` asarray carried the **same coercion hazard** downstream; fixed with an object-dtype array (tested end to end).

### Composite row validation: C-speed
The per-row isinstance+len loop (0.156s at 1M rows) becomes one `set(map(len, x))` + type-set scan. Every malformed shape — including string rows, which *have* `len` — still routes through the original per-row loop, so contract errors keep their row numbers byte-identically (tested per shape).

## End-to-end (profile fixtures)

| fixture | before | after |
|---|---|---|
| deep chain-bearing, 300k rows × 6 its | 1.09s | **0.56s (1.9×)** |
| flat mixed, 1M rows × 8 its | 0.45s | 0.38s |

The flat case's remainder is leaf/categorical encodes — the next profile target.

## Tests

8 new (parity oracle across string/int/mixed-length/empty/len-1 data, first-seen order, no-transition edge, mixed-type distinctness, end-to-end scoring parity, four contract-error shapes); 43 chain-touching tests green; fast gate green modulo the known xdist flakes (pass single-process) and the local stale-editable-install manifest issue.