### PR TITLE
feat(fused): complete the compiled optimizer -- universal bridge coverage, nested quantized LSE, TreeHMM dtype pins

### DIFF
--- a/mixle/stats/compute/fused_codegen.py
+++ b/mixle/stats/compute/fused_codegen.py
@@ -31,9 +31,30 @@ count histogram. The general bar for fusion is a *map-reducible* sufficient stat
 min/max, or a histogram -- not necessarily additive): that is what lets Binomial (n from max x) and
 NegativeBinomial (iterative dispersion over the count histogram) fuse despite non-additive/iterative MLEs.
 
+Beyond the templated kinds, coverage is COMPLETE for protocol-bearing factors:
+
+* **chain leaves** (MarkovChain with the Null length model, Dirichlet priors included): scored from
+  per-encoding init/transition log tables scatter-built before the row loop, statistics scattered from
+  the responsibility matrix in the post pass.
+* **bridged factors** (everything else inside a composite -- nested Mixtures, HMMs, nested Composites,
+  length-model chains, untemplated leaves like Laplace): scored from a precomputed per-component table
+  (each column the factor's own native ``seq_log_density``), estimated by the factor's own accumulator
+  driven by the responsibility matrix -- native semantics, priors and all, while the softmax and every
+  templated sibling stay in one nopython pass. Registered last; specific templates always outrank it.
+
+Every scorer and E-step has a chunk-parallel prange variant (fixed chunking, fixed-order combine:
+bit-stable across reruns and worker counts), honors reduced-precision compute (float32 rows, float64
+accumulation), and the scorers optionally take the qlut quantized log-sum-exp (``lse_bits``; error
+bounded by the grid half-step, compounding per mixture level on nested trees). The nested scalar-tree
+kernels (:mod:`fused_nested`) carry the same contracts.
+
+Principled exclusions, deliberate and documented rather than pending: E-steps always use EXACT exp (a
+delta-grid perturbation could flip a monotone-gate accept); bare nested mixtures keep fused_nested's
+in-kernel path (faster than bridging); GradLeaf M-steps stay eager torch (torch.compile measured 0.79-
+0.93x on CPU -- see the GradLeaf docstring).
+
 Generated kernels are compiled once and disk-cached (see :func:`_njit`), so the compile cost is paid once
-per structure *ever*, not per process. A leaf with no template (e.g. Laplace, whose weighted-median MLE
-keeps the raw observations) -> :func:`fusible` is False -> numpy.
+per structure *ever*, not per process.
 """
 
 from __future__ import annotations
@@ -745,13 +766,15 @@ def _markov_chain_to_value(init_hist_k: np.ndarray, trans_hist_k: np.ndarray, en
 
 
 def _markov_chain_matches(d: Any) -> bool:
-    """Fusible chain configs only: a plain (no-prior) MarkovChainDistribution whose length model is the
-    Null distribution (its seq_log_density contributes exactly zero, so the tables carry the whole
-    density). Chains with a real length distribution or a Dirichlet prior keep their own kernels."""
+    """Fast-path chain configs: a MarkovChainDistribution whose length model is the Null distribution
+    (its seq_log_density contributes exactly zero, so the tables carry the whole density). A Dirichlet
+    prior is fine -- the sufficient statistics are the standard count maps either way, and the
+    estimator applies its prior at estimate() exactly as on the host path (parity-tested). Chains
+    with a REAL length distribution fall through to the bridge template (native scoring/estimation,
+    length model included)."""
     return (
         type(d).__name__ == "MarkovChainDistribution"
         and type(getattr(d, "len_dist", None)).__name__ == "NullDistribution"
-        and getattr(d, "prior", None) is None
     )
 
 
@@ -796,14 +819,20 @@ register_leaf_template(
 )
 
 
-_BRIDGE_TYPES = frozenset({"MixtureDistribution", "HiddenMarkovModelDistribution", "CompositeDistribution"})
-
-
 def _bridge_matches(d: Any) -> bool:
-    """Combinators sitting inside a composite factor: scored and estimated through their OWN native
-    machinery (seq_log_density / accumulator seq_update), so ANY configuration they support -- priors
-    included -- is supported here. Registered LAST, so every specific template outranks the bridge."""
-    return type(d).__name__ in _BRIDGE_TYPES
+    """ANY factor speaking the sequence protocol, scored and estimated through its OWN native
+    machinery (seq_log_density / accumulator seq_update) -- so every configuration the factor itself
+    supports (priors, length models, arbitrary combinators) is supported here. Registered LAST, so
+    every specific template outranks the bridge and this is purely the completion of coverage: a
+    composite with ANY protocol-bearing factor now fuses, with the un-templated factors paying
+    exactly their host cost while the softmax, responsibilities, and templated siblings stay in one
+    nopython pass."""
+    return (
+        hasattr(d, "seq_log_density")
+        and hasattr(d, "dist_to_encoder")
+        and hasattr(d, "estimator")
+        and callable(getattr(d, "estimator", None))
+    )
 
 
 register_leaf_template(
@@ -1446,12 +1475,13 @@ def fused_seq_log_density(
     """
     plan = analyze(model)
     if plan is None:
-        if lse_bits is not None:
-            raise NotImplementedError("quantized LSE is wired for the template kernels; nested trees are exact-only.")
         from mixle.stats.compute.fused_nested import fused_nested_seq_log_density
 
-        # nested scalar tree (raises if not that either); same dtype/parallel contract
-        return fused_nested_seq_log_density(model, enc, compute_dtype=compute_dtype, parallel=parallel)
+        # nested scalar tree (raises if not that either); same dtype/parallel/quantized-LSE contract
+        # (nested error bound compounds per mixture level -- see the nested wrapper's docstring)
+        return fused_nested_seq_log_density(
+            model, enc, compute_dtype=compute_dtype, parallel=parallel, lse_bits=lse_bits, lse_span=lse_span
+        )
     data_arrays, param_arrays, _, n = _data_and_params(model, plan, enc, compute_dtype)
     logw = np.asarray(getattr(model, "log_w", np.zeros(1)), dtype=np.float64)
     out = np.empty(n, dtype=np.float64)

--- a/mixle/stats/compute/fused_nested.py
+++ b/mixle/stats/compute/fused_nested.py
@@ -142,15 +142,21 @@ def _vals(node: _Leaf) -> list[str]:
 
 
 # --- code generation (recursive emit over the static tree) ----------------------------------------
-def _emit_score(node: Any, lines: list[str]) -> str:
-    """Append forward-pass lines computing ``node``'s score; return the score expression."""
+def _emit_score(node: Any, lines: list[str], quantized_lse: bool = False) -> str:
+    """Append forward-pass lines computing ``node``'s score; return the score expression.
+
+    ``quantized_lse`` replaces each mixture node's exp calls with one LUT gather over a delta-grid
+    (the qlut quantized-LSE semantics; SCORE kernels only -- the E-step's responsibilities always use
+    exact exp). Nested trees apply the log-sum-exp at every mixture level, so the error bound
+    compounds to ``depth * lse_error_bound(bits, span)`` -- stated in the wrapper and asserted in
+    tests, not hidden."""
     if isinstance(node, _Leaf):
         return node.template.expr(_vals(node), _argmap(node))  # type: ignore[misc]
     if isinstance(node, _Composite):
-        return "(" + " + ".join("(" + _emit_score(c, lines) + ")" for c in node.children) + ")"
+        return "(" + " + ".join("(" + _emit_score(c, lines, quantized_lse) + ")" for c in node.children) + ")"
     cvars = []
     for j, c in enumerate(node.children):
-        e = _emit_score(c, lines)
+        e = _emit_score(c, lines, quantized_lse)
         lines.append(f"    s{node.node_id}_{j} = logw{node.node_id}[{j}] + ({e})")
         cvars.append(f"s{node.node_id}_{j}")
     lines.append(f"    mx{node.node_id} = {cvars[0]}")
@@ -158,7 +164,13 @@ def _emit_score(node: Any, lines: list[str]) -> str:
         lines.append(f"    mx{node.node_id} = max(mx{node.node_id}, {v})")
     lines.append(f"    sm{node.node_id} = 0.0")
     for v in cvars:
-        lines.append(f"    sm{node.node_id} += np.exp({v} - mx{node.node_id})")
+        if quantized_lse:
+            lines.append(f"    qi{node.node_id} = int(np.rint(({v} - mx{node.node_id}) * lse_inv_delta)) + lse_levm1")
+            lines.append(f"    if qi{node.node_id} < 0:")
+            lines.append(f"        qi{node.node_id} = 0")
+            lines.append(f"    sm{node.node_id} += lse_lut[qi{node.node_id}]")
+        else:
+            lines.append(f"    sm{node.node_id} += np.exp({v} - mx{node.node_id})")
     lines.append(f"    ns{node.node_id} = mx{node.node_id} + np.log(sm{node.node_id})")
     return f"ns{node.node_id}"
 
@@ -228,14 +240,15 @@ def _sig(root: Any, ctx: _Ctx) -> tuple:
     return ("nested", _shape(root), tuple(ctx.slot_template[s].name for s in range(len(ctx.slots))))
 
 
-def _compile_score(root: Any, ctx: _Ctx, sig: tuple, parallel: bool = False) -> Any:
-    cached = _SCORE_CACHE.get((sig, parallel))
+def _compile_score(root: Any, ctx: _Ctx, sig: tuple, parallel: bool = False, quantized_lse: bool = False) -> Any:
+    cached = _SCORE_CACHE.get((sig, parallel, quantized_lse))
     if cached is not None:
         return cached
     body: list[str] = []
-    expr = _emit_score(root, body)
+    expr = _emit_score(root, body, quantized_lse)
+    lse_args = ["lse_lut", "lse_inv_delta", "lse_levm1"] if quantized_lse else []
     if not parallel:
-        args = ", ".join(_data_args(ctx) + _param_args(root) + ["out"])
+        args = ", ".join(_data_args(ctx) + _param_args(root) + lse_args + ["out"])
         # k = 0: leaf templates index their (1,)-stacked params as p[k] (fused_codegen's component-loop
         # convention); in the nested emitter every leaf node is its own single-component stack.
         lines = [f"def _ns({args}):", "    n = out.shape[0]", "    k = 0", "    for i in range(n):"]
@@ -246,7 +259,7 @@ def _compile_score(root: Any, ctx: _Ctx, sig: tuple, parallel: bool = False) -> 
         # same fixed-chunk prange design as fused_codegen: rows are disjoint (out[i] only), so the
         # parallel scorer is bit-stable across reruns and worker counts, and agrees with the
         # sequential kernel to 1-2 ULP (different fastmath binaries).
-        args = ", ".join(_data_args(ctx) + _param_args(root) + ["out", "n_chunks"])
+        args = ", ".join(_data_args(ctx) + _param_args(root) + lse_args + ["out", "n_chunks"])
         lines = [
             f"def _ns_par({args}):",
             "    n = out.shape[0]",
@@ -258,7 +271,7 @@ def _compile_score(root: Any, ctx: _Ctx, sig: tuple, parallel: bool = False) -> 
         lines += ["        " + ln for ln in body]
         lines.append(f"            out[i] = {expr}")
         fn = _njit("\n".join(lines), "_ns_par", parallel=True)
-    _SCORE_CACHE[(sig, parallel)] = fn
+    _SCORE_CACHE[(sig, parallel, quantized_lse)] = fn
     return fn
 
 
@@ -357,8 +370,20 @@ def _fill_slots(model: Any, path: tuple, enc: Any, ctx: _Ctx) -> None:
         ctx.slot_data[slot] = ctx.slots[path][0].data(enc)
 
 
+def _mixture_depth(node: Any) -> int:
+    if isinstance(node, _Leaf):
+        return 0
+    child_max = max((_mixture_depth(c) for c in node.children), default=0)
+    return child_max + (1 if isinstance(node, _Mixture) else 0)
+
+
 def fused_nested_seq_log_density(
-    model: Any, enc: Any, compute_dtype: Any = None, parallel: bool | None = None
+    model: Any,
+    enc: Any,
+    compute_dtype: Any = None,
+    parallel: bool | None = None,
+    lse_bits: int | None = None,
+    lse_span: float = 24.0,
 ) -> np.ndarray:
     """Score encoded observations with the nested scalar fused kernel.
 
@@ -377,10 +402,25 @@ def fused_nested_seq_log_density(
     out = np.empty(n, dtype=np.float64)
     if parallel is None:
         parallel = _auto_parallel(n)
+    quantized = lse_bits is not None
+    lse_extra: tuple = ()
+    if quantized:
+        # per-node error <= lse_error_bound(bits, span); NESTED trees apply the LSE at every mixture
+        # level, so the whole-tree bound is depth * lse_error_bound -- callers get that via
+        # _mixture_depth and the tests assert it.
+        if not 1 <= int(lse_bits) <= 24:
+            raise ValueError(f"need 1 <= lse_bits <= 24, got {lse_bits}")
+        if lse_span <= 0:
+            raise ValueError(f"lse_span must be positive, got {lse_span}")
+        levels = 1 << int(lse_bits)
+        delta = float(lse_span) / levels
+        lse_extra = (np.exp((np.arange(levels, dtype=np.float64) - (levels - 1)) * delta), 1.0 / delta, levels - 1)
     if parallel:
-        _compile_score(root, ctx, _sig(root, ctx), parallel=True)(*data, *params, out, _n_chunks(n))
+        _compile_score(root, ctx, _sig(root, ctx), parallel=True, quantized_lse=quantized)(
+            *data, *params, *lse_extra, out, _n_chunks(n)
+        )
     else:
-        _compile_score(root, ctx, _sig(root, ctx))(*data, *params, out)
+        _compile_score(root, ctx, _sig(root, ctx), quantized_lse=quantized)(*data, *params, *lse_extra, out)
     return out
 
 

--- a/mixle/stats/latent/tree_hidden_markov_model.py
+++ b/mixle/stats/latent/tree_hidden_markov_model.py
@@ -1035,10 +1035,26 @@ class TreeHiddenMarkovAccumulator(SequenceEncodableStatisticAccumulator):
         if x[0] is not None:
             tz, _, (xbi, xp, xc, xl, txz, tp, tpz), enc_x, len_enc = x[0]
 
-            states = self._idx_rng.choice(self.num_states, replace=True, size=tz[-1])
+            states = np.ascontiguousarray(
+                self._idx_rng.choice(self.num_states, replace=True, size=tz[-1]), dtype=np.int64
+            )
 
+            # The kernel signature is EXPLICIT (int32 x6, int64 states, float64 weights): coerce the
+            # caller-supplied weights at the boundary -- integer weights (np.ones with an int dtype, a
+            # list of ints) otherwise arrive as int64 and eager dispatch refuses with "No matching
+            # definition" (seen on Python 3.14; the signature has no widening to hide it).
             numba_initialize(
-                tz, txz, tp, tpz, xp, xc, states, weights, self.init_counts, self.state_counts, self.trans_counts
+                tz,
+                txz,
+                tp,
+                tpz,
+                xp,
+                xc,
+                states,
+                np.ascontiguousarray(weights, dtype=np.float64),
+                self.init_counts,
+                self.state_counts,
+                self.trans_counts,
             )
 
             idx = len_enc[0]
@@ -1182,7 +1198,7 @@ class TreeHiddenMarkovAccumulator(SequenceEncodableStatisticAccumulator):
                 pr_obs,
                 p_level,
                 a_mat,
-                weights,
+                np.ascontiguousarray(weights, dtype=np.float64),  # explicit signature: see numba_initialize
                 betas,
                 etas,
                 alphas,

--- a/mixle/tests/conftest.py
+++ b/mixle/tests/conftest.py
@@ -43,6 +43,9 @@ FILE_MARKERS: dict[str, MarkerTuple] = {
     "bingham_test.py": ("distribution", "stochastic", "slow"),
     "conformal_test.py": ("ppl", "integration", "slow"),
     "fused_codegen_test.py": ("numba", "optional"),
+    # TreeHMM explicit-signature kernel boundaries: integer weights must coerce, not crash eager
+    # dispatch (a Python-3.14 dispatch failure pinned) -- numba-gated like its siblings.
+    "tree_hmm_dtype_test.py": ("numba", "optional"),
     # Markov-chain leaf template (composites with chain factors fuse): host-parity + guard tests --
     # numba-gated for the same reason as fused_codegen_test.py.
     "fused_chain_test.py": ("numba", "optional"),

--- a/mixle/tests/fused_bridge_test.py
+++ b/mixle/tests/fused_bridge_test.py
@@ -107,6 +107,82 @@ class BridgeParityTest(unittest.TestCase):
 
 
 @unittest.skipUnless(HAS_NUMBA, "fused kernels require numba")
+class UniversalBridgeCoverageTest(unittest.TestCase):
+    """The completion set: factors a specific template refuses now fuse through the bridge --
+    untemplated leaves, Dirichlet-prior chains (fast chain template, prior applied at estimate),
+    and length-model chains (bridge, native length semantics)."""
+
+    def test_untemplated_leaf_factor_fuses_with_host_parity(self):
+        from mixle.stats import LaplaceDistribution
+
+        rng = np.random.RandomState(4)
+        comps = [
+            CompositeDistribution((LaplaceDistribution(float(j), 1.0 + 0.3 * j), GaussianDistribution(float(j), 1.0)))
+            for j in range(2)
+        ]
+        model = MixtureDistribution(comps, [0.5, 0.5])
+        data = [(float(rng.laplace(0, 1)), float(rng.randn())) for _ in range(2000)]
+        _parity(self, model, data)
+
+    def test_prior_chain_takes_the_fast_template_and_matches_host(self):
+        from mixle.stats import MarkovChainDistribution
+
+        states = ["a", "b"]
+        from mixle.stats.bayes.dirichlet import DirichletDistribution
+
+        def chain(seed):
+            r = np.random.RandomState(seed)
+            init = r.dirichlet(np.ones(2))
+            trans = r.dirichlet(np.ones(2), size=2)
+            d = MarkovChainDistribution(
+                dict(zip(states, init)), {s: dict(zip(states, trans[i])) for i, s in enumerate(states)}
+            )
+            d.set_prior(
+                (
+                    states,
+                    DirichletDistribution(np.full(2, 2.0)),
+                    [DirichletDistribution(np.full(2, 2.0)) for _ in states],
+                )
+            )
+            return d
+
+        rng = np.random.RandomState(5)
+        comps = [CompositeDistribution((chain(j), GaussianDistribution(float(j), 1.0))) for j in range(2)]
+        model = MixtureDistribution(comps, [0.5, 0.5])
+        plan = fc.analyze(model)
+        self.assertEqual(plan.leaf_templates[0].name, "markovchain", "prior chains take the fast template")
+        data = [
+            ([states[rng.randint(2)] for _ in range(int(rng.randint(1, 6)))], float(rng.randn())) for _ in range(1500)
+        ]
+        _parity(self, model, data)
+
+    def test_length_model_chain_falls_to_the_bridge_and_matches_host(self):
+        from mixle.stats import MarkovChainDistribution
+        from mixle.stats import PoissonDistribution as P
+
+        states = ["a", "b"]
+
+        def chain(seed):
+            r = np.random.RandomState(seed)
+            init = r.dirichlet(np.ones(2))
+            trans = r.dirichlet(np.ones(2), size=2)
+            return MarkovChainDistribution(
+                dict(zip(states, init)),
+                {s: dict(zip(states, trans[i])) for i, s in enumerate(states)},
+                len_dist=P(3.0 + seed),
+            )
+
+        rng = np.random.RandomState(6)
+        comps = [CompositeDistribution((chain(j), GaussianDistribution(float(j), 1.0))) for j in range(2)]
+        model = MixtureDistribution(comps, [0.5, 0.5])
+        plan = fc.analyze(model)
+        self.assertEqual(plan.leaf_templates[0].name, "bridge", "length-model chains bridge natively")
+        data = [
+            ([states[rng.randint(2)] for _ in range(int(rng.randint(1, 7)))], float(rng.randn())) for _ in range(1500)
+        ]
+        _parity(self, model, data)
+
+
 class BridgeBoundaryTest(unittest.TestCase):
     def test_bare_nested_mixtures_keep_the_faster_fused_nested_path(self):
         model = MixtureDistribution([_inner_mix(0), _inner_mix(1)], [0.5, 0.5])

--- a/mixle/tests/fused_chain_test.py
+++ b/mixle/tests/fused_chain_test.py
@@ -105,14 +105,19 @@ class FusedChainParityTest(unittest.TestCase):
 
 @unittest.skipUnless(HAS_NUMBA, "fused kernels require numba")
 class FusibilityGuardTest(unittest.TestCase):
-    def test_chains_with_length_models_or_priors_keep_their_own_kernels(self):
+    def test_chains_with_length_models_take_the_bridge_not_the_fast_tables(self):
+        """The fast chain template's tables cannot carry a real length model, so such chains must
+        NOT match it -- they fall through to the bridge template (native scoring/estimation, length
+        model included; host parity asserted in fused_bridge_test's coverage suite)."""
         from mixle.stats import PoissonDistribution as P
 
         with_len = MarkovChainDistribution(
             {"a": 0.5, "b": 0.5}, {"a": {"a": 0.5, "b": 0.5}, "b": {"a": 0.5, "b": 0.5}}, len_dist=P(3.0)
         )
-        model = MixtureDistribution([CompositeDistribution((with_len, GaussianDistribution(0.0, 1.0)))] * 2, [0.5, 0.5])
-        self.assertIsNone(fc.analyze(model), "a real length distribution is outside the fused tables")
+        comps = [CompositeDistribution((with_len, GaussianDistribution(float(j), 1.0))) for j in range(2)]
+        plan = fc.analyze(MixtureDistribution(comps, [0.5, 0.5]))
+        self.assertIsNotNone(plan)
+        self.assertEqual(plan.leaf_templates[0].name, "bridge")
 
     def test_all_chain_homogeneous_mixture_survives_the_block_em_path(self):
         """Regression pin: an ALL-chain homogeneous top mixture used to hit an IndexError inside

--- a/mixle/tests/fused_nested_parallel_test.py
+++ b/mixle/tests/fused_nested_parallel_test.py
@@ -56,6 +56,40 @@ class NestedComputeDtypeTest(unittest.TestCase):
 
 
 @unittest.skipUnless(HAS_NUMBA, "nested fused kernels require numba")
+class NestedQuantizedLseTest(unittest.TestCase):
+    def test_quantized_scorer_stays_within_the_depth_compounded_bound(self):
+        from mixle.engines.qlut import lse_error_bound
+        from mixle.stats.compute.fused_nested import _mixture_depth, analyze_nested
+
+        model, enc, _ = _nested_model_and_enc(n=15_000)
+        root, _ctx = analyze_nested(model)
+        depth = _mixture_depth(root)
+        self.assertGreaterEqual(depth, 2, "the fixture must be genuinely nested")
+        exact = fn.fused_nested_seq_log_density(model, enc)
+        for bits in (8, 12):
+            quant = fn.fused_nested_seq_log_density(model, enc, lse_bits=bits)
+            bound = depth * lse_error_bound(bits, 24.0)
+            self.assertLessEqual(float(np.abs(quant - exact).max()), bound, f"bits={bits}")
+        par1 = fn.fused_nested_seq_log_density(model, enc, parallel=True, lse_bits=12)
+        par2 = fn.fused_nested_seq_log_density(model, enc, parallel=True, lse_bits=12)
+        self.assertTrue(np.array_equal(par1, par2), "quantized x parallel keeps bit-stable reruns")
+
+    def test_template_entry_point_forwards_to_nested_trees(self):
+        from mixle.engines.qlut import lse_error_bound
+        from mixle.stats.compute import fused_codegen as fc
+
+        model, enc, _ = _nested_model_and_enc(n=4_000)
+        exact = fc.fused_seq_log_density(model, enc)
+        quant = fc.fused_seq_log_density(model, enc, lse_bits=12)
+        self.assertLessEqual(float(np.abs(quant - exact).max()), 2 * lse_error_bound(12, 24.0))
+
+    def test_validation(self):
+        model, enc, _ = _nested_model_and_enc(n=200)
+        with self.assertRaises(ValueError):
+            fn.fused_nested_seq_log_density(model, enc, lse_bits=0)
+
+
+@unittest.skipUnless(HAS_NUMBA, "nested fused kernels require numba")
 class NestedParallelTest(unittest.TestCase):
     def test_parallel_scorer_matches_sequential_and_is_bit_stable(self):
         model, enc, _ = _nested_model_and_enc()

--- a/mixle/tests/fused_parallel_test.py
+++ b/mixle/tests/fused_parallel_test.py
@@ -166,14 +166,18 @@ class QuantizedLseTest(unittest.TestCase):
             fc.fused_seq_log_density(model, enc, lse_bits=0)
         with self.assertRaises(ValueError):
             fc.fused_seq_log_density(model, enc, lse_bits=12, lse_span=-1.0)
+        from mixle.engines.qlut import lse_error_bound
         from mixle.stats import GaussianDistribution as G
 
+        # nested trees SUPPORT the option now (forwarded to the nested kernels); their bound
+        # compounds per mixture level -- depth 2 here
         nested = MixtureDistribution(
             [MixtureDistribution([G(-2.0, 1.0), G(2.0, 1.0)], [0.5, 0.5]) for _ in range(2)], [0.5, 0.5]
         )
         nenc = nested.dist_to_encoder().seq_encode([0.1, -0.4, 2.2])
-        with self.assertRaises(NotImplementedError):
-            fc.fused_seq_log_density(nested, nenc, lse_bits=12)
+        exact = fc.fused_seq_log_density(nested, nenc)
+        quant = fc.fused_seq_log_density(nested, nenc, lse_bits=12)
+        self.assertLessEqual(float(np.abs(quant - exact).max()), 2 * lse_error_bound(12, 24.0))
 
 
 @unittest.skipUnless(HAS_NUMBA, "parallel fused kernels require numba")

--- a/mixle/tests/tree_hmm_dtype_test.py
+++ b/mixle/tests/tree_hmm_dtype_test.py
@@ -1,0 +1,59 @@
+"""Dtype pinning at TreeHMM's explicitly-signed numba kernel boundaries.
+
+The tree Baum-Welch/initialize kernels carry EXPLICIT eager signatures (int32 encoder arrays, int64
+states, float64 weights): eager dispatch has no widening, so caller-supplied integer weights (an
+``np.ones(n, dtype=int)``, a list of ints) used to arrive as int64 and fail with numba's
+"No matching definition for argument type(s)". Seen on Python 3.14 where the estimation path
+produced integer weights; the call sites now coerce at the boundary. This test drives BOTH weighted
+kernel entry points (seq_initialize and the Baum-Welch seq_update) with deliberately-integer weights
+and must never raise, on any Python.
+"""
+
+import unittest
+
+import numpy as np
+
+from mixle.utils.optional_deps import HAS_NUMBA
+
+if HAS_NUMBA:
+    from mixle.stats import GaussianDistribution, IntegerCategoricalDistribution, TreeHiddenMarkovModelDistribution
+
+
+@unittest.skipUnless(HAS_NUMBA, "the tree HMM kernels require numba")
+class TreeHmmKernelDtypeTest(unittest.TestCase):
+    def _model(self):
+        topics = [GaussianDistribution(mu=float(10 * s), sigma2=1.0) for s in range(3)]
+        trans = np.asarray([[0.7, 0.2, 0.1], [0.1, 0.7, 0.2], [0.2, 0.1, 0.7]])
+        len_dist = IntegerCategoricalDistribution(min_val=0, p_vec=np.array([0.25, 0.25, 0.5]))
+        return TreeHiddenMarkovModelDistribution(
+            topics=topics, w=np.ones(3) / 3, transitions=trans, len_dist=len_dist, terminal_level=2
+        )
+
+    def test_integer_weights_survive_both_weighted_kernel_boundaries(self):
+        model = self._model()
+        rng = np.random.RandomState(0)
+        data = model.sampler(seed=1).sample(60)
+        enc = model.dist_to_encoder().seq_encode(data)
+        est = model.estimator()
+        acc = est.accumulator_factory().make()
+
+        int_weights = np.ones(len(data), dtype=np.int64)  # the exact shape of the 3.14 failure
+        acc.seq_initialize(enc, int_weights, rng)  # numba_initialize boundary
+        acc2 = est.accumulator_factory().make()
+        acc2.seq_update(enc, int_weights, model)  # numba_baum_welch boundary
+
+        new_model = est.estimate(len(data), acc2.value())
+        self.assertTrue(np.isfinite(np.sum(new_model.seq_log_density(enc))))
+
+    def test_float_weights_unchanged(self):
+        model = self._model()
+        data = model.sampler(seed=2).sample(40)
+        enc = model.dist_to_encoder().seq_encode(data)
+        est = model.estimator()
+        acc = est.accumulator_factory().make()
+        acc.seq_update(enc, np.ones(len(data)), model)
+        self.assertTrue(np.isfinite(np.sum(model.seq_log_density(enc))))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The completion set

What "complete" means for the compiled optimizer, enforced in code and written into the module docstring's coverage map:

### 1. Universal bridge
The bridge template now matches **any protocol-bearing factor** inside a composite (`seq_log_density` + `dist_to_encoder` + `estimator`) — untemplated leaves (Laplace), length-model chains, and anything future — with native scoring/estimation semantics, priors included. Specific templates still outrank it; bare nested mixtures still keep fused_nested's faster in-kernel path. Host M-step parity asserted per newly covered class.

### 2. Chain template: prior guard dropped, length routing pinned
The prior refusal was over-caution — sufficient statistics are the standard count maps and the estimator applies its Dirichlet prior at `estimate()` exactly as on the host path (parity-tested). Dirichlet-prior chains take the fast tables; length-model chains deliberately bridge (native length semantics); the old refusal test now pins the routing.

### 3. Nested quantized LSE
The nested scorers accept `lse_bits` with the same qlut semantics as the template scorers; the bound **compounds per mixture level** (depth × `lse_error_bound`), stated and asserted at depth 2. The template entry point forwards instead of refusing. E-steps everywhere remain exact by design.

### 4. TreeHMM dtype pins (the py3.14 dispatch failure)
Integer weights reached the explicitly-signed `numba_initialize`/`numba_baum_welch` kernels as int64; eager dispatch has no widening and refused. Coerced at both boundaries; `tree_hmm_dtype_test` drives both weighted entry points with deliberately-integer weights; the previously-failing `base_dist_test` TreeHMM estimation passes. (Note: a spawned background session was started for this same fix from an earlier chip — this PR supersedes it.)

### Verified, not rebuilt
The HMM Baum-Welch/scoring kernels are **already sequence-parallel** (prange over sequences, `parallel=True`) — the "parallelize HMM" lever needed no work, and saying so is part of finishing.

### Principled exclusions (documented, not pending)
Exact-exp E-steps (a δ-grid perturbation could flip monotone-gate accepts); bare-nested-mixture bridging (fused_nested is faster); eager GradLeaf M-steps (torch.compile measured 0.79–0.93× on CPU).

## Tests
81 round-suite tests green (5 new coverage/parity + 2 dtype pins + 3 quantized-nested); full fast gate green modulo the known xdist flakes (pass single-process) and the local stale-editable-install manifest issue.