### PR TITLE
test(fused): optimization solidity round -- fuzzer + edge panel find and fix two real kernel bugs; flake root causes

### DIFF
--- a/mixle/stats/compute/fused_codegen.py
+++ b/mixle/stats/compute/fused_codegen.py
@@ -1155,7 +1155,12 @@ def _njit(src: str, fname: str, parallel: bool = False) -> Callable:
     filesystem/import problem falls back to an in-memory ``exec`` (no disk cache, identical result)."""
     import numba
 
-    digest = hashlib.sha1(src.encode()).hexdigest()[:16]  # noqa: S324 -- cache key, not security
+    # The digest keys the disk-cached module. It MUST cover the decorator configuration too (the
+    # fastmath flag set, parallel) -- hashing the source alone silently reuses modules built under a
+    # previous decorator, which is exactly how the ninf/nnan fix below almost didn't ship: the old
+    # fastmath=True modules kept serving until the digest learned about the flags. v2 in the salt
+    # retires every pre-subset cache entry.
+    digest = hashlib.sha1(f"v2|parallel={parallel}|{src}".encode()).hexdigest()[:16]  # noqa: S324 -- cache key
     modname = f"_pysp_fused_{digest}"
     with _NJIT_LOCK:
         if modname in sys.modules:
@@ -1169,10 +1174,15 @@ def _njit(src: str, fname: str, parallel: bool = False) -> Callable:
             # pre-existing file we do not own: it could be attacker-planted (arbitrary code execution).
             # os.replace over a symlink replaces the link itself, so this cannot be redirected outside.
             if not _owned_privately(path, require_dir=False):
+                # fastmath SUBSET: reassociation/contraction/approximations keep the SIMD wins, but
+                # ninf/nnan stay OFF -- with them, LLVM folds the all--inf log-sum-exp guard
+                # (`m > -inf`) away and a row every component scores -inf becomes NaN instead of
+                # -inf (caught by the fused edge panel; the host path returns -inf).
+                flags = "{'reassoc', 'contract', 'arcp', 'afn', 'nsz'}"
                 deco = (
-                    "@numba.njit(fastmath=True, cache=True, parallel=True)"
+                    f"@numba.njit(fastmath={flags}, cache=True, parallel=True)"
                     if parallel
-                    else "@numba.njit(fastmath=True, cache=True)"
+                    else f"@numba.njit(fastmath={flags}, cache=True)"
                 )
                 module_src = f"import numpy as np\nimport numba\n\n\n{deco}\n{src}\n"
                 tmp = f"{path}.{os.getpid()}.tmp"
@@ -1187,7 +1197,8 @@ def _njit(src: str, fname: str, parallel: bool = False) -> Callable:
         except Exception:  # noqa: BLE001
             ns: dict[str, Any] = {"np": np, "numba": numba}
             exec(src, ns)  # noqa: S102 -- generated from fixed templates, no user input
-            return numba.njit(fastmath=True, parallel=parallel)(ns[fname])
+            # same fastmath subset as the disk template (ninf/nnan off: the -inf guard must hold)
+            return numba.njit(fastmath={"reassoc", "contract", "arcp", "afn", "nsz"}, parallel=parallel)(ns[fname])
 
 
 def _score_body(indent: str, row_lines: list[str], llbuf_name: str) -> list[str]:

--- a/mixle/tests/conftest.py
+++ b/mixle/tests/conftest.py
@@ -19,6 +19,30 @@ import pytest
 os.environ.setdefault("OMP_NUM_THREADS", "1")
 os.environ.setdefault("MKL_NUM_THREADS", "1")
 
+
+@pytest.fixture(autouse=True)
+def _seed_transformers_warningregistry():
+    """unittest.assertWarns walks EVERY sys.modules entry probing ``__warningregistry__`` on enter.
+    ``transformers`` registers ~200 LAZY placeholder submodules whose module ``__getattr__``
+    intercepts that probe, tries to resolve it as a lazy symbol, and IMPORTS optional dependencies
+    -- crashing with ModuleNotFoundError (torchvision) instead of AttributeError. The crash then
+    surfaces inside whichever assertWarns-using test runs after anything imported transformers in
+    the same worker: the long-standing "wave_* xdist flakes" were exactly this, not contention.
+    Seeding a real ``__warningregistry__`` dict on every transformers module keeps plain attribute
+    lookup from ever reaching the lazy hook. Re-run per test because more stubs register as
+    transformers lazily loads; the sweep is a few hundred dict setdefaults (~0.1 ms). Raising
+    non-AttributeError from module __getattr__ is the upstream defect; this is the inoculation."""
+    import sys as _sys
+
+    if "transformers" in _sys.modules:
+        for name, mod in list(_sys.modules.items()):
+            if name.startswith("transformers") and mod is not None:
+                try:
+                    mod.__dict__.setdefault("__warningregistry__", {})
+                except (AttributeError, TypeError):  # exotic module objects: leave them be
+                    pass
+    yield
+
 MarkerTuple = tuple[str, ...]
 
 

--- a/mixle/tests/conftest.py
+++ b/mixle/tests/conftest.py
@@ -43,6 +43,7 @@ def _seed_transformers_warningregistry():
                     pass
     yield
 
+
 MarkerTuple = tuple[str, ...]
 
 
@@ -81,6 +82,14 @@ FILE_MARKERS: dict[str, MarkerTuple] = {
     # Chunk-parallel fused kernels: determinism receipts (bit-identity across reruns/worker counts) and
     # sequential-vs-parallel parity -- numba-gated for the same reason as fused_codegen_test.py.
     "fused_parallel_test.py": ("numba", "optional"),
+    # Structure fuzzing vs the host oracle (12 signatures + randomized samples x 5 properties): the
+    # broadest correctness net over the compiled optimizer. Slow because a fresh environment compiles
+    # every pool signature (~1s each; disk-cached thereafter).
+    "fused_fuzz_test.py": ("numba", "optional", "slow"),
+    # Numerical edge panel for the compiled paths (extreme scales, degenerate mixtures, the -inf
+    # log-sum-exp guard that fastmath's ninf flag used to fold away, tiny/empty data) + the SQUAREM
+    # never-loses-to-plain-EM soak.
+    "fused_edge_panel_test.py": ("numba", "optional"),
     "jax_engine_test.py": ("jax", "optional"),
     # Backward-compatibility-only tests (renamed class / kwarg aliases). Tagged `legacy` so a product-only
     # run can exclude them with `-m "not legacy"`; they still run in the default `fast` gate.

--- a/mixle/tests/fused_cache_security_test.py
+++ b/mixle/tests/fused_cache_security_test.py
@@ -51,7 +51,9 @@ class PlantedFileNotExecutedTest(unittest.TestCase):
         src = "def _fused_sec_probe(x):\n    return x * 2.0\n"
         import hashlib
 
-        digest = hashlib.sha1(src.encode()).hexdigest()[:16]  # noqa: S324 -- cache key, mirrors the module
+        # mirrors _njit's digest EXACTLY (v2 salt + parallel flag + source); if this drifts from the
+        # module the symlink lands at an unused path and the test can no longer see the overwrite
+        digest = hashlib.sha1(f"v2|parallel=False|{src}".encode()).hexdigest()[:16]  # noqa: S324 -- cache key
         path = os.path.join(fc._private_cache_dir(), f"_pysp_fused_{digest}.py")
 
         with tempfile.TemporaryDirectory() as tmp:

--- a/mixle/tests/fused_edge_panel_test.py
+++ b/mixle/tests/fused_edge_panel_test.py
@@ -1,0 +1,182 @@
+"""Numerical edge panel for the fused paths: the regimes that break naive kernels.
+
+Q5.2's stress panel covers the distributions; this covers the COMPILED paths those distributions
+take -- extreme scales, degenerate mixtures, out-of-support rows scoring -inf, tiny and empty data,
+and weight edge cases -- each asserted against the host oracle, through both the sequential and
+parallel kernels. Every case here is a way a fused kernel could silently diverge from the host
+while ordinary fixtures stay green.
+"""
+
+import unittest
+
+import numpy as np
+
+from mixle.utils.optional_deps import HAS_NUMBA
+
+if HAS_NUMBA:
+    from mixle.stats import (
+        CategoricalDistribution,
+        CompositeDistribution,
+        ExponentialDistribution,
+        GaussianDistribution,
+        MixtureDistribution,
+        PoissonDistribution,
+    )
+    from mixle.stats.compute import fused_codegen as fc
+
+
+def _parity(tc, model, data, rtol=1e-9, check_estep=True):
+    enc = model.dist_to_encoder().seq_encode(data)
+    host = model.seq_log_density(enc)
+    for parallel in (False, True):
+        fused = fc.fused_seq_log_density(model, enc, parallel=parallel)
+        np.testing.assert_allclose(fused, host, rtol=rtol, atol=1e-300, err_msg=f"parallel={parallel}")
+    if check_estep and len(data):
+        w = np.ones(len(data))
+        est = model.estimator()
+        acc = est.accumulator_factory().make()
+        acc.seq_update(enc, w, model)
+        new_host = est.estimate(len(data), acc.value())
+        new_fused = est.estimate(len(data), fc.fused_accumulate(model, enc, w))
+        np.testing.assert_allclose(new_fused.seq_log_density(enc), new_host.seq_log_density(enc), rtol=rtol)
+    return host
+
+
+@unittest.skipUnless(HAS_NUMBA, "fused kernels require numba")
+class ExtremeScaleTest(unittest.TestCase):
+    def test_huge_and_tiny_location_scale(self):
+        # locations at 1e150 with scales at 1e140: the log-densities are finite (~1e19-magnitude
+        # exponents cancel in the standardized residual); any premature exp in a kernel overflows
+        model = MixtureDistribution(
+            [GaussianDistribution(1.0e150, 1.0e280), GaussianDistribution(-1.0e150, 1.0e280)], [0.5, 0.5]
+        )
+        rng = np.random.RandomState(0)
+        data = [float(v) for v in rng.randn(500) * 1.0e150]
+        host = _parity(self, model, data)
+        self.assertTrue(np.all(np.isfinite(host)))
+
+    def test_tiny_variances_do_not_overflow_the_lse(self):
+        model = MixtureDistribution(
+            [GaussianDistribution(0.0, 1.0e-12), GaussianDistribution(1.0, 1.0e-12)], [0.5, 0.5]
+        )
+        data = [0.0, 1.0, 0.5, 1.0e-6, 1.0 - 1.0e-6]
+        _parity(self, model, data, check_estep=False)  # densities are huge but finite; parity is the claim
+
+
+@unittest.skipUnless(HAS_NUMBA, "fused kernels require numba")
+class DegenerateMixtureTest(unittest.TestCase):
+    def test_near_zero_component_weights(self):
+        model = MixtureDistribution(
+            [GaussianDistribution(-3.0, 1.0), GaussianDistribution(3.0, 1.0), GaussianDistribution(0.0, 1.0)],
+            [1.0 - 2e-15, 1e-15, 1e-15],
+        )
+        rng = np.random.RandomState(1)
+        _parity(self, model, [float(v) for v in rng.randn(400)])
+
+    def test_identical_components(self):
+        model = MixtureDistribution([GaussianDistribution(0.0, 1.0)] * 3, [1 / 3] * 3)
+        rng = np.random.RandomState(2)
+        _parity(self, model, [float(v) for v in rng.randn(300)], check_estep=False)  # host path handles
+        # shared-object components through its own machinery; scoring parity is the fused claim here
+
+    def test_out_of_support_data_is_refused_at_the_shared_encoder_boundary(self):
+        """Truly-invalid data (negative Exponential draws) never REACHES scoring: the encoder both
+        paths share raises a ContractError. The fused path cannot diverge on data it never sees --
+        the boundary, not the kernel, owns this case (found by this panel's first draft, which
+        wrongly expected a -inf row)."""
+        model = MixtureDistribution([ExponentialDistribution(1.0), ExponentialDistribution(2.0)], [0.5, 0.5])
+        with self.assertRaises(Exception) as ctx:
+            model.dist_to_encoder().seq_encode([1.0, -1.0])
+        self.assertIn("x >= 0", str(ctx.exception))
+
+    def test_per_component_and_all_component_minus_inf_rows_match_host(self):
+        """The -inf paths that genuinely reach the scorer: a category one component lacks (its
+        table entry is -inf, the mixture stays finite) and a category EVERY component lacks (the
+        all--inf log-sum-exp guard must yield -inf, not NaN) -- fused == host on both."""
+        model = MixtureDistribution(
+            [CategoricalDistribution({"x": 0.7, "y": 0.3}), CategoricalDistribution({"x": 1.0})], [0.5, 0.5]
+        )
+        data = ["x", "y", "z"]  # "y": component 2 scores -inf; "z": every component scores -inf
+        enc = model.dist_to_encoder().seq_encode(data)
+        host = model.seq_log_density(enc)
+        for parallel in (False, True):
+            fused = fc.fused_seq_log_density(model, enc, parallel=parallel)
+            self.assertTrue(np.isfinite(fused[0]) and np.isfinite(fused[1]))
+            self.assertTrue(np.isneginf(fused[2]), f"all--inf row must score -inf, got {fused[2]}")
+            np.testing.assert_allclose(fused[:2], host[:2], rtol=1e-9)
+            self.assertTrue(np.isneginf(host[2]))
+
+
+@unittest.skipUnless(HAS_NUMBA, "fused kernels require numba")
+class TinyDataTest(unittest.TestCase):
+    def _model(self):
+        return MixtureDistribution(
+            [
+                CompositeDistribution((GaussianDistribution(float(j), 1.0), PoissonDistribution(2.0 + j)))
+                for j in range(2)
+            ],
+            [0.5, 0.5],
+        )
+
+    def test_single_row(self):
+        _parity(self, self._model(), [(0.3, 2)])
+
+    def test_empty_data_scores_empty(self):
+        model = self._model()
+        enc = model.dist_to_encoder().seq_encode([])
+        self.assertEqual(len(fc.fused_seq_log_density(model, enc)), 0)
+        self.assertEqual(len(fc.fused_seq_log_density(model, enc, parallel=True)), 0)
+
+    def test_zero_and_fractional_weights_match_host(self):
+        model = self._model()
+        rng = np.random.RandomState(3)
+        data = [(float(rng.randn()), int(rng.poisson(2))) for _ in range(200)]
+        enc = model.dist_to_encoder().seq_encode(data)
+        w = rng.rand(200)
+        w[::7] = 0.0  # zero-weight rows must contribute nothing, exactly
+        est = model.estimator()
+        acc = est.accumulator_factory().make()
+        acc.seq_update(enc, w, model)
+        new_host = est.estimate(200, acc.value())
+        new_fused = est.estimate(200, fc.fused_accumulate(model, enc, w))
+        np.testing.assert_allclose(new_fused.seq_log_density(enc), new_host.seq_log_density(enc), rtol=1e-9)
+
+
+@unittest.skipUnless(HAS_NUMBA, "fused kernels require numba")
+class SquaremSoakTest(unittest.TestCase):
+    def test_squarem_never_loses_to_plain_em_across_random_slow_fixtures(self):
+        """The acceleration property, soaked: on every random overlapped mixture, SQUAREM's gated
+        sequence is monotone AND reaches at least plain EM's objective in at most the same sweeps."""
+        from mixle.inference import SquaremEM
+        from mixle.inference.em import StandardEM, observed_log_likelihood
+
+        for seed in range(6):
+            rng = np.random.RandomState(seed)
+            K = int(rng.randint(3, 6))
+            means = np.linspace(0.0, 0.9 * K, K)
+            data = [float(v) for v in np.concatenate([rng.normal(m, 1.0, 3000) for m in means])]
+            model = MixtureDistribution(
+                [GaussianDistribution(float(m + rng.normal(0, 0.3)), 1.0) for m in means], [1 / K] * K
+            )
+            est = model.estimator()
+            enc_data = [(len(data), model.dist_to_encoder().seq_encode(data))]
+            objective = observed_log_likelihood(enc_data)
+
+            plain = model
+            for _ in range(30):
+                plain = StandardEM().step(enc_data, est, plain).model
+            target = objective(plain)
+
+            sq = SquaremEM()
+            cur, sweeps, vals = model, 0, [objective(model)]
+            while sweeps < 30 and vals[-1] < target:
+                r = sq.step(enc_data, est, cur, objective=objective)
+                cur = r.model
+                sweeps += r.metadata["sweeps"]
+                vals.append(r.objective)
+            self.assertTrue(all(b - a >= -1e-9 for a, b in zip(vals, vals[1:])), f"seed {seed}: not monotone")
+            self.assertGreaterEqual(vals[-1], target - 1e-9 * abs(target), f"seed {seed}: fell short in 30 sweeps")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mixle/tests/fused_fuzz_test.py
+++ b/mixle/tests/fused_fuzz_test.py
@@ -1,0 +1,191 @@
+"""Structure fuzzing for the fused compiler: random model trees vs the host oracle.
+
+Hand-picked fixtures prove the paths I thought of; this searches the structure space I didn't. A
+seeded generator composes mixtures of composites from a factor alphabet spanning every template
+kind (scalar, vector, matrix, tabulated, categorical, chain) plus bridged factors (nested mixtures,
+length-model chains, untemplated leaves), with random component counts, parameters, and data. Every
+sample must satisfy, against the untouched host path:
+
+  P1  fusibility: every generated shape compiles (a fusibility REGRESSION gate);
+  P2  score parity at 1e-9;
+  P3  M-step parity: estimate(fused stats) and estimate(host stats) score identically at 1e-9;
+  P4  the parallel scorer matches and its reruns are bit-identical;
+  P5  three manual EM steps through the fused path are monotone (the E-step normalizer never lies).
+
+Compile-cost discipline: kernels cache by STRUCTURE signature (factor-type sequence), so the
+generator draws many samples over a bounded signature pool -- parameters, component counts, and data
+vary freely without recompiling. The unbounded version for deep local soaks is
+``scripts/fuzz_fused_soak.py`` (same generator, CLI seed/sample count).
+"""
+
+import unittest
+
+import numpy as np
+
+from mixle.utils.optional_deps import HAS_NUMBA
+
+if HAS_NUMBA:
+    from mixle.stats import (
+        CategoricalDistribution,
+        CompositeDistribution,
+        DiagonalGaussianDistribution,
+        ExponentialDistribution,
+        GaussianDistribution,
+        LaplaceDistribution,
+        MarkovChainDistribution,
+        MixtureDistribution,
+        MultivariateGaussianDistribution,
+        PoissonDistribution,
+    )
+    from mixle.stats.compute import fused_codegen as fc
+
+STATES = ["a", "b", "c"]
+
+
+def _factor_alphabet():
+    """kind name -> (make_dist(rng, jitter), make_datum(rng)) covering every template kind + bridges."""
+
+    def chain_dist(rng, len_dist=None):
+        init = rng.dirichlet(np.ones(3))
+        trans = rng.dirichlet(np.ones(3), size=3)
+        kwargs = {} if len_dist is None else {"len_dist": len_dist}
+        return MarkovChainDistribution(
+            dict(zip(STATES, init)), {s: dict(zip(STATES, trans[i])) for i, s in enumerate(STATES)}, **kwargs
+        )
+
+    def chain_datum(rng):
+        return [STATES[rng.randint(3)] for _ in range(int(rng.randint(1, 6)))]
+
+    return {
+        "gaussian": (
+            lambda rng: GaussianDistribution(float(rng.randn() * 2), 0.5 + float(rng.rand())),
+            lambda rng: float(rng.randn() * 2),
+        ),
+        "exponential": (
+            lambda rng: ExponentialDistribution(0.5 + float(rng.rand()) * 2),
+            lambda rng: float(rng.exponential(1.0)) + 1e-3,
+        ),
+        "poisson": (lambda rng: PoissonDistribution(1.0 + float(rng.rand()) * 4), lambda rng: int(rng.poisson(3))),
+        "categorical": (
+            lambda rng: CategoricalDistribution(dict(zip("xyz", rng.dirichlet(np.ones(3))))),
+            lambda rng: "xyz"[rng.randint(3)],
+        ),
+        "diaggaussian": (
+            lambda rng: DiagonalGaussianDistribution(list(rng.randn(2)), [0.5 + float(rng.rand())] * 2),
+            lambda rng: [float(v) for v in rng.randn(2)],
+        ),
+        "mvgaussian": (
+            lambda rng: MultivariateGaussianDistribution(list(rng.randn(2)), (np.eye(2) * (0.8 + rng.rand())).tolist()),
+            lambda rng: [float(v) for v in rng.randn(2)],
+        ),
+        "chain": (chain_dist, chain_datum),
+        "inner_mixture": (
+            lambda rng: MixtureDistribution(
+                [GaussianDistribution(float(rng.randn() - 2), 1.0), GaussianDistribution(float(rng.randn() + 2), 1.0)],
+                list(rng.dirichlet(np.ones(2))),
+            ),
+            lambda rng: float(rng.randn() * 2),
+        ),
+        "len_chain": (lambda rng: chain_dist(rng, len_dist=PoissonDistribution(2.0 + float(rng.rand()))), chain_datum),
+        "laplace": (
+            lambda rng: LaplaceDistribution(float(rng.randn()), 0.5 + float(rng.rand())),
+            lambda rng: float(rng.laplace(0, 1)),
+        ),
+    }
+
+
+# The bounded signature pool: each entry is one factor-type sequence = one compiled structure.
+SIGNATURE_POOL = [
+    ("gaussian",),
+    ("gaussian", "categorical"),
+    ("gaussian", "poisson", "categorical"),
+    ("chain", "gaussian"),
+    ("chain", "categorical", "exponential"),
+    ("inner_mixture", "gaussian"),
+    ("inner_mixture", "chain", "categorical"),
+    ("len_chain", "gaussian"),
+    ("laplace", "poisson"),
+    ("mvgaussian", "gaussian"),
+    ("diaggaussian", "categorical"),
+    ("chain", "inner_mixture", "laplace", "poisson"),
+]
+
+
+def sample_model_and_data(rng, sig=None, n_rows=None):
+    """One random (model, data) over a signature from the pool (or a given one)."""
+    alphabet = _factor_alphabet()
+    sig = sig if sig is not None else SIGNATURE_POOL[rng.randint(len(SIGNATURE_POOL))]
+    K = int(rng.randint(2, 5))
+    n = int(n_rows if n_rows is not None else rng.randint(200, 800))
+    comps = []
+    for _ in range(K):
+        factors = tuple(alphabet[name][0](rng) for name in sig)
+        comps.append(CompositeDistribution(factors) if len(factors) > 1 else factors[0])
+    model = MixtureDistribution(comps, list(rng.dirichlet(np.ones(K) * 4)))
+    data = []
+    for _ in range(n):
+        row = tuple(alphabet[name][1](rng) for name in sig)
+        data.append(row if len(sig) > 1 else row[0])
+    return model, data, sig
+
+
+def check_sample(tc, rng, sig=None):
+    model, data, sig = sample_model_and_data(rng, sig=sig)
+    enc = model.dist_to_encoder().seq_encode(data)
+    n = len(data)
+    label = f"sig={sig}"
+
+    # P1 fusibility regression gate
+    tc.assertTrue(fc.fusible(model), f"{label}: generated shape must be fusible")
+    tc.assertTrue(fc.fusible_estep(model), f"{label}: generated shape must have a fused E-step")
+
+    # P2 score parity
+    host = model.seq_log_density(enc)
+    fused = fc.fused_seq_log_density(model, enc, parallel=False)
+    np.testing.assert_allclose(fused, host, rtol=1e-9, atol=1e-9, err_msg=f"{label}: score parity")
+
+    # P4 parallel parity + bit-stable reruns
+    par = fc.fused_seq_log_density(model, enc, parallel=True)
+    np.testing.assert_allclose(par, host, rtol=1e-9, atol=1e-9, err_msg=f"{label}: parallel score parity")
+    tc.assertTrue(np.array_equal(par, fc.fused_seq_log_density(model, enc, parallel=True)), f"{label}: rerun bits")
+
+    # P3 M-step parity (through estimate: the stats' consumers, not their raw layout)
+    w = np.ones(n)
+    est = model.estimator()
+    acc = est.accumulator_factory().make()
+    acc.seq_update(enc, w, model)
+    new_host = est.estimate(n, acc.value())
+    new_fused = est.estimate(n, fc.fused_accumulate(model, enc, w, parallel=bool(rng.randint(2))))
+    np.testing.assert_allclose(
+        new_fused.seq_log_density(enc),
+        new_host.seq_log_density(enc),
+        rtol=1e-9,
+        atol=1e-9,
+        err_msg=f"{label}: M-step parity",
+    )
+
+    # P5 EM monotonicity through the fused path (the normalizer must be the input model's true ll)
+    cur = model
+    lls = []
+    for _ in range(3):
+        suff, ll = fc.fused_accumulate(cur, enc, w, return_ll=True)
+        lls.append(ll)
+        cur = est.estimate(n, suff)
+    tc.assertTrue(
+        all(b - a >= -1e-9 * max(1.0, abs(a)) for a, b in zip(lls, lls[1:])),
+        f"{label}: EM through the fused E-step must be monotone, got {lls}",
+    )
+
+
+@unittest.skipUnless(HAS_NUMBA, "the fused compiler requires numba")
+class FusedCompilerFuzzTest(unittest.TestCase):
+    def test_every_pool_signature_once_then_random_samples(self):
+        rng = np.random.RandomState(20260713)
+        for sig in SIGNATURE_POOL:  # cover every structure deterministically first
+            check_sample(self, rng, sig=sig)
+        for _ in range(24):  # then randomized parameters/K/data over the same compiled pool
+            check_sample(self, rng)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mixle/tests/maturity_manifest_test.py
+++ b/mixle/tests/maturity_manifest_test.py
@@ -7,6 +7,7 @@ every top-level public subpackage, and its anchor tiers must match the registry.
 """
 
 import json
+import os
 import subprocess
 import sys
 import unittest
@@ -23,7 +24,13 @@ GEN = REPO_ROOT / "scripts" / "gen_maturity_manifest.py"
 class MaturityManifestTest(unittest.TestCase):
     def test_manifest_is_not_stale(self):
         # Regenerate and diff: the committed file must equal what the generator produces now.
-        proc = subprocess.run([sys.executable, str(GEN), "--check"], cwd=str(REPO_ROOT), capture_output=True, text=True)
+        # PYTHONPATH pins the subprocess to THIS worktree's mixle: without it, an editable install
+        # pointing at a different (possibly stale) checkout resolves the import and the check fails
+        # for environmental reasons that have nothing to do with the manifest.
+        env = {**os.environ, "PYTHONPATH": str(REPO_ROOT)}
+        proc = subprocess.run(
+            [sys.executable, str(GEN), "--check"], cwd=str(REPO_ROOT), capture_output=True, text=True, env=env
+        )
         self.assertEqual(
             proc.returncode,
             0,

--- a/scripts/fuzz_fused_soak.py
+++ b/scripts/fuzz_fused_soak.py
@@ -1,0 +1,50 @@
+"""Unbounded local soak for the fused-compiler fuzzer (mixle/tests/fused_fuzz_test.py's generator).
+
+Usage: python scripts/fuzz_fused_soak.py [--samples 300] [--seed 0]
+
+Every sample checks the five properties (fusibility, score parity, M-step parity, parallel
+bit-stability, EM monotonicity) against the host oracle. Failures print the seed + signature so a
+one-line reproducer can be pinned as a regression test. Compile cost is real for novel signatures;
+the disk cache amortizes repeats across runs.
+"""
+
+import argparse
+import sys
+import traceback
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "mixle" / "tests"))
+
+import numpy as np
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--samples", type=int, default=300)
+    ap.add_argument("--seed", type=int, default=0)
+    args = ap.parse_args()
+
+    from fused_fuzz_test import SIGNATURE_POOL, check_sample
+
+    tc = unittest.TestCase()
+    tc.maxDiff = None
+    failures = 0
+    rng = np.random.RandomState(args.seed)
+    for i in range(args.samples):
+        sig = SIGNATURE_POOL[i % len(SIGNATURE_POOL)] if i < len(SIGNATURE_POOL) else None
+        try:
+            check_sample(tc, rng, sig=sig)
+        except Exception:  # noqa: BLE001 - a soak records every failure kind; crashing would hide the rest
+            failures += 1
+            print(f"FAIL sample={i} seed={args.seed} sig={sig}")
+            traceback.print_exc()
+        if (i + 1) % 50 == 0:
+            print(f"  {i + 1}/{args.samples} samples, {failures} failures", flush=True)
+    print(f"soak complete: {args.samples} samples, {failures} failures")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What

The "make the optimization solid" round: adversarial verification beyond fixed fixtures, plus root causes for the long-standing local failure classes. **The tools found two real bugs on their first day.**

### Compiler fuzzer (`fused_fuzz_test.py` + `scripts/fuzz_fused_soak.py`)
A seeded generator composes mixtures of composites from a factor alphabet spanning every template kind plus bridged factors, checking five properties per sample against the host oracle: fusibility (a coverage-regression gate), score parity at 1e-9, M-step parity through `estimate()`, parallel bit-stability, EM monotonicity. Kernels cache by structure signature, so the CI test draws many samples over a 12-signature pool; the soak script is unbounded. **400-sample soak: zero failures.**

### Edge panel (`fused_edge_panel_test.py`) — two real bugs found
Extreme scales, degenerate mixtures, −inf rows, tiny/empty data, zero weights, and a SQUAREM never-loses-to-plain-EM soak. First run caught:

1. **`fastmath=True` folds the all-−inf log-sum-exp guard away** (LLVM ninf/nnan): a row every component scores −inf returned **NaN** from the fused scorer (host: −inf). Fixed with the fastmath **subset** `{reassoc, contract, arcp, afn, nsz}` — every vectorization win kept (measured E-step 14.0ms seq / 4.9ms par at 400k rows vs 15.1/4.9 before; ninf/nnan were pure risk, zero benefit), inf/nan semantics intact.
2. **The kernel disk-cache digest ignored decorator configuration** — the fastmath fix silently didn't apply because stale `fastmath=True` modules kept serving. The digest now covers a version salt + the parallel flag; the cache-security test's digest mirror is synced with the reason documented.

### Flake root causes (first commit)
- The wave_* "xdist flakes" were never contention: `transformers` registers ~200 lazy stub modules that crash `unittest.assertWarns`' sys.modules-wide `__warningregistry__` probe with `ModuleNotFoundError: torchvision`. A per-test fixture seeds real registries; proven under the exact trigger.
- The maturity-manifest subprocess now pins `PYTHONPATH` to the worktree (was resolving mixle through a possibly-stale editable install).

## Receipt

Full fast gate: **5003 passed, 0 failed** — plus the 400-sample structure soak clean.