### PR TITLE
fix(core): quantize bracket, ViterbiPath delegation, conformal edge, registry/relations guards

### DIFF
--- a/mixle/fault.py
+++ b/mixle/fault.py
@@ -61,10 +61,14 @@ def route_past(tiers: Sequence[Callable[[], Any]], *, names: Sequence[str] | Non
     """``model_error`` mode: try each tier in order; a raising tier is skipped (not fatal) in favor of the
     next. The result is degraded unless the first tier answers cleanly. Raises
     the last tier's exception if every tier fails."""
+    if len(tiers) == 0:
+        raise ValueError("route_past needs at least one tier")
     names = list(names) if names is not None else [f"tier{i}" for i in range(len(tiers))]
+    if len(names) != len(tiers):
+        raise ValueError(f"names has {len(names)} entries for {len(tiers)} tiers; they must match one-to-one")
     failed: list[str] = []
     last_exc: Exception | None = None
-    for name, tier in zip(names, tiers):
+    for name, tier in zip(names, tiers, strict=True):
         try:
             value = tier()
         except Exception as exc:  # noqa: BLE001 -- route past this tier to the next, whatever it raised

--- a/mixle/ops.py
+++ b/mixle/ops.py
@@ -52,10 +52,11 @@ def quantize(
     from mixle.stats.univariate.discrete.categorical import CategoricalDistribution
 
     n = 1 << int(bits)
-    # bracket the bulk of the mass
-    if callable(getattr(dist, "density_quantile", None)):
-        lo = float(dist.density_quantile(lo_q, seed=seed))
-        hi = float(dist.density_quantile(hi_q, seed=seed))
+    # bracket the bulk of the mass with the spatial quantile (inverse CDF) when the family has one,
+    # else an empirical quantile of a sample. NOT ``density_quantile``: that index is descending-DENSITY
+    # order (q=0 is the mode, q -> 1 walks into a tail on either side), so it cannot bracket a support.
+    if callable(getattr(dist, "quantile", None)):
+        lo, hi = float(dist.quantile(lo_q)), float(dist.quantile(hi_q))
     else:
         s = np.asarray(dist.sampler(seed).sample(n_samples), dtype=float).ravel()
         lo, hi = float(np.quantile(s, lo_q)), float(np.quantile(s, hi_q))

--- a/mixle/registry.py
+++ b/mixle/registry.py
@@ -104,7 +104,9 @@ class Registry:
         ``capabilities`` names what this model answers (matched by :meth:`find_for`); ``fingerprint`` is
         typically :func:`~mixle.task.edge.task_fingerprint`'s vector for the training data; ``profile`` is
         free-form (e.g. a :func:`~mixle.task.capability.capture_profile` dict); ``cost`` is the per-request
-        cost used to order :meth:`tier_stack`.
+        cost used to order :meth:`tier_stack`. An explicit ``entry_id`` that already exists (in the index
+        or as an artifact directory) raises rather than duplicating the index row and silently
+        overwriting the artifact; auto-generated ids scan past taken ones.
         """
         if isinstance(model, CalibratedTaskModel):
             kind = "calibrated"
@@ -112,7 +114,17 @@ class Registry:
             kind = "task"
         else:
             raise TypeError(f"Registry only stores TaskModel/CalibratedTaskModel, got {type(model)!r}")
-        entry_id = entry_id or f"entry_{len(self._entries):04d}"
+        taken = {e.entry_id for e in self._entries}
+        if entry_id is not None:
+            if entry_id in taken or os.path.exists(os.path.join(self.dir, entry_id)):
+                raise ValueError(f"registry already has an entry {entry_id!r}; entry ids must be unique")
+        else:
+            # a len()-based id collides after manual index edits, explicit ids, or another writer's
+            # artifacts -- scan forward until the id is free in BOTH the index and the directory
+            i = len(self._entries)
+            while f"entry_{i:04d}" in taken or os.path.exists(os.path.join(self.dir, f"entry_{i:04d}")):
+                i += 1
+            entry_id = f"entry_{i:04d}"
         path = os.path.join(self.dir, entry_id)
         model.save(path)
         entry = RegistryEntry(
@@ -169,11 +181,12 @@ class Registry:
     ) -> list[tuple[str, Any, float]]:
         """Ascending-cost ``(name, model, cost)`` tiers for capability ``task``, ``frontier`` appended last.
 
-        Matching entries are loaded (:meth:`load`) and ordered by their registered ``cost``. The result is
-        exactly the shape :class:`~mixle.task.router.Router` takes as ``tiers=``: each non-final tier exposes
-        ``decide(x)``, the final tier is the callable ``frontier`` fallback. ``costs`` (one entry per matching
-        solution plus one for ``frontier``, mirroring :meth:`~mixle.task.router.Router.from_solutions`) overrides
-        the registered per-entry costs when given.
+        Matching entries are loaded (:meth:`load`) and ordered by their *effective* cost -- the ``costs``
+        override when given, else the registered per-entry cost. The result is exactly the shape
+        :class:`~mixle.task.router.Router` takes as ``tiers=``: each non-final tier exposes ``decide(x)``,
+        the final tier is the callable ``frontier`` fallback. ``costs`` (one entry per matching solution in
+        registered-cost order, plus one for ``frontier``, mirroring
+        :meth:`~mixle.task.router.Router.from_solutions`) overrides the registered per-entry costs when given.
         """
         pool = sorted(self.find_for(task), key=lambda e: e.cost)
         if costs is not None and len(costs) != len(pool) + 1:
@@ -181,5 +194,6 @@ class Registry:
         tier_costs = [float(c) for c in costs] if costs is not None else [e.cost for e in pool] + [1.0]
         tier_names = list(names) if names is not None else [e.entry_id for e in pool] + ["frontier"]
         tiers = [(tier_names[i], self.load(e.entry_id), tier_costs[i]) for i, e in enumerate(pool)]
+        tiers.sort(key=lambda t: t[2])  # a costs= override can reorder the pool; Router assumes ascending tiers
         tiers.append((tier_names[-1], frontier, tier_costs[-1]))
         return tiers

--- a/mixle/relations.py
+++ b/mixle/relations.py
@@ -19,8 +19,9 @@ residual: a cost (minimized) or score (maximized); ``sense`` records which.
 
 Assignment, spanning tree, the edit-distance ball, k-best Viterbi, shortest path, and best-subset
 regression are all specified and consumed the same way, each delegating to whatever engine fits
-(Murty for assignment, Gabow for spanning trees, A* / :func:`best_first_paths` for paths and Viterbi,
-Dijkstra / :func:`nearest_first` for the edit-distance ball, exhaustive ranking for best-subset).
+(Murty for assignment, Gabow for spanning trees, A* / :func:`best_first_paths` for paths,
+:func:`mixle.enumeration.hmm_paths.hmm_best_paths` for Viterbi, Dijkstra / :func:`nearest_first`
+for the edit-distance ball, exhaustive ranking for best-subset).
 The two shared low-level engines are :func:`best_first_paths` (k-best *paths to a goal*) and
 :func:`nearest_first` (distinct *states outward* from a center -- an expanding metric ball).
 
@@ -42,6 +43,7 @@ from typing import Any, NamedTuple
 import numpy as np
 
 from mixle.enumeration.assignment import k_best_assignments
+from mixle.enumeration.hmm_paths import hmm_best_paths
 from mixle.enumeration.spanning import k_best_spanning_trees
 
 __all__ = [
@@ -330,21 +332,27 @@ def min_cut(capacity: Any, source: int, sink: int) -> tuple[float, list[int], li
 def tsp_held_karp(distance: Any) -> tuple[float, list[int]]:
     """Exact minimum-cost Hamiltonian cycle through all nodes (Held-Karp).
 
-    ``distance`` is an ``n x n`` matrix of arc costs (may be asymmetric). Returns ``(cost, tour)`` where
-    ``tour`` starts at node 0, visits every node once, and the cost includes the closing arc back to 0.
-    The Held-Karp bitmask DP is exact in ``O(2^n n^2)`` time / ``O(2^n n)`` memory, so it is intended for
-    small ``n`` (roughly <= 15-18); beyond that use a heuristic.
+    ``distance`` is an ``n x n`` matrix of arc costs (may be asymmetric); a non-finite cost marks a
+    missing arc. Returns ``(cost, tour)`` where ``tour`` starts at node 0, visits every node once, and
+    the cost includes the closing arc back to 0. Raises :class:`ValueError` when the finite arcs admit
+    no Hamiltonian cycle. The Held-Karp bitmask DP is exact in ``O(2^n n^2)`` time / ``O(2^n n)``
+    memory, so it is intended for small ``n`` (roughly <= 15-18); beyond that use a heuristic.
     """
     d = np.asarray(distance, dtype=np.float64)
     n = d.shape[0]
+    no_cycle = "no Hamiltonian cycle: the finite arcs admit no tour visiting every node once"
     if n <= 1:
         return 0.0, list(range(n))
     if n == 2:
+        if not (np.isfinite(d[0, 1]) and np.isfinite(d[1, 0])):
+            raise ValueError(no_cycle)
         return float(d[0, 1] + d[1, 0]), [0, 1]
     full = (1 << (n - 1)) - 1
     # C[(mask, j)] = (min cost of a path 0 -> ... -> j visiting exactly the nodes in mask, predecessor k)
-    # where mask is a bitmask over nodes 1..n-1.
-    cost_to: dict[tuple[int, int], tuple[float, int]] = {(1 << (j - 1), j): (float(d[0, j]), 0) for j in range(1, n)}
+    # where mask is a bitmask over nodes 1..n-1; unreachable (mask, j) simply have no entry.
+    cost_to: dict[tuple[int, int], tuple[float, int]] = {
+        (1 << (j - 1), j): (float(d[0, j]), 0) for j in range(1, n) if np.isfinite(d[0, j])
+    }
     for mask in range(1, full + 1):
         for j in range(1, n):
             bj = 1 << (j - 1)
@@ -353,7 +361,7 @@ def tsp_held_karp(distance: Any) -> tuple[float, list[int]]:
             prev_mask = mask ^ bj
             best: tuple[float, int] | None = None
             for k in range(1, n):
-                if k == j or not (prev_mask & (1 << (k - 1))):
+                if k == j or not (prev_mask & (1 << (k - 1))) or not np.isfinite(d[k, j]):
                     continue
                 pc = cost_to.get((prev_mask, k))
                 if pc is None:
@@ -367,12 +375,14 @@ def tsp_held_karp(distance: Any) -> tuple[float, list[int]]:
     end: tuple[float, int] | None = None
     for j in range(1, n):
         c = cost_to.get((full, j))
-        if c is None:
+        if c is None or not np.isfinite(d[j, 0]):
             continue
         cand = c[0] + float(d[j, 0])
         if end is None or cand < end[0]:
             end = (cand, j)
-    cost, last = end  # type: ignore[misc]
+    if end is None:
+        raise ValueError(no_cycle)
+    cost, last = end
     rev = []
     mask, j = full, last
     while j != 0:
@@ -584,7 +594,7 @@ def branch_and_bound_milp(
     obj = -cvec if sense == "max" else cvec
     if sense not in ("min", "max"):
         raise ValueError("sense must be 'min' or 'max'")
-    integer = range(n) if integer is None else integer
+    integer = list(range(n)) if integer is None else list(integer)  # materialize once: consumed at every node
     lo0 = [(-np.inf if bounds is None else bounds[i][0]) for i in range(n)]
     hi0 = [(np.inf if bounds is None else bounds[i][1]) for i in range(n)]
 
@@ -605,7 +615,9 @@ def branch_and_bound_milp(
         frac = next((i for i in integer if abs(x[i] - round(x[i])) > tol), None)
         if frac is None:
             if f < incumbent[0]:
-                incumbent = [f, np.array(x)]
+                x_int = np.array(x, dtype=np.float64)
+                x_int[integer] = np.round(x_int[integer])  # snap within-tol coordinates to exact integers
+                incumbent = [f, x_int]
             continue
         floor_hi = [hi[j] if j != frac else float(np.floor(x[frac])) for j in range(n)]
         ceil_lo = [lo[j] if j != frac else float(np.ceil(x[frac])) for j in range(n)]
@@ -635,7 +647,8 @@ def cardinality_constrained_milp(
     Adds a cardinality (sparsity) constraint to the linear program ``a_ub @ x <= b_ub`` with per-variable
     ``bounds`` via the standard big-M indicator formulation: a binary ``z_i`` gates each variable
     (``lower_i z_i <= x_i <= upper_i z_i``, so ``z_i = 0`` forces ``x_i = 0``) and ``sum z_i <=
-    max_nonzero``; the extended mixed-integer program is solved by :func:`branch_and_bound_milp`. Returns
+    max_nonzero``; the extended mixed-integer program is solved by :func:`branch_and_bound_milp`. Every
+    bound must be finite -- the bounds are the big-M constants of the indicator rows. Returns
     ``(objective, x)`` (the sparse optimizer) or ``None`` if infeasible. This is the indicator/
     set-membership/cardinality constraint primitive (best-subset selection, sparse design).
     """
@@ -645,6 +658,12 @@ def cardinality_constrained_milp(
     b = np.asarray(b_ub, dtype=np.float64) if b_ub is not None else np.zeros(0)
     lo = np.array([bd[0] for bd in bounds], dtype=np.float64)
     hi = np.array([bd[1] for bd in bounds], dtype=np.float64)
+    if not (np.isfinite(lo).all() and np.isfinite(hi).all()):
+        raise ValueError(
+            "cardinality_constrained_milp needs finite bounds for every variable: the big-M indicator "
+            "rows (lo_i z_i <= x_i <= hi_i z_i) are built from them, and a non-finite bound would put "
+            "inf/nan into the constraint matrix"
+        )
     rows: list[np.ndarray] = []
     rhs: list[float] = []
     for i in range(a.shape[0]):  # original constraints, padded for the z block
@@ -1026,7 +1045,9 @@ class ViterbiPath(Relation):
 
     Standard Viterbi returns only the single best path; this reduces the trellis (nodes ``(t, s)``)
     to a longest-log-prob path and yields the top ``k``. The solution value is a length-``T`` list of
-    state indices.
+    state indices. Delegates to :func:`mixle.enumeration.hmm_paths.hmm_best_paths`, whose backward
+    Viterbi completion value is a tight admissible heuristic: emission log-*densities* may be positive
+    (any density > 1), so a zero-heuristic ``sense="max"`` search would pop suboptimal goals first.
 
     Args:
         log_init: ``log p(state s at t=0)``, length ``S``.
@@ -1047,19 +1068,9 @@ class ViterbiPath(Relation):
         """Yield up to ``k`` hidden-state paths ordered by joint log probability."""
         if self.n_steps == 0:
             return
-        t_last, s = self.n_steps - 1, self.n_states
-        log_init, log_trans, log_obs = self.log_init, self.log_trans, self.log_obs
-
-        def successors(node):
-            t, state = node
-            if t == -1:
-                return [((0, sp), float(log_init[sp]) + float(log_obs[0][sp])) for sp in range(s)]
-            if t >= t_last:
-                return []  # states at the final step are sinks -> goals
-            return [((t + 1, sp), float(log_trans[state][sp]) + float(log_obs[t + 1][sp])) for sp in range(s)]
-
-        for path, score in best_first_paths((-1, -1), successors, sense="max", max_results=k):
-            yield Solution([st for (_t, st) in path[1:]], float(score))
+        log_b = np.asarray(self.log_obs, dtype=np.float64)
+        for path, score in hmm_best_paths(self.log_init, self.log_trans, log_b, k=k):
+            yield Solution(list(path), float(score))
 
 
 # ---------------------------------------------------------------------------

--- a/mixle/scientist.py
+++ b/mixle/scientist.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import os
 import time
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import Any
 
 import numpy as np
@@ -151,7 +151,7 @@ def study(
     """Fit a CERTIFIED classifier over encoder latents: closed-form Gaussian class-conditionals + a
     split-conformal abstention rail. No gradient descent anywhere -- the certificate proves it."""
     import mixle.stats as st
-    from mixle.inference import certify, optimize
+    from mixle.inference import EstimationCertificate, certify, optimize
 
     z = np.asarray(latents, dtype=np.float64)
     y = np.asarray(list(labels))
@@ -166,15 +166,33 @@ def study(
     priors = []
     for c in classes:
         zc = z[fit_idx][y[fit_idx] == c]
+        if len(zc) == 0:
+            raise ValueError(
+                f"class {c!r} has no examples in the fit split (n_fit={len(fit_idx)}, n_cal={n_cal}): "
+                "provide more data for this class, or lower cal_frac so the fit split is bigger"
+            )
         heads.append(optimize(list(zc), st.DiagonalGaussianEstimator(dim=z.shape[1]), out=None, max_its=1))
         priors.append(len(zc))
     priors = np.asarray(priors, dtype=float)
     priors = priors / priors.sum()
 
+    # certify EVERY class head, not just the first: the aggregate guarantee is the weakest head's, and
+    # the per-head blocks (qualified by class) keep the receipt auditable for K > 1 problems
+    head_certificates = [certify(h) for h in heads]
+    certificate = EstimationCertificate(
+        guarantee=min(cert.guarantee for cert in head_certificates),
+        blocks=[
+            replace(b, name=f"head[{c!r}].{b.name}" if b.name else f"head[{c!r}]")
+            for c, cert in zip(classes, head_certificates)
+            for b in cert.blocks
+        ],
+        escape_tested=all(cert.escape_tested for cert in head_certificates),
+    )
+
     model = StudiedModel(
         head=heads,
         classes=classes,
-        certificate=certify(heads[0]),
+        certificate=certificate,
         qhat=0.0,
         alpha=alpha,
         class_priors=priors,
@@ -185,7 +203,10 @@ def study(
     idx = {c: j for j, c in enumerate(classes)}
     scores = 1.0 - p_cal[np.arange(len(cal_idx)), [idx[c] for c in y[cal_idx]]]
     k = int(np.ceil((len(scores) + 1) * (1 - alpha))) - 1
-    model.qhat = float(np.sort(scores)[min(k, len(scores) - 1)])
+    # finite-sample split conformal: when ceil((n_cal+1)(1-alpha)) exceeds n_cal, NO calibration score
+    # certifies the level -- the threshold is +inf (every prediction set is all labels / abstain), not
+    # the max score. n_cal is surfaced in provenance so the regime is visible.
+    model.qhat = float(np.sort(scores)[k]) if k < len(scores) else float("inf")
     model.train_seconds = time.time() - t0
     model.provenance = {"n_fit": len(fit_idx), "n_cal": len(cal_idx), "alpha": alpha, "seed": seed}
     return model

--- a/mixle/tests/core_review_fixes_test.py
+++ b/mixle/tests/core_review_fixes_test.py
@@ -1,0 +1,259 @@
+"""Regression tests for the 0.8.0 core-module review findings C-1..C-11 (audit/CODEBASE_REVIEW_LEDGER.md II.A).
+
+Each test pins the corrected behavior of a verified defect: the quantize support bracket (C-1), k-best
+Viterbi admissibility (C-2), the split-conformal small-n threshold and certificate coverage (C-3..C-5),
+registry id uniqueness and tier ordering (C-6/C-7), and the relations/fault edge-case guards (C-8..C-11).
+"""
+
+import itertools
+import tempfile
+
+import numpy as np
+import pytest
+
+from mixle.relations import ViterbiPath, branch_and_bound_milp, cardinality_constrained_milp, tsp_held_karp
+
+
+# --------------------------------------------------------------- C-1: quantize brackets the SPATIAL quantiles
+def test_quantize_gaussian_preserves_mean_variance_and_both_tails():
+    from mixle import ops
+    from mixle.stats.univariate.continuous.gaussian import GaussianDistribution
+
+    g = GaussianDistribution(mu=0.0, sigma2=1.0)
+    q = ops.quantize(g, bits=6)
+    vals = np.array(list(q.pmap.keys()), dtype=np.float64)
+    probs = np.array([q.pmap[v] for v in q.pmap], dtype=np.float64)
+    mean = float((vals * probs).sum())
+    var = float((probs * (vals - mean) ** 2).sum())
+    # the density_quantile bracket discarded the whole left half (support [0.026, 3.20], mean 0.795)
+    assert vals.min() < 0.0 < vals.max()  # support spans both signs
+    assert abs(mean) < 0.05
+    assert var == pytest.approx(1.0, abs=0.1)
+
+
+# --------------------------------------------------------------- C-2: ViterbiPath with positive log-densities
+def _hmm_path_score(log_init, log_trans, log_obs, path):
+    score = log_init[path[0]] + log_obs[0][path[0]]
+    for t in range(1, len(log_obs)):
+        score += log_trans[path[t - 1]][path[t]] + log_obs[t][path[t]]
+    return float(score)
+
+
+def test_viterbi_top1_matches_brute_force_when_emission_log_densities_are_positive():
+    # continuous-emission log-densities are routinely > 0; the old zero heuristic was inadmissible there
+    n_states, n_steps = 3, 4
+    for seed in range(20):
+        rng = np.random.RandomState(seed)
+        log_init = np.log(rng.dirichlet(np.ones(n_states)))
+        log_trans = np.log([rng.dirichlet(np.ones(n_states)) for _ in range(n_states)])
+        log_obs = rng.uniform(-1.0, 2.0, size=(n_steps, n_states))
+        best = max(
+            _hmm_path_score(log_init, log_trans, log_obs, path)
+            for path in itertools.product(range(n_states), repeat=n_steps)
+        )
+        sol = ViterbiPath(log_init, log_trans, log_obs).solve()
+        assert _hmm_path_score(log_init, log_trans, log_obs, sol.value) == pytest.approx(sol.objective, abs=1e-9)
+        assert sol.objective == pytest.approx(best, abs=1e-9), f"suboptimal top-1 at seed {seed}"
+
+
+def test_viterbi_enumeration_is_nonincreasing_and_k_limits():
+    rng = np.random.RandomState(7)
+    n_states, n_steps = 3, 4
+    log_init = np.log(rng.dirichlet(np.ones(n_states)))
+    log_trans = np.log([rng.dirichlet(np.ones(n_states)) for _ in range(n_states)])
+    log_obs = rng.uniform(-1.0, 2.0, size=(n_steps, n_states))
+    rel = ViterbiPath(log_init, log_trans, log_obs)
+    scores = [sol.objective for sol in rel.enumerator()]
+    assert len(scores) == n_states**n_steps  # k=None enumerates every path
+    assert all(scores[i] >= scores[i + 1] - 1e-12 for i in range(len(scores) - 1))
+    top = rel.top(5)
+    assert len(top) == 5
+    brute = sorted(
+        (
+            _hmm_path_score(log_init, log_trans, log_obs, path)
+            for path in itertools.product(range(n_states), repeat=n_steps)
+        ),
+        reverse=True,
+    )
+    assert [sol.objective for sol in top] == pytest.approx(brute[:5], abs=1e-9)
+    assert all(isinstance(sol.value, list) and len(sol.value) == n_steps for sol in top)
+
+
+# --------------------------------------------------------------- C-3/C-4/C-5: scientist.study edge regimes
+def _two_class_latents(n_per_class=20, dim=3, seed=0):
+    rng = np.random.RandomState(seed)
+    z = np.concatenate([rng.normal(0.0, 1.0, size=(n_per_class, dim)), rng.normal(5.0, 1.0, size=(n_per_class, dim))])
+    y = ["a"] * n_per_class + ["b"] * n_per_class
+    return z, y
+
+
+def test_study_small_calibration_split_yields_infinite_qhat_not_undercoverage():
+    from mixle.scientist import study
+
+    z, y = _two_class_latents()
+    # n_cal = 10 and alpha = 0.01: ceil((10+1) * 0.99) = 11 > 10, so no calibration score certifies the
+    # level -- the finite-sample threshold is +inf (all labels / abstain), not the max score
+    model = study(z, y, alpha=0.01, cal_frac=0.25, seed=0)
+    assert model.provenance["n_cal"] == 10  # the regime is visible in provenance
+    assert np.isinf(model.qhat)
+    sets = model.prediction_sets(z[:5])
+    assert all(s == model.classes for s in sets)  # every label returned: abstention, not silent under-coverage
+    assert model.abstains(z[:5]).all()
+
+
+def test_study_reachable_conformal_level_keeps_a_finite_threshold():
+    from mixle.scientist import study
+
+    z, y = _two_class_latents()
+    model = study(z, y, alpha=0.1, cal_frac=0.25, seed=0)  # ceil(11 * 0.9) = 10 <= n_cal = 10
+    assert np.isfinite(model.qhat)
+
+
+def test_study_certificate_covers_every_class_head():
+    from mixle.scientist import study
+
+    z, y = _two_class_latents()
+    model = study(z, y, alpha=0.1, cal_frac=0.25, seed=0)
+    assert len(model.head) == len(model.classes) == 2
+    block_names = [b.name for b in model.certificate.blocks]
+    for c in model.classes:
+        assert any(f"head[{c!r}]" in name for name in block_names), f"class {c!r} missing from the certificate"
+    assert model.certificate.guarantee.name == "GLOBAL_UNIQUE"  # closed-form Gaussian heads, K of them
+    assert len(model.certificate.gradient_blocks) == 0
+
+
+def test_study_raises_clearly_when_a_class_misses_the_fit_split():
+    from mixle.scientist import study
+
+    rng = np.random.RandomState(0)
+    z = np.concatenate([rng.normal(0.0, 1.0, size=(8, 2)), rng.normal(5.0, 1.0, size=(1, 2))])
+    y = ["common"] * 8 + ["rare"] * 1
+    n_cal = max(1, int(round(0.25 * len(z))))
+    seed = next(s for s in range(100) if 8 in np.random.RandomState(s).permutation(len(z))[:n_cal])
+    with pytest.raises(ValueError, match="'rare' has no examples in the fit split"):
+        study(z, y, alpha=0.1, cal_frac=0.25, seed=seed)
+
+
+# --------------------------------------------------------------- C-6/C-7: registry ids and tier ordering
+def _json_task_model():
+    from mixle.stats.univariate.discrete.categorical import CategoricalDistribution
+    from mixle.task.model import StructuredClassifierIO, TaskModel
+
+    return TaskModel(
+        model=CategoricalDistribution({"x": 0.5, "y": 0.5}),
+        adapter=StructuredClassifierIO(field_keys=None, label_index=0, labels=["x", "y"]),
+        payload="json",
+    )
+
+
+def test_registry_rejects_duplicate_entry_id_instead_of_overwriting():
+    from mixle.registry import Registry
+
+    with tempfile.TemporaryDirectory() as d:
+        reg = Registry(d)
+        reg.register(_json_task_model(), capabilities=["cap"], cost=0.01, entry_id="dup")
+        with pytest.raises(ValueError, match="already has an entry 'dup'"):
+            reg.register(_json_task_model(), capabilities=["cap"], cost=0.02, entry_id="dup")
+        assert [e.entry_id for e in reg.find_for("cap")] == ["dup"]  # one index row, artifact intact
+
+
+def test_registry_auto_ids_scan_past_taken_ones():
+    from mixle.registry import Registry
+
+    with tempfile.TemporaryDirectory() as d:
+        reg = Registry(d)
+        reg.register(_json_task_model(), capabilities=["cap"], cost=0.01, entry_id="entry_0001")
+        # len()-based naming would now mint 'entry_0001' again and silently overwrite its artifact
+        auto = reg.register(_json_task_model(), capabilities=["cap"], cost=0.02)
+        ids = [e.entry_id for e in reg.find_for("cap")]
+        assert auto.entry_id != "entry_0001"
+        assert len(ids) == len(set(ids)) == 2
+        reg.load(auto.entry_id)  # both artifacts reload
+        reg.load("entry_0001")
+
+
+def test_tier_stack_reordering_costs_override_yields_ascending_tiers():
+    from mixle.registry import Registry
+
+    with tempfile.TemporaryDirectory() as d:
+        reg = Registry(d)
+        first = reg.register(_json_task_model(), capabilities=["cap"], cost=0.01)
+        second = reg.register(_json_task_model(), capabilities=["cap"], cost=0.05)
+
+        def frontier(texts):
+            return ["x"] * len(texts)
+
+        # positional override [0.09, 0.02, 1.0] swaps the pool's effective order (Router assumes ascending)
+        stack = reg.tier_stack("cap", frontier=frontier, costs=[0.09, 0.02, 1.0])
+        assert [cost for _name, _model, cost in stack] == [0.02, 0.09, 1.0]
+        assert [name for name, _model, _cost in stack] == [second.entry_id, first.entry_id, "frontier"]
+        assert stack[-1][1] is frontier
+        # without an override the registered-cost order is unchanged
+        stack = reg.tier_stack("cap", frontier=frontier)
+        assert [name for name, _model, _cost in stack] == [first.entry_id, second.entry_id, "frontier"]
+
+
+# --------------------------------------------------------------- C-8: tsp_held_karp infeasibility
+def test_tsp_raises_clearly_when_no_hamiltonian_cycle_exists():
+    inf = np.inf
+    disconnected = np.array([[0.0, 1.0, inf], [1.0, 0.0, inf], [inf, inf, 0.0]])
+    with pytest.raises(ValueError, match="no Hamiltonian cycle"):
+        tsp_held_karp(disconnected)
+    with pytest.raises(ValueError, match="no Hamiltonian cycle"):
+        tsp_held_karp(np.array([[0.0, inf], [1.0, 0.0]]))
+    cost, tour = tsp_held_karp(np.array([[0.0, 1.0, 4.0], [4.0, 0.0, 1.0], [1.0, 4.0, 0.0]]))  # feasible ring
+    assert cost == pytest.approx(3.0)
+    assert tour == [0, 1, 2]
+
+
+# --------------------------------------------------------------- C-9: cardinality MILP bound validation
+def test_cardinality_milp_rejects_nonfinite_bounds():
+    with pytest.raises(ValueError, match="finite bounds"):
+        cardinality_constrained_milp(np.array([1.0, 1.0]), None, None, 1, [(0.0, np.inf), (0.0, 1.0)], sense="min")
+    res = cardinality_constrained_milp(np.array([-1.0, -2.0]), None, None, 1, [(0.0, 1.0), (0.0, 1.0)], sense="min")
+    assert res is not None
+    value, x = res
+    assert value == pytest.approx(-2.0)
+    assert x == pytest.approx([0.0, 1.0])
+
+
+# --------------------------------------------------------------- C-10: route_past guards
+def test_route_past_guards_empty_tiers_and_length_mismatch():
+    from mixle.fault import route_past
+
+    with pytest.raises(ValueError, match="at least one tier"):
+        route_past([])
+    with pytest.raises(ValueError, match="must match one-to-one"):
+        route_past([lambda: 1, lambda: 2], names=["only_one"])
+    ok = route_past([lambda: 1])
+    assert (ok.value, ok.degraded) == (1, False)
+
+    def boom():
+        raise RuntimeError("tier down")
+
+    routed = route_past([boom, lambda: 2], names=["primary", "backup"])
+    assert (routed.value, routed.degraded, routed.mode) == (2, True, "model_error")
+
+
+# --------------------------------------------------------------- C-11: MILP incumbent exactness
+def test_milp_incumbent_integer_coordinates_are_exact_ints():
+    # the LP optimum 0.9999994 is within tol of 1 and must be snapped, not stored raw
+    res = branch_and_bound_milp(
+        np.array([-1.0]), np.array([[2.0]]), np.array([1.9999988]), integer=[0], bounds=[(0.0, 10.0)], sense="min"
+    )
+    assert res is not None
+    _value, x = res
+    assert float(x[0]) == 1.0  # exact, so downstream int(x[0]) cannot truncate to 0
+
+
+def test_milp_accepts_a_generator_for_integer_indices():
+    c = np.array([-1.0, -1.0])
+    a_ub = np.array([[3.0, 2.0]])
+    b_ub = np.array([7.0])
+    bounds = [(0.0, 10.0), (0.0, 10.0)]
+    from_list = branch_and_bound_milp(c, a_ub, b_ub, integer=[0, 1], bounds=bounds)
+    from_gen = branch_and_bound_milp(c, a_ub, b_ub, integer=(i for i in range(2)), bounds=bounds)
+    assert from_list is not None and from_gen is not None
+    assert from_gen[0] == pytest.approx(from_list[0])
+    assert from_gen[1] == pytest.approx(from_list[1])
+    assert all(float(v).is_integer() for v in from_gen[1])


### PR DESCRIPTION
Fixes the eleven verified top-level core-module defects from the 0.8.0 review ledger (`audit/CODEBASE_REVIEW_LEDGER.md`, section II.A), scoped exactly to those findings.

## Findings fixed

| ID | Sev | Where | Fix |
|---|---|---|---|
| C-1 | HIGH | `mixle/ops.py` `quantize` | Bracket the support with the spatial `quantile()` (inverse CDF) when the family has one, else the sampling fallback — never `density_quantile`, whose index is descending-**density** order (q=0 is the mode). Before: `quantize(Gaussian(0,1))` had support `[0.026, 3.20]`, mean 0.795; now support spans both tails, mean ~0, variance ~0.98. |
| C-2 | HIGH | `mixle/relations.py` `ViterbiPath.enumerator` | Delegate to `mixle.enumeration.hmm_paths.hmm_best_paths` (backward-Viterbi value as a tight admissible heuristic). The old zero-heuristic `best_first_paths(sense="max")` is inadmissible when emission log-densities are positive — wrong top-1 in 44/200 audit trials; 0/200 with the delegation. `Solution(value=list-of-states, objective=score)` and `k`/exhaustive semantics preserved; removes a wrong re-implementation (DRY). |
| C-3 | MED | `mixle/scientist.py` `study` | Split-conformal threshold is **+inf** (all labels / abstain) when `ceil((n_cal+1)(1-alpha)) > n_cal`, instead of silently clipping to the max score and voiding the coverage guarantee in the small-n regime; `n_cal` is surfaced in provenance. |
| C-4 | MED | `mixle/scientist.py` `study` | Certify **every** class head: aggregate `EstimationCertificate` with per-class-qualified blocks and `guarantee = min` over heads (previously only `heads[0]` was certified while the result claimed a certified classifier). `.guarantee` / `.gradient_blocks` surface unchanged. |
| C-5 | LOW | `mixle/scientist.py` `study` | A class absent from the fit split raises a clear `ValueError` naming the class and suggesting more data / lower `cal_frac`, instead of optimizing an empty list and taking `log(0)` priors. |
| C-6 | LOW | `mixle/registry.py` `register` | Explicit duplicate `entry_id` raises (previously: duplicate index row + silent artifact overwrite); auto ids scan past taken ids **and** existing artifact directories instead of `len()`-based naming. |
| C-7 | LOW | `mixle/registry.py` `tier_stack` | Tiers re-sorted by effective cost after a `costs=` override, so a reordering override still yields the ascending stack `Router` assumes. |
| C-8 | LOW | `mixle/relations.py` `tsp_held_karp` | Non-finite arcs are treated as missing; infeasible instances raise `ValueError("no Hamiltonian cycle: ...")` instead of a bare `TypeError` (or a silent `inf` tour). |
| C-9 | LOW | `mixle/relations.py` `cardinality_constrained_milp` | Bounds validated finite before building big-M indicator rows; clear error instead of a cryptic solver failure. |
| C-10 | LOW | `mixle/fault.py` `route_past` | Empty `tiers` raises a clear `ValueError` (was `raise None` → `TypeError: exceptions must derive from BaseException`); `names`/`tiers` length mismatch raises instead of silent zip truncation. |
| C-11 | LOW | `mixle/relations.py` `branch_and_bound_milp` | Incumbent integer coordinates snapped to exact ints on acceptance (no more `0.9999993` truncating to 0 downstream); `integer=` materialized once with `list()` so generators survive multi-node searches. |

## Test plan

New `mixle/tests/core_review_fixes_test.py` (15 tests, ~2 s, `-n0 -m ""`), verified fail-before/pass-after: **14/15 fail on the unfixed tree, 15/15 pass after** (the remaining one pins the preserved finite-qhat path):

1. `quantize(Gaussian(mu=0, sigma2=1), bits=6)`: |mean| < 0.05, variance = 1 ± 0.1, support spans both signs.
2. `ViterbiPath` vs brute force on 20 random tiny HMMs with `log_obs ∈ [-1, 2]`: top-1 always matches; full enumeration non-increasing; `top(5)` matches the brute-force head.
3. `study` with `n_cal=10, alpha=0.01` → `qhat = inf`, `prediction_sets` returns all labels, `abstains` everywhere; certificate blocks cover both class heads (`GLOBAL_UNIQUE`, 0 gradient blocks); missing-class `ValueError`; finite-qhat regime unchanged.
4. Registry: duplicate `entry_id` raises; auto ids scan past taken ones and both artifacts reload; reordering `costs=` override yields ascending tiers with names attached to their models.
5. `route_past([])` and names-length mismatch raise clear `ValueError`s; disconnected 3-node (and 2-node) TSP raises the new message while a feasible ring still solves; inf-bound cardinality MILP raises; MILP incumbents are exact ints including via a generator `integer=`.

Existing suites for the touched modules (ops, relations + all its per-algorithm test files, registry, fault, capability/namespaces/sampling surfaces): **179 passed + 1594 subtests, 0 failures** (`ops_test`, `ops_project_test`, `project_test`, `product_of_experts_test`, `relations_test`, `relation_sample_test`, `sampling_api_test`, `admm_test`, `cardinality_milp_test`, `clique_test`, `graph_coloring_test`, `iis_test`, `max_flow_test`, `milp_test`, `min_arborescence_test`, `stable_matching_test`, `tsp_test`, `namespaces_test`, `capability_test`, `registry_test`, `fault_test`, `fault_wired_modes_test`, `evolve_search_test`). `scientist_test.py` and the two dataset smoke tests skip in this environment (optional `datasets`/HF-cache dependencies).

`ruff format` + `ruff check` clean on all changed files.

CHANGELOG entry deferred to the consolidated review-fixes PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)