### PR TITLE
fix(models): eval/train discipline for neural leaves; widen multi-field combine

### DIFF
--- a/mixle/models/dpo_leaf.py
+++ b/mixle/models/dpo_leaf.py
@@ -21,6 +21,7 @@ from typing import Any
 import numpy as np
 
 from mixle.models._neural_serial import decode_module, encode_module
+from mixle.models.grad_leaf import _module_mode
 from mixle.stats.compute.pdist import (
     DataSequenceEncoder,
     DistributionSampler,
@@ -64,7 +65,7 @@ class DPOModel(SequenceEncodableProbabilityDistribution):
     def _logits(self, module: Any, x: np.ndarray) -> np.ndarray:
         torch = _torch()
         module.to(self.device)
-        with torch.no_grad():
+        with _module_mode(module, train=False), torch.no_grad():
             return module(torch.as_tensor(np.atleast_2d(x), dtype=torch.float32).to(self.device)).cpu().numpy()
 
     def seq_log_density(self, enc: Any) -> np.ndarray:
@@ -266,16 +267,17 @@ class DPOModelEstimator(ParameterEstimator):
         wsum = wt.sum().clamp(min=1e-8)
         ar = torch.arange(len(ct), device=dev)
         opt = torch.optim.Adam(self.policy.parameters(), lr=self.lr)
-        with torch.no_grad():  # reference log-probs are constant -- compute once
+        with _module_mode(self.ref, train=False), torch.no_grad():  # reference log-probs are constant -- compute once
             lr_all = torch.log_softmax(self.ref(xt), dim=1)
             lr_ch, lr_rj = lr_all[ar, ct], lr_all[ar, rt]
-        for _ in range(self.m_steps):
-            opt.zero_grad()
-            lp = torch.log_softmax(self.policy(xt), dim=1)
-            margin = (lp[ar, ct] - lr_ch) - (lp[ar, rt] - lr_rj)
-            loss = -(wt * torch.nn.functional.logsigmoid(self.beta * margin)).sum() / wsum  # weighted DPO loss
-            loss.backward()
-            opt.step()
+        with _module_mode(self.policy, train=True):
+            for _ in range(self.m_steps):
+                opt.zero_grad()
+                lp = torch.log_softmax(self.policy(xt), dim=1)
+                margin = (lp[ar, ct] - lr_ch) - (lp[ar, rt] - lr_rj)
+                loss = -(wt * torch.nn.functional.logsigmoid(self.beta * margin)).sum() / wsum  # weighted DPO loss
+                loss.backward()
+                opt.step()
         return out
 
 

--- a/mixle/models/grad_leaf.py
+++ b/mixle/models/grad_leaf.py
@@ -29,6 +29,7 @@ Serialization: the module round-trips as portable bytes (``mixle.models._neural_
 
 from __future__ import annotations
 
+from contextlib import contextmanager
 from typing import Any
 
 import numpy as np
@@ -73,6 +74,41 @@ def _resolve_device(device: Any, torch: Any) -> Any:
         except (TypeError, RuntimeError):
             pass
     return torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+
+def _resolve_dtype(torch: Any) -> Any:
+    """The active compute engine's torch float dtype, or ``None`` when no torch precision policy applies.
+
+    The precision twin of ``_resolve_device`` (one place for the engine-following policy): under
+    ``TorchEngine(dtype=torch.float64)`` a neural leaf should evaluate its module in fp64 like the rest
+    of the substrate math instead of silently dropping to fp32. Outside a torch engine -- including the
+    NumPy default, whose ``dtype`` is a numpy dtype -- this returns ``None`` and callers keep their
+    historical float32 behavior."""
+    from mixle.engines.base import active_engine
+
+    eng_dtype = getattr(active_engine(), "dtype", None)
+    if isinstance(eng_dtype, torch.dtype) and eng_dtype.is_floating_point:
+        return eng_dtype
+    return None
+
+
+@contextmanager
+def _module_mode(module: Any, *, train: bool) -> Any:
+    """Hold ``module`` in train/eval mode for the block, restoring every submodule's prior flag on exit.
+
+    Scoring must be a pure read: without ``eval()`` a Dropout submodule scores stochastically, and a
+    BatchNorm submodule both scores with batch statistics and MUTATES its running stats on a mere
+    ``log_density`` call. The M-step is the converse -- a module the user pre-set to ``eval()`` must
+    still optimize under train-mode semantics. The snapshot is per submodule (not just the root flag),
+    so a deliberately eval-pinned submodule inside a train-mode net comes back exactly as the caller
+    left it. Shared by every gradient-fit leaf, like ``_resolve_device`` above."""
+    states = [(m, m.training) for m in module.modules()]
+    module.train(train)
+    try:
+        yield module
+    finally:
+        for m, was_training in states:
+            m.training = was_training
 
 
 def looks_like_torch_module(obj: Any) -> bool:
@@ -276,6 +312,12 @@ class DataBufferAccumulator(SequenceEncodableStatisticAccumulator):
     def combine(self, other: Any) -> DataBufferAccumulator:
         *fields, ws = other
         if len(ws):
+            # same widen-once rule as _append: a combine()-fed root (the mp/mpi/dask/ray fan-in path)
+            # starts at the declared default arity and must adopt the workers' true arity before
+            # zipping, or every field past the first is silently dropped for conditional leaves.
+            if len(fields) != len(self.parts) and not any(self.parts):
+                self.parts = [[] for _ in fields]
+                self.n_fields = len(fields)
             for buf, f in zip(self.parts, fields):
                 buf.append(np.asarray(f, dtype=float))
             self.w.append(np.asarray(ws, dtype=float).ravel())

--- a/mixle/models/neural_leaf.py
+++ b/mixle/models/neural_leaf.py
@@ -24,7 +24,7 @@ from typing import Any
 import numpy as np
 
 from mixle.models._neural_serial import check_finite, decode_module, encode_module
-from mixle.models.grad_leaf import _resolve_device
+from mixle.models.grad_leaf import _module_mode, _resolve_device, _resolve_dtype
 from mixle.stats.compute.pdist import (
     DataSequenceEncoder,
     DistributionSampler,
@@ -39,6 +39,24 @@ def _torch() -> Any:
     import torch
 
     return torch
+
+
+def _place_module(module: Any, dev: Any, torch: Any) -> Any:
+    """Move ``module`` to ``dev`` and return the float dtype its tensor math must use.
+
+    An active torch engine's declared float dtype wins and the module is cast to match, so a
+    ``TorchEngine(dtype=torch.float64)`` run evaluates the net in fp64 like the rest of the substrate
+    math instead of the old hardcoded fp32. Without an engine policy the module is left untouched and
+    the math follows the module's own parameter dtype (``float32`` for a stock torch module -- today's
+    behavior). Following the parameters, not a literal, keeps E-step scoring consistent after an
+    engine-driven M-step cast the module: the estimation loop activates the engine only around
+    ``estimate()``, so the next scoring pass runs outside the engine context."""
+    dtype = _resolve_dtype(torch)
+    if dtype is not None:
+        module.to(dev, dtype=dtype)
+        return dtype
+    module.to(dev)
+    return next((p.dtype for p in module.parameters() if p.dtype.is_floating_point), torch.float32)
 
 
 class NeuralGaussian(SequenceEncodableProbabilityDistribution):
@@ -68,9 +86,9 @@ class NeuralGaussian(SequenceEncodableProbabilityDistribution):
     def _forward(self, x: np.ndarray) -> np.ndarray:
         torch = _torch()
         dev = _resolve_device(self.device, torch)
-        self.module.to(dev)
-        with torch.no_grad():
-            mean = self.module(torch.as_tensor(np.atleast_2d(x), dtype=torch.float32, device=dev))
+        dtype = _place_module(self.module, dev, torch)
+        with _module_mode(self.module, train=False), torch.no_grad():
+            mean = self.module(torch.as_tensor(np.atleast_2d(x), dtype=dtype, device=dev))
         return np.atleast_2d(mean.detach().cpu().numpy())
 
     def log_density(self, xy: Any) -> float:
@@ -293,23 +311,28 @@ class NeuralGaussianEstimator(ParameterEstimator):
         if len(xs) == 0:
             return NeuralGaussian(self.module, self.noise, self.m_steps, self.lr, self.name, self.device)
         dev = _resolve_device(self.device, torch)
-        self.module.to(dev)
+        dtype = _place_module(self.module, dev, torch)
         xs = np.asarray(xs, dtype=float).reshape(len(xs), -1)
         ys = np.asarray(ys, dtype=float).reshape(len(ys), -1)
-        xt = torch.as_tensor(xs, dtype=torch.float32, device=dev)
-        yt = torch.as_tensor(ys, dtype=torch.float32, device=dev)
-        wt = torch.as_tensor(np.array(ws), dtype=torch.float32, device=dev)
+        xt = torch.as_tensor(xs, dtype=dtype, device=dev)
+        yt = torch.as_tensor(ys, dtype=dtype, device=dev)
+        wt = torch.as_tensor(np.array(ws), dtype=dtype, device=dev)
         wsum = float(wt.sum()) + 1e-8
-        log_noise = torch.log(torch.tensor(float(self.noise), device=dev)).clone().detach().requires_grad_(True)
+        log_noise = (
+            torch.log(torch.tensor(float(self.noise), dtype=dtype, device=dev)).clone().detach().requires_grad_(True)
+        )
         opt = torch.optim.Adam(list(self.module.parameters()) + [log_noise], lr=self.lr)
         d = yt.shape[1]
-        for _ in range(self.m_steps):
-            opt.zero_grad()
-            mean = self.module(xt)
-            sig2 = torch.exp(2.0 * log_noise)
-            nll = (wt * (0.5 * ((yt - mean) ** 2).sum(1) / sig2 + 0.5 * d * torch.log(2.0 * np.pi * sig2))).sum() / wsum
-            nll.backward()
-            opt.step()
+        with _module_mode(self.module, train=True):
+            for _ in range(self.m_steps):
+                opt.zero_grad()
+                mean = self.module(xt)
+                sig2 = torch.exp(2.0 * log_noise)
+                nll = (
+                    wt * (0.5 * ((yt - mean) ** 2).sum(1) / sig2 + 0.5 * d * torch.log(2.0 * np.pi * sig2))
+                ).sum() / wsum
+                nll.backward()
+                opt.step()
         self.noise = float(torch.exp(log_noise).detach())  # warm-start noise for the next EM iteration
         return NeuralGaussian(self.module, self.noise, self.m_steps, self.lr, self.name, self.device)
 

--- a/mixle/models/softmax_leaf.py
+++ b/mixle/models/softmax_leaf.py
@@ -23,6 +23,7 @@ from typing import Any
 import numpy as np
 
 from mixle.models._neural_serial import check_finite, decode_module, encode_module
+from mixle.models.grad_leaf import _module_mode
 from mixle.stats.compute.pdist import (
     DataSequenceEncoder,
     DistributionSampler,
@@ -85,7 +86,7 @@ class NeuralCategorical(SequenceEncodableProbabilityDistribution):
         torch = _torch()
         self.module.to(self.device)
         out = []
-        with torch.no_grad():
+        with _module_mode(self.module, train=False), torch.no_grad():
             xt = torch.as_tensor(np.atleast_2d(x), dtype=torch.float32)
             for k in range(0, xt.shape[0], 4096):  # chunked so a large image set fits in GPU memory
                 out.append(self.module(xt[k : k + 4096].to(self.device)).detach().cpu().numpy())
@@ -342,29 +343,30 @@ class NeuralCategoricalEstimator(ParameterEstimator):
         if self.ewc is not None:  # anchor + Fisher moved to the device once (continued-pretraining anti-forget)
             anchor, fisher, lam = self.ewc
             ewc = ([a.to(dev) for a in anchor], [f.to(dev) for f in fisher], float(lam))
-        for _ in range(self.m_steps):  # m_steps passes over the data (full-batch when batch_size is None)
-            perm = torch.randperm(n) if bs < n else torch.arange(n)
-            for k in range(0, n, bs):
-                if self.max_optimizer_steps is not None and optimizer_steps >= self.max_optimizer_steps:
-                    break
-                idx = perm[k : k + bs]
-                xb, yb, wb = xt[idx].to(dev), yt[idx].to(dev), wt[idx].to(dev)
-                opt.zero_grad()
-                # Uniform minibatches estimate the full responsibility-normalized objective.
-                batch_scale = float(n) / float(len(idx))
-                loss = batch_scale * (wb * ce(self.module(xb), yb)).sum() / total_weight.to(dev)
-                if ewc is not None:  # + lambda * sum_i F_i (theta_i - theta*_i)^2 -- pull the important weights back
-                    anchor, fisher, lam = ewc
-                    loss = loss + lam * sum(
-                        (f * (p - a) ** 2).sum() for p, a, f in zip(self.module.parameters(), anchor, fisher)
-                    )
-                loss.backward()
-                opt.step()
-                optimizer_steps += 1
-            else:
-                epochs_completed += 1
-                continue
-            break
+        with _module_mode(self.module, train=True):
+            for _ in range(self.m_steps):  # m_steps passes over the data (full-batch when batch_size is None)
+                perm = torch.randperm(n) if bs < n else torch.arange(n)
+                for k in range(0, n, bs):
+                    if self.max_optimizer_steps is not None and optimizer_steps >= self.max_optimizer_steps:
+                        break
+                    idx = perm[k : k + bs]
+                    xb, yb, wb = xt[idx].to(dev), yt[idx].to(dev), wt[idx].to(dev)
+                    opt.zero_grad()
+                    # Uniform minibatches estimate the full responsibility-normalized objective.
+                    batch_scale = float(n) / float(len(idx))
+                    loss = batch_scale * (wb * ce(self.module(xb), yb)).sum() / total_weight.to(dev)
+                    if ewc is not None:  # + lambda * sum_i F_i (theta_i - theta*_i)^2 -- pull important weights back
+                        anchor, fisher, lam = ewc
+                        loss = loss + lam * sum(
+                            (f * (p - a) ** 2).sum() for p, a, f in zip(self.module.parameters(), anchor, fisher)
+                        )
+                    loss.backward()
+                    opt.step()
+                    optimizer_steps += 1
+                else:
+                    epochs_completed += 1
+                    continue
+                break
         out.fit_receipt = {
             "nobs": int(n),
             "batch_size": int(min(bs, n)),

--- a/mixle/models/streaming_transformer_leaf.py
+++ b/mixle/models/streaming_transformer_leaf.py
@@ -19,6 +19,7 @@ from typing import Any
 import numpy as np
 
 from mixle.models._neural_serial import decode_module, encode_module
+from mixle.models.grad_leaf import _module_mode
 from mixle.stats.compute.pdist import (
     DataSequenceEncoder,
     DistributionSampler,
@@ -81,7 +82,7 @@ class StreamingTransformer(SequenceEncodableProbabilityDistribution):
         """Return argmax next-token predictions for one or more contexts."""
         torch = _torch()
         self.module.to(self.device)
-        with torch.no_grad():
+        with _module_mode(self.module, train=False), torch.no_grad():
             logits = self.module(torch.as_tensor(np.atleast_2d(x), dtype=torch.float32).to(self.device))
         return logits.argmax(1).cpu().numpy()
 
@@ -95,7 +96,7 @@ class StreamingTransformer(SequenceEncodableProbabilityDistribution):
         x, y = enc
         self.module.to(self.device)
         out = []
-        with torch.no_grad():
+        with _module_mode(self.module, train=False), torch.no_grad():
             xt = torch.as_tensor(np.atleast_2d(x), dtype=torch.float32)
             for k in range(0, xt.shape[0], 4096):
                 out.append(self.module(xt[k : k + 4096].to(self.device)).cpu().numpy())
@@ -179,18 +180,19 @@ class StreamingTransformerAccumulator(SequenceEncodableStatisticAccumulator):
         x, y = enc
         xt = torch.as_tensor(np.asarray(x), dtype=torch.float32).to(self.device)
         yt = torch.as_tensor(np.asarray(y), dtype=torch.long).to(self.device)
-        self.opt.zero_grad()
-        logits = self.module(xt)
-        if weights is None:
-            loss = self.ce(logits, yt)  # pure-streaming path unchanged (uniform)
-        else:
-            # per-token responsibility (mixture expert / streaming decay / sample weight): weighted mean, so the
-            # gradient scale matches the unweighted mean when the weights are uniform (bit-identical then).
-            wt = torch.as_tensor(np.asarray(weights, dtype=float), dtype=torch.float32).to(self.device).ravel()
-            per = torch.nn.functional.cross_entropy(logits, yt, reduction="none")
-            loss = (wt * per).sum() / wt.sum().clamp(min=1e-8)
-        loss.backward()
-        self.opt.step()
+        with _module_mode(self.module, train=True):  # one train step; scoring passes between updates stay eval
+            self.opt.zero_grad()
+            logits = self.module(xt)
+            if weights is None:
+                loss = self.ce(logits, yt)  # pure-streaming path unchanged (uniform)
+            else:
+                # per-token responsibility (mixture expert / streaming decay / sample weight): weighted mean, so the
+                # gradient scale matches the unweighted mean when the weights are uniform (bit-identical then).
+                wt = torch.as_tensor(np.asarray(weights, dtype=float), dtype=torch.float32).to(self.device).ravel()
+                per = torch.nn.functional.cross_entropy(logits, yt, reduction="none")
+                loss = (wt * per).sum() / wt.sum().clamp(min=1e-8)
+            loss.backward()
+            self.opt.step()
         self.last_loss = float(loss.detach())
         self.loss_sum += self.last_loss * len(yt)
         self.tokens += int(len(yt))

--- a/mixle/tests/neural_leaf_discipline_test.py
+++ b/mixle/tests/neural_leaf_discipline_test.py
@@ -1,0 +1,318 @@
+"""Eval/train discipline and fan-in integrity for the neural leaves (review findings G-1, G-2, G-5).
+
+Scoring a leaf must be a pure read: with the module left in train mode, a Dropout submodule scored
+stochastically (log-density diffs up to ~2 between two passes of the SAME leaf on the SAME data) and a
+BatchNorm submodule had its running statistics MUTATED by mere scoring -- so E-step responsibilities
+were random and scoring corrupted the model. The M-step is the converse contract: a module the user
+pre-set to ``eval()`` must still optimize under train-mode semantics, and either way the caller's
+training flag must come back as it was left. ``DataBufferAccumulator.combine`` must adopt a worker's
+field arity on a fresh root (the mp/mpi/dask/ray fan-in path) instead of silently dropping every field
+past the first for conditional leaves. And ``NeuralGaussian`` must follow an active torch engine's
+float dtype instead of hardcoding fp32 against the substrate's precision plan.
+"""
+
+import unittest
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+
+pytestmark = pytest.mark.torch
+
+from mixle.models.dpo_leaf import DPOModel  # noqa: E402
+from mixle.models.grad_leaf import DataBufferAccumulatorFactory, GradEstimator, GradLeafEncoder  # noqa: E402
+from mixle.models.neural_leaf import NeuralGaussian  # noqa: E402
+from mixle.models.softmax_leaf import NeuralCategorical  # noqa: E402
+from mixle.models.streaming_transformer_leaf import StreamingTransformer  # noqa: E402
+
+
+def _dropout_regressor() -> torch.nn.Module:
+    return torch.nn.Sequential(torch.nn.Linear(2, 16), torch.nn.Dropout(p=0.5), torch.nn.Linear(16, 1))
+
+
+def _batchnorm_regressor() -> torch.nn.Module:
+    return torch.nn.Sequential(torch.nn.Linear(2, 8), torch.nn.BatchNorm1d(8), torch.nn.Linear(8, 1))
+
+
+def _dropout_classifier(classes: int = 3) -> torch.nn.Module:
+    return torch.nn.Sequential(torch.nn.Linear(2, 16), torch.nn.Dropout(p=0.5), torch.nn.Linear(16, classes))
+
+
+def _batchnorm_classifier(classes: int = 3) -> torch.nn.Module:
+    return torch.nn.Sequential(torch.nn.Linear(2, 8), torch.nn.BatchNorm1d(8), torch.nn.Linear(8, classes))
+
+
+def _xy(n: int = 24, dim: int = 2, seed: int = 0) -> tuple[np.ndarray, np.ndarray]:
+    rng = np.random.RandomState(seed)
+    return rng.randn(n, dim), rng.randn(n, 1)
+
+
+def _xc(n: int = 24, dim: int = 2, classes: int = 3, seed: int = 0) -> tuple[np.ndarray, np.ndarray]:
+    rng = np.random.RandomState(seed)
+    return rng.randn(n, dim), rng.randint(0, classes, size=n)
+
+
+class NeuralGaussianScoringPurityTest(unittest.TestCase):
+    """G-1: scoring a NeuralGaussian is deterministic, side-effect free, and mode-restoring."""
+
+    def test_dropout_module_scores_identically_across_passes(self):
+        module = _dropout_regressor()
+        module.train()  # the state a freshly built / mid-EM module is naturally in
+        leaf = NeuralGaussian(module=module, noise=1.0)
+        x, y = _xy()
+        first = leaf.seq_log_density((x, y))
+        second = leaf.seq_log_density((x, y))
+        np.testing.assert_array_equal(first, second)
+        self.assertTrue(module.training)  # the caller's mode flag comes back as it was left
+
+    def test_scoring_neither_mutates_batchnorm_stats_nor_uses_batch_statistics(self):
+        module = _batchnorm_regressor()
+        module.train()
+        bn = module[1]
+        leaf = NeuralGaussian(module=module, noise=1.0)
+        x, y = _xy()
+        before_mean = bn.running_mean.clone()
+        before_var = bn.running_var.clone()
+        scored = leaf.seq_log_density((x, y))
+        torch.testing.assert_close(bn.running_mean, before_mean, rtol=0.0, atol=0.0)
+        torch.testing.assert_close(bn.running_var, before_var, rtol=0.0, atol=0.0)
+        # scoring must use eval statistics: match an explicit eval-mode forward's Gaussian log-density
+        module.eval()
+        with torch.no_grad():
+            mean = module(torch.as_tensor(x, dtype=torch.float32)).numpy()
+        expected = -0.5 * ((y - mean) ** 2).sum(axis=1) - 0.5 * np.log(2.0 * np.pi)
+        np.testing.assert_allclose(scored, expected, rtol=1e-6, atol=1e-6)
+
+
+class NeuralCategoricalScoringPurityTest(unittest.TestCase):
+    """G-1: same purity contract for the discriminative sibling."""
+
+    def test_dropout_module_scores_identically_across_passes(self):
+        module = _dropout_classifier()
+        module.train()
+        leaf = NeuralCategorical(module=module)
+        x, c = _xc()
+        first = leaf.seq_log_density((x, c))
+        second = leaf.seq_log_density((x, c))
+        np.testing.assert_array_equal(first, second)
+        self.assertTrue(module.training)
+
+    def test_scoring_neither_mutates_batchnorm_stats_nor_uses_batch_statistics(self):
+        module = _batchnorm_classifier()
+        module.train()
+        bn = module[1]
+        leaf = NeuralCategorical(module=module)
+        x, c = _xc()
+        before_mean = bn.running_mean.clone()
+        before_var = bn.running_var.clone()
+        scored = leaf.seq_log_density((x, c))
+        torch.testing.assert_close(bn.running_mean, before_mean, rtol=0.0, atol=0.0)
+        torch.testing.assert_close(bn.running_var, before_var, rtol=0.0, atol=0.0)
+        module.eval()
+        with torch.no_grad():
+            logp = torch.log_softmax(module(torch.as_tensor(x, dtype=torch.float32)), dim=1).numpy()
+        np.testing.assert_allclose(scored, logp[np.arange(len(c)), c], rtol=1e-6, atol=1e-6)
+
+
+class SiblingLeafScoringPurityTest(unittest.TestCase):
+    """G-1: the streaming-transformer and DPO scoring paths share the same eval discipline."""
+
+    def test_streaming_transformer_dropout_scores_identically(self):
+        module = _dropout_classifier(classes=5)
+        module.train()
+        leaf = StreamingTransformer(module=module)
+        x, c = _xc(classes=5)
+        first = leaf.seq_log_density((x, c))
+        second = leaf.seq_log_density((x, c))
+        np.testing.assert_array_equal(first, second)
+        self.assertTrue(module.training)
+        pred_a = leaf.predict(x)
+        pred_b = leaf.predict(x)
+        np.testing.assert_array_equal(pred_a, pred_b)
+
+    def test_dpo_dropout_policy_scores_identically(self):
+        policy = _dropout_classifier(classes=4)
+        policy.train()
+        ref = _dropout_classifier(classes=4)
+        ref.train()
+        leaf = DPOModel(policy=policy, ref=ref)
+        rng = np.random.RandomState(0)
+        x = rng.randn(16, 2)
+        ch = rng.randint(0, 4, size=16)
+        rj = (ch + 1) % 4
+        first = leaf.seq_log_density((x, ch, rj))
+        second = leaf.seq_log_density((x, ch, rj))
+        np.testing.assert_array_equal(first, second)
+        self.assertTrue(policy.training)
+        self.assertTrue(ref.training)
+
+
+class _ModeRecorder(torch.nn.Module):
+    """A linear module that records ``self.training`` at every forward -- what mode the M-step really ran in."""
+
+    def __init__(self, out_dim: int):
+        super().__init__()
+        self.lin = torch.nn.Linear(2, out_dim)
+        self.modes: list = []
+
+    def forward(self, x):
+        self.modes.append(self.training)
+        return self.lin(x)
+
+
+class FitModeRestoreTest(unittest.TestCase):
+    """G-1: the M-step optimizes under train-mode semantics yet restores the caller's flag, both ways."""
+
+    def _assert_fit_trains_and_restores(self, module: _ModeRecorder, fit) -> None:
+        for pre_training in (False, True):
+            module.train(pre_training)
+            module.modes.clear()
+            fit()
+            self.assertTrue(module.modes)  # the M-step really ran forwards ...
+            self.assertTrue(all(module.modes))  # ... under train-mode semantics, even for a pre-eval()ed module
+            self.assertEqual(module.training, pre_training)  # and the caller's flag comes back as it was left
+            self.assertTrue(all(m.training == pre_training for m in module.modules()))
+
+    def test_neural_gaussian_fit_trains_and_restores_training_flag(self):
+        module = _ModeRecorder(out_dim=1)
+        leaf = NeuralGaussian(module=module, noise=1.0, m_steps=3, lr=0.01)
+        est = leaf.estimator()
+        acc = est.accumulator_factory().make()
+        x, y = _xy()
+        acc.seq_update(leaf.dist_to_encoder().seq_encode(list(zip(x, y))), np.ones(len(x)), leaf)
+        self._assert_fit_trains_and_restores(module, lambda: est.estimate(None, acc.value()))
+
+    def test_neural_categorical_fit_trains_and_restores_training_flag(self):
+        module = _ModeRecorder(out_dim=3)
+        leaf = NeuralCategorical(module=module, m_steps=3, lr=0.01)
+        est = leaf.estimator()
+        acc = est.accumulator_factory().make()
+        x, c = _xc()
+        acc.seq_update(leaf.dist_to_encoder().seq_encode(list(zip(x, c))), np.ones(len(x)), leaf)
+        self._assert_fit_trains_and_restores(module, lambda: est.estimate(None, acc.value()))
+
+    def test_dpo_fit_trains_policy_and_restores_training_flag(self):
+        policy = _ModeRecorder(out_dim=4)
+        ref = _dropout_classifier(classes=4)
+        leaf = DPOModel(policy=policy, ref=ref, beta=0.1, m_steps=3, lr=1e-3)
+        est = leaf.estimator()
+        acc = est.accumulator_factory().make()
+        rng = np.random.RandomState(0)
+        x = rng.randn(12, 2)
+        ch = rng.randint(0, 4, size=12)
+        rj = (ch + 1) % 4
+        acc.seq_update((x, ch, rj), np.ones(len(x)), leaf)
+        self._assert_fit_trains_and_restores(policy, lambda: est.estimate(None, acc.value()))
+
+    def test_streaming_transformer_train_step_trains_and_restores_training_flag(self):
+        module = _ModeRecorder(out_dim=5)
+        est = StreamingTransformer(module=module).estimator()
+        acc = est.accumulator_factory().make()
+        x, c = _xc(classes=5)
+        self._assert_fit_trains_and_restores(module, lambda: acc.seq_update((x, c), np.ones(len(x)), None))
+
+
+class _CondGauss(torch.nn.Module):
+    """The smallest conditional density module: ``p(y | x) = N(y; w x + b, 1)`` (arity-2 log_density)."""
+
+    def __init__(self):
+        super().__init__()
+        self.lin = torch.nn.Linear(1, 1)
+
+    def log_density(self, x, y):
+        return (-0.5 * (y - self.lin(x)) ** 2 - 0.5 * float(np.log(2.0 * np.pi))).sum(-1)
+
+
+class DataBufferFanInTest(unittest.TestCase):
+    """G-2: a fresh root's combine() adopts the worker's field arity instead of dropping fields."""
+
+    @staticmethod
+    def _worker_value() -> tuple:
+        rng = np.random.RandomState(0)
+        x = rng.uniform(-2.0, 2.0, size=40)
+        y = 1.5 * x + 0.1 * rng.randn(40)
+        data = list(zip(x[:, None], y[:, None]))
+        factory = DataBufferAccumulatorFactory(GradLeafEncoder(), n_fields=1)
+        worker = factory.make()
+        worker.seq_update(GradLeafEncoder().seq_encode(data), np.ones(len(data)), None)
+        return worker.value()
+
+    def test_fresh_root_combine_preserves_conditional_arity_and_shapes(self):
+        worker_value = self._worker_value()
+        root = DataBufferAccumulatorFactory(GradLeafEncoder(), n_fields=1).make()
+        root.combine(worker_value)
+        root_value = root.value()
+        self.assertEqual(len(root_value), len(worker_value))  # (x, y, w) survives the fan-in intact
+        for got, expected in zip(root_value, worker_value):
+            np.testing.assert_array_equal(got, expected)
+
+    def test_fan_in_fit_matches_single_worker_fit(self):
+        worker_value = self._worker_value()
+        root = DataBufferAccumulatorFactory(GradLeafEncoder(), n_fields=1).make()
+        root.combine(worker_value)
+
+        torch.manual_seed(7)
+        direct_module = _CondGauss()
+        torch.manual_seed(7)
+        fanned_module = _CondGauss()
+        direct = GradEstimator(module=direct_module, m_steps=5, lr=0.05).estimate(None, worker_value)
+        fanned = GradEstimator(module=fanned_module, m_steps=5, lr=0.05).estimate(None, root.value())
+        torch.testing.assert_close(fanned.module.lin.weight, direct.module.lin.weight, rtol=0.0, atol=0.0)
+        torch.testing.assert_close(fanned.module.lin.bias, direct.module.lin.bias, rtol=0.0, atol=0.0)
+
+
+class _DtypeProbe(torch.nn.Module):
+    """A linear regressor that records the dtype of every forward input."""
+
+    def __init__(self):
+        super().__init__()
+        self.lin = torch.nn.Linear(2, 1)
+        self.seen: list = []
+
+    def forward(self, x):
+        self.seen.append(x.dtype)
+        return self.lin(x)
+
+
+class NeuralGaussianEngineDtypeTest(unittest.TestCase):
+    """G-5: NeuralGaussian follows an active torch engine's float dtype instead of hardcoding fp32."""
+
+    def test_forward_follows_a_float64_engine_and_default_stays_float32(self):
+        from mixle.engines import TorchEngine
+        from mixle.engines.base import using_active_engine
+
+        x, y = _xy()
+        default_probe = _DtypeProbe()
+        NeuralGaussian(module=default_probe, noise=1.0).seq_log_density((x, y))
+        self.assertEqual(default_probe.seen[-1], torch.float32)  # no engine: the historical default
+
+        engine_probe = _DtypeProbe()
+        leaf = NeuralGaussian(module=engine_probe, noise=1.0)
+        with using_active_engine(TorchEngine(dtype=torch.float64)):
+            leaf.seq_log_density((x, y))
+        self.assertEqual(engine_probe.seen[-1], torch.float64)
+        self.assertEqual(next(engine_probe.parameters()).dtype, torch.float64)
+        # scoring after the engine context stays consistent with the engine-cast module (the
+        # estimation loop activates the engine only around estimate(), never around E-step scoring)
+        leaf.seq_log_density((x, y))
+        self.assertEqual(engine_probe.seen[-1], torch.float64)
+
+    def test_m_step_follows_a_float64_engine(self):
+        from mixle.engines import TorchEngine
+        from mixle.engines.base import using_active_engine
+
+        probe = _DtypeProbe()
+        leaf = NeuralGaussian(module=probe, noise=1.0, m_steps=2, lr=0.01)
+        est = leaf.estimator()
+        acc = est.accumulator_factory().make()
+        x, y = _xy()
+        acc.seq_update(leaf.dist_to_encoder().seq_encode(list(zip(x, y))), np.ones(len(x)), leaf)
+        with using_active_engine(TorchEngine(dtype=torch.float64)):
+            fitted = est.estimate(None, acc.value())
+        self.assertEqual(probe.seen[-1], torch.float64)
+        self.assertTrue(np.isfinite(fitted.noise))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes three verified defects from the codebase review ledger, section II.G (`audit/CODEBASE_REVIEW_LEDGER.md`). G-3 and G-4 are deliberately NOT touched here — they live in the perf PR that owns `inference/objectives.py` / `inference/estimation.py`.

## G-1 (HIGH) — neural leaves scored in train mode and trained in whatever mode they were left in

`NeuralGaussian`, `NeuralCategorical`, `StreamingTransformer`, and `DPOModel` scored under `no_grad()` but never called `.eval()`: a Dropout submodule scored stochastically (verified log-density diffs up to ~2 between two passes of the same leaf on the same data) and mere scoring **mutated** BatchNorm running statistics. Their estimators also never set `.train()`, so a pre-`eval()`ed module silently trained with dropout off.

Fix: a shared `_module_mode(module, train=...)` context manager in `grad_leaf.py` (next to `_resolve_device`, the existing shared-policy spot) snapshots every submodule's `training` flag, holds the requested mode for the block, and restores the snapshot on exit. Applied to all four leaves' scoring paths and their estimators' fit paths — the discipline `GradLeaf`/`NeuralDensity`/`EnergyModel` already had, plus restore, so a deliberately eval-pinned submodule comes back exactly as the caller left it.

## G-2 (MED) — fresh-root `combine()` dropped fields for conditional leaves

`DataBufferAccumulator.combine()` zipped incoming fields against `self.parts`, which on a fresh root is `[[]]` and never widened (unlike `_append`) — silently dropping every field past the first when multi-field conditional leaves fan in via a `combine()`-based backend (mp/mpi/dask/ray/resident planner). `combine()` now widens once, from empty, to the incoming arity exactly as `_append` does.

## G-5 (LOW) — `NeuralGaussian` hardcoded fp32 against the engine precision plan

Forward and M-step used four unconditional `torch.float32` literals. New `_resolve_dtype` (the precision twin of `_resolve_device`, same one-place engine-following policy) makes `NeuralGaussian` follow an active torch engine's declared float dtype — `TorchEngine(dtype=torch.float64)` now evaluates the module in fp64 like the rest of the substrate math. Without an engine policy the math follows the module's own parameter dtype (float32 for a stock module — the default path is behavior-preserving), which also keeps E-step scoring consistent after an engine-driven M-step cast the module (the estimation loop activates the engine only around `estimate()`).

## Test plan

New `mixle/tests/neural_leaf_discipline_test.py` (14 tests, `torch`-tagged, in the fast gate; **all 14 fail on the unfixed code, all pass after**):

- dropout scoring determinism + BatchNorm purity/eval-statistics for `NeuralGaussian` and `NeuralCategorical`, plus determinism checks on the `StreamingTransformer` and `DPOModel` scoring paths;
- all four leaves' M-steps run forwards under train-mode semantics and restore the caller's training flag in both directions (pre-set eval and pre-set train), verified with a mode-recording module;
- fresh-root `combine()` preserves a 2-field conditional leaf's arity/shapes, and a fan-in fit matches the single-worker fit bit-exactly;
- `NeuralGaussian` forward and M-step follow a float64 torch engine while the no-engine default stays float32.

Existing suites over the touched modules, run `-n0 -m ""`:

- `grad_leaf_test grad_control_test neural_leaf_serialization_test dpo_and_registry_hardening_test streaming_transformer_weights_test lm_serialization_test neural_composition_grid_test`: **66 passed**
- `neural_leaf_test neural_ppl_test`: **14 passed**
- `torch_neural_test`: **1 passed, 1 skipped** (torchrun smoke is env-gated: `MIXLE_RUN_TORCHRUN_SMOKE=1`)
- `byo_model_contract_test leaf_hotswap_test em_convergence_contract_test block_em_livelock_test torch_parity_test gradient_fit_test hmm_heterogeneous_emissions_test`: **62 passed, 20 subtests passed**

`ruff format` + `ruff check` clean on all changed files.

CHANGELOG entry deferred to the consolidated review-fixes PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)