### PR TITLE
Accelerate structured EM and factor shared MoE work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ to post-0.8 or kept under `mixle.experimental` per the feature freeze.
   is a reviewed diff.
 - Release-engineering gates: a weighted-estimation contract test, a base-install optional-import guard,
   a tracked benchmark harness, a pull-request template, and the 0.8.0 release checklist.
+- `CompiledEM` as a reusable fused full-mixture strategy, recursive SQUAREM packing for nested
+  mixtures/composites, and function-preserving shared-trunk/residual-expert MoE upcycling.
+
+### Fixed
+
+- Block scheduling now prices density, responsibility, and parameter-update work together instead of
+  treating density time as the whole block cost; learned controllers receive the same measured cost.
+- Dirichlet-prior block and freeze/roll-up updates now use the exact MAP objective and carry the
+  posterior weight prior; nested homogeneous mixtures preserve heterogeneous encoding depth.
 
 ## [0.7.0] — 2026-07-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,9 @@ to post-0.8 or kept under `mixle.experimental` per the feature freeze.
   is a reviewed diff.
 - Release-engineering gates: a weighted-estimation contract test, a base-install optional-import guard,
   a tracked benchmark harness, a pull-request template, and the 0.8.0 release checklist.
-- `CompiledEM` as a reusable fused full-mixture strategy, recursive SQUAREM packing for nested
-  mixtures/composites, and function-preserving shared-trunk/residual-expert MoE upcycling.
+- `CompiledEM` as a reusable fused full-mixture strategy, automatically selected by `optimize()` for
+  eligible partially fusible heterogeneous mixtures; recursive SQUAREM packing for nested
+  mixtures/composites; and function-preserving shared-trunk/residual-expert MoE upcycling.
 
 ### Fixed
 

--- a/api_manifest.json
+++ b/api_manifest.json
@@ -528,6 +528,7 @@
     "BootstrapResult",
     "CalibrationReport",
     "Clustering",
+    "CompiledEM",
     "ConditionReceipt",
     "ConjugatePosterior",
     "ConjugateUpdatable",

--- a/mixle/inference/__init__.py
+++ b/mixle/inference/__init__.py
@@ -118,7 +118,7 @@ from mixle.inference.cross_validation import (
 
 # Bayes-optimal decisions under a fitted posterior (decision-theoretic action + tail risk)
 from mixle.inference.decision import RiskProfile, bayes_action
-from mixle.inference.em import EMStrategy, SquaremEM, run_em, squarem_packer
+from mixle.inference.em import CompiledEM, EMStrategy, SquaremEM, run_em, squarem_packer
 from mixle.inference.errors_in_variables import DemingFit, deming_regression, propagate_uncertainty, simex
 from mixle.inference.estimation import BayesianStreamingEstimator, EMStep, best_of, fit, optimize
 
@@ -421,6 +421,7 @@ __all__ = [
     "EMStep",
     "best_of",
     "run_em",
+    "CompiledEM",
     "SquaremEM",
     "squarem_packer",
     "EMStrategy",

--- a/mixle/inference/block_em.py
+++ b/mixle/inference/block_em.py
@@ -10,9 +10,9 @@ optimization only. Any interleaving of a partial E-step (fresh log-density for t
 blocks, cached log-density for the inactive ones) and a per-block conditional M-step (only the
 active blocks are re-estimated; every other block's model object is carried forward byte-for-
 byte unchanged) is a generalized-EM coordinate update. A nonnegative complete-data Q gain
-certifies that the observed objective cannot decrease. Periodic and final exact observed-
-likelihood audits verify that certificate; a candidate without a finite certificate falls back
-to an exact observed-objective gate.
+certifies that the observed objective cannot decrease. Periodic and final exact objective audits
+verify that certificate; a candidate without a finite certificate falls back to an exact gate.
+With parameter priors, every round is gated on the MAP objective.
 
 The scheduler reuses :class:`~mixle.inference.freeze_rollup.FreezeRollupCache` only for blocks
 left inactive in the current round. It does not permanently freeze a component from a heuristic
@@ -114,6 +114,8 @@ class BlockEMTimingReceipt:
     accounting_seconds: float
     total_seconds: float
     component_density_seconds: tuple[tuple[str, int, float], ...] = ()
+    component_update_seconds: tuple[tuple[int, float], ...] = ()
+    component_block_seconds: tuple[tuple[int, float], ...] = ()
 
     @property
     def density_seconds(self) -> float:
@@ -130,7 +132,7 @@ class BlockEMStats:
     """One round's accounting for the block-EM scheduler -- the acceptance-criteria receipt.
 
     ``n_log_density_evals`` records removed model work, while ``wall_time_seconds`` records actual
-    elapsed time. ``objective`` is either the exact observed-data likelihood or its certified EM
+    elapsed time. ``objective`` is either the exact observed-data MLE/MAP objective or its certified EM
     lower bound, as disclosed by ``objective_exact``; ``measured_q_gain`` is the complete-data
     gain used for the next scheduling decision.
 
@@ -176,16 +178,17 @@ def _block_scores(
 ) -> tuple[dict[int, float], dict[int, float], dict[int, float], dict[int, float], str]:
     """Return last measured data-Q gain per cost unit for eligible blocks.
 
-    Cost is the MEASURED per-component density seconds from earlier rounds' timing receipts when
-    every eligible block has one (``cost_model="measured"``); otherwise the structural parameter
-    count proxy. Mixed units are never compared: measured pricing engages all-or-nothing.
+    Cost is the measured end-to-end block work from earlier rounds when every eligible block has
+    one: density evaluation, responsibility construction, and sufficient-statistic/parameter
+    update. Otherwise the structural parameter-count proxy is used. Mixed units are never
+    compared: measured pricing engages all-or-nothing.
     """
     gain_per_cost: dict[int, float] = {}
     cost: dict[int, float] = {}
     residual: dict[int, float] = {}
     q_gain: dict[int, float] = {}
     use_measured = measured_cost is not None and all(measured_cost.get(idx, 0.0) > 0.0 for idx in eligible)
-    basis = "measured_seconds" if use_measured and eligible else "structural_parameter_count"
+    basis = "measured_block_seconds" if use_measured and eligible else "structural_parameter_count"
     for idx in eligible:
         gain = max(float(last_q_gain.get(idx, 0.0)), 0.0)
         if use_measured:
@@ -328,6 +331,7 @@ def _sparse_block_m_step(
     responsibilities: np.ndarray,
     boundary_weight_step: float,
     compute_dtype: Any = None,
+    component_update_seconds: dict[int, float] | None = None,
 ) -> tuple[MixtureDistribution, np.ndarray, float]:
     """Re-estimate active leaves and the active-plus-inactive-mass weight block."""
 
@@ -336,11 +340,14 @@ def _sparse_block_m_step(
     for position, idx in enumerate(active):
         if model.zw[idx] or counts[position] <= 0.0:
             continue
+        started = time.perf_counter()
         enc_i = _component_enc(enc_data, idx)
         suff_stat = _component_suff_stat(
             estimator.estimators[idx], model.components[idx], enc_i, responsibilities[:, position], compute_dtype
         )
         components[idx] = estimator.estimators[idx].estimate(float(counts[position]), suff_stat)
+        if component_update_seconds is not None:
+            component_update_seconds[idx] = time.perf_counter() - started
     weights, inactive_scale = _constrained_block_weights(
         estimator,
         model,
@@ -486,7 +493,7 @@ def run_block_em(
     The first round updates every component. Later rounds rank blocks by the observed Q gain from
     their last update per structural-cost unit, select the highest-value blocks within
     ``budget_fraction``, reuse cached component scores for untouched blocks, and transactionally
-    gate the resulting partial M-step on observed likelihood.
+    gate the resulting partial M-step on the exact MLE or MAP objective.
 
     ``schedule="auto"`` at the :func:`mixle.inference.estimation.optimize` layer dispatches here;
     ``budget_fraction=1.0`` or ``full_tree_every_round=True`` both degenerate this to (numerically
@@ -628,6 +635,14 @@ def run_block_em(
     current_log_density: np.ndarray | None = None
     current_impossible: np.ndarray | None = None
     mutable_state = has_mutable_state(model, estimator)
+    map_objective = estimator.get_prior() is not None
+
+    def objective_value(log_density: np.ndarray, candidate_model: MixtureDistribution) -> float:
+        value = float(np.sum(log_density))
+        if map_objective:
+            value += float(estimator.model_log_density(candidate_model))
+        return value
+
     if objective_audit_interval == "auto":
         # Certificate-aware audit cadence: a tree of exact/GEM updates carries the monotone
         # certificate, so its Q-certified rounds need only sparse exact audits; stochastic
@@ -765,7 +780,7 @@ def run_block_em(
             log_density, gamma = _combine(ll_mat, model.log_w)
             gamma_active = gamma[:, active_indices]
             responsibility_columns = model.num_components
-        current_value = float(np.sum(log_density))
+        current_value = objective_value(log_density, model)
         responsibility_seconds = time.perf_counter() - responsibility_started
         exact_delta = None if old_value is None else current_value - old_value
 
@@ -773,6 +788,7 @@ def run_block_em(
         transaction = MutableStateSnapshot.capture(model, estimator) if mutable_state else None
         snapshot_seconds = time.perf_counter() - snapshot_started
         mstep_started = time.perf_counter()
+        component_update_seconds: dict[int, float] = {}
         if sparse_round:
             candidate, active_counts, inactive_scale = _sparse_block_m_step(
                 enc_payload,
@@ -782,12 +798,21 @@ def run_block_em(
                 gamma_active,
                 boundary_weight_step,
                 compute_dtype=compute_dtype,
+                component_update_seconds=component_update_seconds,
             )
             counts = None
         else:
             if gamma is None:  # pragma: no cover - established by the branch above
                 raise RuntimeError("dense block M-step requires dense responsibilities.")
-            candidate = _m_step(enc_payload, estimator, model, gamma, scheduled_inactive, compute_dtype=compute_dtype)
+            candidate = _m_step(
+                enc_payload,
+                estimator,
+                model,
+                gamma,
+                scheduled_inactive,
+                compute_dtype=compute_dtype,
+                component_update_seconds=component_update_seconds,
+            )
             counts = gamma.sum(axis=0)
             active_counts = counts[list(active_indices)]
             inactive_scale = 1.0
@@ -884,7 +909,7 @@ def run_block_em(
                 raise RuntimeError("dense candidate validation requires a component-score matrix.")
             candidate_log_density = _log_density_from_matrix(ll_mat_c, candidate.log_w)
             candidate_impossible = np.all(np.isneginf(ll_mat_c + candidate.log_w), axis=1)
-        candidate_value = float(np.sum(candidate_log_density))
+        candidate_value = objective_value(candidate_log_density, candidate)
         validation_seconds = time.perf_counter() - validation_started
         post_validation_accounting_started = time.perf_counter()
         audit_failed = q_accepted and candidate_value + accept_tolerance < current_value
@@ -894,9 +919,13 @@ def run_block_em(
         # closed-form leaves; deliberate take-the-step semantics for stochastic ones) -- gating it
         # would just re-reject the proposal the livelock keeps regenerating.
         accepted = (
-            (escape_round and np.isfinite(candidate_value))
-            or (q_accepted and not audit_failed)
-            or (not q_accepted and observed_accepted)
+            observed_accepted
+            if map_objective
+            else (
+                (escape_round and np.isfinite(candidate_value))
+                or (q_accepted and not audit_failed)
+                or (not q_accepted and observed_accepted)
+            )
         )
         if accepted:
             model = candidate
@@ -909,7 +938,9 @@ def run_block_em(
             current_impossible = candidate_impossible
             round_value = candidate_value
             objective_exact = True
-            if escape_round:
+            if map_objective:
+                acceptance_basis = "map_observed_gate"
+            elif escape_round:
                 acceptance_basis = "vanilla_escape"
             elif not q_accepted:
                 acceptance_basis = "observed_fallback"
@@ -933,9 +964,20 @@ def run_block_em(
                 last_q_gain[idx] = 0.0
             rejected_streak += 1
 
+        component_block_cost: dict[int, float] = {}
+        for profile in (estep_profile, candidate_profile):
+            for cost_idx, seconds in profile.component_evaluation_seconds:
+                component_block_cost[cost_idx] = component_block_cost.get(cost_idx, 0.0) + float(seconds)
+        for cost_idx, seconds in component_update_seconds.items():
+            component_block_cost[cost_idx] = component_block_cost.get(cost_idx, 0.0) + float(seconds)
+        if active_indices:
+            responsibility_share = responsibility_seconds / len(active_indices)
+            for cost_idx in active_indices:
+                component_block_cost[cost_idx] = component_block_cost.get(cost_idx, 0.0) + responsibility_share
+
         if controller is not None and controller_state is not None and controller_action is not None:
             realized_gain = max(0.0, round_value - current_value)
-            realized_cost = float(evals_e + evals_c)
+            realized_cost = float(sum(component_block_cost.get(idx, 0.0) for idx in active))
             controller.update(controller_state, controller_action, realized_gain, realized_cost)
 
         selected_cost = float(sum(cost[idx] for idx in active))
@@ -970,10 +1012,11 @@ def run_block_em(
             and forced_cost <= budget_cost + 1.0e-12
         ):
             failures.append("scheduler_budget_exceeded_without_forced_work")
-        for profile in (estep_profile, candidate_profile):
-            for cost_idx, seconds in profile.component_evaluation_seconds:
-                if seconds > 0.0:
-                    measured_cost[cost_idx] = float(seconds)
+        for cost_idx, seconds in component_block_cost.items():
+            if seconds <= 0.0:
+                continue
+            previous = measured_cost.get(cost_idx)
+            measured_cost[cost_idx] = float(seconds) if previous is None else 0.5 * (previous + float(seconds))
         assumptions = BlockEMAssumptionReceipt(
             declared_budget_fraction=round_budget_fraction,
             cost_basis=cost_basis,
@@ -1011,6 +1054,8 @@ def run_block_em(
                 ("estep", idx, seconds) for idx, seconds in estep_profile.component_evaluation_seconds
             )
             + tuple(("candidate", idx, seconds) for idx, seconds in candidate_profile.component_evaluation_seconds),
+            component_update_seconds=tuple(sorted(component_update_seconds.items())),
+            component_block_seconds=tuple(sorted(component_block_cost.items())),
         )
         n_zero = int(np.count_nonzero(model.zw)) if not accepted else int(np.count_nonzero(candidate.zw))
         history.append(
@@ -1047,7 +1092,7 @@ def run_block_em(
 
     if history and current_ll_mat is not None:
         audit_started = time.perf_counter()
-        final_value = float(np.sum(_log_density_from_matrix(current_ll_mat, model.log_w)))
+        final_value = objective_value(_log_density_from_matrix(current_ll_mat, model.log_w), model)
         audit_seconds = time.perf_counter() - audit_started
         if final_value + accept_tolerance < history[-1].objective:
             raise RuntimeError("final observed objective violated the certified EM lower bound.")

--- a/mixle/inference/em.py
+++ b/mixle/inference/em.py
@@ -70,6 +70,51 @@ class StandardEM:
         return EMStepResult(new_model)
 
 
+class CompiledEM:
+    """Local full-mixture EM using the profiled fused component kernels.
+
+    This is the reusable form of the full-tree execution path used by block EM. It keeps the
+    ordinary EM fixed point and update semantics, but can avoid generic accumulator traversal for
+    fusible subtrees of a :class:`~mixle.stats.MixtureDistribution`. Unsupported models or remote
+    execution engines fall back to :class:`StandardEM`.
+    """
+
+    def __init__(self, *, compute_dtype: Any = None) -> None:
+        self.compute_dtype = compute_dtype
+        self._cache: Any | None = None
+
+    def step(
+        self,
+        enc_data: Any,
+        estimator: ParameterEstimator,
+        model: SequenceEncodableProbabilityDistribution,
+        engine: Any | None = None,
+        objective: Callable[[Any], float] | None = None,
+    ) -> EMStepResult:
+        """Run one compiled full-mixture E/M sweep."""
+        from mixle.inference.freeze_rollup import (
+            FreezeRollupCache,
+            compiled_em_step,
+            is_compiled_em_eligible,
+        )
+
+        if engine is not None or not is_compiled_em_eligible(model, estimator):
+            result = StandardEM().step(enc_data, estimator, model, engine=engine, objective=objective)
+            result.metadata = {"compiled": False, "fallback": "unsupported_execution_shape"}
+            return result
+
+        if self._cache is None:
+            self._cache = FreezeRollupCache()
+        candidate, metadata = compiled_em_step(
+            enc_data,
+            estimator,
+            model,
+            compute_dtype=self.compute_dtype,
+            cache=self._cache,
+        )
+        return EMStepResult(candidate, metadata=metadata)
+
+
 class PosteriorTransformEM:
     """EM update that transforms mixture posteriors before the M-step.
 

--- a/mixle/inference/estimation.py
+++ b/mixle/inference/estimation.py
@@ -1022,7 +1022,7 @@ def optimize(
         loop_delta = None if surrogate_update else delta
 
         # D3 block-EM scheduler: 'auto' dispatches to mixle.inference.block_em's greedy
-        # gain-per-cost scheduler when the fit is a plain local MLE MixtureDistribution/
+        # gain-per-cost scheduler when the fit is a local MLE/MAP MixtureDistribution/
         # MixtureEstimator fit with none of the other execution knobs engaged (those all need
         # the standard _em_loop path); everything else silently keeps the 'full' behavior below
         # -- schedule='auto' never errors or changes what is computed, only how it is scheduled.
@@ -1034,7 +1034,7 @@ def optimize(
                 is_block_em_eligible(mm, estimator)
                 and not surrogate_update
                 and strategy is None
-                and resolved_objective == "mle"
+                and resolved_objective in ("mle", "map")
                 and engine is None
                 and resources is None
                 and placement is None

--- a/mixle/inference/estimation.py
+++ b/mixle/inference/estimation.py
@@ -312,6 +312,14 @@ def _local_fused_step(enc_data, estimator, model):
     return nxt, getattr(accumulator, "_seq_ll", None)
 
 
+def _compiled_fused_step(enc_data, estimator, model, strategy):
+    """Compiled full-mixture step plus its already-computed input-model objective."""
+
+    result = strategy.step(enc_data, estimator, model)
+    metadata = result.metadata or {}
+    return result.model, metadata.get("input_data_objective")
+
+
 class EMStep(NamedTuple):
     """One accepted EM iteration, handed to an ``optimize(on_step=...)`` callback.
 
@@ -819,7 +827,7 @@ def optimize(
         root (int): MPI root rank for ``backend='mpi'``.
         root_only (bool): MPI root-only data mode for ``backend='mpi'``.
         strategy (Optional[Any]): Optional EM strategy from ``mixle.inference.em`` (e.g. ``AnnealedEM``,
-            ``HardEM``, ``MonteCarloEM``) or any callable ``(enc, estimator, model) -> model`` to use
+            ``HardEM``, ``MonteCarloEM``, ``CompiledEM``) or any callable ``(enc, estimator, model) -> model`` to use
             in place of the standard exact E/M step. ``None`` uses the standard step.
         reuse_estep_ll (bool): Default True. Reuse the data log-likelihood computed during the E-step
             (the posterior normalizer / forward pass / variational ELBO) for convergence instead of
@@ -868,17 +876,19 @@ def optimize(
             the historical automatic-composite path proceeds untouched. ``'off'`` restores the
             unconditional historical behavior. Only consulted when ``estimator`` is ``None`` and no
             ``prev_estimate``/``init_estimator``/``strategy``/``enc_data`` is supplied.
-        schedule (str): ``'full'`` (default) -- unchanged vanilla full-tree EM, every round scores
-            and re-estimates every component. ``'auto'`` engages the block-coordinate-ascent
-            scheduler (:mod:`mixle.inference.block_em`): after one full bootstrap sweep, components
-            are ranked by their last observed complete-data Q gain per structural-cost unit, and
-            only the highest-value ones within a per-round cost budget are re-estimated. Inactive
-            component scores are cached while their parameters remain unchanged. This is a
+        schedule (str): ``'full'`` (default) performs exact full-tree EM every round and automatically
+            uses whole-model or component-level compiled kernels when the local model is eligible.
+            ``'auto'`` additionally engages the block-coordinate-ascent scheduler
+            (:mod:`mixle.inference.block_em`) when selective work is expected to win: after one full
+            bootstrap sweep, components are ranked by their last observed complete-data Q gain per
+            measured whole-block cost, and only the highest-value ones within a per-round budget are
+            re-estimated. Inactive component scores are cached while their parameters remain unchanged.
+            This is a
             scheduling choice: observed likelihood is transactionally gated non-decreasing every round, and
             when there is no useful ranking to do (e.g. every component looks equally worth
             updating) the scheduler degenerates to doing exactly what ``'full'`` does. Only
-            engaged when the model is a plain local-backend ``MixtureDistribution``/
-            ``MixtureEstimator`` MLE fit with no explicit ``strategy``/``engine``/``resources``/
+            engaged when the model is a local-backend ``MixtureDistribution``/
+            ``MixtureEstimator`` MLE/MAP fit with no explicit ``strategy``/``engine``/``resources``/
             ``placement`` -- anything else silently falls back to ``'full'`` (never an error, never
             a behavior change beyond scheduling).
 
@@ -1020,6 +1030,22 @@ def optimize(
         strict_monotone = _resolve_monotone(monotone, estimator, mm)
         select_best = _resolve_track_best(track_best, estimator)
         loop_delta = None if surrogate_update else delta
+        from mixle.inference.transaction import has_mutable_state
+
+        compiled_full = False
+        if (
+            schedule in ("auto", "full")
+            and strategy is None
+            and resolved_objective == "mle"
+            and engine is None
+            and resources is None
+            and placement is None
+            and backend_name == "local"
+            and not has_mutable_state(mm, estimator)
+        ):
+            from mixle.inference.fusion_policy import prefer_compiled_mixture
+
+            compiled_full = prefer_compiled_mixture(mm, enc_data, max_its)
 
         # D3 block-EM scheduler: 'auto' dispatches to mixle.inference.block_em's greedy
         # gain-per-cost scheduler when the fit is a local MLE/MAP MixtureDistribution/
@@ -1079,17 +1105,25 @@ def optimize(
         # from the accumulator; an explicit engine reads it from a kernel that reports it (the
         # FusedKernel), and gracefully falls back to a scoring pass otherwise.
         fused_step_fn = None
-        from mixle.inference.transaction import has_mutable_state
+        effective_strategy = strategy
+        if compiled_full:
+            from mixle.inference.em import CompiledEM
+
+            effective_strategy = CompiledEM()
+            if out is not None:
+                out.write("compiled-em: component-level fused full-tree execution\n")
 
         if (
             reuse_estep_ll
             and strict_monotone
             and resolved_objective == "mle"
-            and strategy is None
+            and (strategy is None or compiled_full)
             and isinstance(enc_data, list)
             and not has_mutable_state(mm, estimator)
         ):
-            if engine is None:
+            if compiled_full:
+                fused_step_fn = partial(_compiled_fused_step, strategy=effective_strategy)
+            elif engine is None:
                 fused_step_fn = _local_fused_step
             else:
                 fused_step_fn = partial(_engine_fused_step, engine=engine)
@@ -1100,7 +1134,7 @@ def optimize(
             enc_data,
             estimator,
             mm,
-            step_fn=_em_step_fn(engine, strategy, objective_fn),
+            step_fn=_em_step_fn(engine, effective_strategy, objective_fn),
             ll_fn=objective_scorer,
             max_its=max_its,
             delta=loop_delta,

--- a/mixle/inference/freeze_rollup.py
+++ b/mixle/inference/freeze_rollup.py
@@ -12,8 +12,8 @@ Correctness backbone (unchanged from the rest of the D-track): freeze/roll-up is
 optimization only. It never changes what is computed, only how often -- a cached per-datum
 log-density is byte-identical to a freshly recomputed one for the SAME parameters, and the cache
 is invalidated (recomputed) the instant a subtree's parameters move again. This module tracks the
-observed-data log likelihood from :func:`mixle.inference.em.observed_log_likelihood`; that directly
-computed objective is the audit receipt that the cache never silently drifted from a real EM trajectory.
+observed-data MLE or MAP objective; that directly computed objective is the audit receipt that the
+cache never silently drifted from a real EM trajectory.
 
 Scope: this module targets :class:`mixle.stats.latent.mixture.MixtureDistribution`, the
 combinator with the clearest "some subtrees stop mattering" story (a component whose mixture
@@ -142,7 +142,7 @@ class FreezeRollupStats:
     ``n_log_density_evals`` is the model-work receipt this module actually optimizes: the count of
     real ``component.seq_log_density(...)`` calls issued this round (each ``O(nobs)``), as opposed
     to a cache hit (``O(1)``, a dict lookup + signature compare). ``objective`` is the directly
-    evaluated, transactionally monotone observed-data log likelihood for this round.
+    evaluated, transactionally monotone observed-data MLE or MAP objective for this round.
     """
 
     round_index: int
@@ -616,19 +616,31 @@ def _component_log_density_matrix(
     return ll_mat, evals
 
 
-def _mixture_weights(estimator: MixtureEstimator, counts: np.ndarray) -> np.ndarray:
+def _mixture_weight_update(estimator: MixtureEstimator, counts: np.ndarray) -> tuple[np.ndarray, Any | None]:
     """Replicate :meth:`MixtureEstimator.estimate`'s weight-update arithmetic from raw ``counts``.
 
     Needed because the freeze/roll-up M-step (:func:`_m_step`) cannot call
     ``MixtureEstimator.estimate`` directly -- that method unconditionally re-estimates every
     component from its own sufficient statistics, which is exactly the per-round cost D2 exists
     to skip for frozen components. Supports the plain-MLE / ``fixed_weights`` / ``pseudo_count`` /
-    ``w_min``-floor paths (byte-identical arithmetic to the corresponding branches in
-    ``MixtureEstimator.estimate``); a conjugate Dirichlet weight prior is out of scope for the
-    skip-frozen path (see :func:`_m_step`).
+    ``w_min``-floor and conjugate Dirichlet MAP paths (byte-identical arithmetic to the
+    corresponding branches in ``MixtureEstimator.estimate``). The second result is the posterior
+    weight prior that must be attached to the returned model.
     """
     num_components = estimator.num_components
-    if estimator.fixed_weights is not None:
+    posterior = None
+    if estimator.has_conj_prior and estimator.fixed_weights is None:
+        from mixle.stats.bayes.dirichlet import DirichletDistribution
+        from mixle.stats.bayes.symmetric_dirichlet import SymmetricDirichletDistribution
+
+        if isinstance(estimator.prior, SymmetricDirichletDistribution):
+            alpha = np.ones(num_components) * float(estimator.prior.get_parameters())
+        else:
+            alpha = np.asarray(estimator.prior.get_parameters(), dtype=float)
+        cpp = np.maximum(np.add(counts, alpha) - 1.0, 0.0)
+        w = np.ones(num_components) / float(num_components) if cpp.sum() == 0.0 else cpp / cpp.sum()
+        posterior = DirichletDistribution(np.add(counts, alpha))
+    elif estimator.fixed_weights is not None:
         w = np.asarray(estimator.fixed_weights, dtype=float)
     elif estimator.pseudo_count is not None and estimator.suff_stat is None:
         p = estimator.pseudo_count / num_components
@@ -643,11 +655,17 @@ def _mixture_weights(estimator: MixtureEstimator, counts: np.ndarray) -> np.ndar
         else:
             w = counts / counts.sum()
     w = np.asarray(w, dtype=float)
-    if estimator.w_min > 0.0 and estimator.fixed_weights is None:
+    if estimator.w_min > 0.0 and estimator.fixed_weights is None and not estimator.has_conj_prior:
         w = np.where(np.isfinite(w), w, 0.0)
         w = np.maximum(w, estimator.w_min)
         w = w / w.sum()
-    return w
+    return w, posterior
+
+
+def _mixture_weights(estimator: MixtureEstimator, counts: np.ndarray) -> np.ndarray:
+    """Return only the updated weight vector for compatibility with existing callers."""
+
+    return _mixture_weight_update(estimator, counts)[0]
 
 
 def _m_step(
@@ -657,6 +675,7 @@ def _m_step(
     gamma: np.ndarray,
     frozen_idx: set[int],
     compute_dtype: Any = None,
+    component_update_seconds: dict[int, float] | None = None,
 ) -> MixtureDistribution:
     """One freeze/roll-up M-step: only ``frozen_idx``-excluded (active) components are re-estimated.
 
@@ -664,23 +683,75 @@ def _m_step(
     ``estimate`` call -- which is what makes its next-round cache lookup a guaranteed hit (its
     parameter signature cannot have moved because nothing touched it).
     """
-    if getattr(estimator, "has_conj_prior", False) and estimator.fixed_weights is None:
-        raise NotImplementedError(
-            "freeze_rollup does not support a conjugate Dirichlet weight prior; use a plain "
-            "MixtureEstimator(...) (no `prior=`) or mixle.inference.em.run_em for that path."
-        )
     counts = gamma.sum(axis=0)
     new_components = list(model.components)
     for idx in range(model.num_components):
         if idx in frozen_idx or model.zw[idx]:
             continue
+        started = time.perf_counter()
         enc_i = _component_enc(enc_data, idx)
         suff_stat = _component_suff_stat(
             estimator.estimators[idx], model.components[idx], enc_i, gamma[:, idx], compute_dtype
         )
         new_components[idx] = estimator.estimators[idx].estimate(float(counts[idx]), suff_stat)
-    w = _mixture_weights(estimator, counts)
-    return MixtureDistribution(new_components, w, name=estimator.name)
+        if component_update_seconds is not None:
+            component_update_seconds[idx] = time.perf_counter() - started
+    w, posterior = _mixture_weight_update(estimator, counts)
+    return MixtureDistribution(new_components, w, name=estimator.name, prior=posterior)
+
+
+def is_compiled_em_eligible(model: Any, estimator: Any) -> bool:
+    """Whether the local fused full-sweep adapter can execute this model/estimator pair."""
+
+    return isinstance(model, MixtureDistribution) and isinstance(estimator, MixtureEstimator)
+
+
+def compiled_em_step(
+    enc_data: Any,
+    estimator: MixtureEstimator,
+    model: MixtureDistribution,
+    *,
+    compute_dtype: Any = None,
+    cache: FreezeRollupCache | None = None,
+) -> tuple[MixtureDistribution, dict[str, Any]]:
+    """Run one full mixture E/M sweep through the reusable fused component path."""
+
+    if not is_compiled_em_eligible(model, estimator):
+        raise TypeError("compiled_em_step requires a MixtureDistribution/MixtureEstimator pair")
+    cache = FreezeRollupCache() if cache is None else cache
+    payload = _resolve_payload(enc_data)
+    density_started = time.perf_counter()
+    matrix, _, density_profile = _component_log_density_matrix_profiled(
+        model,
+        payload,
+        cache,
+        set(),
+        compute_dtype=compute_dtype,
+    )
+    density_seconds = time.perf_counter() - density_started
+    responsibility_started = time.perf_counter()
+    _, gamma = _combine(matrix, model.log_w)
+    responsibility_seconds = time.perf_counter() - responsibility_started
+    update_seconds: dict[int, float] = {}
+    mstep_started = time.perf_counter()
+    candidate = _m_step(
+        payload,
+        estimator,
+        model,
+        gamma,
+        set(),
+        compute_dtype=compute_dtype,
+        component_update_seconds=update_seconds,
+    )
+    mstep_seconds = time.perf_counter() - mstep_started
+    return candidate, {
+        "compiled": True,
+        "density_profile": density_profile,
+        "density_seconds": density_seconds,
+        "responsibility_seconds": responsibility_seconds,
+        "mstep_seconds": mstep_seconds,
+        "component_update_seconds": tuple(sorted(update_seconds.items())),
+    }
 
 
 def run_em_freeze_rollup(
@@ -714,7 +785,7 @@ def run_em_freeze_rollup(
        receipt, not just an assumption.
 
     Returns ``(final_model, history)`` where ``history[i]`` is round ``i``'s
-    :class:`FreezeRollupStats` (including ``objective``, the observed-data log likelihood for that round,
+    :class:`FreezeRollupStats` (including ``objective``, the observed-data MLE/MAP objective for that round,
     and ``n_log_density_evals``, the component-evaluation work receipt this module optimizes).
     """
     if not isinstance(initial_model, MixtureDistribution):
@@ -734,12 +805,19 @@ def run_em_freeze_rollup(
     model = initial_model
     history: list[FreezeRollupStats] = []
     old_value: float | None = None
+    map_objective = estimator.get_prior() is not None
+
+    def objective_value(log_density: np.ndarray, candidate_model: MixtureDistribution) -> float:
+        value = float(np.sum(log_density))
+        if map_objective:
+            value += float(estimator.model_log_density(candidate_model))
+        return value
 
     for round_index in range(max(1, int(max_its))):
         frozen_idx = detect_frozen(cache, model)
         ll_mat, evals_e = _component_log_density_matrix(model, enc_payload, cache, frozen_idx)
         log_density, gamma = _combine(ll_mat, model.log_w)
-        current_value = float(np.sum(log_density))
+        current_value = objective_value(log_density, model)
         if old_value is None:
             old_value = current_value
 
@@ -748,7 +826,7 @@ def run_em_freeze_rollup(
         candidate_frozen = detect_frozen(cache, candidate)
         ll_mat_c, evals_c = _component_log_density_matrix(candidate, enc_payload, cache, candidate_frozen)
         candidate_log_density = _log_density_from_matrix(ll_mat_c, candidate.log_w)
-        candidate_value = float(np.sum(candidate_log_density))
+        candidate_value = objective_value(candidate_log_density, candidate)
 
         accepted = np.isfinite(candidate_value) and candidate_value + accept_tolerance >= current_value
         if accepted:

--- a/mixle/inference/freeze_rollup.py
+++ b/mixle/inference/freeze_rollup.py
@@ -730,7 +730,7 @@ def compiled_em_step(
     )
     density_seconds = time.perf_counter() - density_started
     responsibility_started = time.perf_counter()
-    _, gamma = _combine(matrix, model.log_w)
+    log_density, gamma = _combine(matrix, model.log_w)
     responsibility_seconds = time.perf_counter() - responsibility_started
     update_seconds: dict[int, float] = {}
     mstep_started = time.perf_counter()
@@ -746,6 +746,7 @@ def compiled_em_step(
     mstep_seconds = time.perf_counter() - mstep_started
     return candidate, {
         "compiled": True,
+        "input_data_objective": float(np.sum(log_density)),
         "density_profile": density_profile,
         "density_seconds": density_seconds,
         "responsibility_seconds": responsibility_seconds,

--- a/mixle/inference/fusion_policy.py
+++ b/mixle/inference/fusion_policy.py
@@ -53,6 +53,46 @@ _BLOCK_MIN_COMPONENT_PARAMS = 32
 _BLOCK_MIN_WEIGHTED_WORK = 5_000_000
 
 
+def prefer_compiled_mixture(model: Any, enc_data: Any, max_its: int) -> bool:
+    """Whether component-level fusion should drive a heterogeneous full-mixture fit.
+
+    Whole-model fusion remains preferable when available. This path targets the middle ground:
+    the root cannot fuse because one or more children are heterogeneous/non-templated, while a
+    meaningful share of expensive combinator children can still use fused scoring and accumulation.
+    """
+
+    components = getattr(model, "components", None)
+    if components is None or len(components) < 2 or not isinstance(enc_data, list):
+        return False
+    try:
+        from mixle.utils.optional_deps import HAS_NUMBA
+
+        if not HAS_NUMBA:
+            return False
+        from mixle.stats.compute.fused_codegen import fusible, fusible_estep
+
+        if fusible(model) and fusible_estep(model):
+            return False
+        from mixle.inference.block_em import _parameter_count
+
+        total_cost = 0
+        compiled_cost = 0
+        for component in components:
+            cost = max(_parameter_count(component), 1)
+            total_cost += cost
+            is_combinator = (
+                getattr(component, "components", None) is not None or getattr(component, "dists", None) is not None
+            )
+            if is_combinator and fusible(component) and fusible_estep(component):
+                compiled_cost += cost
+        if compiled_cost == 0 or compiled_cost / max(total_cost, 1) < 0.25:
+            return False
+        nobs = sum(int(chunk[0]) for chunk in enc_data)
+        return nobs * max(int(max_its), 1) * compiled_cost >= _FUSION_MIN_WORKLOAD
+    except Exception:  # noqa: BLE001 - an optimization probe must preserve the host fallback
+        return False
+
+
 def prefer_block_schedule(model: Any, enc_data: Any, max_its: int) -> bool:
     """Whether ``schedule="auto"`` should route an ELIGIBLE mixture to block-EM rather than the
     full-tree path (which auto-fuses when it can).

--- a/mixle/models/moe.py
+++ b/mixle/models/moe.py
@@ -42,6 +42,7 @@ no-op) when torch is not installed.
 
 from __future__ import annotations
 
+import copy
 from collections.abc import Sequence
 from typing import Any
 
@@ -56,7 +57,14 @@ try:
 except ImportError:  # pragma: no cover - torch is optional
     _HAS_TORCH = False
 
-__all__ = ["expert_collapse_receipt", "upcycle_dense_to_moe"]
+__all__ = [
+    "expert_collapse_receipt",
+    "factorize_dense_mlp_to_moe",
+    "upcycle_dense_to_moe",
+    "upcycle_dense_to_shared_residual_moe",
+]
+if _HAS_TORCH:
+    __all__[:0] = ["MoEBlock", "MoEMLP", "SharedResidualMoEBlock", "SharedResidualMoEMLP"]
 
 if _HAS_TORCH:
 
@@ -142,6 +150,97 @@ if _HAS_TORCH:
 
             return out.reshape(shape)
 
+    class SharedResidualMoEMLP(nn.Module):
+        """A factored MoE with one common FFN and sparsely routed residual FFNs.
+
+        The shared path holds computation common to all token regimes. The gate dispatches only
+        residual structure, so ``top_k=1`` evaluates ``shared_hidden + residual_hidden`` nonlinear
+        units per token rather than duplicating the shared units in every expert. ``disjoint_loss``
+        penalizes pairwise routing overlap; use it together with the balance loss, since disjointness
+        alone admits the unhelpful solution where every token chooses the same expert.
+        """
+
+        def __init__(
+            self,
+            d_model: int,
+            n_experts: int,
+            *,
+            shared_hidden: int,
+            residual_hidden: int,
+            top_k: int = 1,
+            aux_loss_weight: float = 0.01,
+            disjoint_loss_weight: float = 0.01,
+        ) -> None:
+            super().__init__()
+            if not (1 <= top_k <= n_experts):
+                raise ValueError(f"top_k={top_k} must be in [1, n_experts={n_experts}]")
+            if shared_hidden < 1 or residual_hidden < 1:
+                raise ValueError("shared_hidden and residual_hidden must both be positive")
+            self.d_model = int(d_model)
+            self.n_experts = int(n_experts)
+            self.top_k = int(top_k)
+            self.shared_hidden = int(shared_hidden)
+            self.residual_hidden = int(residual_hidden)
+            self.aux_loss_weight = float(aux_loss_weight)
+            self.disjoint_loss_weight = float(disjoint_loss_weight)
+            self.gate = nn.Linear(d_model, n_experts, bias=False)
+            self.shared = nn.Sequential(
+                nn.Linear(d_model, self.shared_hidden), nn.GELU(), nn.Linear(self.shared_hidden, d_model)
+            )
+            self.residual_experts = nn.ModuleList(
+                [
+                    nn.Sequential(
+                        nn.Linear(d_model, self.residual_hidden),
+                        nn.GELU(),
+                        nn.Linear(self.residual_hidden, d_model),
+                    )
+                    for _ in range(n_experts)
+                ]
+            )
+            self.last_gate_probs: Any = None
+            self.last_balance_loss: Any = None
+            self.last_disjoint_loss: Any = None
+            self.last_aux_loss: Any = None
+
+        @property
+        def active_hidden(self) -> int:
+            """Nonlinear hidden units evaluated per token, ignoring dispatch overhead."""
+
+            return self.shared_hidden + self.top_k * self.residual_hidden
+
+        def forward(self, x: Any) -> Any:
+            shape = x.shape
+            flat = x.reshape(-1, shape[-1])
+            n_tokens = flat.shape[0]
+            probs = F.softmax(self.gate(flat), dim=-1)
+            self.last_gate_probs = probs.detach()
+            top_w, top_idx = probs.topk(self.top_k, dim=-1)
+            # Normalize the selected forward weights so an exact dense factorization stays on the
+            # same output scale as routing sharpens. Detaching only the denominator retains a
+            # straight-through task-loss gradient to the selected gate probabilities, including
+            # top_k=1 where an ordinary differentiable normalization would be the constant one.
+            combine_w = top_w / top_w.sum(dim=-1, keepdim=True).detach().clamp_min(torch.finfo(top_w.dtype).tiny)
+
+            residual = flat.new_zeros(n_tokens, self.d_model)
+            for expert_idx, expert in enumerate(self.residual_experts):
+                slot = top_idx == expert_idx
+                token_mask = slot.any(dim=-1)
+                if not bool(token_mask.any()):
+                    continue
+                weight = (combine_w * slot).sum(dim=-1)[token_mask]
+                residual[token_mask] += weight.unsqueeze(-1) * expert(flat[token_mask])
+
+            top1 = top_idx[:, 0]
+            dispatch = torch.zeros(self.n_experts, device=x.device, dtype=probs.dtype)
+            dispatch.scatter_add_(0, top1, torch.ones_like(top1, dtype=probs.dtype))
+            dispatch /= max(n_tokens, 1)
+            balance = self.n_experts * torch.sum(dispatch * probs.mean(dim=0))
+            disjoint = torch.mean(1.0 - torch.sum(probs.square(), dim=-1))
+            self.last_balance_loss = balance
+            self.last_disjoint_loss = disjoint
+            self.last_aux_loss = self.aux_loss_weight * balance + self.disjoint_loss_weight * disjoint
+            return (self.shared(flat) + residual).reshape(shape)
+
     class MoEBlock(nn.Module):
         """Drop-in replacement for :class:`mixle.models.transformer.Block`: identical pre-norm attention,
         MoE-routed MLP in place of the dense one. Same call signature as ``Block`` plus the MoE
@@ -185,6 +284,49 @@ if _HAS_TORCH:
         def routing_weights(self) -> Any:
             """The most recent forward's dense gate softmax, ``(n_tokens, n_experts)``, detached -- feed a
             sequence of these (one per training round) to :func:`expert_collapse_receipt`."""
+            return self.mlp.last_gate_probs
+
+    class SharedResidualMoEBlock(nn.Module):
+        """Transformer block with a common FFN trunk and sparse residual experts."""
+
+        def __init__(
+            self,
+            d_model: int,
+            n_head: int,
+            n_experts: int,
+            *,
+            shared_hidden: int,
+            residual_hidden: int,
+            top_k: int = 1,
+            aux_loss_weight: float = 0.01,
+            disjoint_loss_weight: float = 0.01,
+        ) -> None:
+            super().__init__()
+            from mixle.models.transformer import CausalAttention
+
+            self.ln1 = nn.LayerNorm(d_model)
+            self.ln2 = nn.LayerNorm(d_model)
+            self.attn = CausalAttention(d_model, n_head)
+            self.mlp = SharedResidualMoEMLP(
+                d_model,
+                n_experts,
+                shared_hidden=shared_hidden,
+                residual_hidden=residual_hidden,
+                top_k=top_k,
+                aux_loss_weight=aux_loss_weight,
+                disjoint_loss_weight=disjoint_loss_weight,
+            )
+
+        def forward(self, x: Any) -> Any:
+            x = x + self.attn(self.ln1(x))
+            return x + self.mlp(self.ln2(x))
+
+        @property
+        def aux_loss(self) -> Any:
+            return self.mlp.last_aux_loss
+
+        @property
+        def routing_weights(self) -> Any:
             return self.mlp.last_gate_probs
 
 
@@ -247,6 +389,143 @@ def upcycle_dense_to_moe(
         "probe_tokens": int(probe_tokens),
     }
     return moe_block, receipt
+
+
+def factorize_dense_mlp_to_moe(
+    dense_mlp: Any,
+    n_experts: int,
+    *,
+    common_fraction: float = 0.5,
+    top_k: int = 1,
+    aux_loss_weight: float = 0.01,
+    disjoint_loss_weight: float = 0.01,
+    probe_tokens: int = 64,
+    seed: int = 0,
+) -> tuple[Any, dict]:
+    """Split a dense transformer FFN into a common trunk and identical sparse residual experts.
+
+    Hidden neurons are ranked by the product of their input and output weight norms. The highest
+    scoring ``common_fraction`` are evaluated once in the shared path; the rest seed every residual
+    expert. A zero gate gives uniform probabilities and the forward-normalized top-k combination
+    makes the selected identical experts sum to the original residual exactly. The conversion is
+    therefore function-preserving up to floating-point summation before experts begin specializing.
+    """
+    if not _HAS_TORCH:  # pragma: no cover - torch is optional
+        raise ImportError("factorize_dense_mlp_to_moe requires torch")
+    if not 0.0 < common_fraction < 1.0:
+        raise ValueError("common_fraction must be in (0, 1)")
+    if not isinstance(dense_mlp, nn.Sequential) or len(dense_mlp) != 3:
+        raise TypeError("dense_mlp must be Linear -> GELU -> Linear")
+    first, activation, second = dense_mlp
+    if not isinstance(first, nn.Linear) or not isinstance(activation, nn.GELU) or not isinstance(second, nn.Linear):
+        raise TypeError("dense_mlp must be Linear -> GELU -> Linear")
+    if first.out_features != second.in_features or first.in_features != second.out_features:
+        raise ValueError("dense_mlp input, hidden, and output dimensions do not form a transformer FFN")
+    hidden = first.out_features
+    shared_hidden = min(hidden - 1, max(1, int(round(common_fraction * hidden))))
+    residual_hidden = hidden - shared_hidden
+    module = SharedResidualMoEMLP(
+        first.in_features,
+        n_experts,
+        shared_hidden=shared_hidden,
+        residual_hidden=residual_hidden,
+        top_k=top_k,
+        aux_loss_weight=aux_loss_weight,
+        disjoint_loss_weight=disjoint_loss_weight,
+    ).to(device=first.weight.device, dtype=first.weight.dtype)
+    module.shared[1] = copy.deepcopy(activation)
+    for expert in module.residual_experts:
+        expert[1] = copy.deepcopy(activation)
+
+    with torch.no_grad():
+        importance = torch.linalg.vector_norm(first.weight, dim=1) * torch.linalg.vector_norm(second.weight, dim=0)
+        common_idx = torch.sort(torch.topk(importance, shared_hidden).indices).values
+        residual_mask = torch.ones(hidden, dtype=torch.bool, device=first.weight.device)
+        residual_mask[common_idx] = False
+        residual_idx = torch.arange(hidden, device=first.weight.device)[residual_mask]
+
+        module.shared[0].weight.copy_(first.weight[common_idx])
+        if first.bias is None:
+            module.shared[0].bias.zero_()
+        else:
+            module.shared[0].bias.copy_(first.bias[common_idx])
+        module.shared[2].weight.copy_(second.weight[:, common_idx])
+        if second.bias is None:
+            module.shared[2].bias.zero_()
+        else:
+            module.shared[2].bias.copy_(second.bias)
+        for expert in module.residual_experts:
+            expert[0].weight.copy_(first.weight[residual_idx])
+            if first.bias is None:
+                expert[0].bias.zero_()
+            else:
+                expert[0].bias.copy_(first.bias[residual_idx])
+            expert[2].weight.copy_(second.weight[:, residual_idx])
+            expert[2].bias.zero_()
+        module.gate.weight.zero_()
+
+        generator = torch.Generator().manual_seed(int(seed))
+        probe = torch.randn(probe_tokens, first.in_features, generator=generator).to(
+            device=first.weight.device, dtype=first.weight.dtype
+        )
+        dense_out = dense_mlp(probe)
+        factored_out = module(probe)
+        relative_gap = torch.linalg.vector_norm(factored_out - dense_out) / torch.linalg.vector_norm(
+            dense_out
+        ).clamp_min(1.0e-12)
+
+    module.train(dense_mlp.training)
+    receipt = {
+        "relative_output_diff": float(relative_gap),
+        "dense_hidden": int(hidden),
+        "shared_hidden": int(shared_hidden),
+        "residual_hidden": int(residual_hidden),
+        "active_hidden": int(module.active_hidden),
+        "n_experts": int(n_experts),
+        "top_k": int(top_k),
+        "common_fraction": float(common_fraction),
+    }
+    return module, receipt
+
+
+def upcycle_dense_to_shared_residual_moe(
+    dense_block: Any,
+    n_experts: int,
+    *,
+    common_fraction: float = 0.5,
+    top_k: int = 1,
+    aux_loss_weight: float = 0.01,
+    disjoint_loss_weight: float = 0.01,
+) -> tuple[Any, dict]:
+    """Copy a transformer block and exactly factor its MLP into shared plus routed residual work."""
+    if not _HAS_TORCH:  # pragma: no cover - torch is optional
+        raise ImportError("upcycle_dense_to_shared_residual_moe requires torch")
+    d_model = dense_block.ln1.normalized_shape[0]
+    dense_hidden = dense_block.mlp[0].out_features
+    shared_hidden = min(dense_hidden - 1, max(1, int(round(common_fraction * dense_hidden))))
+    block = SharedResidualMoEBlock(
+        d_model,
+        dense_block.attn.h,
+        n_experts,
+        shared_hidden=shared_hidden,
+        residual_hidden=dense_hidden - shared_hidden,
+        top_k=top_k,
+        aux_loss_weight=aux_loss_weight,
+        disjoint_loss_weight=disjoint_loss_weight,
+    ).to(device=dense_block.mlp[0].weight.device, dtype=dense_block.mlp[0].weight.dtype)
+    block.ln1.load_state_dict(dense_block.ln1.state_dict())
+    block.ln2.load_state_dict(dense_block.ln2.state_dict())
+    block.attn.load_state_dict(dense_block.attn.state_dict())
+    block.mlp, receipt = factorize_dense_mlp_to_moe(
+        dense_block.mlp,
+        n_experts,
+        common_fraction=common_fraction,
+        top_k=top_k,
+        aux_loss_weight=aux_loss_weight,
+        disjoint_loss_weight=disjoint_loss_weight,
+    )
+    block.train(dense_block.training)
+    return block, receipt
 
 
 def expert_collapse_receipt(

--- a/mixle/stats/latent/mixture.py
+++ b/mixle/stats/latent/mixture.py
@@ -1600,12 +1600,23 @@ class _HeteroMixtureEncoded:
         self.encodings = encodings
 
 
+class _SharedMixtureEncoded:
+    """One shared nested-mixture encoding, retaining the current mixture depth."""
+
+    __slots__ = ("encoding",)
+
+    def __init__(self, encoding: Any) -> None:
+        self.encoding = encoding
+
+
 def _component_enc(enc_data: Any, i: int) -> Any:
     """Select the encoding destined for component ``i``.
 
     For a homogeneous mixture (single shared encoding) this returns ``enc_data`` unchanged; for a
     heterogeneous mixture it returns that component's own encoding from the wrapper.
     """
+    if isinstance(enc_data, _SharedMixtureEncoded):
+        return enc_data.encoding
     if isinstance(enc_data, _HeteroMixtureEncoded):
         return enc_data.encodings[i]
     return enc_data
@@ -1692,7 +1703,10 @@ class MixtureDataEncoder(DataSequenceEncoder):
             )
         if self.homogeneous:
             try:
-                return self.encoder.seq_encode(x)
+                encoded = self.encoder.seq_encode(x)
+                if isinstance(encoded, (_HeteroMixtureEncoded, _SharedMixtureEncoded)):
+                    return _SharedMixtureEncoded(encoded)
+                return encoded
             except ContractError as e:
                 raise prefix_contract_error("MixtureDistribution.components", e) from None
             except (TypeError, ValueError, IndexError, KeyError) as e:

--- a/mixle/stats/parameter_packing.py
+++ b/mixle/stats/parameter_packing.py
@@ -26,6 +26,7 @@ def _squarem_leaf_handlers() -> dict[type, tuple[Callable[[Any], list[float]], C
         CategoricalDistribution,
         ExponentialDistribution,
         GaussianDistribution,
+        LaplaceDistribution,
         PoissonDistribution,
     )
 
@@ -52,6 +53,10 @@ def _squarem_leaf_handlers() -> dict[type, tuple[Callable[[Any], list[float]], C
             lambda d: [float(np.log(d.lam))],
             lambda d, v: PoissonDistribution(float(np.exp(v[0])), name=d.name),
         ),
+        LaplaceDistribution: (
+            lambda d: [float(d.mu), float(np.log(d.b))],
+            lambda d, v: LaplaceDistribution(float(v[0]), float(np.exp(v[1])), name=d.name, keys=d.keys),
+        ),
         CategoricalDistribution: (cat_extract, cat_rebuild),
     }
 
@@ -61,9 +66,9 @@ def squarem_packer(
 ) -> tuple[Callable[[Any], np.ndarray], Callable[[np.ndarray], Any]]:
     """Build ``(pack, unpack)`` for :class:`SquaremEM` over ``model``'s primary parameters.
 
-    Supported out of the box: :class:`~mixle.stats.MixtureDistribution` whose components are
-    Gaussian / Exponential / Poisson / Categorical leaves or Composites of them, with no priors
-    attached (a MAP fit changes what the fixed point is; packing would silently ignore it).
+    Supported out of the box: recursively nested :class:`~mixle.stats.MixtureDistribution` and
+    :class:`~mixle.stats.CompositeDistribution` nodes with Gaussian / Laplace / Exponential /
+    Poisson / Categorical leaves and no priors attached (a MAP fit changes the fixed point).
     Anything else raises ``NotImplementedError`` with the escape hatch named: pass an explicit
     ``packer=(pack, unpack)`` to :class:`SquaremEM` for custom models.
 
@@ -74,6 +79,23 @@ def squarem_packer(
 
     handlers = _squarem_leaf_handlers()
 
+    def prior_is_set(value: Any) -> bool:
+        if value is None:
+            return False
+        if isinstance(value, (list, tuple)):
+            return any(prior_is_set(child) for child in value)
+        return True
+
+    def ensure_no_prior(d: Any) -> None:
+        getter = getattr(d, "get_prior", None)
+        prior = getter() if callable(getter) else getattr(d, "prior", None)
+        if prior_is_set(prior):
+            raise NotImplementedError(
+                "squarem_packer does not extrapolate MAP fits (a %s carries a prior): the prior "
+                "changes the fixed point. Pass an explicit packer that includes the prior's "
+                "contribution." % type(d).__name__
+            )
+
     def leaf_pair(d: Any) -> tuple[Callable[[Any], list[float]], Callable[[Any, list[float]], Any], int]:
         pair = handlers.get(type(d))
         if pair is None:
@@ -81,12 +103,7 @@ def squarem_packer(
                 "squarem_packer has no primary-parameter handler for %s; pass an explicit "
                 "packer=(pack, unpack) to SquaremEM for this model." % type(d).__name__
             )
-        if getattr(d, "prior", None) is not None:
-            raise NotImplementedError(
-                "squarem_packer does not extrapolate MAP fits (a %s carries a prior): the prior "
-                "changes the fixed point, and packing only the likelihood parameters would silently "
-                "drop it. Pass an explicit packer that includes the prior's contribution." % type(d).__name__
-            )
+        ensure_no_prior(d)
         return pair[0], pair[1], len(pair[0](d))
 
     if not isinstance(model, MixtureDistribution):
@@ -95,33 +112,71 @@ def squarem_packer(
             "packer=(pack, unpack) to SquaremEM for %s." % type(model).__name__
         )
 
-    def component_factors(comp: Any) -> list[Any]:
-        return list(comp.dists) if isinstance(comp, CompositeDistribution) else [comp]
+    def width(node: Any) -> int:
+        ensure_no_prior(node)
+        if isinstance(node, MixtureDistribution):
+            return sum(width(child) for child in node.components) + node.num_components
+        if isinstance(node, CompositeDistribution):
+            return sum(width(child) for child in node.dists)
+        return leaf_pair(node)[2]
 
-    template = [component_factors(c) for c in model.components]
-    is_composite = [isinstance(c, CompositeDistribution) for c in model.components]
-    sizes = [[leaf_pair(f)[2] for f in factors] for factors in template]
+    expected_width = width(model)
+
+    def pack_node(node: Any, template: Any, theta: list[float]) -> None:
+        if type(node) is not type(template):
+            raise TypeError(
+                "squarem_packer model structure changed from %s to %s." % (type(template).__name__, type(node).__name__)
+            )
+        ensure_no_prior(node)
+        if isinstance(template, MixtureDistribution):
+            if len(node.components) != len(template.components):
+                raise ValueError("squarem_packer mixture arity changed.")
+            for child, child_template in zip(node.components, template.components):
+                pack_node(child, child_template, theta)
+            theta.extend(float(v) for v in np.log(np.maximum(np.asarray(node.w, dtype=np.float64), 1e-300)))
+            return
+        if isinstance(template, CompositeDistribution):
+            if len(node.dists) != len(template.dists):
+                raise ValueError("squarem_packer composite arity changed.")
+            for child, child_template in zip(node.dists, template.dists):
+                pack_node(child, child_template, theta)
+            return
+        theta.extend(leaf_pair(node)[0](node))
+
+    def unpack_node(template: Any, theta: np.ndarray, pos: int) -> tuple[Any, int]:
+        if isinstance(template, MixtureDistribution):
+            components = []
+            for child in template.components:
+                rebuilt, pos = unpack_node(child, theta, pos)
+                components.append(rebuilt)
+            logw = theta[pos : pos + template.num_components]
+            pos += template.num_components
+            weights = np.exp(logw - np.max(logw))
+            weights /= weights.sum()
+            return MixtureDistribution(components, weights, name=template.name), pos
+        if isinstance(template, CompositeDistribution):
+            dists = []
+            for child in template.dists:
+                rebuilt, pos = unpack_node(child, theta, pos)
+                dists.append(rebuilt)
+            return CompositeDistribution(tuple(dists)), pos
+        extract, rebuild, leaf_width = leaf_pair(template)
+        del extract
+        values = [float(value) for value in theta[pos : pos + leaf_width]]
+        return rebuild(template, values), pos + leaf_width
 
     def pack(m: Any) -> np.ndarray:
         theta: list[float] = []
-        for factors in (component_factors(c) for c in m.components):
-            for f in factors:
-                theta.extend(leaf_pair(f)[0](f))
-        theta.extend(float(v) for v in np.log(np.maximum(np.asarray(m.w, dtype=np.float64), 1e-300)))
+        pack_node(m, model, theta)
         return np.asarray(theta, dtype=np.float64)
 
     def unpack(theta: np.ndarray) -> Any:
-        pos = 0
-        comps = []
-        for ci, factors in enumerate(template):
-            rebuilt = []
-            for fi, f in enumerate(factors):
-                width = sizes[ci][fi]
-                rebuilt.append(leaf_pair(f)[1](f, [float(v) for v in theta[pos : pos + width]]))
-                pos += width
-            comps.append(CompositeDistribution(tuple(rebuilt)) if is_composite[ci] else rebuilt[0])
-        logw = np.asarray(theta[pos:], dtype=np.float64)
-        w = np.exp(logw - logw.max())
-        return MixtureDistribution(comps, list(w / w.sum()))
+        values = np.asarray(theta, dtype=np.float64)
+        if values.ndim != 1 or len(values) != expected_width:
+            raise ValueError("squarem_packer expected a vector of length %d." % expected_width)
+        rebuilt, pos = unpack_node(model, values, 0)
+        if pos != expected_width:  # pragma: no cover - recursive width and rebuild are paired
+            raise RuntimeError("squarem_packer internal width mismatch.")
+        return rebuilt
 
     return pack, unpack

--- a/mixle/tests/block_em_efficiency_test.py
+++ b/mixle/tests/block_em_efficiency_test.py
@@ -16,8 +16,9 @@ import pytest
 pytest.importorskip("numba")
 
 from mixle.inference.block_em import run_block_em
+from mixle.inference.estimation import optimize
 from mixle.inference.freeze_rollup import FreezeRollupCache, _component_log_density_matrix_profiled
-from mixle.inference.fusion_policy import prefer_block_schedule
+from mixle.inference.fusion_policy import prefer_block_schedule, prefer_compiled_mixture
 from mixle.stats import (
     GaussianDistribution,
     GaussianEstimator,
@@ -139,6 +140,8 @@ class AuditCadenceAndDispatchTest:
         enc = seq_encode(rng.normal(0.0, 4.0, 20_000), model=deepish)
         # only 3 components, but each is an expensive subtree: block scheduling qualifies
         assert prefer_block_schedule(deepish, enc, max_its=100)
+        # Most expensive child subtrees compile even though the heterogeneous root cannot.
+        assert prefer_compiled_mixture(deepish, enc, max_its=100)
         assert not prefer_block_schedule(deepish, enc, max_its=1)  # weighted-work floor still applies
         cheap = MixtureDistribution([GaussianDistribution(-4.0, 1.0), LaplaceDistribution(4.0, 2.0)], [0.5, 0.5])
         enc_cheap = seq_encode(rng.normal(0.0, 4.0, 20_000), model=cheap)
@@ -233,6 +236,25 @@ class FusedMStepEngagementTest:
 
         monkeypatch.setattr(fr, "_FUSED_SCORING", (fused_seq_log_density, fusible, counting_accumulate, fusible_estep))
         return calls
+
+    def test_optimize_full_dispatch_engages_compiled_component_kernels(self, monkeypatch):
+        start, estimator, enc, _ = _deep_mixed_problem(n=900)
+        calls = self._counting_resolver(monkeypatch)
+        monkeypatch.setattr("mixle.inference.fusion_policy.prefer_compiled_mixture", lambda *_: True)
+
+        fitted = optimize(
+            None,
+            estimator,
+            enc_data=enc,
+            prev_estimate=start,
+            max_its=2,
+            delta=None,
+            schedule="full",
+            out=None,
+        )
+
+        assert isinstance(fitted, MixtureDistribution)
+        assert calls["n"] > 0
 
     def test_flat_subcombinator_components_engage_and_match_host(self, monkeypatch):
         import mixle.inference.freeze_rollup as fr

--- a/mixle/tests/block_em_efficiency_test.py
+++ b/mixle/tests/block_em_efficiency_test.py
@@ -2,7 +2,7 @@
 
 Pins the four changes: (1) per-component FUSED scoring inside the freeze-rollup column builders
 (parity-gated against the host path, with non-fusible components falling back per component);
-(2) measured per-component seconds from the timing receipts feeding the scheduler's cost model
+(2) measured end-to-end per-component seconds from the timing receipts feeding the scheduler's cost model
 (all-or-nothing, disclosed via the assumptions receipt's cost_basis); (3) reduced-precision
 column scoring threaded through run_block_em(compute_dtype=...); (4) the certificate-aware
 "auto" audit cadence and the schedule="auto" dispatch rule.
@@ -75,7 +75,18 @@ class MeasuredCostTest:
         _, history = run_block_em(enc, estimator, start, max_its=5, delta=None, cost_model="measured")
         bases = [h.assumptions.cost_basis for h in history]
         assert bases[0] == "structural_parameter_count"  # nothing measured before round 0 runs
-        assert "measured_seconds" in bases[1:]
+        assert "measured_block_seconds" in bases[1:]
+
+    def test_measured_block_cost_includes_parameter_updates(self):
+        start, estimator, enc, _ = _problem()
+        _, history = run_block_em(enc, estimator, start, max_its=2, delta=None, cost_model="measured")
+        timing = history[0].timing
+        updates = dict(timing.component_update_seconds)
+        blocks = dict(timing.component_block_seconds)
+        assert set(updates) == set(range(start.num_components))
+        assert set(blocks) == set(range(start.num_components))
+        assert all(updates[idx] > 0.0 for idx in updates)
+        assert all(blocks[idx] >= updates[idx] for idx in updates)
 
     def test_structural_default_is_unchanged(self):
         start, estimator, enc, _ = _problem()

--- a/mixle/tests/block_em_test.py
+++ b/mixle/tests/block_em_test.py
@@ -17,6 +17,7 @@ from unittest import mock
 
 import numpy as np
 
+from mixle.inference import estimation as estimation_module
 from mixle.inference.block_em import (
     _active_responsibilities,
     _constrained_block_weights,
@@ -524,6 +525,46 @@ class BlockEMOptimizeDispatchTestCase(unittest.TestCase):
             )
         self.assertTrue(scheduled.called)
         self.assertIsInstance(fitted.get_prior()[0], DirichletDistribution)
+
+    def test_optimize_full_uses_compiled_fused_step_when_policy_selects_it(self):
+        start, estimator, enc = _make_symmetric_problem(seed=23, nobs=300, num_components=3)
+        with (
+            mock.patch("mixle.inference.fusion_policy.prefer_compiled_mixture", return_value=True),
+            mock.patch(
+                "mixle.inference.estimation._compiled_fused_step",
+                wraps=estimation_module._compiled_fused_step,
+            ) as compiled_step,
+        ):
+            fitted = optimize(
+                None,
+                estimator,
+                enc_data=enc,
+                prev_estimate=start,
+                max_its=3,
+                delta=None,
+                schedule="full",
+                out=None,
+            )
+        with mock.patch("mixle.inference.fusion_policy.prefer_compiled_mixture", return_value=False):
+            baseline = optimize(
+                None,
+                estimator,
+                enc_data=enc,
+                prev_estimate=start,
+                max_its=3,
+                delta=None,
+                schedule="full",
+                out=None,
+            )
+        self.assertTrue(compiled_step.called)
+        self.assertIsInstance(fitted, MixtureDistribution)
+        probe = start.dist_to_encoder().seq_encode([-2.0, -0.5, 0.0, 1.0, 3.0])
+        np.testing.assert_allclose(
+            fitted.seq_log_density(probe),
+            baseline.seq_log_density(probe),
+            rtol=1e-11,
+            atol=1e-11,
+        )
 
     def test_optimize_schedule_auto_falls_back_for_non_mixture_models(self):
         """``schedule='auto'`` on a model block-EM does not know how to schedule (anything that

--- a/mixle/tests/block_em_test.py
+++ b/mixle/tests/block_em_test.py
@@ -13,6 +13,7 @@ Acceptance criteria under test (see the ConditionalJIT track's D3 item):
 """
 
 import unittest
+from unittest import mock
 
 import numpy as np
 
@@ -27,6 +28,7 @@ from mixle.inference.em import PosteriorTransformEM, observed_log_likelihood, ru
 from mixle.inference.estimation import optimize
 from mixle.inference.freeze_rollup import _combine, _log_density_from_matrix
 from mixle.stats import GaussianDistribution, GaussianEstimator, MixtureDistribution, MixtureEstimator, seq_encode
+from mixle.stats.bayes.dirichlet import DirichletDistribution
 
 
 def _make_problem(seed=42, nobs=400):
@@ -118,6 +120,51 @@ class BlockEMMonotonicityTestCase(unittest.TestCase):
                 if h.assumptions is not None and h.assumptions.forced_cost <= 0.5 * h.assumptions.eligible_cost
             )
         )
+
+
+class BlockEMMapTestCase(unittest.TestCase):
+    def test_dirichlet_map_full_sweep_matches_standard_update(self):
+        rng = np.random.RandomState(31)
+        data = np.concatenate([rng.normal(-2.0, 0.8, 300), rng.normal(2.5, 1.1, 500)])
+        start = MixtureDistribution(
+            [GaussianDistribution(-0.5, 2.0), GaussianDistribution(0.5, 2.0)],
+            [0.5, 0.5],
+        )
+        estimator = MixtureEstimator(
+            [GaussianEstimator(), GaussianEstimator()],
+            prior=DirichletDistribution(np.array([4.0, 2.0])),
+            w_min=0.45,
+        )
+        enc = seq_encode(data, model=start)
+        expected = PosteriorTransformEM().step(enc, estimator, start).model
+        actual, history = run_block_em(
+            enc,
+            estimator,
+            start,
+            max_its=1,
+            delta=None,
+            full_tree_every_round=True,
+        )
+        np.testing.assert_allclose(actual.w, expected.w, rtol=1e-12, atol=1e-12)
+        np.testing.assert_allclose(
+            [component.mu for component in actual.components],
+            [component.mu for component in expected.components],
+            rtol=1e-12,
+            atol=1e-12,
+        )
+        self.assertEqual(history[0].acceptance_basis, "map_observed_gate")
+        self.assertIsInstance(actual.get_prior()[0], DirichletDistribution)
+
+    def test_dirichlet_map_objective_is_monotone(self):
+        start, _, enc = _make_symmetric_problem(seed=9, nobs=500, num_components=3)
+        estimator = MixtureEstimator(
+            [GaussianEstimator() for _ in range(3)],
+            prior=DirichletDistribution(np.array([2.0, 3.0, 4.0])),
+        )
+        _, history = run_block_em(enc, estimator, start, max_its=8, delta=None)
+        objectives = np.asarray([item.objective for item in history])
+        self.assertTrue(np.all(np.diff(objectives) >= -1e-9), objectives)
+        self.assertTrue(all(item.acceptance_basis == "map_observed_gate" for item in history if item.accepted))
 
 
 class BlockEMSpeedupTestCase(unittest.TestCase):
@@ -454,6 +501,29 @@ class BlockEMOptimizeDispatchTestCase(unittest.TestCase):
         # A legitimate fit: total responsibility-weighted mass should be non-trivial and finite.
         objective = observed_log_likelihood(enc)
         self.assertTrue(np.isfinite(objective(fitted)))
+
+    def test_optimize_schedule_auto_dispatches_dirichlet_map(self):
+        start, _, enc = _make_problem(seed=17, nobs=200)
+        estimator = MixtureEstimator(
+            [GaussianEstimator() for _ in range(start.num_components)],
+            prior=DirichletDistribution(np.full(start.num_components, 2.0)),
+        )
+        with (
+            mock.patch("mixle.inference.fusion_policy.prefer_block_schedule", return_value=True),
+            mock.patch("mixle.inference.block_em.run_block_em", wraps=run_block_em) as scheduled,
+        ):
+            fitted = optimize(
+                None,
+                estimator,
+                enc_data=enc,
+                prev_estimate=start,
+                max_its=4,
+                delta=None,
+                schedule="auto",
+                out=None,
+            )
+        self.assertTrue(scheduled.called)
+        self.assertIsInstance(fitted.get_prior()[0], DirichletDistribution)
 
     def test_optimize_schedule_auto_falls_back_for_non_mixture_models(self):
         """``schedule='auto'`` on a model block-EM does not know how to schedule (anything that

--- a/mixle/tests/freeze_rollup_test.py
+++ b/mixle/tests/freeze_rollup_test.py
@@ -29,6 +29,7 @@ from mixle.stats import (
     MixtureEstimator,
     seq_encode,
 )
+from mixle.stats.bayes.dirichlet import DirichletDistribution
 from mixle.stats.latent.mixture import _component_enc
 
 
@@ -145,6 +146,19 @@ class FreezeRollupMonotonicityTestCase(unittest.TestCase):
         # At least one component should actually have frozen during this run -- otherwise the
         # monotonicity check would be vacuous (identical to plain PosteriorTransformEM).
         self.assertTrue(any(h.n_frozen > 0 for h in history))
+
+    def test_dirichlet_prior_uses_the_map_objective(self):
+        start, _, enc = _make_problem(seed=13, nobs=300)
+        estimator = MixtureEstimator(
+            [GaussianEstimator() for _ in range(start.num_components)],
+            prior=DirichletDistribution(np.full(start.num_components, 2.0)),
+        )
+        model, history = run_em_freeze_rollup(enc, estimator, start, max_its=8, delta=None)
+        objectives = np.asarray([item.objective for item in history])
+        self.assertTrue(np.all(np.diff(objectives) >= -1.0e-9), objectives)
+        expected = observed_log_likelihood(enc)(model) + estimator.model_log_density(model)
+        self.assertAlmostEqual(history[-1].objective, expected, places=8)
+        self.assertIsInstance(model.get_prior()[0], DirichletDistribution)
 
 
 class FreezeRollupCacheInvalidationTestCase(unittest.TestCase):

--- a/mixle/tests/mixture_heterogeneous_test.py
+++ b/mixle/tests/mixture_heterogeneous_test.py
@@ -27,9 +27,11 @@ from mixle.stats import (
     seq_encode,
     seq_log_density_sum,
 )
+from mixle.stats.compute.sequence import seq_estimate
 from mixle.stats.latent.mixture import (
     MixtureEstimator,
     _HeteroMixtureEncoded,
+    _SharedMixtureEncoded,
 )
 
 
@@ -98,6 +100,30 @@ class HeterogeneousMixtureTestCase(unittest.TestCase):
         _, ll = seq_log_density_sum(seq_encode(data, model=model), model)
         self.assertTrue(np.isfinite(ll))
         self.assertTrue(model.dist_to_encoder().homogeneous)
+
+    def test_nested_homogeneous_mixture_preserves_heterogeneous_encoding_depth(self):
+        rng = np.random.RandomState(29)
+        data = rng.gamma(3.0, 1.2, 300).tolist()
+        outer = MixtureDistribution(
+            [
+                MixtureDistribution(
+                    [GaussianDistribution(float(center), 1.5), GammaDistribution(2.0, 1.0)],
+                    [0.6, 0.4],
+                )
+                for center in (1.0, 2.0, 3.0, 4.0)
+            ],
+            [0.25] * 4,
+        )
+        encoder = outer.dist_to_encoder()
+        self.assertTrue(encoder.homogeneous)
+        encoded = encoder.seq_encode(data)
+        self.assertIsInstance(encoded, _SharedMixtureEncoded)
+
+        seq_values = outer.seq_log_density(encoded)
+        scalar_values = np.asarray([outer.log_density(value) for value in data])
+        np.testing.assert_allclose(seq_values, scalar_values, rtol=1e-11, atol=1e-11)
+        candidate = seq_estimate([(len(data), encoded)], outer.estimator(), outer)
+        self.assertTrue(np.isfinite(candidate.seq_log_density(encoded)).all())
 
 
 if __name__ == "__main__":

--- a/mixle/tests/moe_test.py
+++ b/mixle/tests/moe_test.py
@@ -16,7 +16,14 @@ import pytest
 
 torch = pytest.importorskip("torch")
 
-from mixle.models.moe import MoEBlock, expert_collapse_receipt, upcycle_dense_to_moe
+from mixle.models.moe import (
+    MoEBlock,
+    SharedResidualMoEMLP,
+    expert_collapse_receipt,
+    factorize_dense_mlp_to_moe,
+    upcycle_dense_to_moe,
+    upcycle_dense_to_shared_residual_moe,
+)
 from mixle.models.transformer import Block, CausalLM
 
 
@@ -227,3 +234,84 @@ class UpcyclingReceiptTest:
         _, large_noise_receipt = upcycle_dense_to_moe(dense, n_experts=4, top_k=1, seed=0, noise_std=0.2)
 
         assert small_noise_receipt["relative_output_diff"] < large_noise_receipt["relative_output_diff"]
+
+
+class SharedResidualMoETest:
+    def test_dense_factorization_is_function_preserving_at_matched_active_width(self):
+        torch.manual_seed(19)
+        dense = Block(24, 4).mlp
+        factored, receipt = factorize_dense_mlp_to_moe(
+            dense,
+            n_experts=4,
+            common_fraction=0.5,
+            top_k=1,
+        )
+        probe = torch.randn(3, 11, 24)
+        with torch.no_grad():
+            expected = dense(probe)
+            actual = factored(probe)
+        torch.testing.assert_close(actual, expected, rtol=1e-5, atol=1e-6)
+        assert receipt["relative_output_diff"] < 1e-5
+        assert factored.active_hidden == dense[0].out_features
+
+    def test_only_routed_residual_experts_execute(self):
+        module = SharedResidualMoEMLP(
+            8,
+            4,
+            shared_hidden=16,
+            residual_hidden=16,
+            top_k=1,
+        )
+        calls = [0, 0, 0, 0]
+        handles = []
+        for idx, expert in enumerate(module.residual_experts):
+            handles.append(
+                expert.register_forward_hook(lambda _m, _i, _o, idx=idx: calls.__setitem__(idx, calls[idx] + 1))
+            )
+        module(torch.ones(32, 8))
+        for handle in handles:
+            handle.remove()
+        assert sum(calls) == 1
+
+    def test_disjoint_penalty_prefers_peaked_routing(self):
+        module = SharedResidualMoEMLP(
+            4,
+            3,
+            shared_hidden=4,
+            residual_hidden=4,
+            top_k=1,
+        )
+        x = torch.ones(16, 4)
+        with torch.no_grad():
+            module.gate.weight.zero_()
+            module(x)
+            uniform = float(module.last_disjoint_loss)
+            module.gate.weight[0].fill_(4.0)
+            module.gate.weight[1:].fill_(-4.0)
+            module(x)
+            peaked = float(module.last_disjoint_loss)
+        assert peaked < uniform * 0.01
+
+    def test_top1_task_loss_reaches_the_gate(self):
+        dense = Block(12, 3).mlp
+        module, _ = factorize_dense_mlp_to_moe(dense, n_experts=3, top_k=1)
+        loss = module(torch.randn(10, 12)).square().mean()
+        loss.backward()
+        assert module.gate.weight.grad is not None
+        assert torch.linalg.vector_norm(module.gate.weight.grad) > 0.0
+
+    def test_block_upcycle_preserves_the_full_block(self):
+        torch.manual_seed(23)
+        dense = Block(24, 4)
+        moe, receipt = upcycle_dense_to_shared_residual_moe(
+            dense,
+            n_experts=4,
+            common_fraction=0.5,
+            top_k=1,
+        )
+        probe = torch.randn(2, 13, 24)
+        with torch.no_grad():
+            expected = dense(probe)
+            actual = moe(probe)
+        torch.testing.assert_close(actual, expected, rtol=1e-5, atol=1e-6)
+        assert receipt["active_hidden"] == dense.mlp[0].out_features

--- a/mixle/tests/squarem_em_test.py
+++ b/mixle/tests/squarem_em_test.py
@@ -103,6 +103,11 @@ class CompiledEMTest(unittest.TestCase):
         )
         self.assertTrue(result.metadata["compiled"])
         self.assertGreater(result.metadata["mstep_seconds"], 0.0)
+        self.assertAlmostEqual(
+            result.metadata["input_data_objective"],
+            observed_log_likelihood(enc_data)(model),
+            places=9,
+        )
 
     def test_squarem_accepts_compiled_base_strategy(self):
         model, est, enc_data = _overlapping_gmm(n=6_000)

--- a/mixle/tests/squarem_em_test.py
+++ b/mixle/tests/squarem_em_test.py
@@ -12,13 +12,14 @@ import unittest
 
 import numpy as np
 
-from mixle.inference import SquaremEM, squarem_packer
+from mixle.inference import CompiledEM, SquaremEM, squarem_packer
 from mixle.inference.em import StandardEM, observed_log_likelihood
 from mixle.stats import (
     CategoricalDistribution,
     CompositeDistribution,
     ExponentialDistribution,
     GaussianDistribution,
+    LaplaceDistribution,
     MixtureDistribution,
     PoissonDistribution,
 )
@@ -91,6 +92,25 @@ class SquaremGateTest(unittest.TestCase):
         self.assertGreater(result.objective, observed_log_likelihood(enc_data)(model))
 
 
+class CompiledEMTest(unittest.TestCase):
+    def test_compiled_full_sweep_matches_standard_em(self):
+        model, est, enc_data = _overlapping_gmm(n=6_000)
+        expected = StandardEM().step(enc_data, est, model).model
+        result = CompiledEM().step(enc_data, est, model)
+        probe = model.dist_to_encoder().seq_encode([-1.0, 0.0, 1.0, 3.0, 5.0])
+        np.testing.assert_allclose(
+            result.model.seq_log_density(probe), expected.seq_log_density(probe), rtol=1e-11, atol=1e-11
+        )
+        self.assertTrue(result.metadata["compiled"])
+        self.assertGreater(result.metadata["mstep_seconds"], 0.0)
+
+    def test_squarem_accepts_compiled_base_strategy(self):
+        model, est, enc_data = _overlapping_gmm(n=6_000)
+        result = SquaremEM(base_strategy=CompiledEM()).step(enc_data, est, model)
+        self.assertIn(result.metadata["sweeps"], (2, 3))
+        self.assertTrue(np.isfinite(result.objective))
+
+
 class SquaremPackerTest(unittest.TestCase):
     def test_pack_unpack_round_trips_the_supported_families(self):
         model = MixtureDistribution(
@@ -112,6 +132,28 @@ class SquaremPackerTest(unittest.TestCase):
         data = [(0.3, 1.2, 2, "b"), (1.5, 0.4, 4, "a")]
         enc = model.dist_to_encoder().seq_encode(data)
         np.testing.assert_allclose(rebuilt.seq_log_density(enc), model.seq_log_density(enc), rtol=1e-12)
+
+    def test_pack_unpack_round_trips_nested_mixtures_and_laplace(self):
+        inner = MixtureDistribution(
+            [LaplaceDistribution(-1.0, 0.7), GaussianDistribution(1.5, 1.2)],
+            [0.35, 0.65],
+            name="inner",
+        )
+        model = MixtureDistribution(
+            [
+                CompositeDistribution((inner, PoissonDistribution(3.0))),
+                CompositeDistribution((LaplaceDistribution(2.0, 1.1), PoissonDistribution(5.0))),
+            ],
+            [0.4, 0.6],
+            name="outer",
+        )
+        pack, unpack = squarem_packer(model)
+        rebuilt = unpack(pack(model))
+        data = [(-0.5, 2), (1.2, 4), (2.5, 7)]
+        enc = model.dist_to_encoder().seq_encode(data)
+        np.testing.assert_allclose(rebuilt.seq_log_density(enc), model.seq_log_density(enc), rtol=1e-12)
+        self.assertEqual(rebuilt.name, "outer")
+        self.assertEqual(rebuilt.components[0].dists[0].name, "inner")
 
     def test_unsupported_and_map_models_are_refused_with_the_escape_hatch_named(self):
         with self.assertRaises(NotImplementedError) as ctx:


### PR DESCRIPTION
## Summary

- price scheduled mixture blocks from density, responsibility, and parameter-update time; feed the same measured cost to learned controllers
- add reusable `CompiledEM`, recursive nested-mixture/composite SQUAREM packing, and exact Dirichlet/MAP gates for block and freeze/roll-up execution
- automatically route eligible heterogeneous local MLE fits through compiled component scoring and accumulation; reuse the E-step objective instead of rescoring the input model
- keep `schedule="auto"` selective when block updates save work, while `schedule="full"` uses compiled full-tree execution and whole-root fusion retains priority
- preserve encoding depth for homogeneous outer mixtures containing heterogeneous nested mixtures
- add a function-preserving shared-trunk/residual-expert MoE with balanced disjoint routing and top-1 task-loss gradients

## Verification

- 43 focused compiler, block-EM, and SQUAREM tests passed
- 177 fused-engine and architecture tests plus 156 subtests passed
- an end-to-end production-path test verifies that public `optimize()` enters actual fused component accumulation, not only the `CompiledEM` wrapper
- Ruff lint/format and `git diff --check` passed
- ignored warm local benchmarks measured 2.39x for one compiled sweep and 2.25x for six rounds through `optimize(schedule="full")`, with maximum log-density errors of 1.5e-12 and 3.7e-12 respectively
- selective compiled block execution reached the same six-round objective in 0.393s versus 0.500s for compiled full-tree execution
- factored MoE measured roughly 1.9-3.3x for 32-256 routed CPU tokens
- single-token CPU routing remains about 18-23% slower from dispatch overhead; this PR does not claim a universal decode-speed win

The benchmark harness and results remain under ignored `.benchmarks/` and are not part of this PR.