### PR TITLE
fix(fused): compile kernels without ninf/nnan; guard impossible rows in E-step/nested paths

### DIFF
--- a/mixle/stats/compute/fused_codegen.py
+++ b/mixle/stats/compute/fused_codegen.py
@@ -109,6 +109,9 @@ class LeafTemplate:
     # global min/max over x (a map-reducible reduction) for a scalar leaf whose value() needs it (Pareto's xm)
     wants_minmax: bool = False
     to_value_g: Callable[[tuple, float, float, float], tuple] | None = None  # (stats, count, min, max) -> value
+    # scalar accumulators combined by MIN instead of SUM (allocated +inf; the parallel chunk axis and any
+    # merge must min-reduce them) -- per-component weighted support minima, e.g. Pareto's xm
+    min_acc_names: tuple[str, ...] = ()
     # categorical hooks (data is already a category index; score from a (K,C) log-prob table, accumulate a
     # (K,C) weighted count histogram -- the only sufficient statistic). Generalizes the tabulated pattern to
     # value-keyed categories (the table/value depend on the encoding's category list, so they get ``enc``).
@@ -430,10 +433,17 @@ register_leaf_template(
         arity=2,
         # support x >= xm: log p = log a + a log xm - (a+1) log x; below the scale the component is impossible
         expr=lambda v, p: f"(({p['const']}[k] - {p['am1']}[k] * {v[1]}) if {v[0]} >= {p['xm']}[k] else -np.inf)",
-        acc_names=("slogx",),
-        acc_stmt=lambda v, a, r: f"{a['slogx']}[k] += {r} * {v[1]}",
-        wants_minmax=True,  # the scale xm is estimated as the minimum observed x (a global reduction)
-        to_value_g=lambda s, count, mn, mx: (count, s[0], mn),  # (n, sum_w logx, min x)
+        acc_names=("slogx", "wmin"),
+        # wmin tracks the PER-COMPONENT minimum over rows with responsibility > 0 -- the legacy
+        # ParetoAccumulator statistic that ParetoEstimator uses directly as the scale xm. The global
+        # data minimum (to_value_g's mn) is wrong whenever component supports differ.
+        acc_stmt=lambda v, a, r: (
+            f"{a['slogx']}[k] += {r} * {v[1]}; "
+            f"{a['wmin']}[k] = {v[0]} if {r} > 0.0 and {v[0]} < {a['wmin']}[k] else {a['wmin']}[k]"
+        ),
+        wants_minmax=True,  # keeps minmax leaves out of the nested emitter (no to_value / min plumbing there)
+        min_acc_names=("wmin",),
+        to_value_g=lambda s, count, mn, mx: (count, s[0], s[1]),  # (n, sum_w logx, per-component min x)
     )
 )
 
@@ -1304,10 +1314,20 @@ def _compile_estep(plan: FusedPlan, parallel: bool = False) -> Callable:
             "        for k in range(1, kc):",
             "            if llbuf[k] > m:",
             "                m = llbuf[k]",
+            # all components -inf (impossible row): -inf - (-inf) = NaN would poison every statistic.
+            # Mirror the legacy accumulator: responsibilities fall back to the prior mixture weights
+            # and the row's log-likelihood is -inf (the scorer's guard, E-step edition).
+            "        ok = m > -np.inf",
+            "        if not ok:",
+            "            for k in range(kc):",
+            "                llbuf[k] = logw[k]",
+            "                if llbuf[k] > m:",
+            "                    m = llbuf[k]",
             "        s = 0.0",
             "        for k in range(kc):",
             "            s += np.exp(llbuf[k] - m)",
-            "        out_ll[0] += wi * (m + np.log(s))",  # data log-likelihood, free as the posterior normalizer
+            # data log-likelihood, free as the posterior normalizer
+            "        out_ll[0] += wi * (m + np.log(s)) if ok else wi * -np.inf",
             "        for k in range(kc):",
             "            r = np.exp(llbuf[k] - m) / s * wi",
             "            comp_counts[k] += r",
@@ -1359,10 +1379,17 @@ def _compile_estep(plan: FusedPlan, parallel: bool = False) -> Callable:
             "            for k in range(1, kc):",
             "                if llbuf_c[k] > m:",
             "                    m = llbuf_c[k]",
+            # same all-components-impossible guard as the sequential kernel (prior-weight fallback)
+            "            ok = m > -np.inf",
+            "            if not ok:",
+            "                for k in range(kc):",
+            "                    llbuf_c[k] = logw[k]",
+            "                    if llbuf_c[k] > m:",
+            "                        m = llbuf_c[k]",
             "            s = 0.0",
             "            for k in range(kc):",
             "                s += np.exp(llbuf_c[k] - m)",
-            "            out_ll[c] += wi * (m + np.log(s))",
+            "            out_ll[c] += wi * (m + np.log(s)) if ok else wi * -np.inf",
             "            for k in range(kc):",
             "                r = np.exp(llbuf_c[k] - m) / s * wi",
             "                comp_counts[c, k] += r",
@@ -1632,7 +1659,13 @@ def fused_accumulate(
             matrix_acc.append((np.empty(0), np.empty(0)))
             acc_arrays.append(ad["hist"])
         else:
-            ad = {an: np.zeros(chunk((K,)), dtype=np.float64) for an in t.acc_names}
+            # min-combined accumulators (per-component support minima) start at +inf, additive ones at 0
+            ad = {
+                an: np.full(chunk((K,)), np.inf, dtype=np.float64)
+                if an in t.min_acc_names
+                else np.zeros(chunk((K,)), dtype=np.float64)
+                for an in t.acc_names
+            }
             scalar_acc.append(ad)
             matrix_acc.append((np.empty(0), np.empty(0)))
             acc_arrays.extend(ad.values())
@@ -1660,7 +1693,9 @@ def fused_accumulate(
         for i, t in enumerate(plan.leaf_templates):
             if t.kind != "matrix":
                 for an in list(scalar_acc[i]):
-                    scalar_acc[i][an] = scalar_acc[i][an].sum(axis=0)
+                    # support minima are non-additive: chunk partials must min-combine, never sum
+                    chunk_op = np.minimum.reduce if an in t.min_acc_names else np.add.reduce
+                    scalar_acc[i][an] = chunk_op(scalar_acc[i][an], axis=0)
     else:
         comp_counts = np.zeros(K, dtype=np.float64)
         llbuf = np.empty(K, dtype=np.float64)

--- a/mixle/stats/compute/fused_nested.py
+++ b/mixle/stats/compute/fused_nested.py
@@ -111,6 +111,8 @@ def _build(model: Any, path: tuple, ctx: _Ctx) -> Any | None:
     t = _template_for(model)
     if t is None or t.kind != "scalar":  # only scalar leaves nest cleanly (no precompute / BLAS / tables)
         return None
+    if t.wants_minmax:  # minmax leaves (Pareto) need the to_value_g / support-min plumbing this emitter
+        return None  # lacks: _node_value would call to_value (None) and crash mid-fit -- decline instead
     if path not in ctx.slots:
         slot = len(ctx.slots)
         ctx.slots[path] = (t, slot)
@@ -171,7 +173,11 @@ def _emit_score(node: Any, lines: list[str], quantized_lse: bool = False) -> str
             lines.append(f"    sm{node.node_id} += lse_lut[qi{node.node_id}]")
         else:
             lines.append(f"    sm{node.node_id} += np.exp({v} - mx{node.node_id})")
-    lines.append(f"    ns{node.node_id} = mx{node.node_id} + np.log(sm{node.node_id})")
+    # finite-max guard at EVERY mixture node (the flat compiler's guard, nested edition): when all
+    # children score -inf, -inf - (-inf) = NaN above; the host scores such rows -inf.
+    lines.append(
+        f"    ns{node.node_id} = (mx{node.node_id} + np.log(sm{node.node_id})) if mx{node.node_id} > -np.inf else -np.inf"
+    )
     return f"ns{node.node_id}"
 
 
@@ -190,7 +196,12 @@ def _emit_backward(node: Any, rho: str, lines: list[str]) -> None:
     lines.append(f"    {rv} = {rho}")
     for j, c in enumerate(node.children):
         crv = f"{rv}_{j}"
-        lines.append(f"    {crv} = {rv} * np.exp(s{node.node_id}_{j} - ns{node.node_id})")
+        # impossible subtree (ns = -inf, so s_j - ns = NaN): mirror the legacy accumulator -- the
+        # responsibility falls back to the prior mixture weights (a zero rho stays exactly zero).
+        lines.append(
+            f"    {crv} = {rv} * (np.exp(s{node.node_id}_{j} - ns{node.node_id}) "
+            f"if ns{node.node_id} > -np.inf else np.exp(logw{node.node_id}[{j}]))"
+        )
         lines.append(f"    cc{node.node_id}[{j}] += {crv}")
         _emit_backward(c, crv, lines)
 

--- a/mixle/stats/latent/_hidden_markov_numba_kernels.py
+++ b/mixle/stats/latent/_hidden_markov_numba_kernels.py
@@ -12,11 +12,17 @@ import numpy as np
 
 from mixle.utils.optional_deps import numba
 
+# fastmath SUBSET shared by every kernel here: reassociation/contraction/approximations keep the
+# SIMD wins, but ninf/nnan stay OFF -- ``numba_seq_log_density`` adds ``-np.inf`` to the
+# log-likelihood on impossible observations, which full ``fastmath=True`` (LLVM ninf) declares
+# undefined behavior and may fold away (the same policy as fused_codegen._njit).
+_FASTMATH_SUBSET = {"reassoc", "contract", "arcp", "afn", "nsz"}
+
 
 @numba.njit(
     "void(int32, int32[:], float64[:,:], float64[:], float64[:,:], float64[:], float64[:,:], float64[:,:], float64[:])",
     parallel=True,
-    fastmath=True,
+    fastmath=_FASTMATH_SUBSET,
     cache=True,
 )
 def numba_seq_log_density(num_states, tz, prob_mat, init_pvec, tran_mat, max_ll, next_alpha_mat, alpha_buff_mat, out):
@@ -160,7 +166,7 @@ def numba_baum_welch(
     "void(int64, int32[:], float64[:,:], float64[:], float64[:,:], float64[:], float64[:,:], float64[:,:,:], "
     "float64[:,:])",
     parallel=True,
-    fastmath=True,
+    fastmath=_FASTMATH_SUBSET,
     cache=True,
 )
 def numba_baum_welch2(num_states, tz, prob_mat, init_pvec, tran_mat, weights, alpha_loc, xi_acc, pi_acc):
@@ -255,7 +261,7 @@ def numba_baum_welch2(num_states, tz, prob_mat, init_pvec, tran_mat, weights, al
     "void(int64, int32[:], float64[:,:], float64[:], float64[:,:], float64[:], float64[:,:], float64[:,:,:], "
     "float64[:,:])",
     parallel=True,
-    fastmath=True,
+    fastmath=_FASTMATH_SUBSET,
     cache=True,
 )
 def numba_baum_welch_alphas(num_states, tz, prob_mat, init_pvec, tran_mat, weights, alpha_loc, xi_acc, pi_acc):

--- a/mixle/stats/latent/tree_hidden_markov_model.py
+++ b/mixle/stats/latent/tree_hidden_markov_model.py
@@ -2049,10 +2049,17 @@ class TreeHiddenMarkovDataEncoder(DataSequenceEncoder):
             return None, self._seq_encode(x)
 
 
+# fastmath SUBSET for the tree kernels: reassociation/contraction/approximations keep the SIMD wins,
+# but ninf/nnan stay OFF -- the upward recursion scores impossible observations ``-np.inf``, which
+# full ``fastmath=True`` (LLVM ninf) declares undefined behavior and may fold away (the same policy
+# as fused_codegen._njit and _hidden_markov_numba_kernels).
+_FASTMATH_SUBSET = {"reassoc", "contract", "arcp", "afn", "nsz"}
+
+
 @numba.njit(
     "void(int32, int32[:], int32[:], int32[:], int32[:], int32[:], int32[:], int32[:], int32[:], int32[:], int32[:], "
     "int32[:], float64[:,:], float64[:, :], float64[:, :], float64[:], float64[:,:], float64[:,:], float64[:])",
-    fastmath=True,
+    fastmath=_FASTMATH_SUBSET,
     parallel=True,
     cache=True,
 )
@@ -2310,7 +2317,7 @@ def numba_baum_welch(
 @numba.njit(
     "void(int32, int32[:], int32[:], int32[:], int32[:], int32[:], int32[:], int32[:], int32[:], int32[:], int32[:], "
     "int32[:], float64[:,:], float64[:, :], float64[:,:], float64[:,:], float64[:,:])",
-    fastmath=True,
+    fastmath=_FASTMATH_SUBSET,
     parallel=True,
     cache=True,
 )

--- a/mixle/tests/conftest.py
+++ b/mixle/tests/conftest.py
@@ -90,6 +90,11 @@ FILE_MARKERS: dict[str, MarkerTuple] = {
     # log-sum-exp guard that fastmath's ninf flag used to fold away, tiny/empty data) + the SQUAREM
     # never-loses-to-plain-EM soak.
     "fused_edge_panel_test.py": ("numba", "optional"),
+    # Out-of-support / impossible rows through the compiled paths: scoring parity with a -inf leaf
+    # (the fastmath ninf/nnan regression net), the all-components-impossible E-step guard (flat and
+    # nested), the nested wants_minmax decline, and per-component weighted Pareto support minima --
+    # numba-gated like its siblings; the numba-free halves live in fastmath_policy_test.py.
+    "fused_out_of_support_test.py": ("numba", "optional"),
     "jax_engine_test.py": ("jax", "optional"),
     # Backward-compatibility-only tests (renamed class / kwarg aliases). Tagged `legacy` so a product-only
     # run can exclude them with `-m "not legacy"`; they still run in the default `fast` gate.

--- a/mixle/tests/fastmath_policy_test.py
+++ b/mixle/tests/fastmath_policy_test.py
@@ -1,0 +1,160 @@
+"""Fastmath policy + nested-fusion gating for the -inf-semantics kernel modules.
+
+The generated fused kernels and the HMM numba kernels rely on ``-np.inf`` as a SEMANTIC value:
+out-of-support scores, log mixture weights, the all--inf log-sum-exp guard, and the HMM
+``llsum += -np.inf`` impossible-observation branches. Compiling them with full ``fastmath=True``
+sets LLVM's ``ninf``/``nnan`` flags, which declare those values undefined behavior -- and really
+miscompiled: a fused Pareto-mixture scorer returned POSITIVE log-densities on rows where one
+component is out of support. Policy pinned here: these modules may use the safe reassociation
+subset, never full ``fastmath=True`` (no ``ninf``/``nnan``).
+
+Also pinned (source-level, so the fast gate carries the signal without a numba compile):
+
+* ``wants_minmax`` leaf templates (Pareto) must DECLINE nested fusion -- the nested emitter has no
+  ``to_value_g`` / support-min plumbing, so admitting them crashed mid-fit with a ``TypeError``.
+* the nested emitters guard every mixture node's log-sum-exp and responsibility pushdown against
+  all-children--inf rows (no nested-fusible leaf can currently score -inf, so the emitted source
+  is the only place the guard can be asserted without one).
+
+Deliberately numba-free: everything here inspects source or the pure-python analyzers.
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+import mixle.stats as stats
+from mixle.stats.compute import fused_codegen, fused_nested
+
+# every module whose kernels carry -inf semantics (review findings D-1 / D-7)
+_MINUS_INF_KERNEL_MODULES = (
+    "mixle.stats.compute.fused_codegen",
+    "mixle.stats.compute.fused_nested",
+    "mixle.stats.latent._hidden_markov_numba_kernels",
+    "mixle.stats.latent.tree_hidden_markov_model",
+)
+
+
+def _module_source_without_comments(dotted: str) -> str:
+    import importlib
+
+    mod = importlib.import_module(dotted)
+    src = Path(mod.__file__).read_text()
+    # crude comment strip (no '#' appears inside string literals near fastmath usage in these files);
+    # keeps the policy check from tripping on prose that MENTIONS fastmath=True
+    return "\n".join(line.split("#", 1)[0] for line in src.splitlines())
+
+
+class FastmathPolicyTest(unittest.TestCase):
+    def test_no_full_fastmath_in_minus_inf_kernel_modules(self):
+        for dotted in _MINUS_INF_KERNEL_MODULES:
+            code = _module_source_without_comments(dotted)
+            self.assertIsNone(
+                re.search(r"fastmath\s*=\s*True", code),
+                f"{dotted} compiles a kernel with full fastmath=True (ninf/nnan): -inf semantics break",
+            )
+
+    def test_fastmath_flag_sets_never_enable_ninf_or_nnan(self):
+        for dotted in _MINUS_INF_KERNEL_MODULES:
+            code = _module_source_without_comments(dotted)
+            for flag in ("ninf", "nnan"):
+                self.assertNotIn(f"'{flag}'", code, f"{dotted} enables fastmath {flag}")
+                self.assertNotIn(f'"{flag}"', code, f"{dotted} enables fastmath {flag}")
+
+
+class NestedMinmaxExclusionTest(unittest.TestCase):
+    def _pareto_mixture_of_mixtures(self):
+        inner1 = stats.MixtureDistribution(
+            components=[
+                stats.ParetoDistribution(xm=1.0, alpha=2.0),
+                stats.ParetoDistribution(xm=2.0, alpha=3.0),
+            ],
+            w=[0.6, 0.4],
+        )
+        inner2 = stats.MixtureDistribution(
+            components=[
+                stats.ParetoDistribution(xm=1.5, alpha=1.5),
+                stats.ParetoDistribution(xm=3.0, alpha=2.5),
+            ],
+            w=[0.5, 0.5],
+        )
+        return stats.MixtureDistribution(components=[inner1, inner2], w=[0.7, 0.3])
+
+    def test_minmax_leaves_decline_nested_fusion_on_every_gate(self):
+        # wants_minmax templates have to_value=None; the nested emitter would call it mid-fit
+        mm = self._pareto_mixture_of_mixtures()
+        self.assertFalse(fused_nested.fusible_nested(mm))
+        self.assertFalse(fused_codegen.fusible(mm))
+        self.assertFalse(fused_codegen.fusible_estep(mm))
+
+    def test_flat_pareto_mixture_still_fuses(self):
+        # the exclusion is scoped to NESTING: the flat compiler has the minmax plumbing
+        flat = stats.MixtureDistribution(
+            components=[
+                stats.ParetoDistribution(xm=1.0, alpha=2.5),
+                stats.ParetoDistribution(xm=2.0, alpha=1.5),
+            ],
+            w=[0.5, 0.5],
+        )
+        self.assertTrue(fused_codegen.fusible(flat))
+        self.assertTrue(fused_codegen.fusible_estep(flat))
+
+
+class NestedEmitterGuardTest(unittest.TestCase):
+    """The nested emitters must guard EVERY mixture node against all-children--inf rows.
+
+    Without the guard, an impossible subtree turns ``-inf - (-inf)`` into NaN in both the score
+    (log-sum-exp) and the E-step responsibility pushdown, which then poisons the model LL and every
+    sufficient statistic. The numeric behavior is pinned in fused_out_of_support_test (numba); this
+    pins the emitted source itself.
+    """
+
+    def _built_tree(self):
+        inner1 = stats.MixtureDistribution(
+            components=[
+                stats.GaussianDistribution(mu=-1.0, sigma2=1.0),
+                stats.GaussianDistribution(mu=0.0, sigma2=2.0),
+            ],
+            w=[0.6, 0.4],
+        )
+        inner2 = stats.MixtureDistribution(
+            components=[stats.GaussianDistribution(mu=3.0, sigma2=1.0), stats.GaussianDistribution(mu=5.0, sigma2=0.5)],
+            w=[0.5, 0.5],
+        )
+        model = stats.MixtureDistribution(components=[inner1, inner2], w=[0.7, 0.3])
+        built = fused_nested.analyze_nested(model)
+        self.assertIsNotNone(built)
+        return built
+
+    def test_score_emitter_guards_every_mixture_node(self):
+        root, _ = self._built_tree()
+        lines: list[str] = []
+        fused_nested._emit_score(root, lines)
+        src = "\n".join(lines)
+        for mx in fused_nested._mixtures(root):
+            nid = mx.node_id
+            self.assertIn(
+                f"if mx{nid} > -np.inf else -np.inf",
+                src,
+                f"mixture node {nid} lacks the all-children--inf log-sum-exp guard",
+            )
+
+    def test_backward_emitter_falls_back_to_prior_weights(self):
+        root, _ = self._built_tree()
+        fwd: list[str] = []
+        fused_nested._emit_score(root, fwd)
+        bwd: list[str] = []
+        fused_nested._emit_backward(root, "wi", bwd)
+        src = "\n".join(bwd)
+        for mx in fused_nested._mixtures(root):
+            nid = mx.node_id
+            for j in range(len(mx.children)):
+                self.assertIn(
+                    f"if ns{nid} > -np.inf else np.exp(logw{nid}[{j}])",
+                    src,
+                    f"mixture node {nid} child {j} lacks the prior-weight responsibility fallback",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mixle/tests/fused_codegen_test.py
+++ b/mixle/tests/fused_codegen_test.py
@@ -327,7 +327,9 @@ class LeafFamilyTest(unittest.TestCase):
                 ang,
             ),
             ([stats.LogSeriesDistribution(0.4), stats.LogSeriesDistribution(0.7)], stats.LogSeriesEstimator, ge),
-            # Pareto: scale xm is the global min over x (a map-reducible reduction); all data >= xm
+            # Pareto: scale xm is the PER-COMPONENT min over rows with responsibility > 0 (the wmin
+            # accumulator); with shared supports it coincides with the global min. Differing supports
+            # are pinned by fused_out_of_support_test.
             (
                 [stats.ParetoDistribution(0.5, 2.0), stats.ParetoDistribution(0.5, 4.0)],
                 stats.ParetoEstimator,

--- a/mixle/tests/fused_out_of_support_test.py
+++ b/mixle/tests/fused_out_of_support_test.py
@@ -1,0 +1,264 @@
+"""Out-of-support and impossible rows through the compiled fused paths.
+
+Every case pins fused-vs-host parity in a regime where a naive kernel silently diverges:
+
+* scoring parity with a leaf whose expr carries a real ``-np.inf`` branch (Pareto below its scale):
+  full ``fastmath=True`` (ninf/nnan) genuinely miscompiled this -- positive log-densities -- so the
+  parity here is the regression net for the no-ninf/nnan compile policy;
+* a row impossible under EVERY component: the E-step must fall back to the prior mixture weights
+  (the legacy accumulator's convention) and score the row -inf instead of NaN-poisoning counts,
+  statistics, and the fused-EM normalizer;
+* nested mixture-of-mixtures: the same guarantees at every mixture NODE, and ``wants_minmax``
+  leaves (Pareto) must decline nested fusion cleanly instead of crashing mid-fit;
+* the fused Pareto E-step's support minimum is PER-COMPONENT over rows with responsibility > 0
+  (the legacy statistic ``ParetoEstimator`` uses directly as the scale xm), never the global data
+  minimum -- including across parallel chunk combines, where minima must min-reduce, not sum.
+"""
+
+import unittest
+
+import numpy as np
+
+from mixle.utils.optional_deps import HAS_NUMBA
+
+if HAS_NUMBA:
+    import mixle.stats as stats
+    from mixle.stats.compute import fused_codegen as fc
+    from mixle.stats.compute import fused_nested as fn
+
+
+def _legacy_suff_stats(model, enc, weights):
+    est = model.estimator()
+    acc = est.accumulator_factory().make()
+    acc.seq_update(enc, weights, model)
+    return est, acc.value()
+
+
+@unittest.skipUnless(HAS_NUMBA, "fused kernels require numba")
+class ParetoScoringParityTest(unittest.TestCase):
+    """D-1 regression: scoring parity with an out-of-support leaf, sequential and parallel."""
+
+    def _model(self):
+        return stats.MixtureDistribution(
+            components=[
+                stats.ParetoDistribution(xm=1.0, alpha=2.5),
+                stats.ParetoDistribution(xm=2.0, alpha=1.5),
+            ],
+            w=[0.5, 0.5],
+        )
+
+    def test_rows_below_one_component_scale_match_host_exactly(self):
+        # 1.2 / 1.5 / 1.1 sit below comp-2's xm: its -inf branch is live while the mixture stays
+        # finite. Under fastmath=True these rows scored POSITIVE log-densities (+1.38 / +1.57 /
+        # +1.36 measured); the subset-compiled kernel must agree with the host to the last digit.
+        model = self._model()
+        enc = model.dist_to_encoder().seq_encode([1.2, 1.5, 3.0, 5.0, 1.1])
+        host = model.seq_log_density(enc)
+        self.assertTrue(np.all(np.isfinite(host)))
+        for parallel in (False, True):
+            fused = fc.fused_seq_log_density(model, enc, parallel=parallel)
+            np.testing.assert_allclose(fused, host, rtol=1e-12, atol=0.0, err_msg=f"parallel={parallel}")
+
+    def test_row_below_every_scale_scores_minus_inf(self):
+        # complements the edge panel's categorical case with a SCALAR -inf leaf
+        model = self._model()
+        enc = model.dist_to_encoder().seq_encode([0.5, 3.0])
+        host = model.seq_log_density(enc)
+        self.assertTrue(np.isneginf(host[0]))
+        for parallel in (False, True):
+            fused = fc.fused_seq_log_density(model, enc, parallel=parallel)
+            self.assertTrue(np.isneginf(fused[0]), f"parallel={parallel}")
+            np.testing.assert_allclose(fused[1], host[1], rtol=1e-12)
+
+
+@unittest.skipUnless(HAS_NUMBA, "fused kernels require numba")
+class EstepImpossibleRowTest(unittest.TestCase):
+    """D-2: a row impossible under every component must not NaN-poison the fused E-step."""
+
+    def _model(self):
+        return stats.MixtureDistribution(
+            components=[
+                stats.CategoricalDistribution(pmap={"a": 0.7, "b": 0.3}),
+                stats.CategoricalDistribution(pmap={"a": 0.3, "b": 0.7}),
+            ],
+            w=[0.5, 0.5],
+        )
+
+    def test_impossible_row_falls_back_to_prior_weights_and_minus_inf_ll(self):
+        model = self._model()
+        data = ["a", "b", "c", "a"]  # "c" is impossible under BOTH components
+        enc = model.dist_to_encoder().seq_encode(data)
+        w = np.ones(len(data))
+        est, legacy = _legacy_suff_stats(model, enc, w)
+        self.assertTrue(np.all(np.isfinite(legacy[0])))
+        host_ll = float(w @ model.seq_log_density(enc))
+        self.assertTrue(np.isneginf(host_ll))
+        for parallel in (False, True):
+            suff, ll = fc.fused_accumulate(model, enc, w, return_ll=True, parallel=parallel)
+            # counts: finite, and exactly the legacy prior-weight fallback for the impossible row
+            np.testing.assert_allclose(suff[0], legacy[0], rtol=1e-12, err_msg=f"parallel={parallel}")
+            # the row's log-likelihood is -inf, matching seq_log_density (not NaN, not finite)
+            self.assertTrue(np.isneginf(ll), f"parallel={parallel}: ll={ll}")
+            # end to end: the M-step sees the same statistics the legacy accumulator produced
+            new_fused = est.estimate(len(data), suff)
+            new_host = est.estimate(len(data), legacy)
+            np.testing.assert_allclose(new_fused.seq_log_density(enc), new_host.seq_log_density(enc), rtol=1e-12)
+
+
+@unittest.skipUnless(HAS_NUMBA, "fused kernels require numba")
+class NestedImpossibleRowTest(unittest.TestCase):
+    """D-3: nested mixture nodes guard their log-sum-exp and responsibility pushdown.
+
+    Gaussian leaves overflow to a real ``-inf`` score at |x - mu| ~ 1e200 (the squared residual
+    exceeds the float64 range) on the host and fused paths alike, which makes an every-leaf
+    impossible row constructible from nested-fusible leaves.
+    """
+
+    def _model(self):
+        inner1 = stats.MixtureDistribution(
+            components=[
+                stats.GaussianDistribution(mu=-1.0, sigma2=1.0),
+                stats.GaussianDistribution(mu=0.0, sigma2=2.0),
+            ],
+            w=[0.6, 0.4],
+        )
+        inner2 = stats.MixtureDistribution(
+            components=[stats.GaussianDistribution(mu=3.0, sigma2=1.0), stats.GaussianDistribution(mu=5.0, sigma2=0.5)],
+            w=[0.5, 0.5],
+        )
+        return stats.MixtureDistribution(components=[inner1, inner2], w=[0.7, 0.3])
+
+    def test_impossible_row_scores_minus_inf_at_every_level(self):
+        model = self._model()
+        data = [0.5, 1.0e200, 3.2]
+        enc = model.dist_to_encoder().seq_encode(data)
+        with np.errstate(over="ignore"):
+            host = model.seq_log_density(enc)
+        self.assertTrue(np.isneginf(host[1]) and np.isfinite(host[0]) and np.isfinite(host[2]))
+        for parallel in (False, True):
+            fused = fn.fused_nested_seq_log_density(model, enc, parallel=parallel)
+            np.testing.assert_allclose(fused, host, rtol=1e-12, err_msg=f"parallel={parallel}")
+
+    def test_estep_impossible_row_falls_back_to_prior_weights_recursively(self):
+        model = self._model()
+        data = [0.5, 1.0e200, 3.2]
+        enc = model.dist_to_encoder().seq_encode(data)
+        w = np.ones(len(data))
+        with np.errstate(over="ignore"):
+            est, legacy = _legacy_suff_stats(model, enc, w)
+            suff, ll = fn.fused_nested_accumulate(model, enc, w, return_ll=True)
+        # root and inner mixture counts: the impossible row contributes the PRIOR weights at every
+        # level (0.7/0.3 outer times 0.6/0.4 and 0.5/0.5 inner), exactly as the legacy accumulator
+        np.testing.assert_allclose(np.asarray(suff[0]), np.asarray(legacy[0]), rtol=1e-12)
+        for j in range(2):
+            np.testing.assert_allclose(np.asarray(suff[1][j][0]), np.asarray(legacy[1][j][0]), rtol=1e-12)
+            for leaf_fused, leaf_legacy in zip(suff[1][j][1], legacy[1][j][1]):
+                np.testing.assert_allclose(np.asarray(leaf_fused), np.asarray(leaf_legacy), rtol=1e-12)
+        self.assertTrue(np.isneginf(ll))
+
+
+@unittest.skipUnless(HAS_NUMBA, "fused kernels require numba")
+class NestedMinmaxDeclineTest(unittest.TestCase):
+    """D-4: minmax leaves decline nested fusion with the DECLARED ValueError, never a mid-fit crash."""
+
+    def _model(self):
+        inner1 = stats.MixtureDistribution(
+            components=[stats.ParetoDistribution(xm=1.0, alpha=2.0), stats.ParetoDistribution(xm=2.0, alpha=3.0)],
+            w=[0.6, 0.4],
+        )
+        inner2 = stats.MixtureDistribution(
+            components=[stats.ParetoDistribution(xm=1.5, alpha=1.5), stats.ParetoDistribution(xm=3.0, alpha=2.5)],
+            w=[0.5, 0.5],
+        )
+        return stats.MixtureDistribution(components=[inner1, inner2], w=[0.7, 0.3])
+
+    def test_nested_pareto_mixture_declines_instead_of_crashing(self):
+        model = self._model()
+        data = [1.2, 3.0, 0.3]  # 0.3 is below every xm: out of support everywhere
+        enc = model.dist_to_encoder().seq_encode(data)
+        self.assertFalse(fc.fusible(model))
+        self.assertFalse(fc.fusible_estep(model))
+        # the wrappers refuse up front (previously: scoring returned NaN on the 0.3 row and the
+        # E-step crashed with ``TypeError: 'NoneType' object is not callable`` mid-fit)
+        with self.assertRaises(ValueError):
+            fn.fused_nested_seq_log_density(model, enc)
+        with self.assertRaises(ValueError):
+            fn.fused_nested_accumulate(model, enc, np.ones(len(data)))
+        # the host path these models now take scores the out-of-support row -inf and the rest finite
+        host = model.seq_log_density(enc)
+        self.assertTrue(np.isfinite(host[0]) and np.isfinite(host[1]) and np.isneginf(host[2]))
+
+
+@unittest.skipUnless(HAS_NUMBA, "fused kernels require numba")
+class ParetoEstepMinimaTest(unittest.TestCase):
+    """D-5: the fused Pareto suff-stat minimum is per-component and weighted, not the global min."""
+
+    def _model(self):
+        return stats.MixtureDistribution(
+            components=[
+                stats.ParetoDistribution(xm=1.0, alpha=2.5),
+                stats.ParetoDistribution(xm=2.0, alpha=1.5),
+            ],
+            w=[0.5, 0.5],
+        )
+
+    def test_per_component_weighted_minimum_matches_legacy(self):
+        model = self._model()
+        data = [1.2, 1.5, 3.0, 5.0, 1.1]  # comp-2 has responsibility > 0 only on 3.0 and 5.0
+        enc = model.dist_to_encoder().seq_encode(data)
+        w = np.ones(len(data))
+        est, legacy = _legacy_suff_stats(model, enc, w)
+        self.assertEqual([v[2] for v in legacy[1]], [1.1, 3.0])
+        for parallel in (False, True):
+            suff = fc.fused_accumulate(model, enc, w, parallel=parallel)
+            # the global data minimum (1.1) is WRONG for comp-2: its scale would collapse below xm
+            self.assertEqual(
+                [v[2] for v in suff[1]], [1.1, 3.0], f"parallel={parallel}: fused minima are not per-component"
+            )
+            np.testing.assert_allclose(suff[0], legacy[0], rtol=1e-12)
+            for k in range(2):
+                np.testing.assert_allclose(np.asarray(suff[1][k]), np.asarray(legacy[1][k]), rtol=1e-12)
+            # ParetoEstimator uses the minimum directly as xm: the M-step must land on legacy's scales
+            new_fused = est.estimate(len(data), suff)
+            new_host = est.estimate(len(data), legacy)
+            self.assertEqual([c.xm for c in new_fused.components], [c.xm for c in new_host.components])
+
+    def test_component_with_no_support_keeps_infinite_minimum(self):
+        # no row reaches comp-2 (xm=100): its weighted minimum must stay +inf exactly like the
+        # legacy accumulator's untouched init, not 0.0 or the global data minimum
+        model = stats.MixtureDistribution(
+            components=[
+                stats.ParetoDistribution(xm=1.0, alpha=2.0),
+                stats.ParetoDistribution(xm=100.0, alpha=2.0),
+            ],
+            w=[0.5, 0.5],
+        )
+        data = [1.5, 2.5, 4.0]
+        enc = model.dist_to_encoder().seq_encode(data)
+        w = np.ones(len(data))
+        _, legacy = _legacy_suff_stats(model, enc, w)
+        suff = fc.fused_accumulate(model, enc, w)
+        self.assertEqual([v[2] for v in suff[1]], [v[2] for v in legacy[1]])
+        self.assertTrue(np.isposinf(suff[1][1][2]))
+
+    def test_parallel_chunk_combine_min_reduces_the_minima(self):
+        # enough rows for two REAL chunks (n // 16384 == 2): a sum-combine of per-chunk minima
+        # (the classic threaded-merge bug) would corrupt xm; the combine must min-reduce
+        rng = np.random.RandomState(7)
+        model = self._model()
+        data = np.concatenate(
+            [
+                (rng.pareto(2.5, size=20_000) + 1.0) * 1.0,
+                (rng.pareto(1.5, size=20_000) + 1.0) * 2.0,
+            ]
+        ).tolist()
+        enc = model.dist_to_encoder().seq_encode(data)
+        w = np.ones(len(data))
+        _, legacy = _legacy_suff_stats(model, enc, w)
+        suff = fc.fused_accumulate(model, enc, w, parallel=True)
+        self.assertEqual([v[2] for v in suff[1]], [v[2] for v in legacy[1]])
+        np.testing.assert_allclose(suff[0], legacy[0], rtol=1e-9)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes ledger findings **D-1, D-2, D-3, D-4, D-5, D-7** (audit/CODEBASE_REVIEW_LEDGER.md §II.D — full review PR to follow).

## Why
- **D-1 (HIGH):** `_njit` compiled every generated kernel with `fastmath=True` (LLVM `ninf`/`nnan`) while kernels rely on −inf out-of-support scores and the `m > -inf` guard — verified real miscompilation: a Pareto mixture returned **positive** log-densities (+1.36) on rows where one component is out of support, and `optimize()` auto-fusion routes fusible models here silently. Kernels now compile with the value-safe subset only.
- **D-2 (HIGH):** the fused E-step lacked the all-components-impossible guard the scorer has → `-inf - (-inf) = NaN` poisoned sufficient statistics. Guard ported.
- **D-3:** nested emitter guards every mixture node's log-sum-exp.
- **D-4:** nested fusion declines `wants_minmax` templates (previously crashed `TypeError: 'NoneType' object is not callable` mid-fit).
- **D-5:** fused Pareto E-step now tracks per-component weighted support minima (was: global data min fed to every component's scale estimate).
- **D-7:** same fastmath policy applied to the HMM/tree-HMM numba kernels.

## Test plan
- New `mixle/tests/fused_out_of_support_test.py` (numba-gated) + `mixle/tests/fastmath_policy_test.py`: fused-vs-legacy scoring parity with out-of-support leaves, all-impossible-row E-step guards (flat + nested), wants_minmax decline, per-component minima.
- Fail-before verified at unfixed HEAD: **11 failed**; after fix: **61/61 pass** (including the existing `fused_codegen_test.py` suite).
- End-to-end repro: Pareto-mixture fused scores now exactly match legacy (`[-0.547, -1.216, -1.686, -3.605, -0.286]`).
- `ruff format` + `ruff check` clean.

CHANGELOG entry deferred to the consolidated review-fixes PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)