### PR TITLE
fix(uq): one-sided test inversion, conformal J+ indices, SIS weights, Geyer ESS, exact p-values

### DIFF
--- a/mixle/inference/conformal.py
+++ b/mixle/inference/conformal.py
@@ -49,6 +49,26 @@ def _conformal_quantile(scores: np.ndarray, alpha: float) -> float:
     return float(s[k - 1])
 
 
+def _jackknife_plus_bounds(lo_vals: np.ndarray, hi_vals: np.ndarray, alpha: float) -> tuple[np.ndarray, np.ndarray]:
+    """Barber et al. (2021) finite-sample J+/CV+ endpoints from ``(n, m)`` per-fold bound matrices.
+
+    Per test point, the lower endpoint is the ``floor(alpha (n+1))``-th smallest of
+    ``mu_{-i}(x) - R_i`` and the upper the ``ceil((1-alpha)(n+1))``-th smallest of
+    ``mu_{-i}(x) + R_i`` -- the explicit ``(n+1)``-based order statistics that carry the J+
+    coverage guarantee (mirroring :func:`_conformal_quantile`; ``np.quantile``'s ``(n-1)``-based
+    virtual indices do not). An out-of-range index (small ``n`` for the requested ``alpha``)
+    yields the honest unbounded endpoint ``-inf`` / ``+inf``.
+    """
+    if not 0.0 <= alpha <= 1.0:
+        raise ValueError(f"alpha must be in [0.0, 1.0], got {alpha!r}.")
+    n, m = lo_vals.shape
+    k_lo = int(np.floor(alpha * (n + 1)))
+    k_hi = int(np.ceil((1.0 - alpha) * (n + 1)))
+    lower = np.full(m, -np.inf) if k_lo < 1 else np.sort(lo_vals, axis=0)[k_lo - 1]
+    upper = np.full(m, np.inf) if k_hi > n else np.sort(hi_vals, axis=0)[k_hi - 1]
+    return lower, upper
+
+
 def split_conformal(
     cal_pred: np.ndarray,
     cal_y: np.ndarray,
@@ -116,9 +136,7 @@ def jackknife_plus(
         preds = np.asarray(fit_predict(x[mask], y[mask], eval_pts), dtype=float).ravel()
         resid[i] = abs(y[i] - preds[0])
         loo_test[i] = preds[1:]
-    lower = np.quantile(loo_test - resid[:, None], alpha, axis=0, method="lower")
-    upper = np.quantile(loo_test + resid[:, None], 1.0 - alpha, axis=0, method="higher")
-    return lower, upper
+    return _jackknife_plus_bounds(loo_test - resid[:, None], loo_test + resid[:, None], alpha)
 
 
 def cv_plus(
@@ -155,9 +173,7 @@ def cv_plus(
         k = fold.shape[0]
         resid[fold] = np.abs(y[fold] - preds[:k])
         loo_test[fold] = np.tile(preds[k:], (k, 1))
-    lower = np.quantile(loo_test - resid[:, None], alpha, axis=0, method="lower")
-    upper = np.quantile(loo_test + resid[:, None], 1.0 - alpha, axis=0, method="higher")
-    return lower, upper
+    return _jackknife_plus_bounds(loo_test - resid[:, None], loo_test + resid[:, None], alpha)
 
 
 def mondrian_conformal(

--- a/mixle/inference/diagnostics.py
+++ b/mixle/inference/diagnostics.py
@@ -55,13 +55,53 @@ def rhat(chains: Any) -> np.ndarray:
     return np.where(w > 0.0, out, 1.0)
 
 
+def _geyer_tau(centered: np.ndarray, var: np.ndarray, lag_limit: int) -> np.ndarray:
+    """Integrated autocorrelation time per component via Geyer's initial monotone sequence.
+
+    Args:
+        centered: ``(n_chains, n_draws, k)`` draws, each chain centered by its own mean.
+        var: ``(k,)`` pooled variances of ``centered`` (all strictly positive).
+        lag_limit: largest autocorrelation lag considered.
+
+    Autocorrelations are pooled across chains and paired lag-by-lag (``P_0 = rho_0 + rho_1``,
+    ``P_j = rho_{2j} + rho_{2j+1}``). Each component *independently* sums its pairs up to (not
+    including) its first non-positive pair -- Geyer's initial positive sequence -- with the retained
+    pairs additionally forced non-increasing (initial monotone sequence), giving
+    ``tau = 2 * sum(P) - 1`` (Geyer 1992). Truncating per component at its own noise floor is what
+    keeps one slowly-mixing component from letting the others accumulate positive autocorrelation
+    noise at post-cutoff lags.
+    """
+    m, n, k = centered.shape
+    if lag_limit < 1:
+        return np.ones(k, dtype=float)
+    psum = np.zeros(k, dtype=float)
+    prev = np.full(k, np.inf)
+    active = np.ones(k, dtype=bool)
+    lag = 0
+    while np.any(active) and lag + 1 <= lag_limit:
+        if lag == 0:
+            rho_even = np.ones(k, dtype=float)
+        else:
+            rho_even = np.mean(centered[:, :-lag] * centered[:, lag:], axis=(0, 1)) / var
+        rho_odd = np.mean(centered[:, : -(lag + 1)] * centered[:, lag + 1 :], axis=(0, 1)) / var
+        pair = np.minimum(rho_even + rho_odd, prev)
+        active &= pair > 0.0
+        psum = np.where(active, psum + pair, psum)
+        prev = np.where(active, pair, prev)
+        lag += 2
+    tau = 2.0 * psum - 1.0
+    # positivity floor for (near-)antithetic chains (rho_1 ~ -1), Stan's 1/log10(N) convention
+    return np.maximum(tau, 1.0 / np.log10(max(float(m * n), 10.0)))
+
+
 def ess(samples: Any, max_lag: int | None = None) -> np.ndarray:
-    """Effective sample size per parameter from positive autocorrelation lags.
+    """Effective sample size per parameter, ``n / tau`` with Geyer's initial-monotone-sequence ``tau``.
 
     Accepts a single chain ``(n_draws,)`` / ``(n_draws, d)`` or a stack of chains
     ``(n_chains, n_draws, d)`` (the chains are pooled into one autocorrelation estimate after
-    centering each chain by its own mean). Uses the initial-positive-sequence truncation
-    (Geyer): sum autocorrelations until the first non-positive lag.
+    centering each chain by its own mean). Adjacent-lag autocorrelation pairs are summed until the
+    first non-positive pair, independently per parameter, with the retained pairs forced
+    non-increasing (Geyer 1992) -- see :func:`_geyer_tau`.
 
     Returns:
         A length-``d`` array of ESS values.
@@ -85,15 +125,7 @@ def ess(samples: Any, max_lag: int | None = None) -> np.ndarray:
     if not np.any(nonzero):
         return out
     lag_limit = n - 1 if max_lag is None else min(int(max_lag), n - 1)
-    tau = np.ones(int(nonzero.sum()), dtype=float)
-    cvar = var[nonzero]
-    cc = centered[:, :, nonzero]
-    for lag in range(1, lag_limit + 1):
-        rho = np.mean(cc[:, :-lag] * cc[:, lag:], axis=(0, 1)) / cvar
-        positive = rho > 0.0
-        if not np.any(positive):
-            break
-        tau += 2.0 * np.where(positive, rho, 0.0)
+    tau = _geyer_tau(centered[:, :, nonzero], var[nonzero], lag_limit)
     out[nonzero] = np.maximum(1.0, n_total / tau)
     return out
 
@@ -114,7 +146,7 @@ def _rank_normalize(arr: np.ndarray) -> np.ndarray:
     out = np.empty_like(arr)
     for k in range(d):
         ranks = rankdata(arr[:, :, k].ravel(), method="average")
-        out[:, :, k] = ndtri((ranks - 0.375) / (total - 0.25)).reshape(m, n)
+        out[:, :, k] = ndtri((ranks - 0.375) / (total + 0.25)).reshape(m, n)
     return out
 
 

--- a/mixle/inference/glm.py
+++ b/mixle/inference/glm.py
@@ -77,6 +77,9 @@ _LINKS: dict[str, Link] = {
         lambda eta: np.exp(eta - np.exp(eta)),
     ),
     "inverse": Link("inverse", lambda mu: 1.0 / mu, lambda eta: 1.0 / eta, lambda eta: -1.0 / eta**2),
+    "inverse_squared": Link(
+        "inverse_squared", lambda mu: 1.0 / mu**2, lambda eta: 1.0 / np.sqrt(eta), lambda eta: -0.5 * eta**-1.5
+    ),
     "sqrt": Link("sqrt", lambda mu: np.sqrt(mu), lambda eta: eta**2, lambda eta: 2.0 * eta),
 }
 
@@ -86,7 +89,14 @@ _LINKS: dict[str, Link] = {
 
 @dataclass(frozen=True)
 class Family:
-    """An exponential-family error model: variance function, canonical link, deviance, dispersion."""
+    """An exponential-family error model: variance function, canonical link, deviance, dispersion.
+
+    ``canonical`` names the family's *mathematical* canonical link; ``default_link`` (when set) is
+    the link :func:`glm` fits with when none is requested. They are separate so families whose
+    canonical link is numerically awkward (gamma's ``inverse``, inverse-Gaussian's
+    ``inverse_squared`` -- neither keeps ``mu`` positive) can default to ``log`` without mislabeling
+    the canonical link.
+    """
 
     name: str
     variance: Callable[[np.ndarray], np.ndarray]
@@ -94,6 +104,7 @@ class Family:
     unit_deviance: Callable[[np.ndarray, np.ndarray], np.ndarray]
     estimate_dispersion: bool
     extra: float = 1.0  # negative-binomial theta
+    default_link: str | None = None  # fitting default when it differs from the canonical link
 
 
 def _binom_dev(y: np.ndarray, mu: np.ndarray) -> np.ndarray:
@@ -132,8 +143,22 @@ _FAMILIES: dict[str, Family] = {
     "gaussian": Family("gaussian", lambda mu: np.ones_like(mu), "identity", lambda y, mu: (y - mu) ** 2, True),
     "binomial": Family("binomial", lambda mu: _clip01(mu) * (1 - _clip01(mu)), "logit", _binom_dev, False),
     "poisson": Family("poisson", lambda mu: mu, "log", _pois_dev, False),
-    "gamma": Family("gamma", lambda mu: mu**2, "log", _gamma_dev, True),
-    "inverse_gaussian": Family("inverse_gaussian", lambda mu: mu**3, "log", _ig_dev, True),
+    "gamma": Family(
+        name="gamma",
+        variance=lambda mu: mu**2,
+        canonical="inverse",
+        unit_deviance=_gamma_dev,
+        estimate_dispersion=True,
+        default_link="log",
+    ),
+    "inverse_gaussian": Family(
+        name="inverse_gaussian",
+        variance=lambda mu: mu**3,
+        canonical="inverse_squared",
+        unit_deviance=_ig_dev,
+        estimate_dispersion=True,
+        default_link="log",
+    ),
 }
 
 
@@ -243,7 +268,9 @@ def glm(
         y: ``(n,)`` response (counts, 0/1 or proportions, positive reals, ... per the family).
         family: ``"gaussian"``, ``"binomial"``, ``"poisson"``, ``"gamma"``, ``"inverse_gaussian"``,
             ``"negativebinomial"``, or a :class:`Family`.
-        link: link name; defaults to the family's canonical link.
+        link: link name; defaults to the family's default link (the canonical link, except gamma /
+            inverse-Gaussian which default to ``log`` -- their canonical ``inverse`` /
+            ``inverse_squared`` links do not keep ``mu`` positive).
         offset: ``(n,)`` known additive term on the linear-predictor scale (e.g. ``log`` exposure).
         weights: ``(n,)`` prior weights.
         max_iter, tol: IRLS controls (convergence on the relative deviance change).
@@ -258,7 +285,7 @@ def glm(
     fam = _resolve_family(
         family, getattr(family, "extra", 1.0) if isinstance(family, Family) else _nb_theta_default(family)
     )
-    lk = _LINKS[link or fam.canonical]
+    lk = _LINKS[link or fam.default_link or fam.canonical]
     off = np.zeros(n) if offset is None else np.asarray(offset, dtype=float).ravel()
     w = np.ones(n) if weights is None else np.asarray(weights, dtype=float).ravel()
 

--- a/mixle/inference/mcmc/nuts_numba.py
+++ b/mixle/inference/mcmc/nuts_numba.py
@@ -122,7 +122,7 @@ def _nuts_core(value_and_grad, theta0, num_samples, warmup, mass, target_accept,
     t0 = 10.0
     kappa = 0.75
 
-    n_keep = num_samples // thin
+    n_keep = num_samples  # retained draws; num_samples * thin post-warmup iterations, keep every thin-th
     samples = np.empty((n_keep, d))
     kept = 0
     total = warmup + num_samples * thin

--- a/mixle/inference/mcmc/samplers.py
+++ b/mixle/inference/mcmc/samplers.py
@@ -15,6 +15,8 @@ from typing import Any
 
 import numpy as np
 
+from mixle.inference.diagnostics import _geyer_tau
+
 from .proposals import Proposal, _normalize_transition_proposals
 
 LogTarget = Callable[[Any], float]
@@ -59,10 +61,11 @@ class MCMCResult:
         return arr
 
     def effective_sample_size(self, max_lag: int | None = None) -> Any:
-        """Estimate effective sample size using positive autocorrelation lags.
+        """Estimate effective sample size via Geyer's initial monotone sequence, per component.
 
         Scalar samples return a float. Vector samples return one ESS value per
-        trailing dimension.
+        trailing dimension (each component's autocorrelation sum truncates
+        independently at its own first non-positive adjacent-lag pair).
         """
         arr = self.sample_array()
         n = int(arr.shape[0])
@@ -77,15 +80,7 @@ class MCMCResult:
             return float(ess[0]) if arr.ndim == 1 else ess.reshape(arr.shape[1:])
 
         lag_limit = n - 1 if max_lag is None else min(int(max_lag), n - 1)
-        tau = np.ones(int(np.sum(positive_var)), dtype=float)
-        centered_pos = centered[:, positive_var]
-        var_pos = var[positive_var]
-        for lag in range(1, lag_limit + 1):
-            rho = np.mean(centered_pos[:-lag] * centered_pos[lag:], axis=0) / var_pos
-            positive = rho > 0.0
-            if not np.any(positive):
-                break
-            tau += 2.0 * np.where(positive, rho, 0.0)
+        tau = _geyer_tau(centered[None, :, positive_var], var[positive_var], lag_limit)
         ess[positive_var] = np.maximum(1.0, n / tau)
         return float(ess[0]) if arr.ndim == 1 else ess.reshape(arr.shape[1:])
 
@@ -524,27 +519,34 @@ def particle_filter(
     particles, rng)`` returns the particles advanced one step through the transition (including process
     noise); ``log_likelihood(particles, y)`` returns the per-particle observation log-density. Each step
     reweights by the likelihood, records the weighted-mean filtered state, and (by default) multinomially
-    resamples to fight weight degeneracy. Returns ``(filtered_means, log_likelihood)`` where the second
-    value is the SMC estimate of the model's marginal log-likelihood ``log p(y_1:T)`` (an unbiased
-    evidence estimate, usable for parameter inference). For a linear-Gaussian model it converges to the
-    exact Kalman filter as ``N -> infinity``.
+    resamples to fight weight degeneracy; with ``resample=False`` it is sequential importance sampling,
+    carrying the weight product ``w_t = w_{t-1} * p(y_t | x_t)`` across steps. Returns
+    ``(filtered_means, log_likelihood)`` where the second value is the SMC estimate of the model's
+    marginal log-likelihood ``log p(y_1:T)`` (an unbiased evidence estimate, usable for parameter
+    inference). For a linear-Gaussian model it converges to the exact Kalman filter as ``N -> infinity``.
     """
     rng = np.random.RandomState() if rng is None else rng
     particles = np.array(initial_particles, dtype=np.float64)
     n = particles.shape[0]
     means: list[np.ndarray] = []
     log_lik = 0.0
+    log_w_cum = np.zeros(n)  # carried log-weights (uniform again after every resample)
     for y in observations:
         particles = np.asarray(propagate(particles, rng), dtype=np.float64)
-        log_w = np.asarray(log_likelihood(particles, y), dtype=np.float64)
-        max_lw = float(np.max(log_w))
-        weights = np.exp(log_w - max_lw)
+        log_w_cum = log_w_cum + np.asarray(log_likelihood(particles, y), dtype=np.float64)
+        max_lw = float(np.max(log_w_cum))
+        weights = np.exp(log_w_cum - max_lw)
         w_sum = float(weights.sum())
-        log_lik += max_lw + np.log(w_sum / n)  # marginal-likelihood increment (log-sum-exp / N)
         weights = weights / w_sum
         means.append(weights @ particles)
         if resample:
+            # weights entered this step uniform, so log mean w is the per-step evidence increment
+            log_lik += max_lw + np.log(w_sum / n)
             particles = particles[rng.choice(n, size=n, p=weights)]
+            log_w_cum = np.zeros(n)
+        else:
+            # pure SIS: the evidence estimate is the mean carried weight, log p(y_1:t) ~= log mean_i w_t^i
+            log_lik = max_lw + np.log(w_sum / n)
     return np.array(means), log_lik
 
 

--- a/mixle/inference/nonparametric.py
+++ b/mixle/inference/nonparametric.py
@@ -112,9 +112,11 @@ class TestResult:
 def brunner_munzel(x: Any, y: Any, *, alternative: str = "two-sided", distribution: str = "t") -> TestResult:
     """Brunner-Munzel test: the generalized Wilcoxon test that does not assume equal variances/shapes.
 
-    Tests the stochastic-equality null ``P(x < y) + 0.5 P(x = y) = 1/2``. ``distribution='t'`` uses a
-    Satterthwaite t reference (recommended for small samples); ``'normal'`` the normal approximation.
-    Reports the estimated relative effect ``p_hat = P(x < y) + 0.5 P(x = y)`` in ``extra``.
+    Tests the stochastic-equality null ``P(x < y) + 0.5 P(x = y) = 1/2``. ``alternative`` is
+    ``'two-sided'``, ``'greater'`` (x > y), or ``'less'`` -- the same direction convention as
+    :func:`mann_whitney_u` (and scipy). ``distribution='t'`` uses a Satterthwaite t reference
+    (recommended for small samples); ``'normal'`` the normal approximation. Reports the estimated
+    relative effect ``p_hat = P(x < y) + 0.5 P(x = y)`` in ``extra``.
     """
     x = np.asarray(x, dtype=float).ravel()
     y = np.asarray(y, dtype=float).ravel()
@@ -140,10 +142,10 @@ def brunner_munzel(x: Any, y: Any, *, alternative: str = "two-sided", distributi
         extra = {"p_hat": float(p_hat)}
     if alternative == "two-sided":
         p = 2.0 * dist.sf(abs(w))
-    elif alternative == "greater":
-        p = dist.sf(w)
-    elif alternative == "less":
+    elif alternative == "greater":  # x > y pushes the y-ranks (and w) DOWN: lower tail
         p = dist.cdf(w)
+    elif alternative == "less":
+        p = dist.sf(w)
     else:
         raise ValueError("alternative must be 'two-sided', 'greater', or 'less'.")
     return TestResult(float(w), float(min(p, 1.0)), extra)
@@ -316,8 +318,9 @@ def wilcoxon_signed_rank(
 
     Ranks ``|d|`` for ``d = x - y`` (mid-ranks for ties), splits into positive / negative rank sums, and
     uses the tie-corrected normal approximation. ``zero_method='wilcox'`` drops zero differences (and
-    their ranks); ``'pratt'`` keeps them in the ranking but drops them from the sums. The matched-pairs
-    rank-biserial correlation is reported as the effect size.
+    their ranks); ``'pratt'`` keeps them in the ranking but drops them from the sums, with the matching
+    Pratt/Cureton zero corrections applied to the null mean and variance (as scipy does). The
+    matched-pairs rank-biserial correlation is reported as the effect size.
     """
     x = np.asarray(x, dtype=float).ravel()
     d = x if y is None else x - np.asarray(y, dtype=float).ravel()
@@ -327,15 +330,22 @@ def wilcoxon_signed_rank(
     if n == 0:
         return WilcoxonResult(0.0, 0.0, 1.0, 0.0, alternative)
     r = _ranks(np.abs(d))
+    n_zero = 0
     if zero_method == "pratt":
+        n_zero = int(np.sum(d == 0))
         keep = d != 0
         r, d = r[keep], d[keep]
     r_plus = float(r[d > 0].sum())
     r_minus = float(r[d < 0].sum())
-    nn = d.size
+    nn = d.size + n_zero  # the ranked count (zeros stay in the ranking under 'pratt')
     t = min(r_plus, r_minus)
-    mu = nn * (nn + 1) / 4.0
-    sigma = np.sqrt((nn * (nn + 1) * (2 * nn + 1) - 0.5 * _tie_term(r)) / 24.0)
+    # Pratt/Cureton (1967) zero corrections: the zero block occupies the lowest ranks but contributes
+    # to neither sum, so its share is subtracted from the null mean and variance (no-op when n_zero=0);
+    # ties among the remaining |d| correct the variance as usual.
+    mu = (nn * (nn + 1) - n_zero * (n_zero + 1)) / 4.0
+    sigma = np.sqrt(
+        (nn * (nn + 1) * (2 * nn + 1) - n_zero * (n_zero + 1) * (2 * n_zero + 1) - 0.5 * _tie_term(r)) / 24.0
+    )
     if sigma == 0:
         z, p = 0.0, 1.0
     else:

--- a/mixle/inference/resampling.py
+++ b/mixle/inference/resampling.py
@@ -137,7 +137,9 @@ def bootstrap(
         groups: ``(n,)`` labels for **stratified** resampling (resample within each group).
         clusters: ``(n,)`` labels for **cluster** resampling (resample whole clusters with replacement).
         block_length: moving-**block** length for serially dependent (time-series) data.
-        m: subsample size for **m-out-of-n** subsampling (without replacement).
+        m: subsample size for **m-out-of-n** subsampling (without replacement). Replicates are
+            rescaled about the point estimate by ``sqrt(m/n)`` (Politis--Romano), so the returned
+            distribution / interval / standard error are at full-sample scale.
 
     Returns:
         A :class:`BootstrapResult`.
@@ -150,6 +152,11 @@ def bootstrap(
     for b in range(n_boot):
         idx = _resample_indices(n, rng, groups=groups, clusters=clusters, block_length=block_length, m=m)
         reps[b] = _call(statistic, _take(data, idx))
+    if m is not None and m < n:
+        # Politis-Romano m-out-of-n rescaling: a size-m subsample statistic fluctuates at the
+        # sqrt(m) rate, so shrink the replicates about the point estimate by sqrt(m/n) to put
+        # them at full-sample scale (assumes the usual sqrt(n)-consistent statistic).
+        reps = estimate + np.sqrt(m / n) * (reps - estimate)
 
     alpha = 1.0 - ci_level
     if method == "bca" and special:
@@ -323,8 +330,13 @@ def _mean_diff(x: np.ndarray, y: np.ndarray) -> float:
     return float(np.mean(x) - np.mean(y))
 
 
-def _pvalue(observed: float, null: np.ndarray, alternative: str) -> float:
-    """Monte-Carlo / exact p-value with the +1 finite-sample correction."""
+def _pvalue(observed: float, null: np.ndarray, alternative: str, *, exact: bool = False) -> float:
+    """Permutation p-value: ``count / n`` when the full group was enumerated, else Monte-Carlo.
+
+    With ``exact=True`` the null set already contains the identity rearrangement, so ``count / n``
+    IS the exact p-value; the ``(count + 1) / (n + 1)`` finite-sample correction (which adds the
+    identity to a *random* sample of rearrangements) would double-count it.
+    """
     n = null.size
     if alternative == "greater":
         count = np.sum(null >= observed)
@@ -334,6 +346,8 @@ def _pvalue(observed: float, null: np.ndarray, alternative: str) -> float:
         count = np.sum(np.abs(null) >= abs(observed))
     else:
         raise ValueError("alternative must be 'two-sided', 'greater', or 'less'.")
+    if exact:
+        return float(count / n)
     return float((count + 1) / (n + 1))
 
 
@@ -394,7 +408,8 @@ def permutation_test(
             for p in range(n_perm):
                 signs = rng.choice([-1.0, 1.0], size=n)
                 null[p] = stat(d * signs, np.zeros_like(d))
-        return PermutationResult(observed, _pvalue(observed, null, alternative), null, null.size, exact, alternative)
+        pval = _pvalue(observed, null, alternative, exact=exact)
+        return PermutationResult(observed, pval, null, null.size, exact, alternative)
 
     observed = stat(x, y)
     pooled = np.concatenate([x, y])
@@ -429,7 +444,8 @@ def permutation_test(
         for p in range(n_perm):
             perm = rng.permutation(pooled)
             null[p] = stat(perm[:nx], perm[nx:])
-    return PermutationResult(observed, _pvalue(observed, null, alternative), null, null.size, exact, alternative)
+    pval = _pvalue(observed, null, alternative, exact=exact)
+    return PermutationResult(observed, pval, null, null.size, exact, alternative)
 
 
 __all__ = [

--- a/mixle/inference/survival.py
+++ b/mixle/inference/survival.py
@@ -244,7 +244,7 @@ def cox_ph(
     cov = np.linalg.inv(-hess)
     se = np.sqrt(np.clip(np.diag(cov), 0.0, None))
 
-    # partial log-likelihood (Breslow) and Breslow baseline cumulative hazard
+    # partial log-likelihood (under the requested ties handling) and Breslow baseline cumulative hazard
     loglik = 0.0
     base_t, base_h = [], []
     for s in np.unique(strata):
@@ -256,8 +256,14 @@ def cox_ph(
             tied = (ts == et) & (es == 1)
             theta = np.exp(Xs[risk] @ beta)
             s0 = theta.sum()
-            loglik += float(np.sum(Xs[tied] @ beta)) - tied.sum() * np.log(s0)
-            cum += tied.sum() / s0
+            d = int(tied.sum())
+            loglik += float(np.sum(Xs[tied] @ beta))
+            if ties == "breslow" or d == 1:
+                loglik -= d * np.log(s0)
+            else:  # Efron: the denominator sheds a growing fraction of the tied-set mass
+                sd0 = np.exp(Xs[tied] @ beta).sum()
+                loglik -= float(np.sum(np.log(s0 - np.arange(d) / d * sd0)))
+            cum += d / s0
             base_t.append(et)
             base_h.append(cum)
     order = np.argsort(base_t)
@@ -458,7 +464,7 @@ def frailty_cox(
         res = _cox_offset(X, time, event, log_w, ties=ties)
         risk_score = np.exp(X @ res)
         base = _breslow_cumhaz(X, time, event, res)
-        H = base[np.searchsorted(np.unique(time[event == 1]), time, side="right").clip(0, len(base) - 1)]
+        H = _cumhaz_at(np.unique(time[event == 1]), base, time)
         w_post = np.empty(len(uniq))
         theta_terms = []
         for gi, g in enumerate(uniq):
@@ -530,6 +536,17 @@ def _breslow_cumhaz(X, time, event, beta):
         cum += tied.sum() / s0
         out.append(cum)
     return np.asarray(out)
+
+
+def _cumhaz_at(event_times, base, t):
+    """Evaluate the cumulative-hazard step function at arbitrary times ``t``.
+
+    ``base[j]`` is the cumulative hazard AT the sorted ``event_times[j]`` (its own increment
+    included); the step function is 0 before the first event and right-continuous, so a time
+    between events takes the value at the most recent event time ``<= t``.
+    """
+    step = np.concatenate([[0.0], np.asarray(base, dtype=float)])
+    return step[np.searchsorted(np.asarray(event_times, dtype=float), t, side="right")]
 
 
 __all__ = [

--- a/mixle/tests/uq_review_fixes_test.py
+++ b/mixle/tests/uq_review_fixes_test.py
@@ -1,0 +1,210 @@
+"""Regression tests for the UQ/statistical-test review fixes (ledger U-1..U-10, I-4, I-5).
+
+Each test pins a defect from audit/CODEBASE_REVIEW_LEDGER.md: inverted one-sided
+brunner_munzel tails (U-1), missing Pratt zero corrections (U-2), dropped SIS weight
+carryover in the particle filter (U-3), (n-1)-based jackknife+ endpoints (U-4), a
+noise-accumulating ESS truncation (U-5), thinning that shrank the retained draw count
+(U-6), an off-by-one cumulative-hazard lookup (U-7), the rank-normalize plotting
+position (U-8), Breslow log-likelihood reported for Efron fits (U-9), mislabeled
+canonical links (U-10), unrescaled m-out-of-n intervals (I-4), and the +1 correction
+applied to fully enumerated permutation nulls (I-5).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from scipy import stats as sps
+from scipy.special import ndtri
+
+from mixle.inference.conformal import jackknife_plus
+from mixle.inference.diagnostics import _rank_normalize, ess
+from mixle.inference.glm import _FAMILIES
+from mixle.inference.mcmc.samplers import particle_filter
+from mixle.inference.nonparametric import brunner_munzel, wilcoxon_signed_rank
+from mixle.inference.resampling import bootstrap, permutation_test
+from mixle.inference.survival import _cumhaz_at, cox_ph
+
+
+# --------------------------------------------------------------------- U-1: one-sided direction
+def test_brunner_munzel_one_sided_matches_scipy() -> None:
+    x = [1, 2, 1, 1, 1, 1, 1, 1, 1, 1, 2, 4, 1, 1]
+    y = [3, 3, 4, 3, 1, 2, 3, 1, 1, 5, 4]
+    for alternative in ("two-sided", "greater", "less"):
+        ours = brunner_munzel(x, y, alternative=alternative)
+        ref = sps.brunnermunzel(x, y, alternative=alternative)
+        assert ours.pvalue == pytest.approx(ref.pvalue, rel=1e-9), alternative
+
+
+# --------------------------------------------------------------------- U-2: Pratt zero corrections
+def test_wilcoxon_pratt_matches_scipy() -> None:
+    d = np.asarray([0.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 4.0])
+    ours = wilcoxon_signed_rank(d, zero_method="pratt")
+    ref = sps.wilcoxon(d, zero_method="pratt", correction=False, mode="approx")
+    assert ours.pvalue == pytest.approx(ref.pvalue, rel=1e-9)
+
+    rng = np.random.RandomState(seed=5)
+    for _ in range(20):
+        dd = rng.randint(-3, 4, size=12).astype(float)
+        if np.all(dd == 0):
+            continue
+        ours = wilcoxon_signed_rank(dd, zero_method="pratt")
+        ref = sps.wilcoxon(dd, zero_method="pratt", correction=False, mode="approx")
+        assert ours.pvalue == pytest.approx(ref.pvalue, rel=1e-9)
+
+
+# --------------------------------------------------------------------- U-3: SIS weight carryover
+def test_particle_filter_without_resampling_matches_kalman_evidence() -> None:
+    phi, q, r = 0.9, 0.3, 0.4
+    rng = np.random.RandomState(seed=7)
+    t_len = 12
+    x_true = np.zeros(t_len)
+    for t in range(1, t_len):
+        x_true[t] = phi * x_true[t - 1] + rng.normal(scale=np.sqrt(q))
+    ys = x_true + rng.normal(scale=np.sqrt(r), size=t_len)
+
+    # exact scalar Kalman log-likelihood
+    mean, var, ll_exact = 0.0, 1.0, 0.0
+    for y in ys:
+        pm, pv = phi * mean, phi * phi * var + q
+        s = pv + r
+        ll_exact += sps.norm.logpdf(y, loc=pm, scale=np.sqrt(s))
+        gain = pv / s
+        mean, var = pm + gain * (y - pm), (1.0 - gain) * pv
+
+    def propagate(particles: np.ndarray, prng: np.random.RandomState) -> np.ndarray:
+        return phi * particles + prng.normal(scale=np.sqrt(q), size=particles.shape)
+
+    def log_likelihood(particles: np.ndarray, y: float) -> np.ndarray:
+        return sps.norm.logpdf(y, loc=particles[:, 0], scale=np.sqrt(r))
+
+    init = np.random.RandomState(seed=11).normal(size=(4000, 1))
+    _, ll_sis = particle_filter(ys, propagate, log_likelihood, init, resample=False, rng=np.random.RandomState(seed=13))
+    assert ll_sis == pytest.approx(ll_exact, abs=0.75)
+
+
+# --------------------------------------------------------------------- U-4: J+ order statistics
+def test_jackknife_plus_uses_finite_sample_order_statistics() -> None:
+    def fit_predict(x_train: np.ndarray, y_train: np.ndarray, x_eval: np.ndarray) -> np.ndarray:
+        return np.full(len(x_eval), float(np.mean(y_train)))
+
+    rng = np.random.RandomState(seed=3)
+
+    # n=5, alpha=0.1: ceil(0.9*6)=6 > 5 and floor(0.1*6)=0 < 1 -> both endpoints unbounded
+    x5, y5 = rng.normal(size=(5, 1)), rng.normal(size=5)
+    lower, upper = jackknife_plus(x5, y5, fit_predict, x5[:2], alpha=0.1)
+    assert np.all(np.isinf(lower)) and np.all(lower < 0)
+    assert np.all(np.isinf(upper)) and np.all(upper > 0)
+
+    # n=12, alpha=0.1: lower is the 1st smallest of mu_-i - R_i, upper the 12th smallest (max)
+    x12, y12 = rng.normal(size=(12, 1)), rng.normal(size=12)
+    x_test = rng.normal(size=(3, 1))
+    lower, upper = jackknife_plus(x12, y12, fit_predict, x_test, alpha=0.1)
+    lo_mat = np.empty((12, 3))
+    hi_mat = np.empty((12, 3))
+    for i in range(12):
+        keep = np.arange(12) != i
+        mu_loo = fit_predict(x12[keep], y12[keep], x_test)
+        resid = abs(y12[i] - fit_predict(x12[keep], y12[keep], x12[i : i + 1])[0])
+        lo_mat[i], hi_mat[i] = mu_loo - resid, mu_loo + resid
+    np.testing.assert_allclose(lower, np.sort(lo_mat, axis=0)[0])
+    np.testing.assert_allclose(upper, np.sort(hi_mat, axis=0)[11])
+
+
+# --------------------------------------------------------------------- U-5: Geyer ESS truncation
+def test_ess_iid_vector_and_ar1_chains() -> None:
+    rng = np.random.RandomState(seed=17)
+    iid = rng.normal(size=(1, 1500, 6))
+    per_dim = ess(iid)
+    assert np.all(per_dim >= 0.75 * 1500), per_dim
+
+    rho, n = 0.9, 4000
+    chain = np.empty(n)
+    chain[0] = rng.normal()
+    for t in range(1, n):
+        chain[t] = rho * chain[t - 1] + rng.normal(scale=np.sqrt(1 - rho * rho))
+    theory = n * (1 - rho) / (1 + rho)
+    got = float(ess(chain[None, :, None])[0])
+    assert got == pytest.approx(theory, rel=0.35), (got, theory)
+
+
+# --------------------------------------------------------------------- U-6: nuts_numba thinning
+@pytest.mark.numba
+@pytest.mark.optional
+def test_nuts_numba_thin_keeps_num_samples() -> None:
+    numba = pytest.importorskip("numba")
+    from mixle.inference.mcmc.nuts_numba import nuts_numba
+
+    @numba.njit(cache=False)
+    def value_and_grad(x: np.ndarray) -> tuple[float, np.ndarray]:
+        return -0.5 * np.sum(x * x), -x
+
+    result = nuts_numba(value_and_grad, np.zeros(2), num_samples=50, warmup=50, thin=3)
+    assert np.asarray(result.samples).shape[0] == 50
+
+
+# --------------------------------------------------------------------- U-7: cumulative-hazard lookup
+def test_cumhaz_step_function_is_right_continuous_from_zero() -> None:
+    event_times = np.asarray([1.0, 2.0, 3.0])
+    base = np.asarray([0.1, 0.3, 0.6])
+    t = np.asarray([0.5, 1.0, 1.5, 2.0, 2.5])
+    np.testing.assert_allclose(_cumhaz_at(event_times, base, t), [0.0, 0.1, 0.1, 0.3, 0.3])
+
+
+# --------------------------------------------------------------------- U-9: Efron reported loglik
+def test_cox_reported_loglik_matches_requested_ties_method() -> None:
+    time = np.asarray([1.0, 1.0, 2.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+    event = np.asarray([1, 1, 1, 1, 1, 0, 1, 0])
+    x = np.asarray([[0.5], [-0.2], [1.0], [0.1], [-0.7], [0.3], [0.9], [-1.1]])
+    res_b = cox_ph(x, time, event, ties="breslow")
+    res_e = cox_ph(x, time, event, ties="efron")
+
+    def efron_loglik(beta: np.ndarray) -> float:
+        eta = x @ beta
+        w = np.exp(eta)
+        ll = 0.0
+        for t in np.unique(time[event == 1]):
+            tied = (time == t) & (event == 1)
+            risk = time >= t
+            d = int(tied.sum())
+            s0, sd0 = w[risk].sum(), w[tied].sum()
+            ll += float(eta[tied].sum()) - float(np.sum(np.log(s0 - np.arange(d) / d * sd0)))
+        return ll
+
+    assert res_e.loglik == pytest.approx(efron_loglik(res_e.coef), rel=1e-9)
+    assert res_e.loglik != pytest.approx(res_b.loglik, rel=1e-12)
+
+
+# --------------------------------------------------------------------- U-10: canonical link labels
+def test_family_canonical_links_are_mathematically_correct() -> None:
+    assert _FAMILIES["gamma"].canonical == "inverse"
+    assert _FAMILIES["inverse_gaussian"].canonical == "inverse_squared"
+    # the numerically-safe fitting default is preserved, separately from the label
+    assert _FAMILIES["gamma"].default_link == "log"
+    assert _FAMILIES["inverse_gaussian"].default_link == "log"
+
+
+# --------------------------------------------------------------------- U-8: rank-normal position
+def test_rank_normalize_uses_blom_plotting_position() -> None:
+    chains = np.arange(24.0).reshape(2, 12, 1)
+    got = _rank_normalize(chains)
+    ranks = np.arange(1, 25, dtype=float)
+    expected = ndtri((ranks - 0.375) / (24 + 0.25)).reshape(2, 12, 1)
+    np.testing.assert_allclose(got, expected)
+
+
+# --------------------------------------------------------------------- I-4: m-out-of-n rescaling
+def test_m_out_of_n_bootstrap_is_at_full_sample_scale() -> None:
+    rng = np.random.RandomState(seed=23)
+    data = rng.normal(size=400)
+    full = bootstrap(data, np.mean, n_boot=600, method="percentile", seed=1)
+    sub = bootstrap(data, np.mean, n_boot=600, method="percentile", seed=2, m=40)
+    width_full = float(full.ci_high - full.ci_low)
+    width_sub = float(sub.ci_high - sub.ci_low)
+    assert width_sub == pytest.approx(width_full, rel=0.30), (width_sub, width_full)
+
+
+# --------------------------------------------------------------------- I-5: exact p-values
+def test_exact_permutation_pvalue_has_no_plus_one_correction() -> None:
+    res = permutation_test(np.asarray([1.0, 2.0]), np.asarray([3.0, 4.0]), alternative="less")
+    assert res.pvalue == pytest.approx(1.0 / 6.0)


### PR DESCRIPTION
Fixes ledger findings **U-1..U-10, I-4, I-5** (audit/CODEBASE_REVIEW_LEDGER.md §II.F, §II.E — full review PR to follow).

## Why
- **U-1 (HIGH):** `brunner_munzel` one-sided p-values were exactly swapped vs scipy (verified 0.00289 vs 0.99711 on the scipy doc example) — a user testing a real one-sided effect got p≈1.
- **U-2:** Pratt zero-method now applies the Pratt/Cureton null mean/variance corrections (matches scipy on 20 random tied datasets).
- **U-3:** `particle_filter(resample=False)` now carries the SIS weight product; evidence estimate agrees with the exact Kalman value on a linear-Gaussian check (was ~12 nats off).
- **U-4:** J+/CV+ endpoints use the Barber et al. (n+1) order statistics with honest ±∞ small-n endpoints (shared `_jackknife_plus_bounds`), restoring the finite-sample guarantee.
- **U-5:** ESS is Geyer's initial-monotone sequence, truncated per component (was 3.7× underestimate on d=8 iid chains); one implementation shared by samplers + diagnostics.
- **U-6:** `nuts_numba(num_samples=N, thin=k)` returns N draws (was N//k).
- **U-7:** `frailty_cox` cumulative hazard is a right-continuous step function from 0 (`_cumhaz_at`); was off by one increment per subject.
- **U-8:** rank-normalization uses the Blom position `(r−3/8)/(S+1/4)` (sign fix, found independently by two review lanes).
- **U-9:** Cox `ties='efron'` reports the Efron partial likelihood it maximized.
- **U-10:** gamma/inverse-Gaussian `canonical` labels corrected (`inverse`, `inverse_squared` — new link added); numerically-safe `log` retained as a separate `default_link`, fits unchanged.
- **I-4:** m-out-of-n bootstrap replicates rescaled by √(m/n) (Politis–Romano) — intervals at full-sample scale (verified width parity with the full bootstrap).
- **I-5:** fully enumerated permutation tests return exact `count/n` p-values (1/6, not 2/7).

## Test plan
- New `mixle/tests/uq_review_fixes_test.py`: 12 tests, one per finding, scipy/Kalman/manual-order-statistic cross-checks — **12/12 pass** (~4 s; the nuts test is numba/optional-marked). The file cannot collect at unfixed HEAD (imports the new `_cumhaz_at`), and each defect was reproduced against the unfixed tree during the review.
- Existing suites over every touched module: conformal (×3), glm (×2), mcmc diagnostics/convergence/summary, nonparametric, survival (×2), particle filter, NUTS mass adaptation — **129 passed, 0 failed**.
- `ruff format` + `ruff check` clean.

CHANGELOG entry deferred to the consolidated review-fixes PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)