### PR TITLE
fix(ppl): VI noncentered transform, LMM convergence+GLS SEs, MAP convention, slot naming

### DIFF
--- a/mixle/ppl/autograd.py
+++ b/mixle/ppl/autograd.py
@@ -132,9 +132,13 @@ class GradTarget:
     + positivity Jacobian) but is backed by Torch autograd, so ``value_and_grad`` returns
     the analytic gradient. ``slots``/``build``/``unpack``/``dmean``/``dstd`` are shared with
     the numerical builder so the caller constructs results identically.
+
+    ``jacobian=True`` (samplers / VI) includes the support-transform log|J|, making the target
+    the joint density in the unconstrained space; ``jacobian=False`` (point estimates, MAP)
+    scores the joint in the constrained parameter space, so flat priors reduce to the MLE.
     """
 
-    def __init__(self, rv, data, slots, build, unpack, dmean, dstd, missing="error"):
+    def __init__(self, rv, data, slots, build, unpack, dmean, dstd, missing="error", jacobian=True):
         import torch
 
         self._torch = torch
@@ -145,6 +149,7 @@ class GradTarget:
         self.unpack = unpack
         self.dmean = dmean
         self.dstd = dstd
+        self._jacobian = bool(jacobian)
 
         from mixle.engines import TorchEngine
 
@@ -222,6 +227,8 @@ class GradTarget:
                 ]
                 xt = theta.reshape(1)
                 plp = plp + apply_p(pargs, prep_p(xt, torch), xt, self._eng).sum()
+        if not self._jacobian:  # point-estimate objective: constrained-space density (no log|J|)
+            return ll + plp
         return ll + plp + logj
 
     def _logtarget_batch(self, U, x=None, data_terms=None, lik_scale=1.0, w=None):
@@ -274,6 +281,8 @@ class GradTarget:
                 ]
                 xt = vals[s.index].reshape(B, 1)
                 plp = plp + apply_p(pargs, prep_p(xt, torch), xt, self._eng).sum(dim=1)
+        if not self._jacobian:  # point-estimate objective: constrained-space density (no log|J|)
+            return ll + plp
         return ll + plp + logj
 
     def log_target(self, u_np) -> float:
@@ -349,14 +358,12 @@ class GradTarget:
             family=family,
             alpha=alpha,
         )
-        vals = np.empty_like(U)
-        for k, s in enumerate(self.slots):
-            if s.support == "positive":
-                vals[:, k] = np.exp(U[:, k])
-            elif s.support == "unit":
-                vals[:, k] = 1.0 / (1.0 + np.exp(-U[:, k]))
-            else:
-                vals[:, k] = U[:, k]
+        from mixle.ppl.inference import _u_to_vals
+
+        # Shared with the samplers' readout: applies each slot's support transform AND the
+        # non-centered back-transform ``value = loc + scale * z`` (``reparam == "loc_scale"``),
+        # so the returned draws are parameter values, never z-space latents.
+        vals = _u_to_vals(self.slots, U)
         return vals, mean_np, scale_np, objective
 
 
@@ -367,7 +374,7 @@ class MixtureGradTarget(GradTarget):
     (Gamma-represented) mixture weights. Other combinators (HMM, sequence) stay on the numeric path.
     """
 
-    def __init__(self, rv, data, slots, build, dmean, dstd, comp_layouts, weight, comp_family):
+    def __init__(self, rv, data, slots, build, dmean, dstd, comp_layouts, weight, comp_family, jacobian=True):
         import torch
 
         from mixle.engines import TorchEngine
@@ -379,6 +386,7 @@ class MixtureGradTarget(GradTarget):
         self.unpack = None
         self.dmean = dmean
         self.dstd = dstd
+        self._jacobian = bool(jacobian)
         self._eng = TorchEngine(dtype="float64")
         self._scorers = _scorers()
         self._x = torch.tensor(np.asarray(data, dtype=float), dtype=torch.float64)
@@ -429,10 +437,12 @@ class MixtureGradTarget(GradTarget):
             for j, wi in enumerate(self._weight[1]):
                 a = float(self._weight[2][j])
                 plp = plp + ((a - 1.0) * torch.log(vals[wi]) - vals[wi] - math.lgamma(a))
+        if not self._jacobian:  # point-estimate objective: constrained-space density (no log|J|)
+            return ll + plp
         return ll + plp + logj
 
 
-def _mixture_grad_target(rv, data, scorers):
+def _mixture_grad_target(rv, data, scorers, jacobian=True):
     """Build a MixtureGradTarget for a Mix of same-family leaf components, or None if it isn't one
     (heterogeneous components, a composite component, or a missing Torch scorer)."""
     comps, weights_arg = rv._args[0], rv._args[1]
@@ -480,15 +490,17 @@ def _mixture_grad_target(rv, data, scorers):
         return None
     arr = np.asarray(data, dtype=float)
     dmean, dstd = float(arr.mean()), float(arr.std() or 1.0)
-    return MixtureGradTarget(rv, data, slots, build, dmean, dstd, comp_layouts, weight, fam0)
+    return MixtureGradTarget(rv, data, slots, build, dmean, dstd, comp_layouts, weight, fam0, jacobian=jacobian)
 
 
-def grad_target(rv: RandomVariable, data, missing: str = "error"):
+def grad_target(rv: RandomVariable, data, missing: str = "error", jacobian: bool = True):
     """Build a Torch autograd target for a flat model or a mixture-of-leaves, or ``None``.
 
     Returns ``None`` (caller falls back to the numerical path) when Torch is missing, or the model
     is neither a flat ``Sample`` nor a supported mixture, or any family has no Torch scorer.
     ``missing='marginalize'`` integrates NaN observations out of the likelihood (flat models only here).
+    ``jacobian=False`` builds the constrained-space point-estimate objective (MAP; flat priors == MLE);
+    the default keeps the support-transform log|J| the samplers and VI need.
     """
     if not torch_available() or rv._kind != "sample":
         return None
@@ -501,7 +513,7 @@ def grad_target(rv: RandomVariable, data, missing: str = "error"):
             if missing == "marginalize":
                 return None  # mixture-of-leaves missing handling not wired here; caller raises clearly
             try:
-                return _mixture_grad_target(rv, data, scorers)
+                return _mixture_grad_target(rv, data, scorers, jacobian=jacobian)
             except Exception:  # noqa: BLE001
                 return None
         return None
@@ -524,4 +536,4 @@ def grad_target(rv: RandomVariable, data, missing: str = "error"):
             return None
     _require_flat(rv)
     fam, slots, build, unpack, (dmean, dstd) = _target_parts(rv, data)
-    return GradTarget(rv, data, slots, build, unpack, dmean, dstd, missing=missing)
+    return GradTarget(rv, data, slots, build, unpack, dmean, dstd, missing=missing, jacobian=jacobian)

--- a/mixle/ppl/inference.py
+++ b/mixle/ppl/inference.py
@@ -407,10 +407,16 @@ def _collect_composite(rv: RandomVariable):
     ``w = g / sum(g)`` (so ``w ~ Dirichlet(alpha)`` exactly, with no simplex Jacobian needed).
     Child models (an RV, or a list of RVs) are recursed into; other args (lengths, fixed
     weights) are kept. ``collect`` and ``rebuild`` traverse identically, so the k-th parameter
-    encountered is ``slots[k]``."""
+    encountered is ``slots[k]``.
+
+    Auto-generated slot names inside a multi-component list are qualified by the component path
+    (``comp0.arg0``, ``comp1.arg0``, ...): without the qualifier a K-component mixture of
+    same-shaped components yields K colliding ``arg{i}`` names, and ``summary()`` / ``samples()``
+    / R-hat (all keyed by name) silently drop all but one. User-chosen names and any names in a
+    single-component list are kept as-is."""
     slots: list[_Slot] = []
 
-    def collect(node: RandomVariable):
+    def collect(node: RandomVariable, prefix: str = ""):
         fam = node._family
         if isinstance(fam, CompositeFamily):
             # Components of a finite mixture are exchangeable -> tag their slots with the component
@@ -418,10 +424,11 @@ def _collect_composite(rv: RandomVariable):
             exch = fam.name in ("Mixture", "SemiMix")
             for a in node._args:
                 if isinstance(a, (list, tuple)):
+                    multi = sum(1 for c in a if isinstance(c, RandomVariable)) > 1
                     for gi, c in enumerate(a):
                         if isinstance(c, RandomVariable):
                             before = len(slots)
-                            collect(c)
+                            collect(c, f"{prefix}comp{gi}." if multi else prefix)
                             if exch:  # tag only the outermost exchangeable level (nested groups keep theirs)
                                 for s in slots[before:]:
                                     if s.group is None:
@@ -430,25 +437,29 @@ def _collect_composite(rv: RandomVariable):
                 spec = _struct_spec_for(node, a)
                 if spec is not None:  # structural vector/matrix parameter -> scalar slots
                     handle = _handle_of(a)  # a param(...) handle is referenceable in constraints
+                    named = bool(getattr(spec, "name", None))  # user-chosen spec names stay unqualified
                     for gi, (prior, support, nm) in enumerate(_spec_slot_defs(spec)):
+                        nm = nm if named else f"{prefix}{nm}"
                         s = _Slot(len(slots), prior, support == "positive", nm, handle, support)
                         if exch:  # mixture weights: weight j pairs with component j -> permute together
                             s.group, s.role = gi, "weight"
                         slots.append(s)
                 elif isinstance(a, RandomVariable):
-                    collect(a)  # child model
+                    collect(a, prefix)  # child model
             return
         for i, a in enumerate(node._args):
             if _spec_of(a) is not None:  # a vector/matrix leaf parameter (Dirichlet alpha, Categorical probs)
                 handle = _handle_of(a)
-                for prior, support, nm in _spec_slot_defs(_spec_of(a)):
+                spec = _spec_of(a)
+                named = bool(getattr(spec, "name", None))
+                for prior, support, nm in _spec_slot_defs(spec):
+                    nm = nm if named else f"{prefix}{nm}"
                     slots.append(_Slot(len(slots), prior, support == "positive", nm, handle, support))
             elif isinstance(a, RandomVariable):
-                slots.append(
-                    _Slot(len(slots), lower(a, target="dist"), fam.positive[i], a.name or f"arg{i}", a, fam.support[i])
-                )
+                nm = a.name or f"{prefix}arg{i}"
+                slots.append(_Slot(len(slots), lower(a, target="dist"), fam.positive[i], nm, a, fam.support[i]))
             elif a is free:
-                slots.append(_Slot(len(slots), None, fam.positive[i], f"arg{i}", None, fam.support[i]))
+                slots.append(_Slot(len(slots), None, fam.positive[i], f"{prefix}arg{i}", None, fam.support[i]))
 
     collect(rv)
     if not slots:
@@ -581,8 +592,13 @@ def _target_parts(rv: RandomVariable, data, extra_latents=()):
     return fam, slots, build, unpack, (dmean, dstd)
 
 
-def _build_target(rv: RandomVariable, data, extra_latents=()):
-    """Return (log_target(u), slots, fam, build, unpack, (dmean,dstd)) for unconstrained u."""
+def _build_target(rv: RandomVariable, data, extra_latents=(), jacobian: bool = True):
+    """Return (log_target(u), slots, fam, build, unpack, (dmean,dstd)) for unconstrained u.
+
+    ``jacobian=True`` (samplers / VI / Laplace) includes the support-transform log|J|, so
+    ``log_target`` is the joint density in the *unconstrained* space. ``jacobian=False`` builds
+    the point-estimate objective: the joint scored in the constrained parameter space, so MAP
+    maximizes ``ll + log prior`` there and reduces to the MLE under flat priors."""
     fam, slots, build, unpack, (dmean, dstd) = _target_parts(rv, data, extra_latents)
     if fam is not None:
         enc = _encoder_for(fam).seq_encode(list(data))
@@ -612,7 +628,7 @@ def _build_target(rv: RandomVariable, data, extra_latents=()):
                 plp += float(s.handle._family.make_dist(tuple(pargs), s.handle._name).log_density(vals[s.index]))
             elif s.prior is not None:
                 plp += float(s.prior.log_density(vals[s.index]))
-        return ll + plp + logj
+        return ll + plp + (logj if jacobian else 0.0)
 
     return log_target, slots, fam, build, unpack, (dmean, dstd)
 
@@ -1142,7 +1158,8 @@ def _lp_gamma(x, k, theta, xp):
 
 
 def _lp_halfnormal(x, s, xp):
-    return 0.2257913526447274 - _xlog(s, xp) - 0.5 * (x / s) ** 2
+    # log sqrt(2/pi) = -0.22579...: the folded-Normal doubling (+log 2) net of the Normal constant.
+    return -0.2257913526447274 - _xlog(s, xp) - 0.5 * (x / s) ** 2
 
 
 def _lp_exponential(x, rate, xp):
@@ -1585,12 +1602,18 @@ def sample_fit(rv: RandomVariable, data, **kw) -> RandomVariable:
 def map_fit(
     rv: RandomVariable, data, *, rng=None, constraints=None, penalty=None, potentials=None, missing="error"
 ) -> RandomVariable:
-    """Fit a PPL model by maximum a posteriori optimization."""
+    """Fit a PPL model by maximum a posteriori optimization.
+
+    The point estimate maximizes ``log p(data | theta) + log p(theta)`` in the *constrained*
+    parameter space -- no support-transform log-Jacobian -- so with flat priors MAP coincides
+    with the MLE (e.g. the ``sqrt(S/n)`` sd for a Normal). The samplers and VI/Laplace keep the
+    Jacobian: they need the unconstrained-space density.
+    """
     from scipy.optimize import minimize
 
     from mixle.ppl import autograd as _ag
 
-    g = None if potentials is not None else _ag.grad_target(rv, data, missing=missing)
+    g = None if potentials is not None else _ag.grad_target(rv, data, missing=missing, jacobian=False)
     if g is None and constraints is None and penalty is None and potentials is None and not _ag.torch_available():
         # Without Torch, the analytic-gradient L-BFGS path is unavailable and MAP uses a derivative-free
         # optimizer. Warn once rather than letting callers infer the route from timing.
@@ -1620,7 +1643,9 @@ def map_fit(
         return RandomVariable._bound(g.build(vals), name=rv._name)
 
     # derivative-free path (no Torch, an unsupported family, or a constrained / penalized region)
-    log_target, slots, fam, build, unpack, (dmean, dstd) = _build_target(rv, data, _potential_latents(potentials))
+    log_target, slots, fam, build, unpack, (dmean, dstd) = _build_target(
+        rv, data, _potential_latents(potentials), jacobian=False
+    )
     soft = _soft_penalty(constraints, slots, _auto_penalty(constraints, penalty))
     # penalty=... enforces the constraints softly (a log-joint term), so it replaces hard rejection.
     feasible = None if soft is not None else _feasibility(constraints, slots)
@@ -1734,6 +1759,7 @@ def vi_fit(
     family: str = "meanfield",
     alpha: float = 1.0,
     rng=None,
+    seed: int | None = None,
     missing: str = "error",
 ) -> RandomVariable:
     """Variational Bayes (ADVI) — a Gaussian variational posterior fit by reparameterized-MC Adam.
@@ -1744,11 +1770,13 @@ def vi_fit(
     ``alpha<1`` is mass-covering (widens the often-too-narrow KL fit). ``batch_size`` subsamples the
     data per step (SGVB). Without Torch it falls back to derivative-free mean-field ELBO. Works for
     *non-conjugate* priors; returns a variational Posterior with draws and posterior-predictive.
+    ``seed`` makes the fit deterministic when ``rng`` is not given (``fit(how='vi', seed=...)``,
+    matching the samplers' seeding).
     """
     from mixle.ppl import autograd as _ag
 
     if rng is None:
-        rng = np.random.RandomState()
+        rng = np.random.RandomState(seed)
 
     ag = _ag.grad_target(rv, data, missing=missing)
     if ag is None and missing == "marginalize":
@@ -2084,6 +2112,13 @@ def _nig_conjugate_fit(rv, data, *, mu0=0.0, kappa=0.0, alpha=1.0, beta=0.0) -> 
         return np.asarray(nig.sampler(seed=int(rng.randint(1, 2**31))).sample(k), dtype=float).reshape(k, 2)
 
     mean_sigma2 = b_n / (a_n - 1.0) if a_n > 1.0 else b_n / a_n  # E[sigma^2] under the inverse-gamma marginal
+    # E[sigma] under sigma^2 ~ InvGamma(a_n, b_n) is sqrt(b_n) * Gamma(a_n - 1/2) / Gamma(a_n)
+    # (finite for a_n > 1/2); sqrt(E[sigma^2]) overstates it (Jensen).
+    mean_sigma = (
+        math.sqrt(b_n) * math.exp(math.lgamma(a_n - 0.5) - math.lgamma(a_n))
+        if (a_n > 0.5 and b_n > 0.0)
+        else float(np.sqrt(mean_sigma2))
+    )
     entries = {
         "mu": {
             "index": 0,
@@ -2097,7 +2132,7 @@ def _nig_conjugate_fit(rv, data, *, mu0=0.0, kappa=0.0, alpha=1.0, beta=0.0) -> 
             "index": 1,
             "handle": None,
             "name": "sqrt-InverseGamma",
-            "mean": float(np.sqrt(mean_sigma2)),
+            "mean": mean_sigma,
             "hyper": {"alpha_n": a_n, "beta_n": b_n},
             "sample": lambda k, rng: 1.0 / np.sqrt(_draw(k, rng)[:, 1]),
         },

--- a/mixle/ppl/regression.py
+++ b/mixle/ppl/regression.py
@@ -9,10 +9,12 @@ link:
 
 Coefficients may be ``free`` or may carry Normal penalty handles.  Fitting is
 IRLS/Fisher scoring for a likelihood or penalized-likelihood point estimate.
-For Normal responses this module uses the ridge/penalized-least-squares
-convention documented in the book and reports a scale-adjusted
-inverse-curvature diagnostic; it is not a full Gaussian-prior posterior
-unless the likelihood and prior precisions are scaled consistently.  Fit with
+For Normal responses a Normal coefficient prior is scaled by the residual
+variance (the fixed ``sigma``, or the working ``sigma^2`` when it is free), so
+``result.beta`` / ``result.cov`` are the exact Gaussian posterior mean and
+covariance at that plug-in scale.  Non-Gaussian GLM families (Bernoulli /
+Poisson) have unit dispersion, so the prior enters the IRLS equations
+unscaled -- the exact penalized-likelihood (MAP) mode.  Fit with
 ``.fit(y, given={"x": xs})``.
 """
 
@@ -298,16 +300,37 @@ def _lmm_fit(rv, y, given, linpred, max_iter, tol):
             pred = Zg @ b_g
             err2 += float((rg - pred) @ (rg - pred))
             trace_term += float(np.trace(Zg @ cov_g @ Zg.T))
-        Sigma = SS / G  # M-step
-        sigma2 = max((err2 + trace_term) / N, 1e-8)
+        Sigma_new = SS / G  # M-step
+        sigma2_new = max((err2 + trace_term) / N, 1e-8)
         Zb = np.einsum("nq,nq->n", Z, b[g])
         beta_new = np.linalg.lstsq(X, yv - Zb, rcond=None)[0]
-        if np.max(np.abs(beta_new - beta)) < tol:
-            beta = beta_new
+        # Converge on (beta, Sigma, sigma^2) JOINTLY. In a balanced design beta is an exact
+        # fixed point after one update (the BLUP means cancel), so a beta-only test exits at
+        # iteration ~0 with the variance components one EM step from their crude init.
+        delta = max(
+            float(np.max(np.abs(beta_new - beta))),
+            float(np.max(np.abs(Sigma_new - Sigma))),
+            abs(sigma2_new - sigma2),
+        )
+        beta, Sigma, sigma2 = beta_new, Sigma_new, sigma2_new
+        if delta < tol:
             break
-        beta = beta_new
 
-    cov = np.linalg.inv(X.T @ X / sigma2) if p else np.zeros((0, 0))
+    # GLS fixed-effect covariance (X' V^-1 X)^-1 with V = Z Sigma Z' + sigma^2 I (block-diagonal
+    # per group). inv(X'X / sigma^2) would ignore the random-effect term and is badly
+    # anti-conservative under grouping. Woodbury per group reuses the E-step posterior:
+    # V_g^-1 = (I - Z_g cov_g Z_g' / sigma^2) / sigma^2 with cov_g = (Sigma^-1 + Z_g'Z_g/sigma^2)^-1.
+    if p:
+        Sinv = np.linalg.inv(Sigma)
+        xtvx = np.zeros((p, p))
+        for idx in groups:
+            Xg, Zg = X[idx], Z[idx]
+            cov_g = np.linalg.inv(Sinv + Zg.T @ Zg / sigma2)
+            XtZ = Xg.T @ Zg
+            xtvx += (Xg.T @ Xg - XtZ @ cov_g @ XtZ.T / sigma2) / sigma2
+        cov = np.linalg.inv(xtvx)
+    else:
+        cov = np.zeros((0, 0))
     result = LMMResult(names, beta, cov, Sigma, np.sqrt(sigma2), b, list(levels), re_names)
     return RandomVariable._bound(None, name=rv._name, result=result)
 
@@ -417,8 +440,12 @@ def _glmm_fit(rv, y, given, linpred, link, max_iter, tol):
                 beta = beta_new
                 break
             beta = beta_new
-        Sigma = (sum(np.outer(b[gi], b[gi]) + cov_groups[gi] for gi in range(G))) / G  # M-step
-        if np.max(np.abs(beta - beta_prev)) < tol:
+        Sigma_new = (sum(np.outer(b[gi], b[gi]) + cov_groups[gi] for gi in range(G))) / G  # M-step
+        # Converge on (beta, Sigma) JOINTLY -- a beta-only test can exit while the variance
+        # components are still moving (the same failure as the LMM in balanced designs).
+        delta = max(float(np.max(np.abs(beta - beta_prev))), float(np.max(np.abs(Sigma_new - Sigma))))
+        Sigma = Sigma_new
+        if delta < tol:
             break
 
     result = GLMMResult(rv._family.name, link, names, beta, cov, Sigma, b, list(levels), re_names)
@@ -723,7 +750,15 @@ def regression_fit(
         result = RegressionResult(names, idx_of, beta, np.zeros((p, p)), sigma, columns, link="identity")
         return RandomVariable._bound(None, name=rv._name, result=result)
 
-    # IRLS / Fisher scoring (one step is OLS for the Gaussian identity link)
+    # IRLS / Fisher scoring (one step is OLS for the Gaussian identity link).
+    # For a Normal response the likelihood precision is X'X / sigma^2, so a Normal coefficient
+    # prior (precision P0, in 1/coef^2 units) must enter the working normal equations -- which
+    # are in X'X units -- scaled by sigma^2: (X'X + sigma^2 P0) beta = X'y + sigma^2 P0 m0 is
+    # the exact Gaussian posterior mode. Unscaled, the "Bayesian" fit is ridge-at-sigma=1.
+    # Non-Gaussian GLM families (Bernoulli/Poisson) have unit dispersion, so X'WX is already the
+    # likelihood precision and P0 enters unscaled (the exact penalized-likelihood / MAP mode).
+    sigma_fixed = fam != "Normal" or not (scale is FREE or isinstance(scale, RandomVariable))
+    sigma2_work = float(scale) ** 2 if (fam == "Normal" and sigma_fixed) else 1.0
     beta = np.zeros(p)
     cov = np.eye(p)
     for _ in range(max_iter):
@@ -731,23 +766,27 @@ def regression_fit(
         mu = _link_inv(link, eta)
         W = _irls_weight(link, mu)
         z = (eta - offset) + (y - mu) / W  # working response (predictor space)
+        if fam == "Normal" and not sigma_fixed and np.any(p0 > 0.0):
+            # free sigma: plug in the working residual variance (stabilizes as beta converges)
+            sigma2_work = max(float((y - mu) @ (y - mu)) / N, 1e-8)
         WX = X * W[:, None]
-        A = X.T @ WX + P0
+        A = X.T @ WX + sigma2_work * P0
         cov = np.linalg.inv(A)
-        new_beta = cov @ (X.T @ (W * z) + P0 @ m0)
+        new_beta = cov @ (X.T @ (W * z) + sigma2_work * (P0 @ m0))
         if np.max(np.abs(new_beta - beta)) < tol:
             beta = new_beta
             break
         beta = new_beta
 
     if fam == "Normal":  # residual scale
-        sigma_fixed = not (scale is FREE or isinstance(scale, RandomVariable))
         if sigma_fixed:
             sigma = float(scale)
         else:
             resid = y - (offset + X @ beta)
             sigma = float(np.sqrt(max(resid @ resid / N, 1e-8)))
-        cov = cov * (sigma**2)  # OLS coef cov scales with sigma^2
+        # coef cov scales with sigma^2: with the sigma^2-scaled prior above this is exactly
+        # (X'X / sigma^2 + P0)^-1, the Gaussian posterior covariance (OLS curvature when P0 = 0)
+        cov = cov * (sigma**2)
     else:
         sigma = float("nan")
 

--- a/mixle/ppl/scaling_laws.py
+++ b/mixle/ppl/scaling_laws.py
@@ -252,11 +252,23 @@ def fit_scaling_law(
         resid = loss - mu
         return -0.5 * float(np.sum(resid * resid)) / (sigma_v * sigma_v) - loss.size * log_sigma_v
 
+    carrier_sd = 50.0
+    carrier_obs = 1.0
+
+    def evidence_ll(e_v, log_a_v, log_alpha_v, log_b_v, log_beta_v, log_sigma_v):
+        # The MCMC route needs a carrier observation to build its target, and the carrier
+        # ``Normal(e_rv, carrier_sd)`` scored on ``[carrier_obs]`` contributes a REAL
+        # ``N(carrier_obs | E, carrier_sd^2)`` likelihood factor (precision 1/carrier_sd^2)
+        # pulling E toward the carrier point. Cancel its E-dependent term here so the carrier
+        # is genuinely vacuous and the physics potential is the ONLY evidence.
+        ll = physics_ll(e_v, log_a_v, log_alpha_v, log_b_v, log_beta_v, log_sigma_v)
+        return ll + 0.5 * (carrier_obs - e_v) ** 2 / (carrier_sd * carrier_sd)
+
     fit_rng = np.random.RandomState(seed) if rng is None else rng
-    fitted = Normal(e_rv, 50.0).fit(  # a vacuous carrier observation; the potential IS the evidence
-        [1.0],
+    fitted = Normal(e_rv, carrier_sd).fit(  # carrier observation; its E-factor is cancelled in evidence_ll
+        [carrier_obs],
         how="mcmc",
-        potentials=potential(physics_ll, e_rv, log_a, log_alpha, log_b, log_beta, log_sigma),
+        potentials=potential(evidence_ll, e_rv, log_a, log_alpha, log_b, log_beta, log_sigma),
         draws=int(draws),
         burn=int(burn),
         scale=scale,

--- a/mixle/ppl/statespace.py
+++ b/mixle/ppl/statespace.py
@@ -101,13 +101,25 @@ def _kalman_em(y, phi_free, max_its, tol):
     prev_ll = None
     for _ in range(max_its):
         xs, Ps, Pcov, ll = _kalman_smooth(y, phi, q, r, x0, P0)
+        # The filter treats (x0, P0) as the state BEFORE the first observation (its first
+        # prediction is phi*x0), so the E-step must smooth one extra step back to that same
+        # pre-sample state (Shumway & Stoffer): assigning the time-0 posterior instead mixes
+        # timing conventions and breaks EM monotonicity on short series.
+        Pp0 = phi * phi * P0 + q  # the filter's first prediction from (x0, P0)
+        J0 = phi * P0 / Pp0
+        xs_init = x0 + J0 * (xs[0] - phi * x0)
+        Ps_init = P0 + J0 * J0 * (Ps[0] - Pp0)
+        Pcov0 = J0 * Ps[0]  # lag-one smoothed covariance Cov(x_init, x_0 | y)
         Exx = Ps + xs**2
         Exx1 = Pcov[1:] + xs[1:] * xs[:-1]
+        # transition sums include the pre-sample -> time-0 step, matching the filter's timing
+        num = float(Pcov0 + xs[0] * xs_init) + float(np.sum(Exx1))  # sum E[x_t x_{t-1}]
+        den = float(Ps_init + xs_init * xs_init) + float(np.sum(Exx[:-1]))  # sum E[x_{t-1}^2]
         if phi_free:
-            phi = float(np.sum(Exx1) / max(np.sum(Exx[:-1]), 1e-12))
-        q = max(float(np.mean(Exx[1:] - 2 * phi * Exx1 + phi * phi * Exx[:-1])), 1e-8)
+            phi = float(num / max(den, 1e-12))
+        q = max(float((np.sum(Exx) - 2 * phi * num + phi * phi * den) / T), 1e-8)
         r = max(float(np.mean((y - xs) ** 2 + Ps)), 1e-8)
-        x0, P0 = float(xs[0]), float(Ps[0])
+        x0, P0 = float(xs_init), max(float(Ps_init), 1e-8)
         if prev_ll is not None and abs(ll - prev_ll) < tol:
             break
         prev_ll = ll

--- a/mixle/tests/ppl_review_fixes_test.py
+++ b/mixle/tests/ppl_review_fixes_test.py
@@ -1,0 +1,209 @@
+"""Regression tests for the 2026-07 codebase-review `mixle.ppl` fixes.
+
+Each test pins a specific defect from audit/CODEBASE_REVIEW_LEDGER.md section II.B (P-1..P-11)
+so it cannot silently regress. Test names carry the finding id.
+"""
+
+import importlib.util
+import math
+
+import numpy as np
+import pytest
+
+from mixle.ppl import Field, Group, Mix, Normal, free
+
+HAS_TORCH = importlib.util.find_spec("torch") is not None
+
+
+# --------------------------------------------------------------------------- P-1 / P-11
+@pytest.mark.skipif(not HAS_TORCH, reason="the ADVI route under test needs torch")
+def test_p1_vi_noncentered_returns_value_space_params():
+    # The ADVI readout never applied the non-centered back-transform value = loc + scale*z:
+    # fit(how="vi") on Normal(Normal(0, 10).noncentered(), 1) with data mean ~5 returned the
+    # z-space latent (~0.5) as the parameter posterior and bound the model at z.
+    rng = np.random.RandomState(0)
+    data = list(rng.normal(5.0, 1.0, size=80))
+    m = Normal(mean=Normal(mean=0.0, sd=10.0).noncentered(), sd=1.0).fit(
+        data, how="vi", steps=300, samples=800, rng=np.random.RandomState(1)
+    )
+    assert abs(float(m.dist.mu) - 5.0) < 0.5  # bound in value space, not z-space
+    assert abs(float(m.result.mean("arg0")) - 5.0) < 0.5  # posterior draws in value space
+
+
+def test_p11_vi_accepts_seed_and_is_deterministic():
+    # fit(how="vi", seed=...) raised TypeError (vi_fit had no `seed`); now threads it as the rng.
+    rng = np.random.RandomState(2)
+    data = list(rng.normal(1.0, 1.0, size=40))
+    kw = {"how": "vi", "seed": 1, "steps": 60, "samples": 200, "max_iter": 200}
+    a = Normal(mean=Normal(mean=0.0, sd=5.0), sd=1.0).fit(data, **kw)
+    b = Normal(mean=Normal(mean=0.0, sd=5.0), sd=1.0).fit(data, **kw)
+    assert float(a.dist.mu) == pytest.approx(float(b.dist.mu), abs=0.0)  # same seed -> same fit
+
+
+# --------------------------------------------------------------------------- P-2 / P-3
+def _reference_lmm_em(y, g, n_groups, iters):
+    """Random-intercept EM (intercept-only fixed effect) run to convergence, as keyword-built
+    reference: y_gi = beta + b_g + eps, b_g ~ N(0, tau^2), eps ~ N(0, sigma^2)."""
+    y = np.asarray(y, dtype=float)
+    n = y.size
+    beta = float(y.mean())
+    var0 = max(float(np.var(y)), 1e-3)
+    tau2, sigma2 = 0.5 * var0, 0.5 * var0
+    bb = np.zeros(n_groups)
+    for _ in range(iters):
+        resid = y - beta
+        ss, err2, tr = 0.0, 0.0, 0.0
+        for gi in range(n_groups):
+            idx = np.where(g == gi)[0]
+            v = 1.0 / (1.0 / tau2 + idx.size / sigma2)
+            m = v * float(resid[idx].sum()) / sigma2
+            bb[gi] = m
+            ss += m * m + v
+            err2 += float(((resid[idx] - m) ** 2).sum())
+            tr += idx.size * v
+        tau2 = ss / n_groups
+        sigma2 = max((err2 + tr) / n, 1e-8)
+        beta = float((y - bb[g]).mean())
+    return beta, math.sqrt(tau2), math.sqrt(sigma2)
+
+
+def test_p2_p3_balanced_lmm_converges_variance_components_and_gls_se():
+    # Balanced design: beta is an exact EM fixed point after one update, so the old beta-only
+    # convergence test exited at iteration ~0 with sigma one step from its 0.5*var(y) init
+    # (P-2), and the fixed-effect covariance inv(X'X/sigma^2) ignored the random effects (P-3).
+    rng = np.random.RandomState(42)
+    n_groups, n_per = 20, 5
+    tau_true, sigma_true = 3.0, 1.0
+    g = np.repeat(np.arange(n_groups), n_per)
+    b = rng.normal(0.0, tau_true, n_groups)
+    y = list(2.0 + b[g] + rng.normal(0.0, sigma_true, n_groups * n_per))
+
+    m = Normal(mean=Group("g") + free, sd=free).fit(y, given={"g": list(g)})
+    res = m.result
+    _, tau_ref, sigma_ref = _reference_lmm_em(y=y, g=g, n_groups=n_groups, iters=1000)
+
+    # P-2: sigma near truth and matching a reference EM run to convergence (not the init).
+    assert abs(res.sigma - sigma_true) / sigma_true < 0.15
+    assert res.sigma == pytest.approx(sigma_ref, abs=0.02)
+    assert res.tau == pytest.approx(tau_ref, abs=0.05)
+
+    # P-3: intercept SE from the GLS covariance (X'V^-1 X)^-1, V = tau^2 J + sigma^2 I per group.
+    xtvx = 0.0
+    for gi in range(n_groups):
+        idx = np.where(g == gi)[0]
+        v_g = tau_ref**2 * np.ones((idx.size, idx.size)) + sigma_ref**2 * np.eye(idx.size)
+        ones = np.ones((idx.size, 1))
+        xtvx += float((ones.T @ np.linalg.solve(v_g, ones))[0, 0])
+    se_gls = math.sqrt(1.0 / xtvx)
+    se_fit = float(math.sqrt(res.cov[0, 0]))
+    assert abs(se_fit - se_gls) / se_gls < 0.20
+
+
+# --------------------------------------------------------------------------- P-4
+@pytest.mark.skipif(not HAS_TORCH, reason="the 1e-6 tolerance needs the analytic-gradient MAP")
+def test_p4_map_with_flat_priors_is_the_mle():
+    # how="map" used to maximize ll + prior + log|J| (the unconstrained-space density), so a
+    # flat-prior MAP returned the sqrt(S/(n-1)) sd. The point estimate now drops the Jacobian:
+    # MAP with flat priors == MLE, sd = sqrt(S/n).
+    rng = np.random.RandomState(0)
+    data = list(rng.normal(5.0, 1.0, size=80))
+    m = Normal(mean=free, sd=free).fit(data, how="map")
+    arr = np.asarray(data, dtype=float)
+    s = float(((arr - arr.mean()) ** 2).sum())
+    sd_mle = math.sqrt(s / arr.size)
+    assert float(np.sqrt(m.dist.sigma2)) == pytest.approx(sd_mle, abs=1e-6)
+    assert float(m.dist.mu) == pytest.approx(float(arr.mean()), abs=1e-6)
+
+
+# --------------------------------------------------------------------------- P-5
+def test_p5_mixture_unnamed_prior_slots_do_not_collide():
+    # Unnamed prior slots were named arg{i} positionally WITHIN each component, so a 2-component
+    # mixture produced two "arg0" slots and summary()/samples() silently dropped one component.
+    from mixle.ppl.inference import _collect_composite
+
+    mix = Mix(
+        [
+            Normal(mean=Normal(mean=-2.0, sd=3.0), sd=1.0),
+            Normal(mean=Normal(mean=2.0, sd=3.0), sd=1.0),
+        ],
+        weights=np.array([0.5, 0.5]),
+    )
+    slots, _rebuild = _collect_composite(mix)
+    names = [s.name for s in slots]
+    assert len(set(names)) == len(names)  # unique
+    assert names == ["comp0.arg0", "comp1.arg0"]
+
+    rng = np.random.RandomState(3)
+    data = list(np.concatenate([rng.normal(-2.0, 1.0, 25), rng.normal(2.0, 1.0, 25)]))
+    m = mix.fit(data, how="mcmc", draws=200, burn=100, rng=np.random.RandomState(4))
+    rows = {k: v for k, v in m.result.summary().items() if not k.startswith("_")}
+    assert set(rows) == {"comp0.arg0", "comp1.arg0"}  # one row per slot, no collision
+    a = m.result.samples("comp0.arg0")
+    b = m.result.samples("comp1.arg0")
+    assert a.shape == b.shape and not np.array_equal(a, b)
+
+
+# --------------------------------------------------------------------------- P-6
+def test_p6_lp_halfnormal_matches_scipy_on_a_grid():
+    # The normalizing constant had the wrong sign: +0.22579 instead of log sqrt(2/pi) = -0.22579.
+    from scipy.stats import halfnorm
+
+    from mixle.ppl.inference import _lp_halfnormal
+
+    xs = np.linspace(0.05, 6.0, 25)
+    for s in (0.5, 1.0, 2.3):
+        got = np.array([_lp_halfnormal(x, s, np) for x in xs])
+        want = halfnorm.logpdf(xs, scale=s)
+        np.testing.assert_allclose(got, want, atol=1e-12)
+
+
+# --------------------------------------------------------------------------- P-7
+def test_p7_gaussian_coefficient_prior_is_scaled_by_sigma2():
+    # Normal coefficient priors entered IRLS as X'WX + P0 without the 1/sigma^2 likelihood
+    # scaling -- ridge-at-sigma=1, not the posterior. With a fixed scale the fit now matches the
+    # exact Gaussian posterior mean and covariance.
+    rng = np.random.RandomState(7)
+    xs = rng.normal(0.0, 1.0, 40)
+    sigma = 3.0
+    y = list(1.3 + 0.6 * xs + rng.normal(0.0, sigma, 40))
+    m = Normal(mean=Normal(mean=0.0, sd=1.0) * Field("x") + Normal(mean=0.0, sd=1.0), sd=sigma).fit(
+        y, given={"x": list(xs)}
+    )
+    design = np.column_stack([xs, np.ones_like(xs)])  # column order: slope, intercept
+    prior_prec = np.eye(2)  # 1/sd^2 with sd=1
+    a_exact = design.T @ design / sigma**2 + prior_prec
+    beta_exact = np.linalg.solve(a_exact, design.T @ np.asarray(y) / sigma**2)
+    np.testing.assert_allclose(m.result.beta, beta_exact, atol=1e-6)
+    np.testing.assert_allclose(m.result.cov, np.linalg.inv(a_exact), atol=1e-6)
+
+
+# --------------------------------------------------------------------------- P-9
+def test_p9_kalman_em_loglik_is_nondecreasing_on_short_series():
+    # The initial-state M-step assigned the smoothed time-0 posterior while the filter treats
+    # (x0, P0) as pre-first-observation; on short series that broke EM monotonicity (LL drops
+    # of ~0.6 nats on the first step). The M-step now smooths back to the pre-sample state.
+    from mixle.ppl.statespace import _kalman_em
+
+    for seed in (7, 14, 39):  # series that exposed LL decreases before the fix
+        y = np.random.RandomState(seed).normal(0.0, 1.0, 4)
+        for phi_free in (True, False):
+            lls = [_kalman_em(y, phi_free, k, 0.0).loglik for k in range(1, 25)]
+            increments = np.diff(np.asarray(lls))
+            assert increments.min() > -1e-9, f"LL decreased (seed={seed}, phi_free={phi_free})"
+
+
+# --------------------------------------------------------------------------- P-10
+def test_p10_nig_sigma_posterior_mean_is_e_sigma_not_sqrt_e_sigma2():
+    # The NIG summary labeled sqrt(E[sigma^2]) as sigma's "mean"; the inverse-gamma marginal has
+    # E[sigma] = sqrt(b_n) * Gamma(a_n - 1/2) / Gamma(a_n).
+    rng = np.random.RandomState(11)
+    data = list(rng.normal(0.0, 2.0, size=60))
+    m = Normal(mean=free, sd=free).fit(data, how="conjugate")
+    arr = np.asarray(data, dtype=float)
+    s = float(((arr - arr.mean()) ** 2).sum())
+    a_n, b_n = 1.0 + arr.size / 2.0, 0.5 * s
+    e_sigma = math.sqrt(b_n) * math.exp(math.lgamma(a_n - 0.5) - math.lgamma(a_n))
+    assert m.result.summary()["sigma"]["mean"] == pytest.approx(e_sigma, rel=1e-12)
+    # sanity: the Monte-Carlo mean of sigma draws agrees with the labeled mean
+    draws = m.result.samples("sigma", n=4000, rng=np.random.RandomState(0))
+    assert float(draws.mean()) == pytest.approx(e_sigma, rel=0.05)


### PR DESCRIPTION
Fixes ledger findings **P-1..P-11** (audit/CODEBASE_REVIEW_LEDGER.md §II.B — full review PR to follow).

## Why
- **P-1 (HIGH):** `fit(how='vi')` on a `.noncentered()` prior returned the z-space draw as the posterior (mean 0.505 where the data mean is 5.07) — the loc+scale·z back-transform was never applied on the VI path. Now shares the inference-path unconstrain→constrain mapping.
- **P-2 (HIGH):** balanced-design LMM EM exited at iteration ~0 (β is an exact fixed point after one update; convergence tested β only) → σ̂ 1.490 vs 1.055 correct. Now converges on (β, τ, σ) jointly; `_glmm_fit`'s outer loop fixed the same way.
- **P-3:** fixed-effect SEs use the GLS covariance `(XᵀV⁻¹X)⁻¹` (were 4.6× anti-conservative).
- **P-4:** `how='map'` no longer includes the support-transform log-Jacobian — MAP with flat priors equals the MLE again (sampling fitters keep the Jacobian, as they must).
- **P-5:** unnamed prior slots are component-qualified — K-component summaries no longer collapse to one `arg0` row.
- **P-6:** `_lp_halfnormal` constant sign fixed (was +log√(2/π)); scipy grid cross-check added.
- **P-7:** Normal coefficient priors scaled by the working σ² in IRLS (was ridge-at-σ=1 labeled as the posterior).
- **P-8:** the scaling-laws MCMC carrier observation's E-dependent term is cancelled analytically — the physics potential is now the only evidence, as the comment always claimed.
- **P-9:** Kalman EM initial-state update aligned with the filter's pre-first-observation convention.
- **P-10:** NIG summary reports E[σ] (inverse-gamma mean of √), not √E[σ²].
- **P-11:** `vi_fit` accepts `seed=` (was TypeError) and is deterministic under it.

## Test plan
- New `mixle/tests/ppl_review_fixes_test.py`: 9 tests, one per finding cluster. Fail-before verified by stashing the source fixes: **9/9 fail at unfixed HEAD, 9/9 pass fixed** (~2 s).
- Existing ppl suites: **319 passed, 0 failed** (~104 s, all `ppl*` test files).
- `ruff format` + `ruff check` clean.

CHANGELOG entry deferred to the consolidated review-fixes PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)