### PR TITLE
fix(latent): real Viterbi backtracking, taus scoring, heterogeneous read-outs, EM guards

### DIFF
--- a/mixle/stats/latent/hidden_markov.py
+++ b/mixle/stats/latent/hidden_markov.py
@@ -792,29 +792,44 @@ class HiddenMarkovModelDistribution(SequenceEncodableProbabilityDistribution):
             return retval
 
         else:
-            x_iter = iter(x)
             log_w = self.log_w
             log_taus = self.log_taus
-            n_states = self.n_states
-            x0 = next(x_iter)
+            num_states = self.n_states
 
-            obs_log_density_by_topic = np.asarray([u.log_density(x0) for u in self.topics])
-            log_likelihood_by_state = np.asarray(
-                [log_w[i] + vec.weighted_log_sum(obs_log_density_by_topic, log_taus[i, :]) for i in range(n_states)]
-            )
+            # State i's emission is the topic mixture b_i(x_t) = sum_j taus[i, j] p_j(x_t); run the
+            # same scaled forward recursion as the plain branch above on those mixture emissions.
+            def state_log_b(obs) -> np.ndarray:
+                obs_log_density_by_topic = np.asarray([u.log_density(obs) for u in self.topics])
+                return np.asarray(
+                    [vec.weighted_log_sum(obs_log_density_by_topic, log_taus[i, :]) for i in range(num_states)]
+                )
 
-            for x in x_iter:
-                obs_log_density_by_topic = np.asarray([u.log_density(x) for u in self.topics])
-                log_likelihood_by_state = [
-                    vec.weighted_log_sum(obs_log_density_by_topic, log_taus[:, i])
-                    + vec.weighted_log_sum(obs_log_density_by_topic, log_taus[i, :])
-                    for i in range(n_states)
-                ]
+            obs_log_likelihood = log_w + state_log_b(x[0])
 
-            rv = vec.log_sum(log_likelihood_by_state)
-            rv += self.len_dist.log_density(len(x))
+            max_ll = obs_log_likelihood.max()
+            if max_ll == -np.inf:
+                return -np.inf
+            obs_log_likelihood -= max_ll
+            np.exp(obs_log_likelihood, out=obs_log_likelihood)
+            retval = np.log(np.sum(obs_log_likelihood)) + max_ll
 
-            return rv
+            for k in range(1, len(x)):
+                np.dot(self.transitions.T, obs_log_likelihood, out=obs_log_likelihood)
+                obs_log_likelihood /= obs_log_likelihood.sum()
+                np.log(obs_log_likelihood, out=obs_log_likelihood)
+                obs_log_likelihood += state_log_b(x[k])
+
+                max_ll = obs_log_likelihood.max()
+                if max_ll == -np.inf:
+                    # x[k] is outside every mixture emission's support: zero-probability sequence.
+                    return -np.inf
+                obs_log_likelihood -= max_ll
+                np.exp(obs_log_likelihood, out=obs_log_likelihood)
+                retval += np.log(np.sum(obs_log_likelihood)) + max_ll
+
+            retval += self.len_dist.log_density(len(x))
+
+            return retval
 
     def _terminal_states_seq_log_density(self, x: E1 | E2) -> np.ndarray:
         """Vectorized terminal-state forward: per-sequence stopping-time likelihood from encoded emissions."""
@@ -839,6 +854,29 @@ class HiddenMarkovModelDistribution(SequenceEncodableProbabilityDistribution):
             out[s] = terminal_forward_loglik(self.log_w, self.log_transitions, log_b, self._terminal_mask)
         return out
 
+    def _state_seq_log_densities(self, enc_data) -> np.ndarray:
+        """Per-state log emission densities for encoded observations (one column per hidden state).
+
+        This is the shared emission read-out for the vectorized scoring and decoding paths. It
+        handles the two non-plain emission layouts: per-state heterogeneous emission encodings
+        (PR #275), scored group-by-group via ``_iter_emission_groups``, and the taus/topic-mixture
+        parameterization, where state ``i`` emits the ``taus[i, :]``-weighted mixture of the shared
+        topics: ``b_i(x) = sum_j taus[i, j] p_j(x)``, mixed stably in log space.
+        """
+        num_dists = self.n_topics
+        cols = [None] * num_dists
+        if self._homogeneous_emissions:
+            for i in range(num_dists):
+                cols[i] = self.topics[i].seq_log_density(enc_data)
+        else:
+            for group_indices, group_enc in _iter_emission_groups(enc_data):
+                for i in group_indices:
+                    cols[i] = self.topics[i].seq_log_density(group_enc)
+        log_topics = np.column_stack(cols).astype(np.float64, copy=False)
+        if not self.has_topics:
+            return log_topics
+        return logsumexp(log_topics[:, None, :] + self.log_taus[None, :, :], axis=2)
+
     def seq_log_density(self, x: E1 | E2) -> np.ndarray:
         """Return one HMM log-density value per encoded observation sequence.
 
@@ -860,17 +898,10 @@ class HiddenMarkovModelDistribution(SequenceEncodableProbabilityDistribution):
 
             good = idx_mat >= 0
 
-            pr_obs = np.zeros((tot_cnt, num_states))
             ll_ret = np.zeros(num_seq)
 
             # Compute state likelihood vectors and scale the max to one
-            if self._homogeneous_emissions:
-                for i in range(num_states):
-                    pr_obs[:, i] = self.topics[i].seq_log_density(enc_data)
-            else:
-                for group_indices, group_enc in _iter_emission_groups(enc_data):
-                    for i in group_indices:
-                        pr_obs[:, i] = self.topics[i].seq_log_density(group_enc)
+            pr_obs = self._state_seq_log_densities(enc_data)
 
             with np.errstate(invalid="ignore"):  # impossible rows have max -inf -> ll_ret sanitized below
                 pr_max0 = pr_obs.max(axis=1, keepdims=True)
@@ -919,18 +950,11 @@ class HiddenMarkovModelDistribution(SequenceEncodableProbabilityDistribution):
             tot_cnt = len(idx)
             num_seq = len(sz)
 
-            pr_obs = np.zeros((tot_cnt, num_states), dtype=np.float64)
             ll_ret = np.zeros(num_seq, dtype=np.float64)
             tz = np.concatenate([[0], sz]).cumsum().astype(dtype=np.int32)
 
             # Compute state likelihood vectors and scale the max to one
-            if self._homogeneous_emissions:
-                for i in range(num_states):
-                    pr_obs[:, i] = self.topics[i].seq_log_density(enc_data)
-            else:
-                for group_indices, group_enc in _iter_emission_groups(enc_data):
-                    for i in group_indices:
-                        pr_obs[:, i] = self.topics[i].seq_log_density(group_enc)
+            pr_obs = self._state_seq_log_densities(enc_data)
 
             with np.errstate(invalid="ignore"):  # impossible rows have max -inf -> sanitized after the kernel
                 pr_max0 = pr_obs.max(axis=1)
@@ -1067,8 +1091,13 @@ class HiddenMarkovModelDistribution(SequenceEncodableProbabilityDistribution):
             rv = rv + backend_seq_log_density(self.len_dist, len_enc, engine)
         return rv
 
-    def seq_posterior(self, x: E2) -> list[np.ndarray] | None:
-        """Return vectorized posterior state probabilities for encoded observations."""
+    def seq_posterior(self, x: E2, filtered: bool = False) -> list[np.ndarray] | None:
+        """Return per-sequence posterior state probabilities for encoded observations.
+
+        Each returned array holds the forward-backward SMOOTHING marginals ``P(z_t = k | x_1..T)``
+        (one row per position), matching every other ``seq_posterior`` in the package. Pass
+        ``filtered=True`` for the forward-only filtered probabilities ``P(z_t = k | x_1..t)``.
+        """
         if not self.use_numba:
             return None
 
@@ -1079,7 +1108,6 @@ class HiddenMarkovModelDistribution(SequenceEncodableProbabilityDistribution):
         tot_cnt = len(idx)
         seq_cnt = len(sz)
         num_states = self.n_states
-        pr_obs = np.zeros((tot_cnt, num_states), dtype=np.float64)
         weights = np.ones(seq_cnt, dtype=np.float64)
         max_len = sz.max()
         tz = np.concatenate([[0], sz]).cumsum().astype(dtype=np.int32)
@@ -1088,8 +1116,7 @@ class HiddenMarkovModelDistribution(SequenceEncodableProbabilityDistribution):
         tran_mat = self.transitions
 
         # Compute state likelihood vectors and scale the max to one
-        for i in range(num_states):
-            pr_obs[:, i] = self.topics[i].seq_log_density(enc_data)
+        pr_obs = self._state_seq_log_densities(enc_data)
 
         pr_max = pr_obs.max(axis=1, keepdims=True)
         with np.errstate(invalid="ignore"):  # impossible rows have max -inf -> NaN; zeroed below
@@ -1100,36 +1127,43 @@ class HiddenMarkovModelDistribution(SequenceEncodableProbabilityDistribution):
         alphas = np.zeros((tot_cnt, num_states), dtype=np.float64)
         xi_acc = np.zeros((seq_cnt, num_states, num_states), dtype=np.float64)
         pi_acc = np.zeros((seq_cnt, num_states), dtype=np.float64)
-        numba_baum_welch_alphas(num_states, tz, pr_obs, init_pvec, tran_mat, weights, alphas, xi_acc, pi_acc)
+        # The full Baum-Welch kernel leaves the smoothing marginals gamma in `alphas` (its backward
+        # pass rescales each row in place); the forward-only kernel leaves the filtered alphas.
+        kernel = numba_baum_welch_alphas if filtered else numba_baum_welch2
+        kernel(num_states, tz, pr_obs, init_pvec, tran_mat, weights, alphas, xi_acc, pi_acc)
 
         return [alphas[tz[i] : tz[i + 1], :] for i in range(len(tz) - 1)]
 
     def viterbi(self, x: list[T]) -> np.ndarray:
-        """Return the most likely latent-state path for a single observation sequence."""
+        """Return the most likely latent-state path for a single observation sequence.
+
+        The path is recovered by backpointer backtracking (max-product / Viterbi), so it is the
+        jointly most probable state SEQUENCE -- not the per-position argmax of the score matrix.
+        """
         nn = len(x)
         num_states = self.n_states
 
-        v = np.zeros((nn, num_states), dtype=np.float64)
-        ptr = np.zeros(nn, dtype=np.int32)
-        pr_obs = np.zeros((nn, num_states), dtype=np.float64)
-        enc_x = self.topics[0].dist_to_encoder().seq_encode(x)
+        path = np.zeros(nn, dtype=np.int32)
+        if nn == 0:
+            return path
 
-        for i in range(num_states):
-            pr_obs[:, i] = self.topics[i].seq_log_density(enc_x)
+        emission_encoder, _ = _build_emission_encoder(_emission_encoders_from_dists(self.topics))
+        pr_obs = self._state_seq_log_densities(emission_encoder.seq_encode(list(x)))
 
-        v[0, :] += pr_obs[0, :] + self.log_w
+        delta = np.zeros((nn, num_states), dtype=np.float64)
+        psi = np.zeros((nn, num_states), dtype=np.int32)
+        delta[0, :] = pr_obs[0, :] + self.log_w
 
         for t in range(1, nn):
-            temp = np.zeros((num_states, num_states), dtype=np.float64)
-            temp += np.reshape(v[t - 1, :], (num_states, 1))
-            temp += self.log_transitions
-            temp += np.reshape(pr_obs[t, :], (1, num_states))
-            v[t, :] += temp.max(axis=0, keepdims=False)
+            temp = np.reshape(delta[t - 1, :], (num_states, 1)) + self.log_transitions  # (from, to)
+            psi[t, :] = np.argmax(temp, axis=0)
+            delta[t, :] = temp[psi[t, :], np.arange(num_states)] + pr_obs[t, :]
 
-        for t in range(nn - 1, -1, -1):
-            ptr[t] = np.argmax(v[t, :])
+        path[-1] = int(np.argmax(delta[-1, :]))
+        for t in range(nn - 2, -1, -1):
+            path[t] = psi[t + 1, path[t + 1]]
 
-        return ptr
+        return path
 
     def latent_posterior(self, x: list[T]) -> MarkovChainLatentPosterior:
         """Return the exact chain posterior ``q(z | x)`` over hidden states for one observation sequence.
@@ -1138,10 +1172,8 @@ class HiddenMarkovModelDistribution(SequenceEncodableProbabilityDistribution):
         ``.marginals()`` (forward-backward smoothing probabilities), ``.sample(rng)`` a full state path
         by FFBS, ``.mode()`` (the Viterbi path), or ``.entropy()`` (the exact chain entropy).
         """
-        enc = self.topics[0].dist_to_encoder().seq_encode(list(x))
-        log_b = np.empty((len(x), self.n_states))
-        for k in range(self.n_states):
-            log_b[:, k] = self.topics[k].seq_log_density(enc)
+        emission_encoder, _ = _build_emission_encoder(_emission_encoders_from_dists(self.topics))
+        log_b = self._state_seq_log_densities(emission_encoder.seq_encode(list(x)))
         return MarkovChainLatentPosterior(self.log_w, self.log_transitions, log_b)
 
     def posterior_predictive(self, x: list[T], seed: int | None = None) -> list[Any]:
@@ -1156,52 +1188,90 @@ class HiddenMarkovModelDistribution(SequenceEncodableProbabilityDistribution):
         topic_samplers = [t.sampler(seed=rng.randint(maxrandint)) for t in self.topics]
         return [topic_samplers[k].sample() for k in z]
 
-    def seq_viterbi(self, x: E2):
+    def seq_viterbi(self, x: E1 | E2):
         """Return maximum-likelihood hidden-state assignments for encoded sequences.
 
-        The result is indexed in the encoder's flattened sequence layout. Use
-        the data encoder metadata to map flattened assignments back to individual
-        sequences when working directly with encoded data.
+        Each sequence's assignment is its Viterbi path, recovered by backpointer backtracking. The
+        result is indexed in the encoder's flattened sequence layout (time-banded for the blocked
+        encoding, sequence-contiguous for the numba encoding). Use the data encoder metadata to map
+        flattened assignments back to individual sequences when working directly with encoded data.
         """
         x0, x1 = x
+        num_states = self.n_states
+        log_w = self.log_w
+        log_a_mat = self.log_transitions
+
         if x1 is None:
-            num_states = self.n_states
             (tot_cnt, idx_bands, has_next, len_vec, idx_mat, idx_vec, enc_data), _, len_enc = x0
-            log_w = self.log_w
-            log_a_mat = self.log_transitions
 
             max_len = len(idx_bands)
             num_seq = idx_mat.shape[0]
 
-            good = idx_mat >= 0
-
-            pr_obs = np.zeros((tot_cnt, num_states))
-            v = np.zeros((tot_cnt, num_states), dtype=np.float64)
             ptr = np.zeros(tot_cnt, dtype=np.int32)
+            if tot_cnt == 0:
+                return ptr
 
-            # Compute state likelihood vectors and scale the max to one
-            for i in range(num_states):
-                pr_obs[:, i] = self.topics[i].seq_log_density(enc_data)
+            pr_obs = self._state_seq_log_densities(enc_data)
+            v = np.zeros((tot_cnt, num_states), dtype=np.float64)
+            psi = np.zeros((tot_cnt, num_states), dtype=np.int32)
 
-            # Vectorized alpha pass
+            # Vectorized Viterbi score pass with backpointers
             prev_band_idx = np.arange(idx_bands[0][0], idx_bands[0][1])
-            v[prev_band_idx, :] += pr_obs[prev_band_idx, :] + log_w
+            v[prev_band_idx, :] = pr_obs[prev_band_idx, :] + log_w
 
             for i in range(1, max_len):
                 nxt_band_idx = np.arange(idx_bands[i][0], idx_bands[i][1])
                 has_next_loc = has_next[i - 1]
 
-                temp = np.zeros((len(has_next_loc), num_states, num_states), dtype=np.float64)
-                temp += np.reshape(v[prev_band_idx[has_next_loc], :], (-1, num_states, 1)) + log_a_mat
-                temp += np.reshape(pr_obs[nxt_band_idx, :], (-1, 1, num_states))
+                temp = np.reshape(v[prev_band_idx[has_next_loc], :], (-1, num_states, 1)) + log_a_mat  # (B, from, to)
+                psi[nxt_band_idx, :] = np.argmax(temp, axis=1)
+                v[nxt_band_idx, :] = np.max(temp, axis=1) + pr_obs[nxt_band_idx, :]
 
-                v[nxt_band_idx, :] += np.max(temp, axis=1)
+                prev_band_idx = nxt_band_idx
 
-                prev_band_idx = nxt_band_idx.copy()
+            # Backtrack each sequence from its final position
+            for s in range(num_seq):
+                length = int(len_vec[s])
+                if length == 0:
+                    continue
+                rows = idx_mat[s, :length]
+                state = int(np.argmax(v[rows[-1], :]))
+                ptr[rows[-1]] = state
+                for t in range(length - 2, -1, -1):
+                    state = int(psi[rows[t + 1], state])
+                    ptr[rows[t]] = state
 
-            for i in range(max_len - 1, -1, -1):
-                prev_band_idx = np.arange(idx_bands[i][0], idx_bands[i][1])
-                ptr[prev_band_idx] += np.argmax(v[prev_band_idx, :], axis=1)
+            return ptr
+
+        else:
+            (idx, sz, enc_data), len_enc = x1
+
+            sz = np.asarray(sz)
+            tot_cnt = int(sz.sum())
+            tz = np.concatenate([[0], sz]).cumsum().astype(np.int64)
+
+            ptr = np.zeros(tot_cnt, dtype=np.int32)
+            if tot_cnt == 0:
+                return ptr
+
+            pr_obs = self._state_seq_log_densities(enc_data)
+
+            for s in range(len(sz)):
+                s0, s1 = int(tz[s]), int(tz[s + 1])
+                if s0 == s1:
+                    continue
+                length = s1 - s0
+                delta = pr_obs[s0, :] + log_w
+                psi = np.zeros((length, num_states), dtype=np.int32)
+                for t in range(1, length):
+                    temp = np.reshape(delta, (num_states, 1)) + log_a_mat  # (from, to)
+                    psi[t, :] = np.argmax(temp, axis=0)
+                    delta = temp[psi[t, :], np.arange(num_states)] + pr_obs[s0 + t, :]
+                state = int(np.argmax(delta))
+                ptr[s1 - 1] = state
+                for t in range(length - 2, -1, -1):
+                    state = int(psi[t + 1, state])
+                    ptr[s0 + t] = state
 
             return ptr
 
@@ -3505,19 +3575,25 @@ class HiddenMarkovDataEncoder(DataSequenceEncoder):
     def __eq__(self, other: object) -> bool:
         """Return whether another encoder is equivalent to this encoder.
 
+        The emission encoder participates in the comparison: the heterogeneous grouping machinery
+        (e.g. a mixture over HMMs with unlike emission families) keys off encoder equality, so two
+        HMM encoders are interchangeable only when their emission encodings are.
+
         Args:
             other (object): Object to compare.
 
         Returns:
-            True if other is HiddenMarkovDataEncoder with equivalent 'len_encoder' and 'use_numba', else False.
+            True if other is a HiddenMarkovDataEncoder with equivalent 'emission_encoder',
+            'len_encoder', and 'use_numba', else False.
 
         """
-        if isinstance(other, HiddenMarkovDataEncoder):
-            if self.use_numba == other.use_numba:
-                if self.len_encoder == other.len_encoder:
-                    return True
-        else:
+        if not isinstance(other, HiddenMarkovDataEncoder):
             return False
+        return (
+            self.use_numba == other.use_numba
+            and self.len_encoder == other.len_encoder
+            and self.emission_encoder == other.emission_encoder
+        )
 
     def _seq_encode(self, x: list[list[T]]) -> tuple[E1, None]:
         """Sequence encoding for iid HMM sequence for vectorized numpy functions that do not use numba.
@@ -3833,14 +3909,24 @@ def hmm_engine_forward_backward(engine, log_emit, log_w, log_a, mask, weights=No
     # gamma (posterior state probabilities). Empty/all-padded sequences give -inf alpha+beta whose
     # normalization is -inf - (-inf) = NaN; zero the padded slots with a mask-select (not a
     # multiply, since NaN * 0 = NaN) so degenerate sequences contribute nothing.
+    #
+    # Impossible-observation guard (the engine analogue of _zero_impossible_emission_rows on the
+    # host paths): a zero-mass sequence -- some VALID step has -inf emissions under every state --
+    # also normalizes by logsumexp(ab) = -inf, making log_gamma NaN at its valid steps, which the
+    # padding mask does not touch. Such a sequence contributes zero statistics on the host E-step,
+    # so zero its gamma/xi/pi here too instead of NaN-poisoning the engine-resident statistics
+    # (its ll is already -inf from the forward pass).
     zero = engine.asarray(0.0)
     ab = alpha_stack + beta_stack
     log_gamma = ab - engine.logsumexp(ab, axis=2, keepdims=True)
     gamma = engine.exp(log_gamma) * wvec[:, None, None]
     gamma = engine.where(m[:, :, None] > 0, gamma, zero)
+    gamma = engine.where(engine.isnan(gamma), zero, gamma)
     pi = gamma[:, 0, :]
 
-    # xi (expected transition counts) summed over valid transitions
+    # xi (expected transition counts) summed over valid transitions. For a zero-mass sequence the
+    # -ll term is +inf but always pairs with a -inf alpha/emission/beta term, so bad entries are
+    # NaN (never bare +inf); the same guard zeroes them.
     xi_sum = engine.asarray(np.zeros((num_states, num_states)))
     for t in range(tmax - 1):
         log_xi = (
@@ -3851,6 +3937,7 @@ def hmm_engine_forward_backward(engine, log_emit, log_w, log_a, mask, weights=No
         )
         contrib = engine.exp(log_xi) * wvec[:, None, None]
         contrib = engine.where((m[:, t + 1] > 0)[:, None, None], contrib, zero)
+        contrib = engine.where(engine.isnan(contrib), zero, contrib)
         xi_sum = xi_sum + engine.sum(contrib, axis=0)
 
     return ll, gamma, xi_sum, pi

--- a/mixle/stats/latent/hierarchical_mixture.py
+++ b/mixle/stats/latent/hierarchical_mixture.py
@@ -91,6 +91,7 @@ class HierarchicalMixtureDistribution(SequenceEncodableProbabilityDistribution):
             ),
             statistics=(
                 StatisticSpec("component_counts"),
+                StatisticSpec("outer_weight_counts"),  # document-level outer posteriors (the w M-step)
                 StatisticSpec("topics", kind="tuple"),
                 StatisticSpec("length", kind="child_stat"),
             ),

--- a/mixle/stats/latent/hierarchical_mixture.py
+++ b/mixle/stats/latent/hierarchical_mixture.py
@@ -545,11 +545,14 @@ class HierarchicalMixtureEstimatorAccumulator(SequenceEncodableStatisticAccumula
                 Each SequenceEncodableStatisticAccumulator should be compatible with data type T.
             num_topics (int): Number of topic distributions. Length of accumulators above.
             num_mixtures (int): Number of outer mixture components.
-            comp_counts (ndarray): Numpy array of shape ('num_mixtures', 'num_topics') for tracking component counts,
-                used to estimate the weights.
+            comp_counts (ndarray): Numpy array of shape ('num_mixtures', 'num_topics') for tracking token-level
+                component counts, used to estimate the topic weights 'taus'.
+            w_counts (ndarray): Numpy array of length 'num_mixtures' with document-level outer-posterior sums,
+                used to estimate the outer weights 'w'.
             len_accumulator (Optional[SequenceEncodableStatisticAccumulator]): Optional accumulator for the
                 length of the topic distributions.
-            weight_key (Optional[str]): If set, comp_counts are merged with objects containing matching weight_key.
+            weight_key (Optional[str]): If set, comp_counts/w_counts are merged with objects containing matching
+                weight_key.
             comp_key (Optional[str]): If set, the components of the outer-mixture are merged with objects containing
                 a matching comp_key.
             _init_rng (bool): False if rng for accumulators has not been set.
@@ -564,6 +567,12 @@ class HierarchicalMixtureEstimatorAccumulator(SequenceEncodableStatisticAccumula
         self.num_topics = len(accumulators)
         self.num_mixtures = num_mixtures
         self.comp_counts = vec.zeros((self.num_mixtures, self.num_topics))
+        # Document-level outer-posterior sums, one entry per outer mixture component. The EM
+        # maximizer for the outer weights `w` is the sum of DOCUMENT posteriors; deriving `w` from
+        # the token-level `comp_counts` row sums weights each document by its length, which is not
+        # the EM update and breaks monotonicity on variable-length corpora. `comp_counts` stays
+        # token-level (its row-normalization is the correct `taus` update).
+        self.w_counts = vec.zeros(self.num_mixtures)
         self.len_accumulator = len_accumulator if len_accumulator is not None else NullAccumulator()
         keys_temp = keys if keys is not None else (None, None)
         self.weight_key = keys_temp[0]
@@ -634,6 +643,7 @@ class HierarchicalMixtureEstimatorAccumulator(SequenceEncodableStatisticAccumula
             self._rng_initialize(rng)
 
         idx1 = self._w_rng.choice(self.num_mixtures)
+        self.w_counts[idx1] += weight
 
         for j in range(len(x)):
             idx2 = self._tau_rng.choice(self.num_topics)
@@ -677,6 +687,8 @@ class HierarchicalMixtureEstimatorAccumulator(SequenceEncodableStatisticAccumula
         idx1 = self._w_rng.choice(self.num_mixtures, size=sz, replace=True)  # draw component
         idx2 = self._tau_rng.choice(self.num_topics, size=tsz, replace=True)  # draw seqeucne mixture in component
         ww = weights[idx]
+
+        self.w_counts += np.bincount(idx1, weights=weights, minlength=self.num_mixtures)
 
         for i in range(self.num_topics):
             w = np.zeros_like(ww)
@@ -767,6 +779,10 @@ class HierarchicalMixtureEstimatorAccumulator(SequenceEncodableStatisticAccumula
             self._seq_ll += float(np.dot(weights, row_ll))
 
         rv /= ll_sum
+        # Outer weights: accumulate the DOCUMENT-level outer posteriors (one row per document,
+        # weighted by the document weight) -- the EM maximizer for `w`. The token-level expansion
+        # below (rv[idx, :]) feeds only the taus/topic statistics.
+        self.w_counts += np.dot(weights, rv)
         rv = rv[idx, :]
         ww = np.reshape(weights[idx], (-1, 1))
 
@@ -798,6 +814,9 @@ class HierarchicalMixtureEstimatorAccumulator(SequenceEncodableStatisticAccumula
         tsz = len(idx)
         weights_np = np.asarray(engine.to_numpy(weights) if hasattr(engine, "to_numpy") else weights, dtype=np.float64)
         if tsz == 0:
+            if sz and estimate is not None:
+                # every document is empty: its outer posterior is the prior (matches host seq_update)
+                self.w_counts += float(np.sum(weights_np)) * np.asarray(estimate.w, dtype=np.float64)
             if self.len_accumulator is not None:
                 self.len_accumulator.seq_update(enc_len, weights_np, None if estimate is None else estimate.len_dist)
             return
@@ -824,6 +843,9 @@ class HierarchicalMixtureEstimatorAccumulator(SequenceEncodableStatisticAccumula
         rv = rv - engine.logsumexp(rv, axis=1, keepdims=True)
         rv = engine.exp(rv)  # outer posteriors (sz, M)
 
+        # Outer weights: document-level outer-posterior sums (matches the host seq_update).
+        self.w_counts += np.dot(weights_np, np.asarray(engine.to_numpy(rv)))
+
         rv_items = rv[idx_e, :]  # (tsz, M)
         ww = engine.asarray(weights_np)[idx_e][:, None]
         taus = engine.asarray(np.asarray(estimate.taus, dtype=np.float64))  # (M, T)
@@ -848,62 +870,73 @@ class HierarchicalMixtureEstimatorAccumulator(SequenceEncodableStatisticAccumula
             self.len_accumulator.seq_update(enc_len, weights_np, None if estimate is None else estimate.len_dist)
 
     def combine(
-        self, suff_stat: tuple[np.ndarray, tuple[SS1, ...], SS2 | None]
+        self, suff_stat: tuple[np.ndarray, np.ndarray, tuple[SS1, ...], SS2 | None]
     ) -> "HierarchicalMixtureEstimatorAccumulator":
         """Combine the sufficient statistics of 'suff_stat; with attribute variables.
 
-        Arg suff_stat is a Tuple of length 3 containing,
-            suff_stat[0] (ndarray[float]): Aggregated component counts with shape (num_mixtures, num_topics).
-            suff_stat[1] (Tuple[SS1,...]): Tuple of 'num_topics' sufficient statistics for the topics.
-            suff_stat[2] (Optional[SS2]): Optional sufficient statistic for length accumulator.
+        Arg suff_stat is a Tuple of length 4 containing,
+            suff_stat[0] (ndarray[float]): Aggregated token-level component counts with shape
+                (num_mixtures, num_topics).
+            suff_stat[1] (ndarray[float]): Aggregated document-level outer-posterior sums with length num_mixtures.
+            suff_stat[2] (Tuple[SS1,...]): Tuple of 'num_topics' sufficient statistics for the topics.
+            suff_stat[3] (Optional[SS2]): Optional sufficient statistic for length accumulator.
 
         Args:
-            suff_stat (Tuple[np.ndarray, Tuple[SS1, ...], Optional[SS2]]): See above for details.
+            suff_stat (Tuple[np.ndarray, np.ndarray, Tuple[SS1, ...], Optional[SS2]]): See above for details.
 
         Returns:
             HierarchicalMixtureEstimatorAccumulator object.
 
         """
         self.comp_counts += suff_stat[0]
+        self.w_counts += suff_stat[1]
         for i in range(self.num_topics):
-            self.accumulators[i].combine(suff_stat[1][i])
+            self.accumulators[i].combine(suff_stat[2][i])
 
-        self.len_accumulator.combine(suff_stat[2])
+        self.len_accumulator.combine(suff_stat[3])
 
         return self
 
-    def value(self) -> tuple[np.ndarray, tuple[Any, ...], Any | None]:
-        """Returns sufficient statistics of type Tuple[np.ndarray, Tuple[SS1,...], Optional[SS2]]."""
-        return self.comp_counts, tuple([u.value() for u in self.accumulators]), self.len_accumulator.value()
+    def value(self) -> tuple[np.ndarray, np.ndarray, tuple[Any, ...], Any | None]:
+        """Returns sufficient statistics of type Tuple[np.ndarray, np.ndarray, Tuple[SS1,...], Optional[SS2]]."""
+        return (
+            self.comp_counts,
+            self.w_counts,
+            tuple([u.value() for u in self.accumulators]),
+            self.len_accumulator.value(),
+        )
 
     def from_value(
-        self, x: tuple[np.ndarray, tuple[SS1, ...], SS2 | None]
+        self, x: tuple[np.ndarray, np.ndarray, tuple[SS1, ...], SS2 | None]
     ) -> "HierarchicalMixtureEstimatorAccumulator":
         """Set the attribute variables for sufficient statistics to arg 'x'.
 
-        Arg 'x' is a Tuple of length 3 containing,
-            x[0] (ndarray[float]): Aggregated component counts with shape (num_mixtures, num_topics).
-            x[1] (Tuple[SS1,...]): Tuple of 'num_topics' sufficient statistics for the topics.
-            x[2] (Optional[SS2]): Optional sufficient statistic for length accumulator.
+        Arg 'x' is a Tuple of length 4 containing,
+            x[0] (ndarray[float]): Aggregated token-level component counts with shape (num_mixtures, num_topics).
+            x[1] (ndarray[float]): Aggregated document-level outer-posterior sums with length num_mixtures.
+            x[2] (Tuple[SS1,...]): Tuple of 'num_topics' sufficient statistics for the topics.
+            x[3] (Optional[SS2]): Optional sufficient statistic for length accumulator.
 
         Args:
-            x (Tuple[np.ndarray, Tuple[SS1, ...], Optional[SS2]]): See above for details.
+            x (Tuple[np.ndarray, np.ndarray, Tuple[SS1, ...], Optional[SS2]]): See above for details.
 
         Returns:
             HierarchicalMixtureEstimatorAccumulator object.
 
         """
         self.comp_counts = x[0]
+        self.w_counts = x[1]
         for i in range(self.num_topics):
-            self.accumulators[i].from_value(x[1][i])
+            self.accumulators[i].from_value(x[2][i])
 
-        self.len_accumulator.from_value(x[2])
+        self.len_accumulator.from_value(x[3])
 
         return self
 
     def scale(self, c: float) -> "HierarchicalMixtureEstimatorAccumulator":
         """Scale linear counts and delegate child/length sufficient statistics."""
         self.comp_counts *= c
+        self.w_counts *= c
         for acc in self.accumulators:
             acc.scale(c)
         self.len_accumulator.scale(c)
@@ -912,7 +945,8 @@ class HierarchicalMixtureEstimatorAccumulator(SequenceEncodableStatisticAccumula
     def key_merge(self, stats_dict: dict[str, Any]) -> None:
         """Merge this accumulator into keyed sufficient statistics.
 
-        Merges ``comp_counts`` when ``weight_key`` is set, and merges topic accumulators when ``comp_key`` is set.
+        Merges ``comp_counts``/``w_counts`` when ``weight_key`` is set, and merges topic accumulators when
+        ``comp_key`` is set.
 
         Also delegates keyed merging to the topic and length accumulators.
 
@@ -925,9 +959,11 @@ class HierarchicalMixtureEstimatorAccumulator(SequenceEncodableStatisticAccumula
         """
         if self.weight_key is not None:
             if self.weight_key in stats_dict:
-                stats_dict[self.weight_key] += self.comp_counts
+                keyed_comp_counts, keyed_w_counts = stats_dict[self.weight_key]
+                keyed_comp_counts += self.comp_counts
+                keyed_w_counts += self.w_counts
             else:
-                stats_dict[self.weight_key] = self.comp_counts
+                stats_dict[self.weight_key] = (self.comp_counts, self.w_counts)
 
         if self.comp_key is not None:
             if self.comp_key in stats_dict:
@@ -945,7 +981,8 @@ class HierarchicalMixtureEstimatorAccumulator(SequenceEncodableStatisticAccumula
     def key_replace(self, stats_dict: dict[str, Any]) -> None:
         """Replace this accumulator's statistics from matching keyed values.
 
-        Replaces ``comp_counts`` when ``weight_key`` is set, and replaces topic accumulators when ``comp_key`` is set.
+        Replaces ``comp_counts``/``w_counts`` when ``weight_key`` is set, and replaces topic accumulators when
+        ``comp_key`` is set.
 
         Also delegates keyed replacement to the topic and length accumulators.
 
@@ -958,7 +995,7 @@ class HierarchicalMixtureEstimatorAccumulator(SequenceEncodableStatisticAccumula
         """
         if self.weight_key is not None:
             if self.weight_key in stats_dict:
-                self.comp_counts = stats_dict[self.weight_key]
+                self.comp_counts, self.w_counts = stats_dict[self.weight_key]
 
         if self.comp_key is not None:
             if self.comp_key in stats_dict:
@@ -1074,14 +1111,18 @@ class HierarchicalMixtureEstimator(ParameterEstimator):
         return HierarchicalMixtureEstimatorAccumulatorFactory(est_factories, self.num_mixtures, len_factory, self.keys)
 
     def estimate(
-        self, nobs: float | None, suff_stat: tuple[np.ndarray, SS1, SS2 | None]
+        self, nobs: float | None, suff_stat: tuple[np.ndarray, np.ndarray, SS1, SS2 | None]
     ) -> "HierarchicalMixtureDistribution":
         """Estimate a hierarchical mixture from aggregated sufficient statistics.
 
-        ``suff_stat`` is a three-item tuple containing:
-            suff_stat[0] (ndarray[float]): Aggregated component counts with shape (num_mixtures, num_topics).
-            suff_stat[1] (Tuple[SS1,...]): One sufficient-statistic value per topic.
-            suff_stat[2] (Optional[SS2]): Sufficient statistics for the length estimator.
+        ``suff_stat`` is a four-item tuple containing:
+            suff_stat[0] (ndarray[float]): Aggregated token-level component counts with shape
+                (num_mixtures, num_topics). Row-normalized into the topic weights ``taus``.
+            suff_stat[1] (ndarray[float]): Aggregated document-level outer-posterior sums with length
+                num_mixtures. Normalized into the outer weights ``w`` -- the EM maximizer for ``w``
+                is the document-level posterior sum, NOT the (length-weighted) token-level row sums.
+            suff_stat[2] (Tuple[SS1,...]): One sufficient-statistic value per topic.
+            suff_stat[3] (Optional[SS2]): Sufficient statistics for the length estimator.
 
         Args:
             nobs (Optional[float]): Number of observations used in accumulation of 'suff_stat'.
@@ -1093,7 +1134,7 @@ class HierarchicalMixtureEstimator(ParameterEstimator):
         """
         num_components = self.num_components
         num_mixtures = self.num_mixtures
-        counts, comp_suff_stats, len_suff_stats = suff_stat
+        counts, w_counts, comp_suff_stats, len_suff_stats = suff_stat
         len_dist = self.len_estimator.estimate(None, len_suff_stats) if len_suff_stats is not None else self.len_dist
 
         components = [self.estimators[i].estimate(None, comp_suff_stats[i]) for i in range(num_components)]
@@ -1101,30 +1142,28 @@ class HierarchicalMixtureEstimator(ParameterEstimator):
         if self.pseudo_count is not None and self.suff_stat is None:
             p = self.pseudo_count / (num_components * num_mixtures)
             taus = counts + p
-            w = taus.sum(axis=1, keepdims=True)
-            taus /= w
-            w /= w.sum()
-            w = w.flatten()
+            taus /= taus.sum(axis=1, keepdims=True)
+            w = w_counts + self.pseudo_count / num_mixtures
+            w = w / w.sum()
 
         elif self.pseudo_count is not None and self.suff_stat is not None:
             taus = (counts + self.suff_stat * self.pseudo_count) / (counts.sum() + self.pseudo_count)
-            w = taus.sum(axis=1, keepdims=True)
-            taus /= w
-            w /= w.sum()
-            w = w.flatten()
+            taus /= taus.sum(axis=1, keepdims=True)
+            w = w_counts + self.pseudo_count * np.asarray(self.suff_stat).sum(axis=1)
+            w = w / w.sum()
 
         else:
             taus = counts
-            w = taus.sum(axis=1, keepdims=True)
-            w_pos = w[:, 0] > 0
-            taus[w_pos, :] /= w[w_pos, :]
-            taus[~w_pos, :] = 1.0 / float(num_components)
-            w_sum = w.sum()
+            row_sums = taus.sum(axis=1, keepdims=True)
+            rows_pos = row_sums[:, 0] > 0
+            taus[rows_pos, :] /= row_sums[rows_pos, :]
+            taus[~rows_pos, :] = 1.0 / float(num_components)
+            w_sum = w_counts.sum()
 
             if w_sum == 0:
                 w = np.ones(num_mixtures) / float(num_mixtures)
             else:
-                w = (w / w_sum).flatten()
+                w = w_counts / w_sum
 
         return HierarchicalMixtureDistribution(components, w, taus, len_dist=len_dist, name=self.name, keys=self.keys)
 

--- a/mixle/stats/latent/lda.py
+++ b/mixle/stats/latent/lda.py
@@ -1373,9 +1373,9 @@ def seq_posterior2(estimate: LDADistribution, x: tuple[int, np.ndarray, np.ndarr
     alpha_loc = np.repeat(np.reshape(alpha, (1, num_topics)), num_documents, axis=0)
 
     if gammas is None:
-        document_gammas = alpha_loc + np.reshape(np.bincount(idx_full.flat), (num_documents, num_topics)) / float(
-            num_topics
-        )
+        document_gammas = alpha_loc + np.reshape(
+            np.bincount(idx_full.flat, minlength=num_documents * num_topics), (num_documents, num_topics)
+        ) / float(num_topics)
     else:
         document_gammas = gammas.copy()
 
@@ -1457,9 +1457,9 @@ def _lda_vi_fixed_point(
     idx_full += np.reshape(np.arange(num_topics), (1, num_topics))
 
     if gammas is None:
-        document_gammas = alphas_loc + np.reshape(np.bincount(idx_full.flat), (num_documents, num_topics)) / float(
-            num_topics
-        )
+        document_gammas = alphas_loc + np.reshape(
+            np.bincount(idx_full.flat, minlength=num_documents * num_topics), (num_documents, num_topics)
+        ) / float(num_topics)
     else:
         document_gammas = gammas.copy()
 
@@ -1512,7 +1512,7 @@ def _lda_vi_fixed_point(
         posterior_sum_ll_loc /= rel_counts
         log_density_gamma_loc /= posterior_sum_ll_loc
 
-        gamma_updates = np.bincount(idx_full.flat, weights=log_density_gamma_loc.flat)
+        gamma_updates = np.bincount(idx_full.flat, weights=log_density_gamma_loc.flat, minlength=alphas_loc2.size)
         gamma_updates = np.reshape(gamma_updates, (-1, num_topics))
         gamma_updates += alphas_loc2
 
@@ -1590,7 +1590,7 @@ def _lda_vi_fixed_point(
     idx_full *= num_topics
     idx_full += np.reshape(np.arange(num_topics), (1, num_topics))
 
-    gamma_updates = np.bincount(idx_full.flat, weights=log_density_gamma.flat)
+    gamma_updates = np.bincount(idx_full.flat, weights=log_density_gamma.flat, minlength=alphas_loc.size)
     gamma_updates = np.reshape(gamma_updates, (-1, num_topics))
     gamma_updates += alphas_loc
     final_gammas = gamma_updates
@@ -1636,7 +1636,7 @@ def _lda_elbo_from_gamma(
     elob1 = elob0[idx, :]
     elob2 = ldg * (elob1 + per_topic_log_densities - np.log(ldg) + np.log(np.reshape(counts, (-1, 1))))
     elob3 = np.sum(elob0 * ((per_doc_alpha - 1.0) - (dg - 1.0)), axis=1)
-    elob4 = np.bincount(idx_full.flat, weights=elob2.flat)
+    elob4 = np.bincount(idx_full.flat, weights=elob2.flat, minlength=document_gammas.size)
     elob5 = np.sum(np.reshape(elob4, (-1, num_topics)), axis=1)
     elob6 = np.sum(gammaln(dg), axis=1) - gammaln(dg.sum(axis=1))
     if per_doc_alpha.ndim == 1:

--- a/mixle/stats/latent/structured_hmm.py
+++ b/mixle/stats/latent/structured_hmm.py
@@ -466,23 +466,26 @@ class StructuredHMM:
         T, _ = log_b.shape
         op = self.transition
         mx = log_b.max(axis=1, keepdims=True)
-        b = np.exp(log_b - mx)  # (T,K) scaled emissions
+        b = np.exp(log_b - np.where(np.isfinite(mx), mx, 0.0))  # (T,K) scaled; all-impossible row -> b=0
+
         alpha = np.zeros((T, self.K))
         c = np.zeros(T)
         alpha[0] = (self.pi if pi is None else pi) * b[0]
         c[0] = alpha[0].sum()
-        alpha[0] /= c[0]
+        alpha[0] = alpha[0] / c[0] if c[0] > 0 else alpha[0]
         for t in range(1, T):
             alpha[t] = op.forward(alpha[t - 1]) * b[t]
             c[t] = alpha[t].sum()
-            alpha[t] /= c[t]
-        loglik = float(np.sum(np.log(c)) + np.sum(mx))  # add the per-step maxima back
+            alpha[t] = alpha[t] / c[t] if c[t] > 0 else alpha[t]
+        with np.errstate(divide="ignore"):  # an impossible observation gives c=0 -> loglik -inf, not NaN
+            loglik = float(np.sum(np.log(c)) + np.sum(mx))  # add the per-step maxima back
         beta = np.zeros((T, self.K))
         beta[T - 1] = 1.0
         for t in range(T - 2, -1, -1):
-            beta[t] = op.backward(b[t + 1] * beta[t + 1]) / c[t + 1]
+            beta[t] = op.backward(b[t + 1] * beta[t + 1]) / c[t + 1] if c[t + 1] > 0 else beta[t + 1]
         gamma = alpha * beta
-        gamma /= gamma.sum(axis=1, keepdims=True)
+        gsum = gamma.sum(axis=1, keepdims=True)
+        gamma = np.divide(gamma, gsum, out=np.full_like(gamma, 1.0 / self.K), where=gsum > 0)
         return alpha, beta, c, b, gamma, loglik
 
     def _final_forward_backward(self, log_b, pi=None):
@@ -492,7 +495,7 @@ class StructuredHMM:
         T, _ = log_b.shape
         op = self.transition
         mx = log_b.max(axis=1, keepdims=True)
-        b = np.exp(log_b - mx)
+        b = np.exp(log_b - np.where(np.isfinite(mx), mx, 0.0))  # all-impossible row -> b=0, not NaN
         alpha = np.zeros((T, self.K))
         c = np.zeros(T)
         alpha[0] = (self.pi if pi is None else pi) * b[0]
@@ -523,7 +526,7 @@ class StructuredHMM:
         op = self.transition
         nonterm = ~self.term_mask
         mx = log_b.max(axis=1, keepdims=True)
-        b = np.exp(log_b - mx)
+        b = np.exp(log_b - np.where(np.isfinite(mx), mx, 0.0))  # all-impossible row -> b=0, not NaN
         alpha = np.zeros((T, self.K))
         c = np.zeros(T)
         alpha[0] = (self.pi if pi is None else pi) * b[0]
@@ -612,7 +615,12 @@ class StructuredHMM:
         """The numba dense forward-backward applies for a plain dense transition with no terminal states."""
         from mixle.utils.optional_deps import HAS_NUMBA
 
-        return HAS_NUMBA and self.term_mask is None and type(self.transition) is DenseTransition
+        return (
+            HAS_NUMBA
+            and self.term_mask is None
+            and self.final_mask is None  # the fast kernel is unconstrained; final_states needs the masked backward
+            and type(self.transition) is DenseTransition
+        )
 
     def fit(self, seqs, *, max_its: int = 50, tol: float = 1e-6, fast: bool = True):
         """EM (Baum-Welch) through the transition operator. Returns ``(fitted_hmm, loglik_trace)``.
@@ -649,7 +657,7 @@ class StructuredHMM:
                     emit_accs[k].seq_update(enc, gamma[:, k], self.emissions[k])
                     nk[k] += gamma[:, k].sum()
             self.transition = self.transition.estimate(trans_acc)
-            self.pi = pi_acc / pi_acc.sum()
+            self.pi = pi_acc / pi_acc.sum() if pi_acc.sum() > 0 else self.pi
             self.emissions = [self._emit_est[k].estimate(float(nk[k]), emit_accs[k].value()) for k in range(self.K)]
             ll_trace.append(total_ll)
             if len(ll_trace) > 1 and abs(ll_trace[-1] - ll_trace[-2]) < tol * max(1.0, abs(ll_trace[-2])):
@@ -821,15 +829,23 @@ def fit_chunked(
     seqs = [list(s) for s in seqs]
     uniform = np.ones(hmm.K) / hmm.K
     ll_trace = []
+    scaled_trace = []
 
     def chunk_estep(args):
         seq, ctx_lo, ctx_hi, keep_lo, keep_hi = args
         log_b = hmm._log_b(seq)[ctx_lo:ctx_hi]
         pi = hmm.pi if ctx_lo == 0 else uniform
         alpha, beta, c, b, gamma, ll = hmm._forward_backward(log_b, pi=pi)
-        # transition mass over kept interior transitions only
-        contrib_ll = float(np.sum(np.log(c[keep_lo : max(keep_lo + 1, keep_hi)])))
-        return seq, ctx_lo, keep_lo, keep_hi, alpha, beta, c, b, gamma, contrib_ll
+        # transition mass over kept interior transitions only; c is in the mx-scaled frame of
+        # _forward_backward, so the kept window's per-position emission maxima must be added back
+        # for the REPORTED trace (the full-fit loglik does the same) -- without them the returned
+        # ll_trace is offset by a parameter-dependent amount. The convergence break below keeps
+        # using the scaled-frame quantity so stopping behavior is unchanged.
+        win = slice(keep_lo, max(keep_lo + 1, keep_hi))
+        with np.errstate(divide="ignore"):
+            contrib_scaled = float(np.sum(np.log(c[win])))
+            contrib_ll = contrib_scaled + float(np.sum(log_b[win].max(axis=1)))
+        return seq, ctx_lo, keep_lo, keep_hi, alpha, beta, c, b, gamma, (contrib_ll, contrib_scaled)
 
     for _ in range(int(max_its)):
         tasks = [
@@ -849,8 +865,10 @@ def fit_chunked(
         emit_accs = [est.accumulator_factory().make() for est in hmm._emit_est]
         nk = np.zeros(hmm.K)
         total_ll = 0.0
-        for seq, ctx_lo, keep_lo, keep_hi, alpha, beta, c, b, gamma, contrib_ll in results:
+        total_scaled = 0.0
+        for seq, ctx_lo, keep_lo, keep_hi, alpha, beta, c, b, gamma, (contrib_ll, contrib_scaled) in results:
             total_ll += contrib_ll
+            total_scaled += contrib_scaled
             if ctx_lo == 0:
                 pi_acc += gamma[0]
             for t in range(keep_lo, keep_hi):  # kept interior transitions
@@ -866,7 +884,10 @@ def fit_chunked(
         hmm.pi = pi_acc / pi_acc.sum() if pi_acc.sum() > 0 else hmm.pi
         hmm.emissions = [hmm._emit_est[k].estimate(float(nk[k]), emit_accs[k].value()) for k in range(hmm.K)]
         ll_trace.append(total_ll)
-        if len(ll_trace) > 1 and abs(ll_trace[-1] - ll_trace[-2]) < tol * max(1.0, abs(ll_trace[-2])):
+        scaled_trace.append(total_scaled)
+        # break on the scaled-frame quantity (historical behavior): the reported ll includes the
+        # parameter-dependent emission-max offset, which would rescale the relative tolerance
+        if len(scaled_trace) > 1 and abs(scaled_trace[-1] - scaled_trace[-2]) < tol * max(1.0, abs(scaled_trace[-2])):
             break
     return hmm, ll_trace
 
@@ -1142,19 +1163,20 @@ class InputOutputHMM:
         term = self.term_mask
         nonterm = None if term is None else ~term
         mx = log_b.max(axis=1, keepdims=True)
-        b = np.exp(log_b - mx)
+        b = np.exp(log_b - np.where(np.isfinite(mx), mx, 0.0))  # all-impossible row -> b=0, not NaN
         alpha = np.zeros((t_len, self.K))
         c = np.zeros(t_len)
         alpha[0] = self.pi * b[0]
         c[0] = alpha[0].sum()
-        alpha[0] /= c[0]
+        alpha[0] = alpha[0] / c[0] if c[0] > 0 else alpha[0]
         for t in range(1, t_len):
             prev = alpha[t - 1] if nonterm is None else np.where(nonterm, alpha[t - 1], 0.0)
             alpha[t] = self.transitions[inputs[t - 1]].forward(prev) * b[t]
             c[t] = alpha[t].sum()
             alpha[t] = alpha[t] / c[t] if c[t] > 0 else alpha[t]
         if term is None:
-            loglik = float(np.sum(np.log(c)) + np.sum(mx))
+            with np.errstate(divide="ignore"):  # impossible observation: c=0 -> -inf, not NaN
+                loglik = float(np.sum(np.log(c)) + np.sum(mx))
         else:
             tm = float(alpha[t_len - 1][term].sum())
             loglik = float(np.sum(np.log(c)) + np.sum(mx) + np.log(tm + 1e-300))
@@ -1162,7 +1184,8 @@ class InputOutputHMM:
         beta[t_len - 1] = 1.0 if term is None else np.where(term, 1.0, 0.0)
         for t in range(t_len - 2, -1, -1):
             back = self.transitions[inputs[t]].backward(b[t + 1] * beta[t + 1])
-            beta[t] = (back if nonterm is None else np.where(nonterm, back, 0.0)) / c[t + 1]
+            scaled = back if nonterm is None else np.where(nonterm, back, 0.0)
+            beta[t] = scaled / c[t + 1] if c[t + 1] > 0 else scaled
         gamma = alpha * beta
         gs = gamma.sum(axis=1, keepdims=True)
         gamma = np.divide(gamma, gs, out=np.zeros_like(gamma), where=gs > 0)
@@ -1209,7 +1232,7 @@ class InputOutputHMM:
                     emit_accs[k].seq_update(enc, gamma[:, k], self.emissions[k])
                     nk[k] += gamma[:, k].sum()
             self.transitions = [self.transitions[m].estimate(trans_accs[m]) for m in range(self.M)]
-            self.pi = pi_acc / pi_acc.sum()
+            self.pi = pi_acc / pi_acc.sum() if pi_acc.sum() > 0 else self.pi
             self.emissions = [self._emit_est[k].estimate(float(nk[k]), emit_accs[k].value()) for k in range(self.K)]
             ll_trace.append(total_ll)
             if len(ll_trace) > 1 and abs(ll_trace[-1] - ll_trace[-2]) < tol * max(1.0, abs(ll_trace[-2])):
@@ -1492,7 +1515,7 @@ class ExplicitDurationHMM:
                     enc = self.emissions[k].dist_to_encoder().seq_encode(seq)
                     emit_accs[k].seq_update(enc, occ[:, k], self.emissions[k])
                     nk[k] += occ[:, k].sum()
-            self.pi = pi_acc / pi_acc.sum()
+            self.pi = pi_acc / pi_acc.sum() if pi_acc.sum() > 0 else self.pi
             np.fill_diagonal(trans_acc, 0.0)
             self.a = _row_normalize(trans_acc) if trans_acc.sum() > 0 else self.a
             self.dur = _row_normalize(dur_acc)

--- a/mixle/tests/compute_metadata_test.py
+++ b/mixle/tests/compute_metadata_test.py
@@ -985,7 +985,7 @@ class ComputeMetadataTestCase(unittest.TestCase):
         hier_decl = declaration_for(hier)
         self.assertEqual(hier_decl.name, "hierarchical_mixture")
         self.assertEqual(hier_decl.parameter_names, ("w", "taus"))
-        self.assertEqual(hier_decl.statistic_names, ("component_counts", "topics", "length"))
+        self.assertEqual(hier_decl.statistic_names, ("component_counts", "outer_weight_counts", "topics", "length"))
         self.assertEqual(hier_decl.child_roles, ("topic_0", "topic_1", "length"))
         self.assertFalse(hier_decl.differentiable)
 

--- a/mixle/tests/latent_readout_correctness_test.py
+++ b/mixle/tests/latent_readout_correctness_test.py
@@ -349,10 +349,14 @@ class EngineForwardBackwardImpossibleObservationTest(unittest.TestCase):
     def test_kernel_statistics_are_finite(self):
         dist = self._model()
         data = [["a", "b", "a"], ["a", "z", "b"], ["b", "b"]]  # "z" is out of support in every state
-        _, ((idx, sz, xs), _) = dist.dist_to_encoder().seq_encode(data)
-        pr_obs = np.empty((int(np.sum(sz)), dist.n_states), dtype=np.float64)
+        # build the padded emission matrix from the raw data (the HMM encoder's internal payload
+        # layout varies with numba availability, which is exactly what CI's base matrix lacks)
+        flat = [x for s in data for x in s]
+        sz = np.asarray([len(s) for s in data], dtype=np.int64)
+        enc_flat = dist.topics[0].dist_to_encoder().seq_encode(flat)
+        pr_obs = np.empty((len(flat), dist.n_states), dtype=np.float64)
         for i in range(dist.n_states):
-            pr_obs[:, i] = dist.topics[i].seq_log_density(xs)
+            pr_obs[:, i] = dist.topics[i].seq_log_density(enc_flat)
         padded, mask, _ = hmm_pad_log_emissions(pr_obs, sz)
         with np.errstate(divide="ignore", invalid="ignore"):
             log_w = np.log(dist.w)

--- a/mixle/tests/latent_readout_correctness_test.py
+++ b/mixle/tests/latent_readout_correctness_test.py
@@ -1,0 +1,468 @@
+"""Correctness tests for the latent-model read-out APIs and EM updates (review findings L-1..L-12).
+
+Each test pins a defect found in the `stats/latent` review against an independent brute-force
+reference on a tiny model:
+
+  * Viterbi backtracking (not per-position argmax) for ``viterbi``/``seq_viterbi``  [L-1]
+  * hierarchical-mixture EM monotonicity on variable-length documents             [L-2]
+  * taus/topic-mixture emission scoring, scalar == vectorized == brute force      [L-3, L-4]
+  * StructuredHMM ``fit(fast=True)`` honoring ``final_states``                    [L-5]
+  * heterogeneous-emission HMM read-outs (viterbi/posterior variants)             [L-6]
+  * HMM encoder equality comparing emission encoders (mixtures of HMMs)           [L-7]
+  * ``seq_posterior`` returning smoothing (not filtered) marginals                [L-8]
+  * engine forward-backward impossible-observation guard                          [L-9]
+  * LDA corpora whose LAST document is empty                                      [L-10]
+  * ``fit_chunked`` log-likelihood including the emission-max terms               [L-11]
+  * StructuredHMM-family zero-mass / empty-batch guards                           [L-12]
+"""
+
+import itertools
+import unittest
+
+import numpy as np
+from scipy.special import logsumexp
+
+from mixle.engines import NUMPY_ENGINE
+from mixle.stats import (
+    CategoricalDistribution,
+    CategoricalEstimator,
+    ExponentialDistribution,
+    GaussianDistribution,
+    HiddenMarkovModelDistribution,
+    HierarchicalMixtureDistribution,
+    HierarchicalMixtureEstimator,
+    LDADistribution,
+    MixtureDistribution,
+)
+from mixle.stats.latent.hidden_markov import hmm_engine_forward_backward, hmm_pad_log_emissions
+from mixle.stats.latent.structured_hmm import DenseTransition, InputOutputHMM, StructuredHMM, fit_chunked
+
+
+def _emission_log_density(hmm, state, obs):
+    """State ``state``'s log emission density: the topic itself, or the taus-weighted topic mixture."""
+    if getattr(hmm, "has_topics", False):
+        return logsumexp([hmm.log_taus[state, j] + hmm.topics[j].log_density(obs) for j in range(hmm.n_topics)])
+    return hmm.topics[state].log_density(obs)
+
+
+def _path_log_prob(hmm, x, path):
+    """Joint log-probability of one hidden path and the observations (no length term)."""
+    lp = np.log(hmm.w[path[0]]) + _emission_log_density(hmm, path[0], x[0])
+    for t in range(1, len(x)):
+        lp += np.log(hmm.transitions[path[t - 1], path[t]]) + _emission_log_density(hmm, path[t], x[t])
+    return lp
+
+
+def _brute_force_paths(hmm, x):
+    """All ``(path, log_prob)`` pairs by exhaustive path enumeration."""
+    return [(path, _path_log_prob(hmm, x, path)) for path in itertools.product(range(hmm.n_states), repeat=len(x))]
+
+
+def _brute_force_log_density(hmm, x):
+    """Sequence log-likelihood by exhaustive path enumeration (no length term)."""
+    return logsumexp([lp for _, lp in _brute_force_paths(hmm, x)])
+
+
+def _brute_force_viterbi(hmm, x):
+    """The exact max-probability hidden path and its log-probability."""
+    best_path, best_lp = max(_brute_force_paths(hmm, x), key=lambda pair: pair[1])
+    return list(best_path), best_lp
+
+
+def _brute_force_gamma(hmm, x):
+    """Exact smoothing marginals P(z_t = k | x) by exhaustive path enumeration."""
+    gamma = np.zeros((len(x), hmm.n_states))
+    for path, lp in _brute_force_paths(hmm, x):
+        p = np.exp(lp)
+        for t, state in enumerate(path):
+            gamma[t, state] += p
+    return gamma / gamma.sum(axis=1, keepdims=True)
+
+
+def _sticky_hmm(use_numba):
+    """The ledger's L-1 repro: a sticky 2-state HMM whose per-position argmax is NOT the Viterbi path."""
+    topics = [
+        CategoricalDistribution(pmap={"a": 0.9, "b": 0.1}),
+        CategoricalDistribution(pmap={"a": 0.2, "b": 0.8}),
+    ]
+    return HiddenMarkovModelDistribution(
+        topics,
+        w=[0.8, 0.2],
+        transitions=[[0.999, 0.001], [0.001, 0.999]],
+        use_numba=use_numba,
+    )
+
+
+def _heterogeneous_hmm(use_numba):
+    """A two-state HMM whose states emit from DIFFERENT families (PR #275 heterogeneous emissions).
+
+    Gaussian + Categorical is the ledger's L-6 repro: their encoders produce structurally different
+    encodings, so any read-out that encodes with ``topics[0]``'s encoder alone cannot score state 1.
+    """
+    topics = [GaussianDistribution(mu=0.0, sigma2=1.0), CategoricalDistribution(pmap={1.0: 0.7, 2.0: 0.3})]
+    return HiddenMarkovModelDistribution(
+        topics,
+        w=[0.6, 0.4],
+        transitions=[[0.8, 0.2], [0.3, 0.7]],
+        use_numba=use_numba,
+    )
+
+
+class ViterbiBacktrackingTest(unittest.TestCase):
+    """L-1: viterbi()/seq_viterbi() must return the max-likelihood PATH, not per-position argmaxes."""
+
+    x = ["a", "b", "b", "b", "b"]
+
+    def test_viterbi_matches_brute_force(self):
+        hmm = _sticky_hmm(use_numba=False)
+        true_path, true_lp = _brute_force_viterbi(hmm, self.x)
+        path = list(hmm.viterbi(self.x))
+        self.assertEqual(path, true_path)
+        self.assertAlmostEqual(_path_log_prob(hmm, self.x, path), true_lp, places=9)
+
+    def test_seq_viterbi_matches_brute_force_blocked_encoding(self):
+        hmm = _sticky_hmm(use_numba=False)
+        seqs = [self.x, ["a", "b", "b"]]
+        enc = hmm.dist_to_encoder().seq_encode(seqs)
+        flat = hmm.seq_viterbi(enc)
+        (_, _, _, len_vec, idx_mat, _, _), _, _ = enc[0]
+        for s, seq in enumerate(seqs):
+            path = [int(flat[idx_mat[s, t]]) for t in range(int(len_vec[s]))]
+            true_path, _ = _brute_force_viterbi(hmm, seq)
+            self.assertEqual(path, true_path, "sequence %d" % s)
+
+    def test_seq_viterbi_matches_brute_force_numba_encoding(self):
+        hmm = _sticky_hmm(use_numba=True)
+        seqs = [self.x, ["a", "b", "b"]]
+        enc = hmm.dist_to_encoder().seq_encode(seqs)
+        flat = hmm.seq_viterbi(enc)
+        self.assertIsNotNone(flat)
+        (_, sz, _), _ = enc[1]
+        tz = np.concatenate([[0], np.asarray(sz)]).cumsum()
+        for s, seq in enumerate(seqs):
+            path = [int(v) for v in flat[tz[s] : tz[s + 1]]]
+            true_path, _ = _brute_force_viterbi(hmm, seq)
+            self.assertEqual(path, true_path, "sequence %d" % s)
+
+
+class HierarchicalMixtureMonotoneEMTest(unittest.TestCase):
+    """L-2: EM on variable-length documents must not decrease the log-likelihood."""
+
+    def _em_trace(self, seed, iterations=10):
+        rng = np.random.RandomState(seed)
+        symbols = ["a", "b", "c"]
+        docs = []
+        for _ in range(12):
+            length = int(rng.randint(1, 8))
+            probs = rng.dirichlet(np.ones(len(symbols)))
+            docs.append([symbols[i] for i in rng.choice(len(symbols), size=length, p=probs)])
+
+        def random_topic():
+            probs = rng.dirichlet(np.ones(len(symbols)))
+            return CategoricalDistribution(pmap=dict(zip(symbols, probs)))
+
+        model = HierarchicalMixtureDistribution(
+            [random_topic(), random_topic()],
+            rng.dirichlet(np.ones(2)),
+            rng.dirichlet(np.ones(2), size=2),
+        )
+        estimator = HierarchicalMixtureEstimator([CategoricalEstimator(), CategoricalEstimator()], num_mixtures=2)
+        enc = model.dist_to_encoder().seq_encode(docs)
+        weights = np.ones(len(docs))
+        trace = []
+        for _ in range(iterations):
+            trace.append(float(np.sum(model.seq_log_density(enc))))
+            accumulator = estimator.accumulator_factory().make()
+            accumulator.seq_update(enc, weights, model)
+            model = estimator.estimate(None, accumulator.value())
+        trace.append(float(np.sum(model.seq_log_density(enc))))
+        return np.asarray(trace)
+
+    def test_em_log_likelihood_is_monotone(self):
+        # Seeds 13/15/17 produce genuine LL decreases (up to ~1e-2/iteration) under the token-level
+        # outer-weight M-step; 0/1/2 are unremarkable controls.
+        for seed in (13, 15, 17, 0, 1, 2):
+            with self.subTest(seed=seed):
+                trace = self._em_trace(seed)
+                deltas = np.diff(trace)
+                self.assertGreaterEqual(
+                    float(deltas.min()), -1.0e-9, "seed %d: EM decreased the log-likelihood: %s" % (seed, trace)
+                )
+
+
+class TausMixtureEmissionTest(unittest.TestCase):
+    """L-3 + L-4: the taus/topic-mixture parameterization must score correctly and consistently."""
+
+    def _taus_hmm(self, use_numba):
+        topics = [
+            CategoricalDistribution(pmap={"a": 0.8, "b": 0.2}),
+            CategoricalDistribution(pmap={"a": 0.1, "b": 0.9}),
+        ]
+        return HiddenMarkovModelDistribution(
+            topics,
+            w=[0.6, 0.4],
+            transitions=[[0.9, 0.1], [0.3, 0.7]],
+            taus=[[0.7, 0.3], [0.2, 0.8]],
+            use_numba=use_numba,
+        )
+
+    def test_scalar_and_seq_log_density_match_brute_force(self):
+        seqs = [["a", "b", "a"], ["b"], ["b", "b", "a", "a"]]
+        for use_numba in (False, True):
+            hmm = self._taus_hmm(use_numba=use_numba)
+            enc = hmm.dist_to_encoder().seq_encode(seqs)
+            seq_ll = np.asarray(hmm.seq_log_density(enc))
+            for s, seq in enumerate(seqs):
+                expected = _brute_force_log_density(hmm, seq)
+                with self.subTest(use_numba=use_numba, seq=s):
+                    self.assertAlmostEqual(hmm.log_density(seq), expected, places=9)
+                    self.assertAlmostEqual(float(seq_ll[s]), expected, places=9)
+
+
+class StructuredHMMFinalStatesFastFitTest(unittest.TestCase):
+    """L-5: fit(fast=True) must optimize the SAME objective as fast=False on final_states models."""
+
+    def _model(self):
+        return StructuredHMM(
+            [GaussianDistribution(mu=-3.0, sigma2=1.0), GaussianDistribution(mu=3.0, sigma2=1.0)],
+            [0.6, 0.4],
+            DenseTransition(np.array([[0.7, 0.3], [0.4, 0.6]])),
+            final_states={1},
+        )
+
+    def test_fast_fit_matches_slow_fit_objective(self):
+        rng = np.random.RandomState(0)
+        seqs = [[float(v) for v in rng.normal(0.0, 3.0, size=6)] for _ in range(4)]
+        reference_ll = float(np.sum(self._model().seq_log_density(seqs)))
+        _, fast_trace = self._model().fit(seqs, max_its=1, fast=True)
+        _, slow_trace = self._model().fit(seqs, max_its=1, fast=False)
+        self.assertAlmostEqual(fast_trace[0], slow_trace[0], places=9)
+        self.assertAlmostEqual(fast_trace[0], reference_ll, places=9)
+
+
+class HeterogeneousEmissionReadoutTest(unittest.TestCase):
+    """L-6: viterbi/latent_posterior/seq_posterior/seq_viterbi must support heterogeneous emissions."""
+
+    x = [0.1, 1.0, 2.0, 0.3]
+
+    def test_viterbi_matches_brute_force(self):
+        hmm = _heterogeneous_hmm(use_numba=True)
+        true_path, _ = _brute_force_viterbi(hmm, self.x)
+        self.assertEqual(list(hmm.viterbi(self.x)), true_path)
+
+    def test_latent_posterior_marginals_match_brute_force(self):
+        hmm = _heterogeneous_hmm(use_numba=True)
+        np.testing.assert_allclose(hmm.latent_posterior(self.x).marginals(), _brute_force_gamma(hmm, self.x), atol=1e-9)
+
+    def test_seq_posterior_matches_brute_force(self):
+        hmm = _heterogeneous_hmm(use_numba=True)
+        seqs = [self.x, [0.2, 1.0]]
+        enc = hmm.dist_to_encoder().seq_encode(seqs)
+        posteriors = hmm.seq_posterior(enc)
+        for s, seq in enumerate(seqs):
+            np.testing.assert_allclose(
+                posteriors[s], _brute_force_gamma(hmm, seq), atol=1e-9, err_msg="sequence %d" % s
+            )
+
+    def test_seq_viterbi_matches_brute_force(self):
+        hmm = _heterogeneous_hmm(use_numba=True)
+        seqs = [self.x, [0.2, 1.0]]
+        enc = hmm.dist_to_encoder().seq_encode(seqs)
+        flat = hmm.seq_viterbi(enc)
+        self.assertIsNotNone(flat)
+        (_, sz, _), _ = enc[1]
+        tz = np.concatenate([[0], np.asarray(sz)]).cumsum()
+        for s, seq in enumerate(seqs):
+            true_path, _ = _brute_force_viterbi(hmm, seq)
+            self.assertEqual([int(v) for v in flat[tz[s] : tz[s + 1]]], true_path, "sequence %d" % s)
+
+    def test_seq_viterbi_blocked_encoding_matches_brute_force(self):
+        hmm = _heterogeneous_hmm(use_numba=False)
+        enc = hmm.dist_to_encoder().seq_encode([self.x])
+        flat = hmm.seq_viterbi(enc)
+        (_, _, _, len_vec, idx_mat, _, _), _, _ = enc[0]
+        path = [int(flat[idx_mat[0, t]]) for t in range(int(len_vec[0]))]
+        true_path, _ = _brute_force_viterbi(hmm, self.x)
+        self.assertEqual(path, true_path)
+
+
+class MixtureOfHeterogeneousHMMsTest(unittest.TestCase):
+    """L-7: HMM encoder equality must compare emission encoders (mixtures of unlike HMMs)."""
+
+    def _mixture(self):
+        hmm_gaussian = HiddenMarkovModelDistribution(
+            [GaussianDistribution(mu=-1.0, sigma2=1.0), GaussianDistribution(mu=1.0, sigma2=1.0)],
+            w=[0.5, 0.5],
+            transitions=[[0.8, 0.2], [0.2, 0.8]],
+        )
+        hmm_categorical = HiddenMarkovModelDistribution(
+            [CategoricalDistribution(pmap={1.0: 0.7, 2.0: 0.3}), CategoricalDistribution(pmap={1.0: 0.2, 2.0: 0.8})],
+            w=[0.5, 0.5],
+            transitions=[[0.6, 0.4], [0.4, 0.6]],
+        )
+        return MixtureDistribution([hmm_gaussian, hmm_categorical], [0.5, 0.5])
+
+    def test_encoder_not_declared_homogeneous(self):
+        mixture = self._mixture()
+        encoders = [component.dist_to_encoder() for component in mixture.components]
+        self.assertFalse(encoders[0] == encoders[1])
+        self.assertFalse(mixture.dist_to_encoder().homogeneous)
+
+    def test_seq_log_density_matches_scalar(self):
+        mixture = self._mixture()
+        seqs = [[1.0, 2.0, 1.0], [0.5, 1.0]]
+        enc = mixture.dist_to_encoder().seq_encode(seqs)
+        seq_ll = np.asarray(mixture.seq_log_density(enc))
+        scalar_ll = np.asarray([mixture.log_density(seq) for seq in seqs])
+        np.testing.assert_allclose(seq_ll, scalar_ll, atol=1e-9)
+
+    def test_encoder_equality_returns_bool(self):
+        mixture = self._mixture()
+        encoders = [component.dist_to_encoder() for component in mixture.components]
+        self.assertIs(encoders[0] == encoders[1], False)  # no None fall-through
+
+
+class SeqPosteriorSmoothingTest(unittest.TestCase):
+    """L-8: seq_posterior must return SMOOTHING marginals P(z_t | x_1..T), not filtered ones."""
+
+    def test_seq_posterior_matches_brute_force_gamma(self):
+        hmm = _sticky_hmm(use_numba=True)
+        seqs = [["a", "b", "b", "b", "b"], ["b", "a"]]
+        enc = hmm.dist_to_encoder().seq_encode(seqs)
+        posteriors = hmm.seq_posterior(enc)
+        for s, seq in enumerate(seqs):
+            np.testing.assert_allclose(
+                posteriors[s], _brute_force_gamma(hmm, seq), atol=1e-9, err_msg="sequence %d" % s
+            )
+
+
+class EngineForwardBackwardImpossibleObservationTest(unittest.TestCase):
+    """L-9: the engine E-step must guard impossible observations like the host paths do."""
+
+    def _model(self):
+        topics = [
+            CategoricalDistribution(pmap={"a": 0.7, "b": 0.3}),
+            CategoricalDistribution(pmap={"a": 0.2, "b": 0.8}),
+        ]
+        return HiddenMarkovModelDistribution(topics, w=[0.6, 0.4], transitions=[[0.7, 0.3], [0.4, 0.6]])
+
+    def test_kernel_statistics_are_finite(self):
+        dist = self._model()
+        data = [["a", "b", "a"], ["a", "z", "b"], ["b", "b"]]  # "z" is out of support in every state
+        _, ((idx, sz, xs), _) = dist.dist_to_encoder().seq_encode(data)
+        pr_obs = np.empty((int(np.sum(sz)), dist.n_states), dtype=np.float64)
+        for i in range(dist.n_states):
+            pr_obs[:, i] = dist.topics[i].seq_log_density(xs)
+        padded, mask, _ = hmm_pad_log_emissions(pr_obs, sz)
+        with np.errstate(divide="ignore", invalid="ignore"):
+            log_w = np.log(dist.w)
+            log_a = np.log(dist.transitions)
+            _, gamma, xi_sum, pi = hmm_engine_forward_backward(NUMPY_ENGINE, padded, log_w, log_a, mask)
+        self.assertTrue(np.all(np.isfinite(gamma)), "gamma contains non-finite values")
+        self.assertTrue(np.all(np.isfinite(xi_sum)), "xi contains non-finite values")
+        self.assertTrue(np.all(np.isfinite(pi)), "pi contains non-finite values")
+
+    def test_engine_estep_matches_host(self):
+        dist = self._model()
+        data = [["a", "b", "a"], ["a", "z", "b"], ["b", "b"]]
+        enc = dist.dist_to_encoder().seq_encode(data)
+        weights = np.ones(len(data))
+        estimator = dist.estimator()
+
+        host = estimator.accumulator_factory().make()
+        host.seq_update(enc, weights, dist)
+        engine_acc = estimator.accumulator_factory().make()
+        with np.errstate(divide="ignore", invalid="ignore"):
+            engine_acc.seq_update_engine(enc, weights, dist, NUMPY_ENGINE)
+
+        np.testing.assert_allclose(engine_acc.init_counts, host.init_counts, atol=1e-9)
+        np.testing.assert_allclose(engine_acc.state_counts, host.state_counts, atol=1e-9)
+        np.testing.assert_allclose(engine_acc.trans_counts, host.trans_counts, atol=1e-9)
+        self.assertTrue(np.all(np.isfinite(engine_acc.init_counts)))
+        self.assertTrue(np.all(np.isfinite(engine_acc.state_counts)))
+        self.assertTrue(np.all(np.isfinite(engine_acc.trans_counts)))
+
+
+class LDAEmptyLastDocumentTest(unittest.TestCase):
+    """L-10: a corpus whose LAST document is empty must encode and score without crashing."""
+
+    def _model(self):
+        topics = [
+            CategoricalDistribution(pmap={"a": 0.6, "b": 0.3, "c": 0.1}),
+            CategoricalDistribution(pmap={"a": 0.1, "b": 0.3, "c": 0.6}),
+        ]
+        return LDADistribution(topics, alpha=[0.7, 0.4])
+
+    def test_seq_log_density_and_seq_posterior_with_empty_last_document(self):
+        model = self._model()
+        docs = [[("a", 2.0), ("b", 1.0)], [("c", 3.0)], []]
+        enc = model.dist_to_encoder().seq_encode(docs)
+        ll = np.asarray(model.seq_log_density(enc))
+        self.assertEqual(len(ll), len(docs))
+        self.assertTrue(np.all(np.isfinite(ll[:2])))
+        posterior = np.asarray(model.seq_posterior(enc))
+        self.assertEqual(posterior.shape[0], len(docs))
+
+
+class FitChunkedLogLikelihoodTest(unittest.TestCase):
+    """L-11: fit_chunked's ll_trace must include the per-position emission-max terms."""
+
+    def _model(self):
+        return StructuredHMM(
+            [GaussianDistribution(mu=-2.0, sigma2=1.0), GaussianDistribution(mu=2.0, sigma2=1.0)],
+            [0.5, 0.5],
+            DenseTransition(np.array([[0.8, 0.2], [0.3, 0.7]])),
+        )
+
+    def test_single_chunk_ll_matches_full_fit(self):
+        rng = np.random.RandomState(1)
+        seqs = [[float(v) for v in rng.normal(0.0, 2.0, size=8)] for _ in range(3)]
+        _, full_trace = self._model().fit(seqs, max_its=1, fast=False)
+        _, chunked_trace = fit_chunked(self._model(), seqs, chunk=8, overlap=0, max_its=1)
+        self.assertAlmostEqual(chunked_trace[0], full_trace[0], places=9)
+
+
+class StructuredHMMZeroMassGuardsTest(unittest.TestCase):
+    """L-12: out-of-support observations and empty batches must degrade cleanly, not to NaN."""
+
+    def _model(self, **kwargs):
+        return StructuredHMM(
+            [ExponentialDistribution(1.0), ExponentialDistribution(3.0)],
+            [0.5, 0.5],
+            DenseTransition(np.array([[0.8, 0.2], [0.3, 0.7]])),
+            **kwargs,
+        )
+
+    def test_impossible_observation_scores_neg_inf_not_nan(self):
+        hmm = self._model()
+        with np.errstate(divide="ignore", invalid="ignore"):
+            ll = hmm.seq_log_density([[1.0, -1.0, 2.0]])  # -1.0 is out of support in every state
+        self.assertEqual(float(ll[0]), -np.inf)
+        self.assertFalse(np.isnan(ll[0]))
+
+    def test_impossible_observation_posteriors_are_finite(self):
+        hmm = self._model()
+        with np.errstate(divide="ignore", invalid="ignore"):
+            gamma = hmm.state_posteriors([1.0, -1.0, 2.0])
+        self.assertTrue(np.all(np.isfinite(gamma)), "state posteriors contain non-finite values")
+
+    def test_fit_on_empty_batch_keeps_parameters_finite(self):
+        hmm = self._model()
+        with np.errstate(divide="ignore", invalid="ignore"):
+            fitted, _ = hmm.fit([[]], max_its=1, fast=False)
+        self.assertTrue(np.all(np.isfinite(fitted.pi)), "pi became non-finite on an empty batch")
+
+    def test_iohmm_impossible_first_observation_is_neg_inf_not_nan(self):
+        iohmm = InputOutputHMM(
+            [ExponentialDistribution(1.0), ExponentialDistribution(3.0)],
+            [0.5, 0.5],
+            [DenseTransition(np.array([[0.8, 0.2], [0.3, 0.7]]))],
+        )
+        with np.errstate(divide="ignore", invalid="ignore"):
+            ll = iohmm.log_density([(-1.0, 0), (1.0, 0)])
+        self.assertEqual(float(ll), -np.inf)
+        self.assertFalse(np.isnan(ll))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes ledger findings **L-1..L-12** (audit/CODEBASE_REVIEW_LEDGER.md §II.C — full review PR to follow).

## Why (highlights)
- **L-1 (HIGH):** `viterbi()`/`seq_viterbi()` had no backpointer backtracking — a sticky 2-state HMM returned a path with log-prob −9.57 vs the true −3.88. Now proper ψ + backtrack, verified against brute-force enumeration.
- **L-2 (HIGH):** hierarchical-mixture EM was **non-monotone** on variable-length documents (outer weights from token-level counts). Document-level posteriors now accumulated; monotonicity tested across seeds.
- **L-3/L-4 (HIGH):** the `taus` parameterization was wrong in *both* scoring paths (scalar branch was a broken non-recursion scoring `len_dist` on a loop variable; vectorized path ignored `taus` entirely). Both now match brute-force path sums, with a scalar/seq parity test.
- **L-5:** `fit(fast=True)` no longer optimizes the unconstrained likelihood for `final_states` models (`_can_fast_fb` checks `final_mask`); `EDHMM.to_structured_hmm().fit()` hit this by default.
- **L-6/L-7:** heterogeneous emissions (PR #275) plumbed through `viterbi`/`latent_posterior`/`seq_posterior`/`seq_viterbi` (previously crashed); `HiddenMarkovDataEncoder.__eq__` compares emission encoders so mixed-family HMM mixtures encode correctly.
- **L-8:** `seq_posterior` returns smoothing marginals P(z_t | x_{1:T}) as documented (was forward-filtered only) — verified against brute-force gamma.
- **L-9/L-12:** impossible observations score −∞ (not NaN) through the engine E-step, the plain and IOHMM forward-backward, and the fit-loop normalizations (finite-safe max scaling + guarded divisions, mirroring the `_final_`/`_terminal_` variants).
- **L-10:** LDA `bincount`s pass `minlength` — a corpus whose **last** document is empty no longer crashes `seq_log_density`/`seq_posterior` (three weighted-bincount sites fixed beyond the ledgered pair).
- **L-11:** `fit_chunked` reports the true log-likelihood trace (per-position emission maxima restored); the convergence break deliberately keeps the historical scaled-frame quantity so fit trajectories are unchanged (serial==parallel exactness preserved and tested).

## Test plan
- New `mixle/tests/latent_readout_correctness_test.py`: 23 tests + 12 subtests (Viterbi vs brute force, EM monotonicity over seeds, taus parity, heterogeneous read-outs, smoothing-vs-filtered, final-states fast-fit parity, zero-mass guards, empty-last-document LDA). Fail-before verified by stashing the source fixes: **30 fail at unfixed HEAD → all pass fixed** (~2 s).
- Existing suites (hidden_markov, structured_hmm incl. `ForgettingParallelTest`, hierarchical, lda, labeled_lda, mixture*): **151 passed + 14 subtests, 0 failed** (1 pre-existing jax env-skip).
- `ruff format` + `ruff check` clean.

CHANGELOG entry deferred to the consolidated review-fixes PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)