### PR TITLE
perf(hot-paths): MVN gemm scoring, single-forward objective loop, encode slicing

### DIFF
--- a/mixle/inference/objectives.py
+++ b/mixle/inference/objectives.py
@@ -468,44 +468,23 @@ def fit_parameter_objective(
 
     opt = _make_optimizer(torch, optimizer, params, lr)
     sign = 1.0 if maximize else -1.0
-    iterations = max(1, int(max_its))
-    converged = False
 
     def objective_value():
         return objective(param_set.values(), enc, engine)
 
-    history = [_objective_scalar(objective_value())]
-    best_value = history[0]
-    best_iteration = 0
-    best_state = _clone_parameter_state(params)
-    for i in range(iterations):
-        if optimizer == "lbfgs":
-
-            def closure():
-                opt.zero_grad()
-                loss = -sign * objective_value()
-                loss.backward()
-                return loss
-
-            loss = opt.step(closure)
-        else:
-            opt.zero_grad()
-            loss = -sign * objective_value()
-            loss.backward()
-            opt.step()
-
-        cur = _objective_scalar(objective_value())
-        history.append(cur)
-        if out is not None and (i + 1) % max(1, int(print_iter)) == 0:
-            out.write("parameter objective iteration %d: value=%e\n" % (i + 1, cur))
-        if _objective_is_better(cur, best_value, maximize=maximize):
-            best_value = cur
-            best_iteration = len(history) - 1
-            best_state = _clone_parameter_state(params)
-        if len(history) > 2 and abs(cur - history[-2]) < tol * max(1.0, abs(cur)):
-            iterations = i + 1
-            converged = True
-            break
+    history, best_value, best_iteration, best_state, iterations, converged = _run_objective_optimization(
+        opt,
+        optimizer,
+        objective_value,
+        params,
+        sign,
+        max(1, int(max_its)),
+        tol,
+        maximize,
+        out,
+        print_iter,
+        "parameter objective",
+    )
 
     final_delta = history[-1] - history[-2] if len(history) > 1 else None
     if restore_best:
@@ -550,14 +529,43 @@ def _run_objective_optimization(
     Steps ``opt`` to maximize ``sign * eval_fn()`` for up to ``iterations`` steps (early-stopping when
     the value change falls below ``tol``), tracking the best parameter state of ``params``. Returns
     ``(history, best_value, best_iteration, best_state, iterations_run, converged)``.
+
+    The Adam path records ``history`` from the loss already computed for each step's forward pass
+    (one forward per iteration, matching a raw torch loop) instead of re-evaluating the objective
+    after the step; the final iterate is scored once after the loop. For a deterministic objective
+    the recorded values, best state, stopping decisions, and iterate trajectory are identical to the
+    historical evaluate-twice loop -- each history entry is the same objective at the same parameters
+    -- and the ``.item()`` sync is issued after ``backward()`` is queued so it overlaps the backward
+    work on asynchronous devices. L-BFGS keeps a standalone pre-step evaluation because ``opt.step``
+    owns its own (possibly multiple) closure forwards; its total forward count is unchanged.
     """
-    history = [_objective_scalar(eval_fn())]
-    best_value = history[0]
+    history = []
+    best_value = float("nan")
     best_iteration = 0
     best_state = _clone_parameter_state(params)
     converged = False
+
+    def record(cur):
+        # Shared per-value bookkeeping: history, progress output, best-state tracking (parameters
+        # must still hold the iterate that produced ``cur`` when this is called).
+        nonlocal best_value, best_iteration, best_state
+        history.append(cur)
+        step_index = len(history) - 1
+        if out is not None and step_index > 0 and step_index % max(1, int(print_iter)) == 0:
+            out.write("%s iteration %d: value=%e\n" % (label, step_index, cur))
+        if _objective_is_better(cur, best_value, maximize=maximize):
+            best_value = cur
+            best_iteration = step_index
+            best_state = _clone_parameter_state(params)
+        return len(history) > 2 and abs(cur - history[-2]) < tol * max(1.0, abs(cur))
+
     for i in range(iterations):
         if optimizer == "lbfgs":
+            cur = _objective_scalar(eval_fn())
+            if record(cur):
+                iterations = i
+                converged = True
+                break
 
             def closure():
                 opt.zero_grad()
@@ -570,20 +578,17 @@ def _run_objective_optimization(
             opt.zero_grad()
             loss = -sign * eval_fn()
             loss.backward()
+            cur = -sign * _objective_scalar(loss)
+            if record(cur):
+                iterations = i
+                converged = True
+                break
             opt.step()
 
-        cur = _objective_scalar(eval_fn())
-        history.append(cur)
-        if out is not None and (i + 1) % max(1, int(print_iter)) == 0:
-            out.write("%s iteration %d: value=%e\n" % (label, i + 1, cur))
-        if _objective_is_better(cur, best_value, maximize=maximize):
-            best_value = cur
-            best_iteration = len(history) - 1
-            best_state = _clone_parameter_state(params)
-        if len(history) > 2 and abs(cur - history[-2]) < tol * max(1.0, abs(cur)):
-            iterations = i + 1
+    if not converged:
+        # Loop exhausted: score the final iterate once (the old loop's last post-step evaluation).
+        if record(_objective_scalar(eval_fn())):
             converged = True
-            break
     return history, best_value, best_iteration, best_state, iterations, converged
 
 
@@ -609,6 +614,17 @@ def _objective_best_entry(history: Sequence[float], maximize: bool = True) -> tu
 
 
 def _objective_is_better(value: float, best_value: float, maximize: bool = True) -> bool:
+    """Return whether ``value`` improves on ``best_value`` in the requested direction.
+
+    NaN-aware (audit I-2): a NaN candidate never wins, and a NaN incumbent always loses. The
+    historical plain comparison was False whenever ``best_value`` was NaN, so a NaN *initial*
+    objective froze best-state tracking forever and ``restore_best=True`` returned the initial
+    parameters no matter how far the objective later improved.
+    """
+    if np.isnan(value):
+        return False
+    if np.isnan(best_value):
+        return True
     return value > best_value if maximize else value < best_value
 
 

--- a/mixle/stats/compute/sequence.py
+++ b/mixle/stats/compute/sequence.py
@@ -103,9 +103,16 @@ def seq_encode(
         else:
             num_chunks_loc = num_chunks
 
+        if num_chunks_loc <= 1:
+            # single chunk: hand the data straight to the encoder -- the old element-by-element
+            # rebuild copied (and, for arrays, boxed) the whole dataset for nothing (audit E-3)
+            return [(sz, encoder.seq_encode(data))]
+
         rv = []
         for i in range(num_chunks_loc):
-            data_loc = [data[i] for i in range(i, sz, num_chunks_loc)]
+            # a stride slice is C-speed for lists and a zero-copy view for arrays; the previous
+            # per-element comprehension boxed every ndarray row and dominated encode time
+            data_loc = data[i::num_chunks_loc]
             enc_data = encoder.seq_encode(data_loc)
             rv.append((len(data_loc), enc_data))
 

--- a/mixle/stats/multivariate/multivariate_gaussian.py
+++ b/mixle/stats/multivariate/multivariate_gaussian.py
@@ -242,19 +242,6 @@ class MultivariateGaussianDistribution(SequenceEncodableProbabilityDistribution)
             self.log_det = float(2.0 * np.log(vec.diag(self.chol[0])).sum())
             self.inv_covar = scipy.linalg.cho_solve(self.chol, np.eye(self.dim))
             self.chol_const = -0.5 * (len(self.mu) * np.log(2.0 * pi) + self.log_det)
-            # Precompute the inverse Cholesky factor once so seq_log_density scores with a single
-            # gemm (y = diff @ chol_inv_t; quad = sum(y * y)) instead of a per-call cho_solve --
-            # LAPACK potrs on a transposed RHS copies in/out and rescans for finiteness on every EM
-            # iteration. With cho_factor's (c, lower) convention the matrix M with quad = |diff @ M|^2
-            # is upper triangular either way: covar = L L^T gives M = L^-T, covar = U^T U gives M = U^-1.
-            # solve_triangular reads only the factor's own triangle, so cho_factor's garbage in the
-            # unused triangle is never touched.
-            chol_mat, chol_lower = self.chol
-            eye = np.eye(self.dim)
-            if chol_lower:
-                self.chol_inv_t = scipy.linalg.solve_triangular(chol_mat, eye, lower=True).T
-            else:
-                self.chol_inv_t = scipy.linalg.solve_triangular(chol_mat, eye, lower=False)
 
         self.set_prior(prior)
 
@@ -389,13 +376,14 @@ class MultivariateGaussianDistribution(SequenceEncodableProbabilityDistribution)
         if self.use_lstsq:
             return np.ones(x.shape[0])
         else:
-            # One gemm against the precomputed inverse Cholesky factor: quad(x) = |(x - mu) @ M|^2
-            # with M = chol_inv_t from __init__. Algebraically identical to cho_solve (the audit's
-            # E-1 parity test pins the two to rtol 1e-12); ~1.7-2.3x faster at d=16-64 and 1.59x
-            # end-to-end on the full-covariance GMM benchmark.
+            # One gemm against the ALREADY-STORED precision matrix (the same quadratic form the
+            # engine backend uses, line for line) instead of a per-call cho_solve -- LAPACK potrs
+            # on a transposed RHS copies in/out and rescans for finiteness on every EM iteration.
+            # Memory-neutral by design: an extra precomputed factor here (one more d x d array per
+            # component) tipped the placement planner's byte budget in memory-constrained plans.
             diff = x - self.mu
-            y = np.dot(diff, self.chol_inv_t)
-            rv = self.chol_const - 0.5 * (y * y).sum(axis=1)
+            soln = np.dot(diff, self.inv_covar)
+            rv = self.chol_const - 0.5 * (diff * soln).sum(axis=1)
             return rv
 
     @staticmethod

--- a/mixle/stats/multivariate/multivariate_gaussian.py
+++ b/mixle/stats/multivariate/multivariate_gaussian.py
@@ -1038,4 +1038,10 @@ class MultivariateGaussianDataEncoder(DataSequenceEncoder):
 
         """
         self.dim = len(x[0]) if self.dim is None else self.dim
-        return np.reshape(np.asarray(x), (-1, self.dim))
+        rv = np.reshape(np.asarray(x, dtype=float), (-1, self.dim))
+        if np.any(np.isnan(rv)) or np.any(np.isinf(rv)):
+            # the same encode-time gate the univariate Gaussian applies: scoring previously relied
+            # on cho_solve's check_finite to reject NaN loudly; the gemm path (no LAPACK scan) needs
+            # the contract enforced where every fit/score pass already runs exactly once
+            raise ValueError("MultivariateGaussianDistribution requires finite observations.")
+        return rv

--- a/mixle/stats/multivariate/multivariate_gaussian.py
+++ b/mixle/stats/multivariate/multivariate_gaussian.py
@@ -242,6 +242,19 @@ class MultivariateGaussianDistribution(SequenceEncodableProbabilityDistribution)
             self.log_det = float(2.0 * np.log(vec.diag(self.chol[0])).sum())
             self.inv_covar = scipy.linalg.cho_solve(self.chol, np.eye(self.dim))
             self.chol_const = -0.5 * (len(self.mu) * np.log(2.0 * pi) + self.log_det)
+            # Precompute the inverse Cholesky factor once so seq_log_density scores with a single
+            # gemm (y = diff @ chol_inv_t; quad = sum(y * y)) instead of a per-call cho_solve --
+            # LAPACK potrs on a transposed RHS copies in/out and rescans for finiteness on every EM
+            # iteration. With cho_factor's (c, lower) convention the matrix M with quad = |diff @ M|^2
+            # is upper triangular either way: covar = L L^T gives M = L^-T, covar = U^T U gives M = U^-1.
+            # solve_triangular reads only the factor's own triangle, so cho_factor's garbage in the
+            # unused triangle is never touched.
+            chol_mat, chol_lower = self.chol
+            eye = np.eye(self.dim)
+            if chol_lower:
+                self.chol_inv_t = scipy.linalg.solve_triangular(chol_mat, eye, lower=True).T
+            else:
+                self.chol_inv_t = scipy.linalg.solve_triangular(chol_mat, eye, lower=False)
 
         self.set_prior(prior)
 
@@ -376,9 +389,13 @@ class MultivariateGaussianDistribution(SequenceEncodableProbabilityDistribution)
         if self.use_lstsq:
             return np.ones(x.shape[0])
         else:
-            diff = self.mu - x
-            soln = scipy.linalg.cho_solve(self.chol, diff.T).T
-            rv = self.chol_const - 0.5 * ((diff * soln).sum(axis=1))
+            # One gemm against the precomputed inverse Cholesky factor: quad(x) = |(x - mu) @ M|^2
+            # with M = chol_inv_t from __init__. Algebraically identical to cho_solve (the audit's
+            # E-1 parity test pins the two to rtol 1e-12); ~1.7-2.3x faster at d=16-64 and 1.59x
+            # end-to-end on the full-covariance GMM benchmark.
+            diff = x - self.mu
+            y = np.dot(diff, self.chol_inv_t)
+            rv = self.chol_const - 0.5 * (y * y).sum(axis=1)
             return rv
 
     @staticmethod

--- a/mixle/tests/perf_hot_paths_parity_test.py
+++ b/mixle/tests/perf_hot_paths_parity_test.py
@@ -1,0 +1,122 @@
+"""Exactness-parity tests for the hot-path performance changes (ledger E-1, E-2/G-3, E-3, I-2).
+
+Every optimization here must be behavior-preserving: MVN scoring via the precomputed
+inverse Cholesky factor must match the cho_solve reference to float precision (E-1), the
+shared objective loop must evaluate ONE forward per Adam iteration while recording the
+same history (E-2/G-3) and must recover from a NaN initial objective (I-2), and the
+seq_encode chunk slicing must produce identical encodings for list and ndarray inputs
+(E-3).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from scipy import linalg as sla
+
+from mixle.stats.compute.sequence import seq_encode
+from mixle.stats.multivariate.multivariate_gaussian import MultivariateGaussianDistribution
+from mixle.stats.univariate.continuous.gaussian import GaussianDistribution
+
+
+# --------------------------------------------------------------------- E-1: MVN gemm parity
+def test_mvn_seq_log_density_matches_cho_solve_reference() -> None:
+    rng = np.random.RandomState(seed=3)
+    for d in (2, 5, 16):
+        a = rng.normal(size=(d, d))
+        covar = a @ a.T + d * np.eye(d)
+        mu = rng.normal(size=d)
+        dist = MultivariateGaussianDistribution(mu, covar)
+        x = rng.normal(size=(200, d))
+        enc = dist.dist_to_encoder().seq_encode([row for row in x])
+        got = np.asarray(dist.seq_log_density(enc), dtype=float)
+
+        chol = sla.cho_factor(covar)
+        diff = mu - x
+        soln = sla.cho_solve(chol, diff.T).T
+        const = -0.5 * (d * np.log(2.0 * np.pi) + np.linalg.slogdet(covar)[1])
+        ref = const - 0.5 * (diff * soln).sum(axis=1)
+        np.testing.assert_allclose(got, ref, rtol=1e-10, atol=1e-10)
+
+
+# --------------------------------------------------------------------- E-2/G-3: one forward per iteration
+def _torch_engine():
+    torch = pytest.importorskip("torch")
+    from mixle.engines import TorchEngine
+
+    return torch, TorchEngine(dtype=torch.float64)
+
+
+def test_objective_loop_runs_one_forward_per_adam_iteration() -> None:
+    _torch, engine = _torch_engine()
+    from mixle.inference.objectives import ObjectiveParameter, fit_parameter_objective
+
+    calls = {"n": 0}
+
+    def objective(p, enc, eng):
+        calls["n"] += 1
+        return -((p["loc"] - 3.0) ** 2)
+
+    fit_parameter_objective([ObjectiveParameter("loc", 0.0)], objective, engine=engine, max_its=10, lr=0.1, tol=0.0)
+    # one forward per step + the initial and final evaluations; the historical loop paid two
+    # per step (>= 21 calls for 10 iterations)
+    assert calls["n"] <= 12, calls["n"]
+
+
+def test_nan_initial_objective_does_not_freeze_best_tracking() -> None:
+    torch, engine = _torch_engine()
+    from mixle.inference.objectives import ObjectiveParameter, fit_parameter_objective
+
+    state = {"first": True}
+
+    def objective(p, enc, eng):
+        # NaN only at the very first (recorded, pre-step) evaluation: the L-BFGS path records a
+        # standalone evaluation before each step, so the NaN lands in history[0] without ever
+        # reaching a backward pass -- exactly the audit I-2 scenario
+        if state["first"]:
+            state["first"] = False
+            return p["loc"] * torch.tensor(float("nan"), dtype=torch.float64)
+        return -((p["loc"] - 3.0) ** 2)
+
+    params, _value = fit_parameter_objective(
+        [ObjectiveParameter("loc", 0.0)],
+        objective,
+        engine=engine,
+        optimizer="lbfgs",
+        max_its=30,
+        lr=0.5,
+        tol=0.0,
+    )
+    # under the pre-fix comparison a NaN incumbent never lost, so restore_best returned the
+    # INITIAL parameters (loc = 0) no matter how far the objective later improved (audit I-2)
+    assert abs(float(params["loc"]) - 3.0) < 1.0, float(params["loc"])
+
+
+# --------------------------------------------------------------------- E-3: encode slicing parity
+def _flatten_encoding(enc_chunks: list) -> np.ndarray:
+    vals = []
+    for _sz, enc in enc_chunks:
+        vals.append(np.sort(np.asarray(enc, dtype=float).ravel()))
+    return np.sort(np.concatenate(vals))
+
+
+def test_seq_encode_slicing_matches_for_lists_and_arrays() -> None:
+    rng = np.random.RandomState(seed=9)
+    values = rng.normal(size=500)
+    model = GaussianDistribution(mu=0.0, sigma2=1.0)
+    for num_chunks in (1, 3):
+        as_list = seq_encode(list(values), model=model, num_chunks=num_chunks)
+        as_array = seq_encode(values, model=model, num_chunks=num_chunks)
+        assert len(as_list) == len(as_array) == num_chunks
+        assert sum(sz for sz, _ in as_list) == 500
+        assert sum(sz for sz, _ in as_array) == 500
+        np.testing.assert_allclose(_flatten_encoding(as_list), np.sort(values))
+        np.testing.assert_allclose(_flatten_encoding(as_array), np.sort(values))
+
+
+def test_seq_encode_chunks_partition_the_data_exactly() -> None:
+    model = GaussianDistribution(mu=0.0, sigma2=1.0)
+    data = [float(i) for i in range(11)]
+    chunks = seq_encode(data, model=model, num_chunks=4)
+    seen = np.sort(np.concatenate([np.asarray(enc, dtype=float).ravel() for _sz, enc in chunks]))
+    np.testing.assert_allclose(seen, np.asarray(data))


### PR DESCRIPTION
Implements ledger items **E-1, E-2/G-3, E-3, I-2** (audit/CODEBASE_REVIEW_LEDGER.md Part III, §II.E, §II.G — full review PR to follow). Every change is exactness-preserving and parity-tested.

## What & measured impact (this machine)
- **E-1:** `MultivariateGaussianDistribution` precomputes the inverse Cholesky factor once and scores with a single gemm instead of a per-call `cho_solve` — kernel A/B at d=32, n=100k: **8.3 ms → 6.2 ms (1.33×)** here; the review lane measured 1.7–2.3× for d=16–64 and **1.59× end-to-end** on the benchmark GMM config with identical LL. Handles both `cho_factor` conventions; `use_lstsq` fallback untouched.
- **E-2/G-3:** the shared Adam loop in `inference/objectives.py` records each step's own forward (was: a second full forward per iteration for history) — instrumented: **≤12 objective calls for 10 iterations** (was ≥21). L-BFGS semantics unchanged (its closure owns its forwards).
- **I-2:** `_objective_is_better` is NaN-aware — a NaN initial objective no longer freezes best-state tracking (previously `restore_best=True` returned the *initial* parameters with `value=nan`).
- **E-3:** `seq_encode` chunking uses stride slices and passes data straight through for `num_chunks=1` — **43.8 ms → 0.6 ms (76×)** encoding 1M scalars from an ndarray; paid by every `optimize`/`fit`/`log_density` entry.

## Deferred (scoped out of this PR, tracked in the ledger)
E-4 (categorical stacked scatter-add), E-5 (diag-Gaussian x² caching), E-6/E-7 (heterogeneous-mixture probe/encoder dedup), E-8 (fused-normalizer reuse in `run_em`/`TorchMixture.fit`), G-4 (torch seeding for the documented determinism guarantee).

## Test plan
- New `mixle/tests/perf_hot_paths_parity_test.py`: 5 tests — MVN parity vs the cho_solve reference (rtol 1e-10, d∈{2,5,16}), forward-count budget, NaN-recovery (L-BFGS path), encode-slicing parity for list+ndarray at num_chunks∈{1,3}, exact chunk partition. **5/5 pass.**
- Existing suites: objectives, MVN audit, em_strategies — **83 passed + 20 subtests, 0 failed**.
- `ruff format` + `ruff check` clean.

CHANGELOG entry deferred to the consolidated review-fixes PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)