### PR TITLE
docs(rng): scope the determinism claim; record the degenerate-Dirichlet init as intentional

### DIFF
--- a/mixle/inference/estimation.py
+++ b/mixle/inference/estimation.py
@@ -822,8 +822,12 @@ def optimize(
             If None, estimator is used. Must be consistent with estimator.
         init_p (float): Value in (0.0,1.0] for randomizing the proportion of data points used in initialization.
         rng (RandomState): RandomState used to set seed for initializing EM algorithm. ``None`` resolves to
-            a FIXED seed, so an un-seeded ``optimize``/``fit`` is deterministic by default; pass your own
-            RandomState when you WANT different initializations across calls (e.g. hand-rolled restarts).
+            a FIXED seed, so the NumPy-driven parts of an un-seeded ``optimize``/``fit`` (initialization,
+            EM, subsampling) are deterministic by default; pass your own RandomState when you WANT
+            different initializations across calls (e.g. hand-rolled restarts). Torch-backed leaves are
+            the deliberate exception: modules that consume torch's global RNG (dropout, VAE
+            reparameterization draws, minibatch shuffling) follow torch's own default non-determinism --
+            call ``torch.manual_seed`` yourself when a torch-backed fit must be exactly reproducible.
             An integer is accepted and coerced to ``RandomState(rng)``. Mutually exclusive with ``seed``.
         vdata (Optional[Sequence[T]]): Optional validation set.
         prev_estimate (Optional[SeqeuenceEncodableProbabilityDistribution]): Optional model estimate used from prior
@@ -983,7 +987,7 @@ def optimize(
     estimator = _coerce_estimator(estimator, data)
     if init_estimator is not None:
         init_estimator = _coerce_estimator(init_estimator, data)
-    rng = RandomState(0) if rng is None else rng  # fixed default: an un-seeded fit is deterministic
+    rng = RandomState(0) if rng is None else rng  # fixed default: the numpy side of an un-seeded fit is deterministic
     minimal_precision_pending = False
     if precision == "minimal":
         # Data-aware allocation: inspect the data + model and run the reduced-precision fused kernel only
@@ -1515,7 +1519,9 @@ class BayesianStreamingEstimator:
             raise ValueError("mode must be 'posterior_carry' or 'forgetting'.")
         self.model = model
         self.init_p = init_p
-        self.rng = RandomState(0) if rng is None else rng  # fixed default: an un-seeded fit is deterministic
+        self.rng = (
+            RandomState(0) if rng is None else rng
+        )  # fixed default: the numpy side of an un-seeded fit is deterministic
         self.num_chunks = num_chunks
         self.step = 0
         self.nobs = 0.0

--- a/mixle/stats/latent/mixture.py
+++ b/mixle/stats/latent/mixture.py
@@ -1423,7 +1423,13 @@ class MixtureEstimator(ParameterEstimator):
             robust: Enable the robust default path: k-means++ initialization
                 where applicable plus a small data-independent weight floor.
             init: Initialization strategy for the accumulator. ``None`` selects
-                ``"kmeans++"`` in robust mode and ``"dirichlet"`` otherwise.
+                ``"kmeans++"`` in robust mode and ``"dirichlet"`` otherwise. The ``"dirichlet"``
+                default draws per-observation responsibilities from a deliberately degenerate
+                Dirichlet (``alpha = 1/K**2``) -- sparse random assignments, the standard
+                responsibility init. Because random subsets of a large dataset share its pooled
+                moments, every component still starts near the global law as ``n`` grows; for
+                well-separated location families prefer ``init="kmeans++"`` (or ``robust=True`` /
+                :func:`~mixle.inference.best_of` restarts) when a single default fit must separate.
         """
         self.num_components = len(estimators)
         self.estimators = estimators


### PR DESCRIPTION
Closes the review's two deferred design decisions per the maintainer's calls (ledger **G-4**, **I-10** — no behavior changes, documentation only).

- **G-4:** torch-backed leaves deliberately keep torch's default (non-deterministic) global RNG. The `optimize`/`fit` `rng` docstring now states precisely what an un-seeded call guarantees — the NumPy-driven initialization/EM/subsampling is deterministic; modules consuming torch's global RNG (dropout, VAE reparameterization, minibatch shuffling) are not, and users who need exact torch reproducibility call `torch.manual_seed` themselves. Two overbroad inline comments scoped to match.
- **I-10:** the `"dirichlet"` mixture init is the intended degenerate (`alpha = 1/K²`) responsibility draw — standard behavior, kept as the default. Its docstring now records that intent plus the large-n concentration property (random sparse subsets share the pooled moments), and points at the existing escape hatches (`init="kmeans++"`, `robust=True`, `best_of`) for well-separated location families.

## Test plan
Docs-only; `ruff format`/`ruff check` clean; alias + automatic-mixture suites re-run green (30 + 6 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)