### PR TITLE
fix(fused): keyed tying on the engine path; recalibrate the parallel floor (compiler review round 2)

### DIFF
--- a/mixle/inference/estimation.py
+++ b/mixle/inference/estimation.py
@@ -254,6 +254,14 @@ def _engine_fused_step(
             have_ll = False
         else:
             ll += float(chunk_ll)
+    # The key_merge/key_replace pass every other EM driver runs after accumulation (seq_estimate,
+    # _local_fused_step; #432 added it to the posterior-transform strategies). Without it, KEYED
+    # (tied) parameters silently untie on the engine-kernel path -- and the auto-fusion gate routes
+    # large fused-eligible fits here, so a tied-variance mixture at scale estimated per-component
+    # stats instead of pooled ones (proven: sigma2 1.36 vs 3.18 where the host ties both at 1.36).
+    stats_dict: dict = {}
+    accumulator.key_merge(stats_dict)
+    accumulator.key_replace(stats_dict)
     return estimator.estimate(nobs, accumulator.value()), (ll if have_ll else None)
 
 

--- a/mixle/stats/compute/fused_codegen.py
+++ b/mixle/stats/compute/fused_codegen.py
@@ -1002,7 +1002,9 @@ _ESTEP_COMPILED: dict[tuple, Callable] = {}
 # cross-row reduction, but sequential and parallel are DIFFERENT fastmath binaries, and LLVM vectorizes
 # each loop nest differently (measured max 4.7e-16 relative). Bit-identity holds within each variant,
 # never across variants.
-_PARALLEL_MIN_OBS = 262_144  # below this the fork/join overhead eats the win
+_PARALLEL_MIN_OBS = (
+    65_536  # measured crossover ~48k on a 3-component composite (0.89x at 32k, 1.49x at 64k, 2.44x at 262k)
+)
 _PARALLEL_MAX_CHUNKS = 256
 _PARALLEL_CHUNK_TARGET = 16_384
 
@@ -1496,7 +1498,7 @@ def fused_seq_log_density(
     ``compute_dtype`` (e.g. ``np.float32``) runs the row arithmetic in reduced precision while the
     log-sum-exp accumulator and output stay float64; ``None`` keeps the byte-identical float64 path.
 
-    ``parallel``: ``None`` auto-engages the chunked prange scorer for large inputs (>= 262144 rows and
+    ``parallel``: ``None`` auto-engages the chunked prange scorer for large inputs (>= 65536 rows -- the measured crossover -- and
     more than one numba worker); ``True``/``False`` force it. Rows are disjoint (no cross-row
     reduction), so the parallel scorer is bit-identical across runs and worker counts; against the
     sequential kernel it agrees to 1-2 ULP (different fastmath binaries vectorize differently --
@@ -1583,7 +1585,7 @@ def fused_accumulate(
     ``(suff_stat, ll)`` so the EM loop can skip a separate scoring pass. Raises ``ValueError`` if not
     fusible.
 
-    ``parallel``: ``None`` auto-engages the chunked prange E-step for large inputs (>= 262144 rows and
+    ``parallel``: ``None`` auto-engages the chunked prange E-step for large inputs (>= 65536 rows -- the measured crossover -- and
     more than one numba worker); ``True``/``False`` force it. Chunk boundaries are a pure function of n
     and chunk partials combine in fixed order, so parallel results are bit-identical across runs AND
     across worker counts; they differ from the sequential kernel only by float re-association across

--- a/mixle/tests/conftest.py
+++ b/mixle/tests/conftest.py
@@ -95,6 +95,9 @@ FILE_MARKERS: dict[str, MarkerTuple] = {
     # nested), the nested wants_minmax decline, and per-component weighted Pareto support minima --
     # numba-gated like its siblings; the numba-free halves live in fastmath_policy_test.py.
     "fused_out_of_support_test.py": ("numba", "optional"),
+    # Keyed (tied) parameters through the fused ENGINE path: the #432 bug class's fused edition
+    # (merge_accumulator_keys was skipped exactly where the auto-fusion gate routes large fits).
+    "fused_keyed_tying_test.py": ("numba", "optional"),
     "jax_engine_test.py": ("jax", "optional"),
     # Backward-compatibility-only tests (renamed class / kwarg aliases). Tagged `legacy` so a product-only
     # run can exclude them with `-m "not legacy"`; they still run in the default `fast` gate.

--- a/mixle/tests/fused_keyed_tying_test.py
+++ b/mixle/tests/fused_keyed_tying_test.py
@@ -1,0 +1,58 @@
+"""Keyed (tied) parameters survive the fused engine path (the #432 bug class, fused edition).
+
+merge_accumulator_keys is the pass every EM driver must run exactly once after accumulation.
+_engine_fused_step -- the path optimize()'s auto-fusion gate routes large fits onto -- skipped it,
+so shared-key estimators silently untied: a tied-variance mixture estimated per-component variances
+(1.36 vs 3.18) where the host pools both at 1.36. Found by a compiler review's live probe; fixed by
+running the same pass the local step and seq_estimate run. These tests pin both the engine step and
+the end-to-end optimize route.
+"""
+
+import unittest
+
+import numpy as np
+
+from mixle.utils.optional_deps import HAS_NUMBA
+
+if HAS_NUMBA:
+    from mixle.engines import FUSED_NUMPY_ENGINE
+    from mixle.inference import optimize
+    from mixle.inference.estimation import _engine_fused_step
+    from mixle.stats import GaussianDistribution, MixtureDistribution
+    from mixle.stats.compute.sequence import seq_estimate
+    from mixle.stats.latent.mixture import MixtureEstimator
+    from mixle.stats.univariate.continuous.gaussian import GaussianEstimator
+
+
+def _tied_fixture(n_per=4000):
+    rng = np.random.RandomState(0)
+    data = [float(v) for v in np.concatenate([rng.normal(-3, 1.0, n_per), rng.normal(3, 2.0, n_per)])]
+    model = MixtureDistribution([GaussianDistribution(-2.0, 1.5), GaussianDistribution(2.0, 1.5)], [0.5, 0.5])
+    est = MixtureEstimator([GaussianEstimator(keys=(None, "shared_var")), GaussianEstimator(keys=(None, "shared_var"))])
+    enc_data = [(len(data), model.dist_to_encoder().seq_encode(data))]
+    return model, est, enc_data, data
+
+
+@unittest.skipUnless(HAS_NUMBA, "the fused engine path requires numba")
+class FusedKeyedTyingTest(unittest.TestCase):
+    def test_engine_fused_step_pools_shared_keys_like_the_host(self):
+        model, est, enc_data, _ = _tied_fixture()
+        host = seq_estimate(enc_data, est, model)
+        fused, _ll = _engine_fused_step(enc_data, est, model, FUSED_NUMPY_ENGINE)
+        hv = [c.sigma2 for c in host.components]
+        fv = [c.sigma2 for c in fused.components]
+        self.assertAlmostEqual(hv[0], hv[1], places=12, msg="host must tie the shared-key variances")
+        self.assertAlmostEqual(fv[0], fv[1], places=12, msg="the fused engine path must tie them too")
+        np.testing.assert_allclose(fv, hv, rtol=1e-9)
+
+    def test_optimize_with_the_fused_engine_keeps_tying_end_to_end(self):
+        model, est, enc_data, data = _tied_fixture(n_per=2500)
+        fit = optimize(
+            data, estimator=est, prev_estimate=model, max_its=5, delta=None, engine=FUSED_NUMPY_ENGINE, out=None
+        )
+        sig = [c.sigma2 for c in fit.components]
+        self.assertAlmostEqual(sig[0], sig[1], places=12, msg=f"tied variances diverged: {sig}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

A fresh adversarial review of the compiler at the merged tip (post #414–#437). Two measurement-driven fixes:

### 1. Keyed (tied) parameters silently untied on the fused engine path
The #432 bug class's fused edition: `_engine_fused_step` — exactly where the auto-fusion gate routes large fused-eligible fits — skipped the `merge_accumulator_keys` pass that `seq_estimate`, `_local_fused_step`, and (since #432) the posterior-transform strategies all run. **Live proof**: a shared-key tied-variance mixture estimated σ² = (1.36, 3.18) through the engine path; the host pools both at 1.36. Fixed with the same two-line pass; pinned at the engine-step level and end-to-end through `optimize(engine=FUSED_NUMPY_ENGINE)`.

### 2. The parallel floor was ~4× too conservative
Measured E-step crossover on a 3-component composite: 0.89× @32k, **1.49× @64k, 1.86× @128k**, 2.44× @262k. Floor drops 262,144 → 65,536 — mid-size fits were leaving the 1.5–1.9× band on the table.

## Hypotheses killed by measurement (recorded so nobody re-chases them)
- Per-call marshalling is **2%** of an E-step — a marshalling cache would be dead weight.
- The suspected hierarchical-mixture coverage gap mostly doesn't exist: `fused_nested` already covers mixture-of-mixture-of-scalar-composites. Only chain/bridge-bearing composites **under an inner mixture** fall to host — a narrow residual, documented.

## Cross-wave reconciliation verified
#428's min-combined accumulators compose correctly with the chunked parallel combine (`np.minimum.reduce` over the chunk axis), and its E-step/nested impossible-row guards hold with these changes.

## Receipt
Full gate: **5135 passed, 0 failed**; 2 new pinning tests; the fuzzer and edge panel stay green with the lower floor.