### PR TITLE
Fix keyed-statistic pooling end to end; finish compiler-review follow-ups

### DIFF
--- a/mixle/inference/block_em.py
+++ b/mixle/inference/block_em.py
@@ -449,8 +449,21 @@ def _select_active(
 def is_block_em_eligible(model: Any, estimator: Any) -> bool:
     """Whether ``model``/``estimator`` are a plain ``MixtureDistribution``/``MixtureEstimator`` pair
     the D3 scheduler can drive. Lives here (not in estimation.py) so the high-level estimation driver
-    never imports a concrete distribution type -- see compute_metadata_test.py's layering check."""
-    return isinstance(model, MixtureDistribution) and isinstance(estimator, MixtureEstimator)
+    never imports a concrete distribution type -- see compute_metadata_test.py's layering check.
+
+    Keyed (tied) estimators are ineligible: tying pools statistics ACROSS sites via the
+    merge_accumulator_keys pass, and block-EM's sparse per-component M-steps neither run that pass
+    nor could honor it without re-estimating every tied sibling of an updated block -- exactly the
+    silent-untying bug class #432 fixed in the posterior-transform strategies. schedule='auto'
+    therefore keeps keyed fits on the full-tree path (this predicate), and an EXPLICIT run_block_em
+    call refuses loudly instead of silently untying."""
+    from mixle.stats.compute.pdist import estimator_has_keys
+
+    return (
+        isinstance(model, MixtureDistribution)
+        and isinstance(estimator, MixtureEstimator)
+        and not estimator_has_keys(estimator)
+    )
 
 
 def run_block_em(
@@ -569,6 +582,15 @@ def run_block_em(
     part of this path. ``weight_tol`` controls temporary dormancy only. Use
     :func:`mixle.inference.freeze_rollup.run_em_freeze_rollup` when those controls are desired.
     """
+    from mixle.stats.compute.pdist import estimator_has_keys
+
+    if estimator_has_keys(estimator):
+        raise NotImplementedError(
+            "block-EM does not support keyed (tied) estimators: its sparse per-component M-steps "
+            "cannot run the merge_accumulator_keys pooling pass without re-estimating every tied "
+            "sibling of an updated block, so tying would silently break. Use the full-tree path "
+            "(optimize(schedule='full') or schedule='auto', which reroutes keyed fits automatically)."
+        )
     if not isinstance(initial_model, MixtureDistribution):
         raise TypeError("run_block_em requires a MixtureDistribution model.")
     if (

--- a/mixle/inference/estimation.py
+++ b/mixle/inference/estimation.py
@@ -221,6 +221,11 @@ def _engine_seq_estimate(
     for sz, enc in chunks:
         nobs += sz
         accumulator.combine(kernel.accumulate(enc, np.ones(sz, dtype=np.float64)))
+    # The post-accumulation key pass every EM driver must run -- same omission as _engine_fused_step
+    # had: without it, keyed (tied) parameters silently untie on any engine-kernel fit routed here.
+    stats_dict: dict = {}
+    accumulator.key_merge(stats_dict)
+    accumulator.key_replace(stats_dict)
     # Activate the engine so device-aware M-steps (e.g. NeuralLeaf) follow its device. The context
     # wraps nested component estimates too (a MixtureEstimator's per-leaf estimate runs inside it).
     from mixle.engines.base import using_active_engine
@@ -230,7 +235,11 @@ def _engine_seq_estimate(
 
 
 def _engine_fused_step(
-    enc_data: Any, estimator: ParameterEstimator, prev_estimate: Any, engine: Any
+    enc_data: Any,
+    estimator: ParameterEstimator,
+    prev_estimate: Any,
+    engine: Any,
+    fused_options: dict[str, Any] | None = None,
 ) -> tuple[Any, float | None]:
     """Engine E/M step that also returns the data log-likelihood of ``prev_estimate``.
 
@@ -242,6 +251,10 @@ def _engine_fused_step(
     validate_estimator_keys(estimator)
     chunks = _local_encoded_chunks(enc_data)
     kernel = prev_estimate.kernel(engine=engine, estimator=estimator)
+    if fused_options:
+        for knob, value in fused_options.items():
+            if hasattr(kernel, knob):  # only the FusedKernel carries the tuning attrs
+                setattr(kernel, knob, value)
     accumulator = estimator.accumulator_factory().make()
     nobs = 0.0
     ll = 0.0
@@ -805,6 +818,7 @@ def optimize(
     monotone: bool | None = None,
     track_best: bool | None = None,
     seed: int | None = None,
+    fused_options: dict[str, Any] | None = None,
 ) -> SequenceEncodableProbabilityDistribution:
     """Fit ``estimator`` to ``data`` by a generalized-EM loop, for ``max_its`` iterations or until the
         objective improves by less than ``delta``.
@@ -938,6 +952,14 @@ def optimize(
         seed (Optional[int]): Integer seed for initializing the EM algorithm -- shorthand for
             ``rng=RandomState(seed)``, matching the ``seed=`` argument the samplers and the other
             entry points take. Mutually exclusive with ``rng`` (passing both raises ``TypeError``).
+        fused_options (Optional[dict]): Tuning knobs for the fused compiled kernels, applied when the
+            fit runs on a fused engine (an explicit fused ``engine=`` or the auto-fusion gate).
+            Recognized keys: ``parallel`` (bool -- force the chunk-parallel kernels on or off,
+            overriding the observation-count auto-gate; results are bit-stable either way),
+            ``lse_bits`` (int -- opt SCORING into quantized log-sum-exp with a ~2**-bits relative
+            bound; E-steps always stay exact), and ``lse_span`` (float, default 24.0 -- the clipped
+            LSE exponent range used with ``lse_bits``). Unknown keys raise ``ValueError``. Ignored
+            (with the same validation) when the fit resolves to a non-fused path.
 
     Returns:
         SequenceEncodableProbabilityDistribution corresponding to estimator when stopping criteria of EM algorithm
@@ -945,6 +967,12 @@ def optimize(
 
     """
     rng = _resolve_rng_arg(rng, seed)
+    if fused_options is not None:
+        unknown = set(fused_options) - {"parallel", "lse_bits", "lse_span"}
+        if unknown:
+            raise ValueError(
+                f"optimize(fused_options=...): unknown keys {sorted(unknown)}; expected a subset of ['lse_bits', 'lse_span', 'parallel']"
+            )
     if (
         estimator is None
         and structure == "auto"
@@ -1185,7 +1213,7 @@ def optimize(
             if engine is None:
                 fused_step_fn = _local_fused_step
             else:
-                fused_step_fn = partial(_engine_fused_step, engine=engine)
+                fused_step_fn = partial(_engine_fused_step, engine=engine, fused_options=fused_options)
 
         objective_scorer = _objective_scorer(resolved_objective, estimator, engine)
         objective_fn = lambda candidate: objective_scorer(enc_data, candidate)[1]

--- a/mixle/inference/estimation.py
+++ b/mixle/inference/estimation.py
@@ -254,6 +254,14 @@ def _engine_fused_step(
             have_ll = False
         else:
             ll += float(chunk_ll)
+    # The key_merge/key_replace pass every other EM driver runs after accumulation (seq_estimate,
+    # _local_fused_step; #432 added it to the posterior-transform strategies). Without it, KEYED
+    # (tied) parameters silently untie on the engine-kernel path -- and the auto-fusion gate routes
+    # large fused-eligible fits here, so a tied-variance mixture at scale estimated per-component
+    # stats instead of pooled ones (proven: sigma2 1.36 vs 3.18 where the host ties both at 1.36).
+    stats_dict: dict = {}
+    accumulator.key_merge(stats_dict)
+    accumulator.key_replace(stats_dict)
     return estimator.estimate(nobs, accumulator.value()), (ll if have_ll else None)
 
 

--- a/mixle/inference/fusion_policy.py
+++ b/mixle/inference/fusion_policy.py
@@ -76,7 +76,11 @@ def prefer_block_schedule(model: Any, enc_data: Any, max_its: int) -> bool:
         if HAS_NUMBA:
             from mixle.stats.compute.fused_codegen import fusible
 
-            if fusible(model):
+            # bare_bridge=False: only the FAST fused paths beat block scheduling. The bare-bridge
+            # last resort scores each component through its own native seq_log_density (host-speed
+            # columns + a fused softmax), so it does NOT capture the cross-component win the
+            # docstring numbers are about -- sparse block selection still pays off there.
+            if fusible(model, bare_bridge=False):
                 return False  # the whole-model fused kernel wins outright; see the docstring numbers
     except Exception:  # noqa: BLE001 - fusibility probe must never break dispatch
         pass

--- a/mixle/inference/precision_plan.py
+++ b/mixle/inference/precision_plan.py
@@ -89,7 +89,10 @@ def recommend_compute_precision(
         from mixle.stats.compute.fused_codegen import fusible
     except Exception:  # pragma: no cover - numba optional  # noqa: BLE001
         return PrecisionPlan(np.float64, "fused codegen unavailable -> float64")
-    if not fusible(model):
+    # bare_bridge=False: bare-bridge fusion computes its per-component score tables through each
+    # factor's native float64 seq_log_density, so a float32 band would touch only the softmax --
+    # no real reduced-precision win to recommend there.
+    if not fusible(model, bare_bridge=False):
         return PrecisionPlan(np.float64, "model has no fused reduced-precision kernel -> float64")
 
     # look at the COMPUTATION: leaf families + per-leaf conditioning

--- a/mixle/stats/combinator/hurdle.py
+++ b/mixle/stats/combinator/hurdle.py
@@ -213,6 +213,11 @@ class HurdleAccumulator(SequenceEncodableStatisticAccumulator):
                 zc, t = stats_dict[self.keys]
                 self.zero_count += zc
                 self.total += t
+                # write the POOL back: without this, the dict keeps the FIRST site's stats and
+                # key_replace hands every tied site that truncated pool -- later sites' data was
+                # silently discarded (order-dependent wrong fits; found by the compiler review's
+                # keyed-tying probe, present in 8 families vs the combine-into-dict families)
+                stats_dict[self.keys] = (self.zero_count, self.total)
             else:
                 stats_dict[self.keys] = (self.zero_count, self.total)
 

--- a/mixle/stats/combinator/zero_inflated.py
+++ b/mixle/stats/combinator/zero_inflated.py
@@ -216,6 +216,11 @@ class ZeroInflatedAccumulator(SequenceEncodableStatisticAccumulator):
                 ic, t = stats_dict[self.keys]
                 self.inflation_count += ic
                 self.total += t
+                # write the POOL back: without this, the dict keeps the FIRST site's stats and
+                # key_replace hands every tied site that truncated pool -- later sites' data was
+                # silently discarded (order-dependent wrong fits; found by the compiler review's
+                # keyed-tying probe, present in 8 families vs the combine-into-dict families)
+                stats_dict[self.keys] = (self.inflation_count, self.total)
             else:
                 stats_dict[self.keys] = (self.inflation_count, self.total)
 

--- a/mixle/stats/compute/fused_codegen.py
+++ b/mixle/stats/compute/fused_codegen.py
@@ -1002,7 +1002,9 @@ _ESTEP_COMPILED: dict[tuple, Callable] = {}
 # cross-row reduction, but sequential and parallel are DIFFERENT fastmath binaries, and LLVM vectorizes
 # each loop nest differently (measured max 4.7e-16 relative). Bit-identity holds within each variant,
 # never across variants.
-_PARALLEL_MIN_OBS = 262_144  # below this the fork/join overhead eats the win
+_PARALLEL_MIN_OBS = (
+    65_536  # measured crossover ~48k on a 3-component composite (0.89x at 32k, 1.49x at 64k, 2.44x at 262k)
+)
 _PARALLEL_MAX_CHUNKS = 256
 _PARALLEL_CHUNK_TARGET = 16_384
 
@@ -1496,7 +1498,7 @@ def fused_seq_log_density(
     ``compute_dtype`` (e.g. ``np.float32``) runs the row arithmetic in reduced precision while the
     log-sum-exp accumulator and output stay float64; ``None`` keeps the byte-identical float64 path.
 
-    ``parallel``: ``None`` auto-engages the chunked prange scorer for large inputs (>= 262144 rows and
+    ``parallel``: ``None`` auto-engages the chunked prange scorer for large inputs (>= 65536 rows -- the measured crossover -- and
     more than one numba worker); ``True``/``False`` force it. Rows are disjoint (no cross-row
     reduction), so the parallel scorer is bit-identical across runs and worker counts; against the
     sequential kernel it agrees to 1-2 ULP (different fastmath binaries vectorize differently --
@@ -1583,7 +1585,7 @@ def fused_accumulate(
     ``(suff_stat, ll)`` so the EM loop can skip a separate scoring pass. Raises ``ValueError`` if not
     fusible.
 
-    ``parallel``: ``None`` auto-engages the chunked prange E-step for large inputs (>= 262144 rows and
+    ``parallel``: ``None`` auto-engages the chunked prange E-step for large inputs (>= 65536 rows -- the measured crossover -- and
     more than one numba worker); ``True``/``False`` force it. Chunk boundaries are a pure function of n
     and chunk partials combine in fixed order, so parallel results are bit-identical across runs AND
     across worker counts; they differ from the sequential kernel only by float re-association across

--- a/mixle/stats/compute/fused_codegen.py
+++ b/mixle/stats/compute/fused_codegen.py
@@ -50,11 +50,14 @@ kernels (:mod:`fused_nested`) carry the same contracts.
 
 Principled exclusions, deliberate and documented rather than pending: E-steps always use EXACT exp (a
 delta-grid perturbation could flip a monotone-gate accept); bare nested mixtures keep fused_nested's
-in-kernel path (faster than bridging); GradLeaf M-steps stay eager torch (torch.compile measured 0.79-
-0.93x on CPU -- see the GradLeaf docstring).
+in-kernel path (faster than bridging), and only when fused_nested itself declines (e.g. minmax leaves
+like Pareto) does a LAST-RESORT bare-bridge pass cover the shape -- host-exact semantics, one softmax
+kernel; GradLeaf M-steps stay eager torch (torch.compile measured 0.79-0.93x on CPU -- see the GradLeaf
+docstring).
 
 Generated kernels are compiled once and disk-cached (see :func:`_njit`), so the compile cost is paid once
-per structure *ever*, not per process.
+per structure *ever*, not per process; :func:`clean_fused_cache` garbage-collects entries stranded by
+structure changes or digest-salt bumps.
 """
 
 from __future__ import annotations
@@ -867,6 +870,7 @@ class FusedPlan:
     leaf_templates: tuple[LeafTemplate, ...]  # one per factor (composite factor order)
     signature: tuple
     component_is_composite: bool = False  # whether each leaf-bearing node is a Composite (vs a bare leaf)
+    bare_bridge: bool = False  # last-resort plan: bare combinator components bridged whole (see _node_factors)
 
     @property
     def has_matrix(self) -> bool:
@@ -887,21 +891,23 @@ class FusedPlan:
         return any(t.kind in ("matrix", "chain", "bridge") for t in self.leaf_templates)
 
 
-def _node_factors(node: Any) -> list[Any] | None:
+def _node_factors(node: Any, bare_bridge: bool = False) -> list[Any] | None:
     """The leaf factors of a fusible *node* (an exact Composite, or a templated bare leaf), else None.
 
-    The bare-node check deliberately excludes the bridge template: a bare Mixture-of-Mixtures (no
+    The bare-node check excludes the bridge template BY DEFAULT: a bare Mixture-of-Mixtures (no
     Composite anywhere) belongs to fused_nested's in-kernel nested-tree path, which is faster than
-    bridging. Bridge factors exist for combinators sitting INSIDE a composite, where no in-kernel
-    path exists at all."""
+    bridging. ``bare_bridge=True`` is the LAST-RESORT pass the public entry points try only after
+    both the template plan and fused_nested have declined -- it lets hierarchical mixtures whose
+    inner components are chain/bridge-bearing composites (which neither other path can take) fuse
+    through per-component native scoring instead of falling all the way to the host walk."""
     if type(node).__name__ == "CompositeDistribution":
         return list(node.dists)
-    if _template_for(node, allow_bridge=False) is not None:
+    if _template_for(node, allow_bridge=bare_bridge) is not None:
         return [node]
     return None
 
 
-def analyze(model: Any) -> FusedPlan | None:
+def analyze(model: Any, bare_bridge: bool = False) -> FusedPlan | None:
     """Return a :class:`FusedPlan` if ``model`` is a fusible mixture/composite of templated leaves, else None.
 
     Handles: a single leaf, a Composite of leaves, a Mixture of leaves, and a Mixture of Composites
@@ -914,7 +920,7 @@ def analyze(model: Any) -> FusedPlan | None:
     tname = type(model).__name__
     if tname == "MixtureDistribution":
         comps = list(model.components)
-        per = [_node_factors(c) for c in comps]
+        per = [_node_factors(c, bare_bridge=bare_bridge) for c in comps]
         if any(p is None for p in per):  # a component is not a plain Composite / templated leaf
             return None
         templates = [_template_for(f) for f in per[0]]  # type: ignore[union-attr]
@@ -924,26 +930,40 @@ def analyze(model: Any) -> FusedPlan | None:
         if any([_template_for(f) for f in p] != templates for p in per):  # type: ignore[union-attr]
             return None
         comp_is_composite = type(comps[0]).__name__ == "CompositeDistribution"
-        sig = ("mix", tuple(t.name for t in templates), comp_is_composite)  # type: ignore[union-attr]
-        return FusedPlan(len(comps), True, tuple(templates), sig, comp_is_composite)  # type: ignore[arg-type]
-    factors = _node_factors(model)
+        sig = ("mix", tuple(t.name for t in templates), comp_is_composite, bare_bridge)  # type: ignore[union-attr]
+        return FusedPlan(len(comps), True, tuple(templates), sig, comp_is_composite, bare_bridge)  # type: ignore[arg-type]
+    # The bare-bridge allowance never applies to the ROOT itself: bridging a bare leaf/combinator
+    # root is one native scoring pass wrapped in a kernel -- no softmax, no templated siblings,
+    # nothing fused. It exists solely so a MIXTURE's components can be bridged whole (above).
+    factors = _node_factors(model, bare_bridge=False)
     if factors is None:
         return None
     templates = [_template_for(f) for f in factors]
     if any(t is None for t in templates):  # a composite factor has no leaf template
         return None
     is_composite = tname == "CompositeDistribution"
-    sig = ("comp", tuple(t.name for t in templates), is_composite)  # type: ignore[union-attr]
-    return FusedPlan(1, False, tuple(templates), sig, is_composite)  # type: ignore[arg-type]
+    sig = ("comp", tuple(t.name for t in templates), is_composite, bare_bridge)  # type: ignore[union-attr]
+    return FusedPlan(1, False, tuple(templates), sig, is_composite, bare_bridge)  # type: ignore[arg-type]
 
 
-def fusible(model: Any) -> bool:
-    """Return whether ``model`` can use a fused scoring kernel."""
+def fusible(model: Any, bare_bridge: bool = True) -> bool:
+    """Return whether ``model`` can use a fused scoring kernel.
+
+    ``bare_bridge=False`` restricts the answer to the FAST paths (flat template, nested in-kernel):
+    the bare-bridge last resort scores each component through its own native ``seq_log_density``, so
+    it is host-speed with a fused softmax, not a single-pass win. Policy call sites that use
+    fusibility as a proxy for "a fused kernel would beat this schedule" (block-EM's scheduler, the
+    precision planner) must pass ``bare_bridge=False``; correctness call sites keep the default.
+    """
     if analyze(model) is not None:
         return True
     from mixle.stats.compute.fused_nested import fusible_nested  # nested scalar trees (Mixture-of-Mixture, ...)
 
-    return fusible_nested(model)
+    if fusible_nested(model):
+        return True
+    # last resort: hierarchical mixtures whose inner components carry chain/bridge factors -- the
+    # nested path declines them (non-scalar leaves), so bridge the inner combinators per component
+    return bare_bridge and analyze(model, bare_bridge=True) is not None
 
 
 def _dummy(t: LeafTemplate) -> Any:
@@ -1213,6 +1233,52 @@ def _njit(src: str, fname: str, parallel: bool = False) -> Callable:
             return numba.njit(fastmath={"reassoc", "contract", "arcp", "afn", "nsz"}, parallel=parallel)(ns[fname])
 
 
+def clean_fused_cache(max_age_days: float = 30.0, dry_run: bool = False) -> dict[str, Any]:
+    """Garbage-collect the fused kernel disk cache; returns ``{"removed": [...], "bytes": n, "dir": path}``.
+
+    The cache grows one small module (plus numba's compiled ``__pycache__`` artifacts, the bulk of the
+    bytes) per distinct (structure, decorator-config) forever -- nothing retires entries when a digest
+    salt bump or a structure change strands them. This removes cache-owned files whose modification
+    time is older than ``max_age_days`` (a re-used kernel is re-written/re-compiled cheaply on next
+    use, so an over-aggressive age costs one compile, never correctness), plus crashed writers'
+    ``*.tmp`` leftovers after a day. Only files matching the cache's own naming pattern inside the
+    private cache directory are candidates; everything else is ignored. ``dry_run=True`` reports
+    without deleting.
+    """
+    import glob
+    import time
+
+    report: dict[str, Any] = {"removed": [], "bytes": 0, "dir": None}
+    cache_dir = _private_cache_dir()
+    if cache_dir is None:
+        return report
+    report["dir"] = cache_dir
+    now = time.time()
+    cutoff = now - max_age_days * 86400.0
+    candidates = glob.glob(os.path.join(cache_dir, "_pysp_fused_*.py"))
+    candidates += glob.glob(os.path.join(cache_dir, "__pycache__", "_pysp_fused_*"))
+    candidates += glob.glob(os.path.join(cache_dir, "_pysp_fused_*.py.*.tmp"))
+    for path in candidates:
+        try:
+            info = os.lstat(path)
+        except OSError:
+            continue
+        if not stat.S_ISREG(info.st_mode):
+            continue
+        limit = now - 86400.0 if path.endswith(".tmp") else cutoff
+        if info.st_mtime >= limit:
+            continue
+        report["removed"].append(path)
+        report["bytes"] += int(info.st_size)
+        if not dry_run:
+            try:
+                os.remove(path)
+            except OSError:
+                report["removed"].pop()
+                report["bytes"] -= int(info.st_size)
+    return report
+
+
 def _score_body(indent: str, row_lines: list[str], llbuf_name: str) -> list[str]:
     """The per-row score+log-sum-exp block shared by the sequential and parallel scorers."""
     lines = [f"{indent}for k in range(kc):", f"{indent}    acc = logw[k]"]
@@ -1408,8 +1474,8 @@ def _compile_estep(plan: FusedPlan, parallel: bool = False) -> Callable:
 # --- marshalling ----------------------------------------------------------------------------------
 def _component_factor_lists(model: Any, plan: FusedPlan) -> list[list[Any]]:
     if plan.is_mixture:
-        return [_node_factors(c) for c in model.components]  # type: ignore[misc]
-    return [_node_factors(model)]  # type: ignore[list-item]
+        return [_node_factors(c, bare_bridge=plan.bare_bridge) for c in model.components]  # type: ignore[misc]
+    return [_node_factors(model, bare_bridge=plan.bare_bridge)]  # type: ignore[list-item]
 
 
 def _data_and_params(
@@ -1515,13 +1581,17 @@ def fused_seq_log_density(
     """
     plan = analyze(model)
     if plan is None:
-        from mixle.stats.compute.fused_nested import fused_nested_seq_log_density
+        from mixle.stats.compute.fused_nested import fused_nested_seq_log_density, fusible_nested
 
-        # nested scalar tree (raises if not that either); same dtype/parallel/quantized-LSE contract
-        # (nested error bound compounds per mixture level -- see the nested wrapper's docstring)
-        return fused_nested_seq_log_density(
-            model, enc, compute_dtype=compute_dtype, parallel=parallel, lse_bits=lse_bits, lse_span=lse_span
-        )
+        if fusible_nested(model):
+            # nested scalar tree; same dtype/parallel/quantized-LSE contract (nested error bound
+            # compounds per mixture level -- see the nested wrapper's docstring)
+            return fused_nested_seq_log_density(
+                model, enc, compute_dtype=compute_dtype, parallel=parallel, lse_bits=lse_bits, lse_span=lse_span
+            )
+        plan = analyze(model, bare_bridge=True)  # hierarchical mixtures over chain/bridge composites
+        if plan is None:
+            raise ValueError("%s is not fusible on any path (template, nested, bridge)." % type(model).__name__)
     data_arrays, param_arrays, _, n = _data_and_params(model, plan, enc, compute_dtype)
     logw = np.asarray(getattr(model, "log_w", np.zeros(1)), dtype=np.float64)
     out = np.empty(n, dtype=np.float64)
@@ -1549,13 +1619,20 @@ def fused_seq_log_density(
 
 
 # --- fused E-step (score + responsibilities + per-leaf weighted sufficient statistics, one njit) ----
-def fusible_estep(model: Any) -> bool:
-    """Return whether ``model`` can use a fused E-step accumulation kernel."""
+def fusible_estep(model: Any, bare_bridge: bool = True) -> bool:
+    """Return whether ``model`` can use a fused E-step accumulation kernel.
+
+    ``bare_bridge=False`` restricts to the fast paths, exactly as in :func:`fusible`.
+    """
     plan = analyze(model)
     if plan is None:
         from mixle.stats.compute.fused_nested import fusible_nested  # nested scalar trees fit the E-step too
 
-        return fusible_nested(model)
+        if fusible_nested(model):
+            return True
+        plan = analyze(model, bare_bridge=True) if bare_bridge else None
+        if plan is None:
+            return False
     hook = {
         "scalar": lambda t: t.acc_stmt,
         "vector": lambda t: t.vec_accumulate,
@@ -1594,11 +1671,15 @@ def fused_accumulate(
     """
     plan = analyze(model)
     if plan is None:
-        from mixle.stats.compute.fused_nested import fused_nested_accumulate
+        from mixle.stats.compute.fused_nested import fused_nested_accumulate, fusible_nested
 
-        return fused_nested_accumulate(
-            model, enc, weights, return_ll=return_ll, compute_dtype=compute_dtype, parallel=parallel
-        )  # nested scalar tree
+        if fusible_nested(model):
+            return fused_nested_accumulate(
+                model, enc, weights, return_ll=return_ll, compute_dtype=compute_dtype, parallel=parallel
+            )  # nested scalar tree
+        plan = analyze(model, bare_bridge=True)  # hierarchical mixtures over chain/bridge composites
+        if plan is None:
+            raise ValueError("%s is not fusible on any path (template, nested, bridge)." % type(model).__name__)
     if not fusible_estep(model):
         raise ValueError("%s is not a fusible E-step (an unsupported leaf)." % type(model).__name__)
     K = plan.num_components
@@ -1777,6 +1858,12 @@ class FusedKernel:
         edt = getattr(engine, "dtype", None)
         self.compute_dtype = edt if edt is not None and np.dtype(edt) != np.float64 else None
         self.last_ll: float | None = None  # data LL of the last accumulate() pass (posterior normalizer)
+        # Tuning knobs (``optimize(fused_options=...)`` sets these). ``parallel`` overrides the
+        # observation-count auto-gate in both directions; ``lse_bits``/``lse_span`` opt scoring into
+        # quantized LSE. E-steps stay exact by design, so accumulate() never sees the lse knobs.
+        self.parallel: bool | None = None
+        self.lse_bits: int | None = None
+        self.lse_span: float = 24.0
 
     def encode(self, data: Any) -> Any:
         """Encode raw data through the distribution's sequence encoder."""
@@ -1784,13 +1871,25 @@ class FusedKernel:
 
     def score(self, enc: Any) -> np.ndarray:
         """Score encoded data with the fused log-density kernel."""
-        return fused_seq_log_density(self.dist, getattr(enc, "engine_payload", enc), self.compute_dtype)
+        return fused_seq_log_density(
+            self.dist,
+            getattr(enc, "engine_payload", enc),
+            self.compute_dtype,
+            parallel=self.parallel,
+            lse_bits=self.lse_bits,
+            lse_span=self.lse_span,
+        )
 
     def accumulate(self, enc: Any, weights: Any) -> Any:
         """Accumulate weighted sufficient statistics with the fused E-step kernel."""
         w = np.asarray(self.engine.to_numpy(weights) if hasattr(self.engine, "to_numpy") else weights, dtype=np.float64)
         suff, self.last_ll = fused_accumulate(
-            self.dist, getattr(enc, "engine_payload", enc), w, return_ll=True, compute_dtype=self.compute_dtype
+            self.dist,
+            getattr(enc, "engine_payload", enc),
+            w,
+            return_ll=True,
+            compute_dtype=self.compute_dtype,
+            parallel=self.parallel,
         )
         return suff
 
@@ -1833,6 +1932,7 @@ __all__ = [
     "fusible_estep",
     "fused_seq_log_density",
     "fused_accumulate",
+    "clean_fused_cache",
     "FusedKernel",
     "FusedKernelFactory",
     "FusedPlan",

--- a/mixle/stats/compute/pdist.py
+++ b/mixle/stats/compute/pdist.py
@@ -1272,6 +1272,18 @@ def validate_estimator_keys(estimator: ParameterEstimator) -> None:
     _collect_accumulator_keys(accumulator, accumulator_registry, type(accumulator).__name__, set())
 
 
+def estimator_has_keys(estimator: ParameterEstimator) -> bool:
+    """Whether any site in the estimator tree carries a tying key.
+
+    Keyed sites require the ``merge_accumulator_keys`` pass after accumulation; an EM driver that
+    cannot run it (or whose update decomposition conflicts with pooling, e.g. block-EM's sparse
+    per-component M-steps) must refuse or reroute keyed estimators rather than silently untie them.
+    """
+    registry: dict[Any, tuple[Any, str]] = {}
+    _collect_estimator_keys(estimator, registry, type(estimator).__name__, set())
+    return bool(registry)
+
+
 def validate_accumulator_keys(accumulator: StatisticAccumulator) -> None:
     """Validate keyed sites in an already-created accumulator tree."""
     accumulator_registry: dict[Any, tuple[Any, str]] = {}

--- a/mixle/stats/processes/ctmc.py
+++ b/mixle/stats/processes/ctmc.py
@@ -216,11 +216,16 @@ class ContinuousTimeMarkovChainAccumulator(SequenceEncodableStatisticAccumulator
         return self
 
     def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge keyed transition and dwell statistics into this accumulator."""
-        if self.keys is not None and self.keys in stats_dict:
-            c, d = stats_dict[self.keys]
-            self.counts += c
-            self.dwell += d
+        """Merge keyed transition and dwell statistics into ``stats_dict`` (the pool lives in the dict)."""
+        # Must INSERT when the key is absent: the old shape only merged when another site had already
+        # registered, but no site ever inserted -- so keyed CTMCs never pooled at all (key_merge and
+        # key_replace were both silent no-ops and every tied site kept its own statistics).
+        if self.keys is not None:
+            if self.keys in stats_dict:
+                c, d = stats_dict[self.keys]
+                stats_dict[self.keys] = (c + self.counts, d + self.dwell)
+            else:
+                stats_dict[self.keys] = (self.counts.copy(), self.dwell.copy())
 
     def key_replace(self, stats_dict: dict[str, Any]) -> None:
         """Replace this accumulator's state from keyed statistics when present."""

--- a/mixle/stats/processes/inhomogeneous_poisson.py
+++ b/mixle/stats/processes/inhomogeneous_poisson.py
@@ -266,6 +266,11 @@ class InhomogeneousPoissonProcessAccumulator(SequenceEncodableStatisticAccumulat
                 bc, nr = stats_dict[self.keys]
                 self.bin_counts += bc
                 self.n_realizations += nr
+                # write the POOL back: without this, the dict keeps the FIRST site's stats and
+                # key_replace hands every tied site that truncated pool -- later sites' data was
+                # silently discarded (order-dependent wrong fits; found by the compiler review's
+                # keyed-tying probe, present in 8 families vs the combine-into-dict families)
+                stats_dict[self.keys] = (self.bin_counts, self.n_realizations)
             else:
                 stats_dict[self.keys] = (self.bin_counts.copy(), self.n_realizations)
 

--- a/mixle/stats/univariate/continuous/exponential.py
+++ b/mixle/stats/univariate/continuous/exponential.py
@@ -500,6 +500,11 @@ class ExponentialAccumulator(SequenceEncodableStatisticAccumulator):
                 x0, x1 = stats_dict[self.keys]
                 self.count += x0
                 self.sum += x1
+                # write the POOL back: without this, the dict keeps the FIRST site's stats and
+                # key_replace hands every tied site that truncated pool -- later sites' data was
+                # silently discarded (order-dependent wrong fits; found by the compiler review's
+                # keyed-tying probe, present in 8 families vs the combine-into-dict families)
+                stats_dict[self.keys] = (self.count, self.sum)
             else:
                 stats_dict[self.keys] = (self.count, self.sum)
 

--- a/mixle/stats/univariate/continuous/gamma.py
+++ b/mixle/stats/univariate/continuous/gamma.py
@@ -558,6 +558,11 @@ class GammaAccumulator(SequenceEncodableStatisticAccumulator):
                 self.count += x0
                 self.sum += x1
                 self.sum_of_logs += x2
+                # write the POOL back: without this, the dict keeps the FIRST site's stats and
+                # key_replace hands every tied site that truncated pool -- later sites' data was
+                # silently discarded (order-dependent wrong fits; found by the compiler review's
+                # keyed-tying probe, present in 8 families vs the combine-into-dict families)
+                stats_dict[self.keys] = (self.count, self.sum, self.sum_of_logs)
 
             else:
                 stats_dict[self.keys] = (self.count, self.sum, self.sum_of_logs)

--- a/mixle/stats/univariate/continuous/gaussian.py
+++ b/mixle/stats/univariate/continuous/gaussian.py
@@ -672,6 +672,11 @@ class GaussianAccumulator(SequenceEncodableStatisticAccumulator):
                 self.sum2 += x1
                 self.count += x2
                 self.count2 += x3
+                # write the POOL back: without this, the dict keeps the FIRST site's stats and
+                # key_replace hands every tied site that truncated pool -- later sites' data was
+                # silently discarded (order-dependent wrong fits; found by the compiler review's
+                # keyed-tying probe, present in 8 families vs the combine-into-dict families)
+                stats_dict[self.keys] = (self.sum, self.sum2, self.count, self.count2)
 
             else:
                 stats_dict[self.keys] = (self.sum, self.sum2, self.count, self.count2)

--- a/mixle/stats/univariate/discrete/geometric.py
+++ b/mixle/stats/univariate/discrete/geometric.py
@@ -598,6 +598,11 @@ class GeometricAccumulator(SequenceEncodableStatisticAccumulator):
                 x0, x1 = stats_dict[self.keys]
                 self.count += x0
                 self.sum += x1
+                # write the POOL back: without this, the dict keeps the FIRST site's stats and
+                # key_replace hands every tied site that truncated pool -- later sites' data was
+                # silently discarded (order-dependent wrong fits; found by the compiler review's
+                # keyed-tying probe, present in 8 families vs the combine-into-dict families)
+                stats_dict[self.keys] = (self.count, self.sum)
 
             else:
                 stats_dict[self.keys] = (self.count, self.sum)

--- a/mixle/stats/univariate/discrete/skellam.py
+++ b/mixle/stats/univariate/discrete/skellam.py
@@ -316,6 +316,11 @@ class SkellamAccumulator(SequenceEncodableStatisticAccumulator):
                 self.count += c
                 self.sum += s
                 self.sum2 += s2
+                # write the POOL back: without this, the dict keeps the FIRST site's stats and
+                # key_replace hands every tied site that truncated pool -- later sites' data was
+                # silently discarded (order-dependent wrong fits; found by the compiler review's
+                # keyed-tying probe, present in 8 families vs the combine-into-dict families)
+                stats_dict[self.keys] = (self.count, self.sum, self.sum2)
             else:
                 stats_dict[self.keys] = (self.count, self.sum, self.sum2)
 

--- a/mixle/tests/block_em_efficiency_test.py
+++ b/mixle/tests/block_em_efficiency_test.py
@@ -123,7 +123,9 @@ class AuditCadenceAndDispatchTest:
             ],
             [0.34, 0.33, 0.33],
         )
-        assert not fusible(deepish)  # the Laplace leaf breaks whole-model fusion
+        # the Laplace leaf keeps this off the FAST fused paths (the bare-bridge last resort covers
+        # it at host speed, which is exactly why prefer_block_schedule asks with bare_bridge=False)
+        assert not fusible(deepish, bare_bridge=False)
         rng = np.random.RandomState(3)
         enc = seq_encode(rng.normal(0.0, 4.0, 20_000), model=deepish)
         # only 3 components, but each is an expensive subtree: block scheduling qualifies

--- a/mixle/tests/conftest.py
+++ b/mixle/tests/conftest.py
@@ -95,6 +95,9 @@ FILE_MARKERS: dict[str, MarkerTuple] = {
     # nested), the nested wants_minmax decline, and per-component weighted Pareto support minima --
     # numba-gated like its siblings; the numba-free halves live in fastmath_policy_test.py.
     "fused_out_of_support_test.py": ("numba", "optional"),
+    # Keyed (tied) parameters through the fused ENGINE path: the #432 bug class's fused edition
+    # (merge_accumulator_keys was skipped exactly where the auto-fusion gate routes large fits).
+    "fused_keyed_tying_test.py": ("numba", "optional"),
     "jax_engine_test.py": ("jax", "optional"),
     # Backward-compatibility-only tests (renamed class / kwarg aliases). Tagged `legacy` so a product-only
     # run can exclude them with `-m "not legacy"`; they still run in the default `fast` gate.

--- a/mixle/tests/conftest.py
+++ b/mixle/tests/conftest.py
@@ -98,6 +98,10 @@ FILE_MARKERS: dict[str, MarkerTuple] = {
     # Keyed (tied) parameters through the fused ENGINE path: the #432 bug class's fused edition
     # (merge_accumulator_keys was skipped exactly where the auto-fusion gate routes large fits).
     "fused_keyed_tying_test.py": ("numba", "optional"),
+    # optimize(fused_options=...) plumbing (parallel override, quantized-LSE scoring) + the fused
+    # disk-cache GC. keyed_pooling_test.py is deliberately NOT registered here: it exercises the
+    # host-side key_merge/key_replace pooling protocol only, so it belongs to the default fast gate.
+    "fused_options_test.py": ("numba", "optional"),
     "jax_engine_test.py": ("jax", "optional"),
     # Backward-compatibility-only tests (renamed class / kwarg aliases). Tagged `legacy` so a product-only
     # run can exclude them with `-m "not legacy"`; they still run in the default `fast` gate.

--- a/mixle/tests/fastmath_policy_test.py
+++ b/mixle/tests/fastmath_policy_test.py
@@ -84,8 +84,12 @@ class NestedMinmaxExclusionTest(unittest.TestCase):
         # wants_minmax templates have to_value=None; the nested emitter would call it mid-fit
         mm = self._pareto_mixture_of_mixtures()
         self.assertFalse(fused_nested.fusible_nested(mm))
-        self.assertFalse(fused_codegen.fusible(mm))
-        self.assertFalse(fused_codegen.fusible_estep(mm))
+        self.assertFalse(fused_codegen.fusible(mm, bare_bridge=False))
+        self.assertFalse(fused_codegen.fusible_estep(mm, bare_bridge=False))
+        # the shape is still COVERED, by the bare-bridge last resort: per-component native
+        # scoring/accumulation has no to_value problem (parity pinned in fused_out_of_support_test)
+        self.assertTrue(fused_codegen.fusible(mm))
+        self.assertTrue(fused_codegen.fusible_estep(mm))
 
     def test_flat_pareto_mixture_still_fuses(self):
         # the exclusion is scoped to NESTING: the flat compiler has the minmax plumbing

--- a/mixle/tests/fused_fuzz_test.py
+++ b/mixle/tests/fused_fuzz_test.py
@@ -10,7 +10,11 @@ sample must satisfy, against the untouched host path:
   P2  score parity at 1e-9;
   P3  M-step parity: estimate(fused stats) and estimate(host stats) score identically at 1e-9;
   P4  the parallel scorer matches and its reruns are bit-identical;
-  P5  three manual EM steps through the fused path are monotone (the E-step normalizer never lies).
+  P5  three manual EM steps through the fused path are monotone (the E-step normalizer never lies);
+  P6  keyed tying: with every gaussian site sharing one key, the fused ENGINE DRIVER step matches the
+      host driver and actually ties -- driver-level (the merge pass a driver can forget) and
+      family-level (a key_merge that truncates the pool) keying bugs both existed and both escaped
+      the P1-P5 kernel-parity net, because keys live in the drivers, not the kernels.
 
 Compile-cost discipline: kernels cache by STRUCTURE signature (factor-type sequence), so the
 generator draws many samples over a bounded signature pool -- parameters, component counts, and data
@@ -174,6 +178,53 @@ def check_sample(tc, rng, sig=None):
     tc.assertTrue(
         all(b - a >= -1e-9 * max(1.0, abs(a)) for a, b in zip(lls, lls[1:])),
         f"{label}: EM through the fused E-step must be monotone, got {lls}",
+    )
+
+    # P6 keyed tying through the DRIVERS (kernel parity can't see keys -- they pool in the driver)
+    if "gaussian" in sig:
+        check_keyed_tying(tc, model, data, sig, label)
+
+
+def _keyed_estimator(model, sig, key):
+    """The model's estimator with every gaussian site keyed to ``key`` (whole-state tying)."""
+    from mixle.stats.combinator.composite import CompositeEstimator
+    from mixle.stats.latent.mixture import MixtureEstimator
+    from mixle.stats.univariate.continuous.gaussian import GaussianEstimator
+
+    comp_ests = []
+    for comp in model.components:
+        factors = comp.dists if len(sig) > 1 else (comp,)
+        fests = [GaussianEstimator(keys=key) if name == "gaussian" else f.estimator() for name, f in zip(sig, factors)]
+        comp_ests.append(CompositeEstimator(fests) if len(sig) > 1 else fests[0])
+    return MixtureEstimator(comp_ests)
+
+
+def check_keyed_tying(tc, model, data, sig, label):
+    from mixle.engines import FUSED_NUMPY_ENGINE
+    from mixle.inference.estimation import _engine_fused_step
+    from mixle.stats.compute.sequence import seq_estimate
+
+    keyed = _keyed_estimator(model, sig, key="fz_shared")
+    enc = model.dist_to_encoder().seq_encode(data)
+    enc_data = [(len(data), enc)]
+    host_fit = seq_estimate(enc_data, keyed, model)
+    fused_fit, _ll = _engine_fused_step(enc_data, keyed, model, FUSED_NUMPY_ENGINE)
+
+    def gaussian_params(fit):
+        out = []
+        for comp in fit.components:
+            factors = comp.dists if len(sig) > 1 else (comp,)
+            out.append([(f.mu, f.sigma2) for name, f in zip(sig, factors) if name == "gaussian"])
+        return out
+
+    hp, fp = gaussian_params(host_fit), gaussian_params(fused_fit)
+    tc.assertEqual(len(set(map(tuple, hp))), 1, f"{label}: host must tie all shared-key gaussian sites")
+    tc.assertEqual(len(set(map(tuple, fp))), 1, f"{label}: fused driver must tie all shared-key gaussian sites")
+    np.testing.assert_allclose(
+        np.asarray(fp, dtype=np.float64),
+        np.asarray(hp, dtype=np.float64),
+        rtol=1e-9,
+        err_msg=f"{label}: keyed M-step parity (driver merge pass or family key_merge pooling broke)",
     )
 
 

--- a/mixle/tests/fused_keyed_tying_test.py
+++ b/mixle/tests/fused_keyed_tying_test.py
@@ -1,0 +1,58 @@
+"""Keyed (tied) parameters survive the fused engine path (the #432 bug class, fused edition).
+
+merge_accumulator_keys is the pass every EM driver must run exactly once after accumulation.
+_engine_fused_step -- the path optimize()'s auto-fusion gate routes large fits onto -- skipped it,
+so shared-key estimators silently untied: a tied-variance mixture estimated per-component variances
+(1.36 vs 3.18) where the host pools both at 1.36. Found by a compiler review's live probe; fixed by
+running the same pass the local step and seq_estimate run. These tests pin both the engine step and
+the end-to-end optimize route.
+"""
+
+import unittest
+
+import numpy as np
+
+from mixle.utils.optional_deps import HAS_NUMBA
+
+if HAS_NUMBA:
+    from mixle.engines import FUSED_NUMPY_ENGINE
+    from mixle.inference import optimize
+    from mixle.inference.estimation import _engine_fused_step
+    from mixle.stats import GaussianDistribution, MixtureDistribution
+    from mixle.stats.compute.sequence import seq_estimate
+    from mixle.stats.latent.mixture import MixtureEstimator
+    from mixle.stats.univariate.continuous.gaussian import GaussianEstimator
+
+
+def _tied_fixture(n_per=4000):
+    rng = np.random.RandomState(0)
+    data = [float(v) for v in np.concatenate([rng.normal(-3, 1.0, n_per), rng.normal(3, 2.0, n_per)])]
+    model = MixtureDistribution([GaussianDistribution(-2.0, 1.5), GaussianDistribution(2.0, 1.5)], [0.5, 0.5])
+    est = MixtureEstimator([GaussianEstimator(keys=(None, "shared_var")), GaussianEstimator(keys=(None, "shared_var"))])
+    enc_data = [(len(data), model.dist_to_encoder().seq_encode(data))]
+    return model, est, enc_data, data
+
+
+@unittest.skipUnless(HAS_NUMBA, "the fused engine path requires numba")
+class FusedKeyedTyingTest(unittest.TestCase):
+    def test_engine_fused_step_pools_shared_keys_like_the_host(self):
+        model, est, enc_data, _ = _tied_fixture()
+        host = seq_estimate(enc_data, est, model)
+        fused, _ll = _engine_fused_step(enc_data, est, model, FUSED_NUMPY_ENGINE)
+        hv = [c.sigma2 for c in host.components]
+        fv = [c.sigma2 for c in fused.components]
+        self.assertAlmostEqual(hv[0], hv[1], places=12, msg="host must tie the shared-key variances")
+        self.assertAlmostEqual(fv[0], fv[1], places=12, msg="the fused engine path must tie them too")
+        np.testing.assert_allclose(fv, hv, rtol=1e-9)
+
+    def test_optimize_with_the_fused_engine_keeps_tying_end_to_end(self):
+        model, est, enc_data, data = _tied_fixture(n_per=2500)
+        fit = optimize(
+            data, estimator=est, prev_estimate=model, max_its=5, delta=None, engine=FUSED_NUMPY_ENGINE, out=None
+        )
+        sig = [c.sigma2 for c in fit.components]
+        self.assertAlmostEqual(sig[0], sig[1], places=12, msg=f"tied variances diverged: {sig}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mixle/tests/fused_keyed_tying_test.py
+++ b/mixle/tests/fused_keyed_tying_test.py
@@ -2,8 +2,9 @@
 
 merge_accumulator_keys is the pass every EM driver must run exactly once after accumulation.
 _engine_fused_step -- the path optimize()'s auto-fusion gate routes large fits onto -- skipped it,
-so shared-key estimators silently untied: a tied-variance mixture estimated per-component variances
-(1.36 vs 3.18) where the host pools both at 1.36. Found by a compiler review's live probe; fixed by
+so shared-key estimators silently untied: a shared-key (whole-state-tied) Gaussian mixture estimated
+per-component variances (1.36 vs 3.18) where the host pools both. Found by a compiler review's live
+probe; fixed by
 running the same pass the local step and seq_estimate run. These tests pin both the engine step and
 the end-to-end optimize route.
 """
@@ -28,7 +29,7 @@ def _tied_fixture(n_per=4000):
     rng = np.random.RandomState(0)
     data = [float(v) for v in np.concatenate([rng.normal(-3, 1.0, n_per), rng.normal(3, 2.0, n_per)])]
     model = MixtureDistribution([GaussianDistribution(-2.0, 1.5), GaussianDistribution(2.0, 1.5)], [0.5, 0.5])
-    est = MixtureEstimator([GaussianEstimator(keys=(None, "shared_var")), GaussianEstimator(keys=(None, "shared_var"))])
+    est = MixtureEstimator([GaussianEstimator(keys="shared"), GaussianEstimator(keys="shared")])
     enc_data = [(len(data), model.dist_to_encoder().seq_encode(data))]
     return model, est, enc_data, data
 
@@ -44,6 +45,14 @@ class FusedKeyedTyingTest(unittest.TestCase):
         self.assertAlmostEqual(hv[0], hv[1], places=12, msg="host must tie the shared-key variances")
         self.assertAlmostEqual(fv[0], fv[1], places=12, msg="the fused engine path must tie them too")
         np.testing.assert_allclose(fv, hv, rtol=1e-9)
+
+    def test_engine_seq_estimate_pools_shared_keys_too(self):
+        from mixle.inference.estimation import _engine_seq_estimate
+
+        model, est, enc_data, _ = _tied_fixture()
+        host = seq_estimate(enc_data, est, model)
+        fused = _engine_seq_estimate(enc_data, est, model, FUSED_NUMPY_ENGINE)
+        np.testing.assert_allclose([c.sigma2 for c in fused.components], [c.sigma2 for c in host.components], rtol=1e-9)
 
     def test_optimize_with_the_fused_engine_keeps_tying_end_to_end(self):
         model, est, enc_data, data = _tied_fixture(n_per=2500)

--- a/mixle/tests/fused_options_test.py
+++ b/mixle/tests/fused_options_test.py
@@ -1,0 +1,127 @@
+"""optimize(fused_options=...) reaches the fused kernels: parallel override + quantized-LSE scoring.
+
+The chunk-parallel kernels and quantized LSE existed but had no user-facing switch -- parallel was
+auto-gated on observation count only, and lse_bits was reachable only by calling the codegen wrappers
+directly. These tests pin the plumbing: unknown keys refuse loudly, ``parallel=True`` engages the
+parallel E-step below the auto-gate floor with allclose-identical fits, and ``lse_bits`` bounds the
+scorer against the exact path while E-steps stay exact (the knob never reaches accumulate()).
+"""
+
+import unittest
+
+import numpy as np
+
+from mixle.utils.optional_deps import HAS_NUMBA
+
+if HAS_NUMBA:
+    from mixle.engines import FUSED_NUMPY_ENGINE
+    from mixle.inference import optimize
+    from mixle.stats import GaussianDistribution, MixtureDistribution
+    from mixle.stats.compute import fused_codegen
+    from mixle.stats.latent.mixture import MixtureEstimator
+    from mixle.stats.univariate.continuous.gaussian import GaussianEstimator
+
+
+class FusedCacheGcTest(unittest.TestCase):
+    """clean_fused_cache removes only stale cache-owned files (age-gated, pattern-gated, dry-runnable)."""
+
+    def test_gc_removes_stale_cache_files_and_nothing_else(self):
+        import os
+        import tempfile
+        from unittest import mock
+
+        from mixle.stats.compute import fused_codegen as fc
+
+        with tempfile.TemporaryDirectory() as td:
+            os.chmod(td, 0o700)
+            pyc = os.path.join(td, "__pycache__")
+            os.makedirs(pyc)
+            old = os.path.join(td, "_pysp_fused_deadbeef00000000.py")
+            old_nb = os.path.join(pyc, "_pysp_fused_deadbeef00000000.cpython-314.nbc")
+            fresh = os.path.join(td, "_pysp_fused_cafe000000000000.py")
+            alien = os.path.join(td, "keep_me.py")
+            tmp_orphan = os.path.join(td, "_pysp_fused_deadbeef00000000.py.999.tmp")
+            for p in (old, old_nb, fresh, alien, tmp_orphan):
+                with open(p, "w") as fh:
+                    fh.write("# cache test\n")
+            stale_t = 1.0  # epoch -- ancient
+            os.utime(old, (stale_t, stale_t))
+            os.utime(old_nb, (stale_t, stale_t))
+            os.utime(alien, (stale_t, stale_t))
+            os.utime(tmp_orphan, (stale_t, stale_t))
+            with mock.patch.object(fc, "_CACHE_DIR", td):
+                dry = fc.clean_fused_cache(max_age_days=30.0, dry_run=True)
+                self.assertEqual(sorted(dry["removed"]), sorted([old, old_nb, tmp_orphan]))
+                self.assertTrue(all(os.path.exists(p) for p in (old, old_nb, fresh, alien, tmp_orphan)))
+                wet = fc.clean_fused_cache(max_age_days=30.0)
+                self.assertEqual(sorted(wet["removed"]), sorted([old, old_nb, tmp_orphan]))
+            self.assertFalse(os.path.exists(old))
+            self.assertFalse(os.path.exists(old_nb))
+            self.assertFalse(os.path.exists(tmp_orphan))
+            self.assertTrue(os.path.exists(fresh), "fresh cache entries must survive")
+            self.assertTrue(os.path.exists(alien), "non-cache-pattern files must never be touched")
+
+
+def _fixture(n_per=1500):
+    rng = np.random.RandomState(7)
+    data = [float(v) for v in np.concatenate([rng.normal(-3, 1.0, n_per), rng.normal(3, 2.0, n_per)])]
+    model = MixtureDistribution([GaussianDistribution(-2.0, 1.5), GaussianDistribution(2.0, 1.5)], [0.5, 0.5])
+    est = MixtureEstimator([GaussianEstimator(), GaussianEstimator()])
+    return data, model, est
+
+
+@unittest.skipUnless(HAS_NUMBA, "fused kernels require numba")
+class FusedOptionsTest(unittest.TestCase):
+    def test_unknown_keys_refuse_loudly(self):
+        data, model, est = _fixture(n_per=50)
+        with self.assertRaisesRegex(ValueError, "unknown keys.*prallel"):
+            optimize(data, estimator=est, prev_estimate=model, max_its=1, fused_options={"prallel": True})
+
+    def test_parallel_true_engages_below_the_auto_gate_and_matches_the_sequential_fit(self):
+        data, model, est = _fixture()  # 3,000 obs << the 65,536 auto-gate floor
+        base = optimize(
+            data, estimator=est, prev_estimate=model, max_its=4, delta=None, engine=FUSED_NUMPY_ENGINE, out=None
+        )
+        # evict this signature's parallel E-step so engagement is provable regardless of which
+        # earlier test already compiled it (the cache is process-global; recompiles on demand)
+        sig = fused_codegen.analyze(model).signature
+        fused_codegen._ESTEP_COMPILED.pop((sig, True), None)
+        forced = optimize(
+            data,
+            estimator=est,
+            prev_estimate=model,
+            max_its=4,
+            delta=None,
+            engine=FUSED_NUMPY_ENGINE,
+            out=None,
+            fused_options={"parallel": True},
+        )
+        self.assertIn(
+            (sig, True),
+            fused_codegen._ESTEP_COMPILED,
+            "parallel=True below the floor must compile and use the parallel E-step variant",
+        )
+        for b, f in zip(base.components, forced.components):
+            self.assertAlmostEqual(b.mu, f.mu, places=9)
+            self.assertAlmostEqual(b.sigma2, f.sigma2, places=9)
+
+    def test_lse_bits_bounds_the_scorer_and_never_touches_the_estep(self):
+        data, model, _ = _fixture(n_per=400)
+        kernel = fused_codegen.FusedKernel(model, FUSED_NUMPY_ENGINE)
+        enc = kernel.encode(data)
+        exact = kernel.score(enc)
+        kernel.lse_bits = 12
+        quantized = kernel.score(enc)
+        bound = 2.0**-12 * 4.0  # generous multiple of the per-level relative bound
+        self.assertTrue(np.all(np.abs(quantized - exact) <= np.abs(exact) * bound + 1e-12))
+        self.assertFalse(np.allclose(quantized, exact, rtol=0, atol=0), "lse_bits must actually change the scorer path")
+        # E-step: the knob is scoring-only; accumulate stays exact regardless
+        w = np.ones(len(data), dtype=np.float64)
+        suff_q = kernel.accumulate(enc, w)
+        kernel.lse_bits = None
+        suff_e = kernel.accumulate(enc, w)
+        np.testing.assert_array_equal(np.asarray(suff_q[0], dtype=np.float64), np.asarray(suff_e[0], dtype=np.float64))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mixle/tests/fused_out_of_support_test.py
+++ b/mixle/tests/fused_out_of_support_test.py
@@ -159,7 +159,9 @@ class NestedImpossibleRowTest(unittest.TestCase):
 
 @unittest.skipUnless(HAS_NUMBA, "fused kernels require numba")
 class NestedMinmaxDeclineTest(unittest.TestCase):
-    """D-4: minmax leaves decline nested fusion with the DECLARED ValueError, never a mid-fit crash."""
+    """D-4: minmax leaves decline the NESTED template with the DECLARED ValueError, never a mid-fit
+    crash -- and the bare-bridge last resort then covers the shape with host-exact semantics (it
+    drives each inner mixture's own accumulator, so weighted per-component minima survive)."""
 
     def _model(self):
         inner1 = stats.MixtureDistribution(
@@ -172,21 +174,32 @@ class NestedMinmaxDeclineTest(unittest.TestCase):
         )
         return stats.MixtureDistribution(components=[inner1, inner2], w=[0.7, 0.3])
 
-    def test_nested_pareto_mixture_declines_instead_of_crashing(self):
+    def test_nested_pareto_mixture_declines_the_template_and_bridges_with_parity(self):
         model = self._model()
         data = [1.2, 3.0, 0.3]  # 0.3 is below every xm: out of support everywhere
         enc = model.dist_to_encoder().seq_encode(data)
-        self.assertFalse(fc.fusible(model))
-        self.assertFalse(fc.fusible_estep(model))
-        # the wrappers refuse up front (previously: scoring returned NaN on the 0.3 row and the
-        # E-step crashed with ``TypeError: 'NoneType' object is not callable`` mid-fit)
+        # the nested TEMPLATE still refuses up front (previously: scoring returned NaN on the 0.3
+        # row and the E-step crashed with ``TypeError: 'NoneType' object is not callable`` mid-fit)
         with self.assertRaises(ValueError):
             fn.fused_nested_seq_log_density(model, enc)
         with self.assertRaises(ValueError):
             fn.fused_nested_accumulate(model, enc, np.ones(len(data)))
-        # the host path these models now take scores the out-of-support row -inf and the rest finite
+        # ...but the shape is fusible anyway: the bare-bridge last resort picks it up
+        self.assertTrue(fc.fusible(model))
+        self.assertTrue(fc.fusible_estep(model))
         host = model.seq_log_density(enc)
         self.assertTrue(np.isfinite(host[0]) and np.isfinite(host[1]) and np.isneginf(host[2]))
+        fused = fc.fused_seq_log_density(model, enc)
+        np.testing.assert_allclose(fused[:2], host[:2], rtol=1e-9)
+        self.assertTrue(np.isneginf(fused[2]), "the out-of-support row must stay -inf, never NaN")
+        # M-step parity through the bridge E-step (weighted minima handled by the host accumulator)
+        w = np.ones(len(data))
+        est = model.estimator()
+        acc = est.accumulator_factory().make()
+        acc.seq_update(enc, w, model)
+        new_host = est.estimate(len(data), acc.value())
+        new_fused = est.estimate(len(data), fc.fused_accumulate(model, enc, w))
+        np.testing.assert_allclose(new_fused.seq_log_density(enc), new_host.seq_log_density(enc), rtol=1e-9, atol=1e-12)
 
 
 @unittest.skipUnless(HAS_NUMBA, "fused kernels require numba")

--- a/mixle/tests/keyed_pooling_test.py
+++ b/mixle/tests/keyed_pooling_test.py
@@ -1,0 +1,131 @@
+"""The keyed-pooling protocol: every tied site estimates from the FULL pool, order-independently.
+
+Eight families implemented ``key_merge`` as pull-from-dict-into-self WITHOUT writing the pooled
+result back, so the dict kept the first site's statistics and ``key_replace`` handed that truncated
+pool to every tied site -- later sites' data silently discarded, with order-dependent wrong fits
+(found by the compiler review's keyed-tying probe: a tied-variance Gaussian mixture stamped
+component 1's statistics onto both components and crashed the likelihood before "converging" to a
+wrong fixed point). The canonical protocol (Poisson, Categorical, and 100 other files) accumulates
+the pool IN the dict. These tests pin the pooled-sum and order-invariance properties for every
+previously-broken family, plus the Gaussian mixture's analytic pooled fixed point end-to-end.
+"""
+
+import unittest
+
+import numpy as np
+
+from mixle.stats import (
+    ExponentialDistribution,
+    GammaDistribution,
+    GaussianDistribution,
+    GeometricDistribution,
+    MixtureDistribution,
+    SkellamDistribution,
+)
+
+
+def _pooled_stats(dist, est_kwargs, data_a, data_b, order):
+    """Run the merge/replace protocol over two keyed sites and return both sites' values."""
+    est = dist.estimator()
+    fac = type(est)(keys="k").accumulator_factory() if _ctor_takes_keys(type(est)) else None
+    if fac is None:
+        raise unittest.SkipTest(f"{type(est).__name__} has no keys ctor")
+    acc_a, acc_b = fac.make(), fac.make()
+    enc = dist.dist_to_encoder()
+    acc_a.seq_update(enc.seq_encode(data_a), np.ones(len(data_a)), dist)
+    acc_b.seq_update(enc.seq_encode(data_b), np.ones(len(data_b)), dist)
+    stats: dict = {}
+    first, second = (acc_a, acc_b) if order == "ab" else (acc_b, acc_a)
+    first.key_merge(stats)
+    second.key_merge(stats)
+    first.key_replace(stats)
+    second.key_replace(stats)
+    return acc_a.value(), acc_b.value()
+
+
+def _ctor_takes_keys(est_cls):
+    import inspect
+
+    return "keys" in inspect.signature(est_cls.__init__).parameters
+
+
+def _flat(v):
+    out = []
+
+    def walk(u):
+        if isinstance(u, (tuple, list)):
+            for piece in u:
+                walk(piece)
+        elif isinstance(u, dict):
+            for k in sorted(u, key=repr):
+                walk(u[k])
+        elif u is not None:
+            out.extend(np.asarray(u, dtype=np.float64).ravel().tolist())
+
+    walk(v)
+    return np.asarray(out)
+
+
+class KeyedPoolingProtocolTest(unittest.TestCase):
+    FAMILIES = [
+        (GaussianDistribution(0.0, 1.0), [0.5, -1.2, 2.0], [3.1, -0.4]),
+        (ExponentialDistribution(1.0), [0.5, 1.2, 2.0], [3.1, 0.4]),
+        (GammaDistribution(2.0, 1.0), [0.5, 1.2, 2.0], [3.1, 0.4]),
+        (GeometricDistribution(0.5), [1, 2, 3], [4, 1]),
+        (SkellamDistribution(2.0, 1.0), [1, -2, 3], [0, 2]),
+    ]
+
+    def test_both_sites_hold_the_full_pool_and_order_does_not_matter(self):
+        for dist, data_a, data_b in self.FAMILIES:
+            with self.subTest(family=type(dist).__name__):
+                va_ab, vb_ab = _pooled_stats(dist, {}, data_a, data_b, order="ab")
+                va_ba, vb_ba = _pooled_stats(dist, {}, data_a, data_b, order="ba")
+                # both sites identical (the pool), regardless of merge order
+                np.testing.assert_allclose(_flat(va_ab), _flat(vb_ab), rtol=1e-12)
+                np.testing.assert_allclose(_flat(va_ab), _flat(va_ba), rtol=1e-12)
+                # and the pool equals accumulating ALL the data at one site
+                est = type(dist.estimator())(keys="k")
+                acc_all = est.accumulator_factory().make()
+                enc = dist.dist_to_encoder()
+                both = list(data_a) + list(data_b)
+                acc_all.seq_update(enc.seq_encode(both), np.ones(len(both)), dist)
+                np.testing.assert_allclose(_flat(va_ab), _flat(acc_all.value()), rtol=1e-12)
+
+    def test_ctmc_keys_actually_pool(self):
+        # The CTMC accumulator had a THIRD failure shape: neither key_merge nor key_replace ever
+        # INSERTED the key, so both were unconditional no-ops and keyed CTMCs silently never tied.
+        from mixle.stats.processes.ctmc import ContinuousTimeMarkovChainAccumulator
+
+        acc_a = ContinuousTimeMarkovChainAccumulator(num_states=2, keys="q")
+        acc_b = ContinuousTimeMarkovChainAccumulator(num_states=2, keys="q")
+        acc_a.counts[:] = [[0.0, 2.0], [1.0, 0.0]]
+        acc_a.dwell[:] = [1.5, 0.5]
+        acc_b.counts[:] = [[0.0, 4.0], [3.0, 0.0]]
+        acc_b.dwell[:] = [2.0, 1.0]
+        stats: dict = {}
+        acc_a.key_merge(stats)
+        acc_b.key_merge(stats)
+        acc_a.key_replace(stats)
+        acc_b.key_replace(stats)
+        for acc in (acc_a, acc_b):
+            np.testing.assert_array_equal(acc.counts, [[0.0, 6.0], [4.0, 0.0]])
+            np.testing.assert_array_equal(acc.dwell, [3.5, 1.5])
+
+    def test_tied_gaussian_mixture_reaches_the_analytic_pooled_fixed_point(self):
+        from mixle.stats.compute.sequence import seq_estimate
+        from mixle.stats.latent.mixture import MixtureEstimator
+        from mixle.stats.univariate.continuous.gaussian import GaussianEstimator
+
+        rng = np.random.RandomState(0)
+        data = [float(v) for v in np.concatenate([rng.normal(-3, 1, 2000), rng.normal(3, 2, 2000)])]
+        model = MixtureDistribution([GaussianDistribution(-2.0, 1.5), GaussianDistribution(2.0, 1.5)], [0.5, 0.5])
+        keyed = MixtureEstimator([GaussianEstimator(keys="shared"), GaussianEstimator(keys="shared")])
+        enc_data = [(len(data), model.dist_to_encoder().seq_encode(data))]
+        fit = seq_estimate(enc_data, keyed, model)
+        for c in fit.components:
+            self.assertAlmostEqual(c.mu, float(np.mean(data)), places=10)
+            self.assertAlmostEqual(c.sigma2, float(np.var(data)), places=8)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Follow-ups from the second compiler review (#439), plus the much larger pre-existing bug the review's keyed-tying probe exposed once pulled on.

## Keyed pooling was broken in three independent places

**Eight families discarded tied data** (`gaussian`, `exponential`, `gamma`, `geometric`, `skellam`, `hurdle`, `zero_inflated`, `inhomogeneous_poisson`): their `key_merge` pulled the dict's stats into the accumulator **without writing the pool back**, so the dict kept the first site's statistics and `key_replace` handed that truncated pool to every tied site. Later sites' data was silently discarded — order-dependent wrong fits. Live proof pre-fix: a whole-state-tied Gaussian mixture drove the likelihood from −17,276 down to −49,549 (non-monotone) and "converged" both components onto site 1's weighted mean. Post-fix it reaches the exact pooled solution (μ = mean(data), σ² = var(data)) in one step, monotone after.

**CTMC keys were dead**: neither `key_merge` nor `key_replace` ever *inserted* the key, so both passes were unconditional no-ops — keyed CTMCs never pooled at all. Now canonical combine-into-dict.

**`_engine_seq_estimate` skipped the key pass** — the same omission #439 fixed in `_engine_fused_step`, so keyed fits routed through any engine kernel untied. Now runs it.

All 109 `key_merge` implementations were swept; the remaining 100 are correct (canonical combine-into-dict, delegating combinators, stat-less, or pool-by-aliasing).

New `keyed_pooling_test.py` pins the protocol per family (pooled-sum equality, merge-order invariance), the analytic pooled fixed point end-to-end, and the CTMC case. Fuzzer property **P6** ties every gaussian site through BOTH EM drivers vs the host oracle — driver-level (forgotten merge pass) and family-level (pool truncation) keying bugs are now caught automatically; the kernel-parity properties alone can't see keys because keys pool in the drivers.

## Review follow-ups

- **Block-EM keyed guard**: pooling needs a global post-accumulation pass, which conflicts with block-EM's sparse per-component M-steps. `is_block_em_eligible` now reroutes keyed estimators (`schedule="auto"` falls back to full-tree) and `run_block_em` raises `NotImplementedError` instead of silently untying.
- **Bare-bridge coverage residual**: hierarchical shapes that BOTH the flat template and `fused_nested` decline (nested Pareto mixtures — minmax leaves) now fuse via a bridge-only plan with host-exact semantics: score parity including out-of-support −inf rows, M-step parity through each factor's own accumulator. Fallthrough: template → nested → bare bridge.
- **Fast-path vs any-path fusibility**: `fusible()`/`fusible_estep()` take `bare_bridge=` so policy call sites can ask about the *fast* paths only. Bare-bridge fusion is host-speed columns + a fused softmax, so it no longer disqualifies block-EM scheduling (`prefer_block_schedule`) and never justifies a float32 recommendation (precision planner). The allowance also never applies to a bare root — bridging a lone leaf fuses nothing.
- **`optimize(fused_options=...)`**: `parallel` overrides the observation-count auto-gate in either direction (bit-stable both ways), `lse_bits`/`lse_span` opt *scoring* into quantized LSE (E-steps stay exact by design); unknown keys raise.
- **`clean_fused_cache()`**: age-gated GC for the kernel disk cache (generated modules, numba `__pycache__` artifacts, crashed-writer `*.tmp` leftovers), `dry_run` supported, pattern-gated so nothing else is ever touched.
- `fused_keyed_tying_test` now uses the documented string key form (the Gaussian ctor silently accepts a stray tuple; post-fix it pools correctly as one opaque key, so no ctor churn — the hazard was the pooling bug).

## Testing

Full local gate green (`pytest mixle/tests -n auto`), including the extended fuzzer, the fused suites, and the three policy suites whose premises the bare-bridge fallthrough touched (`block_em_efficiency`, `fastmath_policy`, `precision_plan`).
