### PR TITLE
Close the keying story: all-family protocol sweep + seven more broken families

### DIFF
--- a/mixle/inference/estimation.py
+++ b/mixle/inference/estimation.py
@@ -1398,6 +1398,7 @@ def best_of(
     reuse_estep_ll: bool = True,
     objective: str = "auto",
     seed: int | None = None,
+    fused_options: dict[str, Any] | None = None,
 ) -> tuple[float, SequenceEncodableProbabilityDistribution]:
     """Performs EM algorithm for trials-number of randomized initial conditions. Returns the best model fit in terms of
         maximum log-likelihood value from validation data.
@@ -1426,6 +1427,8 @@ def best_of(
             ``'auto'`` (default) selects MLE / MAP / variational Bayes from the prior (see ``optimize``).
         seed (Optional[int]): Integer seed -- shorthand for ``rng=RandomState(seed)``. Mutually
             exclusive with ``rng`` (passing both raises ``TypeError``).
+        fused_options (Optional[dict]): Fused-kernel tuning knobs forwarded to every trial's
+            ``optimize`` call -- see ``optimize(fused_options=...)`` for the recognized keys.
 
     Returns:
         Tuple of log-likelihood of best fitting model and the best fitting model from number of trials.
@@ -1468,6 +1471,7 @@ def best_of(
             print_iter=print_iter,
             reuse_estep_ll=reuse_estep_ll,
             objective=objective,
+            fused_options=fused_options,
         )
         _, vll = seq_log_density_sum(score_data, mm)
         if out is not None:

--- a/mixle/stats/combinator/optional.py
+++ b/mixle/stats/combinator/optional.py
@@ -592,12 +592,14 @@ class OptionalEstimatorAccumulator(SequenceEncodableStatisticAccumulator):
         return self
 
     def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace keyed statistics in ``stats_dict`` with this accumulator state."""
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                stats_dict[self.keys].from_value(self.value())
-            else:
-                stats_dict[self.keys] = self
+        """Replace this accumulator's state from the pooled keyed statistics when present."""
+        # The pull direction matters: this used to PUSH self.value() INTO the dict-held pool,
+        # which overwrote the pooled statistics with the last site's own and left the site itself
+        # untouched -- tied sites never received the pool (caught by the keyed-protocol sweep).
+        if self.keys is not None and self.keys in stats_dict:
+            pooled = stats_dict[self.keys]
+            if pooled is not self:
+                self.from_value(pooled.value())
 
     def key_merge(self, stats_dict: dict[str, Any]) -> None:
         """Merge this accumulator into ``stats_dict`` under the configured key."""

--- a/mixle/stats/compute/pdist.py
+++ b/mixle/stats/compute/pdist.py
@@ -1256,6 +1256,43 @@ def _collect_accumulator_keys(
                     _collect_accumulator_keys(child, registry, "%s.%s[%d]" % (path, name, i), visited)
 
 
+def _flag_annotation_mismatched_keys(estimator: ParameterEstimator, path: str, visited: set[int]) -> None:
+    """Raise when a ``keys`` value's shape contradicts the family's own ctor declaration.
+
+    Scalar families declare ``keys: str | None`` and use the value WHOLE as the shared-statistics
+    dict key, while combinator families declare ``keys: tuple[...]`` and split it across their
+    sub-accumulators. A tuple handed to a scalar family therefore never means what the caller
+    intended (it ties as one opaque composite key instead of per-slot keys) -- and it used to slip
+    through silently. The family's ``__init__`` annotation is the source of truth, so no per-family
+    churn; families without an annotation are skipped.
+    """
+    import inspect
+
+    obj_id = id(estimator)
+    if obj_id in visited:
+        return
+    visited.add(obj_id)
+    keys = getattr(estimator, "keys", None)
+    if isinstance(keys, (list, tuple)):
+        try:
+            ann = inspect.signature(type(estimator).__init__).parameters["keys"].annotation
+        except (ValueError, KeyError, TypeError):
+            ann = inspect.Parameter.empty
+        ann_text = ann if isinstance(ann, str) else str(ann)
+        if ann is not inspect.Parameter.empty and "tuple" not in ann_text.lower() and "any" not in ann_text.lower():
+            raise ValueError(
+                "%s (%s) declares keys: %s but got the %s %r -- pass one shared string per site; "
+                "tuple keys are the combinator convention only"
+                % (path, type(estimator).__name__, ann_text, type(keys).__name__, keys)
+            )
+    for name, value in sorted(vars(estimator).items()):
+        for child in _iter_children(value):
+            if isinstance(child, ParameterEstimator):
+                _flag_annotation_mismatched_keys(child, "%s.%s" % (path, name), visited)
+        if isinstance(value, ParameterEstimator):
+            _flag_annotation_mismatched_keys(value, "%s.%s" % (path, name), visited)
+
+
 def validate_estimator_keys(estimator: ParameterEstimator) -> None:
     """Validate keyed estimator and accumulator sites before EM folds stats.
 
@@ -1264,6 +1301,7 @@ def validate_estimator_keys(estimator: ParameterEstimator) -> None:
     key string.  Validation is intentionally protocol-level and best-effort; a
     family can still perform stricter checks in its own factory if needed.
     """
+    _flag_annotation_mismatched_keys(estimator, type(estimator).__name__, set())
     estimator_registry: dict[Any, tuple[Any, str]] = {}
     _collect_estimator_keys(estimator, estimator_registry, type(estimator).__name__, set())
 

--- a/mixle/stats/directional/von_mises_fisher.py
+++ b/mixle/stats/directional/von_mises_fisher.py
@@ -580,7 +580,10 @@ class VonMisesFisherAccumulator(SequenceEncodableStatisticAccumulator):
             self.count += suff_stat[0]
 
         elif suff_stat[1] is not None and self.ssum is None:
-            self.ssum = suff_stat[1]
+            # copy on adopt: value() hands out the LIVE array, so adopting the caller's reference
+            # makes every later in-place += here mutate the DONOR accumulator too (chunk combines
+            # and keyed pooling both hit this -- caught by the keyed-protocol sweep)
+            self.ssum = np.asarray(suff_stat[1], dtype=np.float64).copy()
             self.count = suff_stat[0]
 
         return self
@@ -596,7 +599,7 @@ class VonMisesFisherAccumulator(SequenceEncodableStatisticAccumulator):
             x (Tuple[float, np.ndarray]): Tuple of count and weighted vector sum.
 
         """
-        self.ssum = x[1]
+        self.ssum = None if x[1] is None else np.asarray(x[1], dtype=np.float64).copy()
         self.count = x[0]
         self.dim = None if self.ssum is None else len(self.ssum)
         return self
@@ -614,6 +617,10 @@ class VonMisesFisherAccumulator(SequenceEncodableStatisticAccumulator):
         if self.keys is not None:
             if self.keys in stats_dict:
                 self.combine(stats_dict[self.keys].value())
+                # write the POOL back: the dict must end holding the pooled accumulator, else
+                # key_replace hands every tied site the FIRST site's statistics (later sites'
+                # data silently discarded -- caught by the keyed-protocol sweep)
+                stats_dict[self.keys] = self
             else:
                 stats_dict[self.keys] = self
 

--- a/mixle/stats/latent/chained_attention.py
+++ b/mixle/stats/latent/chained_attention.py
@@ -271,6 +271,10 @@ class ChainedAttentionAccumulator(SequenceEncodableStatisticAccumulator):
         if self.keys is not None:
             if self.keys in stats_dict:
                 self.combine(stats_dict[self.keys])
+                # write the POOL back: without this the dict keeps the FIRST site's value and
+                # key_replace hands that truncated pool to every tied site (later sites' data
+                # silently discarded -- caught by the keyed-protocol sweep)
+                stats_dict[self.keys] = self.value()
             else:
                 stats_dict[self.keys] = self.value()
 

--- a/mixle/stats/latent/responsibility_attention.py
+++ b/mixle/stats/latent/responsibility_attention.py
@@ -290,6 +290,10 @@ class ResponsibilityAttentionAccumulator(SequenceEncodableStatisticAccumulator):
         if self.keys is not None:
             if self.keys in stats_dict:
                 self.combine(stats_dict[self.keys])
+                # write the POOL back: without this the dict keeps the FIRST site's value and
+                # key_replace hands that truncated pool to every tied site (later sites' data
+                # silently discarded -- caught by the keyed-protocol sweep)
+                stats_dict[self.keys] = self.value()
             else:
                 stats_dict[self.keys] = self.value()
 

--- a/mixle/stats/latent/variational_embedding_attention.py
+++ b/mixle/stats/latent/variational_embedding_attention.py
@@ -296,6 +296,10 @@ class VariationalEmbeddingAttentionAccumulator(SequenceEncodableStatisticAccumul
         if self.keys is not None:
             if self.keys in stats_dict:
                 self.combine(stats_dict[self.keys])
+                # write the POOL back: without this the dict keeps the FIRST site's value and
+                # key_replace hands that truncated pool to every tied site (later sites' data
+                # silently discarded -- caught by the keyed-protocol sweep)
+                stats_dict[self.keys] = self.value()
             else:
                 stats_dict[self.keys] = self.value()
 

--- a/mixle/stats/latent/variational_multihop_attention.py
+++ b/mixle/stats/latent/variational_multihop_attention.py
@@ -255,6 +255,10 @@ class VariationalMultiHopAttentionAccumulator(SequenceEncodableStatisticAccumula
         if self.keys is not None:
             if self.keys in stats_dict:
                 self.combine(stats_dict[self.keys])
+                # write the POOL back: without this the dict keeps the FIRST site's value and
+                # key_replace hands that truncated pool to every tied site (later sites' data
+                # silently discarded -- caught by the keyed-protocol sweep)
+                stats_dict[self.keys] = self.value()
             else:
                 stats_dict[self.keys] = self.value()
 

--- a/mixle/stats/multivariate/diagonal_gaussian.py
+++ b/mixle/stats/multivariate/diagonal_gaussian.py
@@ -580,8 +580,11 @@ class DiagonalGaussianAccumulator(SequenceEncodableStatisticAccumulator):
             self.count += suff_stat[2]
 
         elif suff_stat[0] is not None and self.sum is None:
-            self.sum = suff_stat[0]
-            self.sum2 = suff_stat[1]
+            # copy on adopt: value() hands out the LIVE arrays, so adopting the caller's reference
+            # makes every later in-place += here mutate the DONOR accumulator too (chunk combines
+            # and keyed pooling both hit this -- caught by the keyed-protocol sweep)
+            self.sum = np.asarray(suff_stat[0], dtype=np.float64).copy()
+            self.sum2 = np.asarray(suff_stat[1], dtype=np.float64).copy()
             self.count = suff_stat[2]
 
         return self
@@ -601,8 +604,8 @@ class DiagonalGaussianAccumulator(SequenceEncodableStatisticAccumulator):
             This accumulator.
 
         """
-        self.sum = x[0]
-        self.sum2 = x[1]
+        self.sum = None if x[0] is None else np.asarray(x[0], dtype=np.float64).copy()
+        self.sum2 = None if x[1] is None else np.asarray(x[1], dtype=np.float64).copy()
         self.count = x[2]
         return self
 
@@ -619,6 +622,10 @@ class DiagonalGaussianAccumulator(SequenceEncodableStatisticAccumulator):
         if self.keys is not None:
             if self.keys in stats_dict:
                 self.combine(stats_dict[self.keys].value())
+                # write the POOL back: the dict must end holding the pooled accumulator, else
+                # key_replace hands every tied site the FIRST site's statistics (later sites'
+                # data silently discarded -- caught by the keyed-protocol sweep)
+                stats_dict[self.keys] = self
             else:
                 stats_dict[self.keys] = self
 
@@ -634,7 +641,9 @@ class DiagonalGaussianAccumulator(SequenceEncodableStatisticAccumulator):
         """
         if self.keys is not None:
             if self.keys in stats_dict:
-                self.from_value(stats_dict[self.keys])
+                # the dict holds the pooled ACCUMULATOR (see key_merge); passing it whole made
+                # from_value subscript an accumulator object -- keyed use crashed with TypeError
+                self.from_value(stats_dict[self.keys].value())
 
     def acc_to_encoder(self) -> "DiagonalGaussianDataEncoder":
         """Return an encoder compatible with this accumulator's dimension."""

--- a/mixle/stats/multivariate/multivariate_gaussian.py
+++ b/mixle/stats/multivariate/multivariate_gaussian.py
@@ -697,8 +697,11 @@ class MultivariateGaussianAccumulator(SequenceEncodableStatisticAccumulator):
             self.count += suff_stat[2]
 
         elif suff_stat[0] is not None and self.sum is None:
-            self.sum = suff_stat[0]
-            self.sum2 = suff_stat[1]
+            # copy on adopt: value() hands out the LIVE arrays, so adopting the caller's reference
+            # makes every later in-place += here mutate the DONOR accumulator too (chunk combines
+            # and keyed pooling both hit this -- caught by the keyed-protocol sweep)
+            self.sum = np.asarray(suff_stat[0], dtype=np.float64).copy()
+            self.sum2 = np.asarray(suff_stat[1], dtype=np.float64).copy()
             self.count = suff_stat[2]
 
         return self
@@ -718,8 +721,8 @@ class MultivariateGaussianAccumulator(SequenceEncodableStatisticAccumulator):
             This accumulator.
 
         """
-        self.sum = x[0]
-        self.sum2 = x[1]
+        self.sum = None if x[0] is None else np.asarray(x[0], dtype=np.float64).copy()
+        self.sum2 = None if x[1] is None else np.asarray(x[1], dtype=np.float64).copy()
         self.count = x[2]
         return self
 

--- a/mixle/tests/fused_options_test.py
+++ b/mixle/tests/fused_options_test.py
@@ -77,6 +77,14 @@ class FusedOptionsTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "unknown keys.*prallel"):
             optimize(data, estimator=est, prev_estimate=model, max_its=1, fused_options={"prallel": True})
 
+    def test_best_of_forwards_fused_options(self):
+        from mixle.inference.estimation import best_of
+
+        data, model, est = _fixture(n_per=50)
+        # the unknown-key refusal proves the knob reaches optimize through the trials wrapper
+        with self.assertRaisesRegex(ValueError, "unknown keys.*prallel"):
+            best_of(data, None, est, trials=1, max_its=1, init_p=1.0, delta=1e-9, fused_options={"prallel": True})
+
     def test_parallel_true_engages_below_the_auto_gate_and_matches_the_sequential_fit(self):
         data, model, est = _fixture()  # 3,000 obs << the 65,536 auto-gate floor
         base = optimize(

--- a/mixle/tests/keyed_pooling_test.py
+++ b/mixle/tests/keyed_pooling_test.py
@@ -111,6 +111,21 @@ class KeyedPoolingProtocolTest(unittest.TestCase):
             np.testing.assert_array_equal(acc.counts, [[0.0, 6.0], [4.0, 0.0]])
             np.testing.assert_array_equal(acc.dwell, [3.5, 1.5])
 
+    def test_malformed_tuple_keys_on_scalar_families_refuse_loudly(self):
+        # Scalar families declare keys: str|None but silently accepted tuples (the combinator
+        # convention), tying as one opaque composite key instead of what the caller meant. The
+        # validator now checks the value against each family's OWN ctor annotation.
+        from mixle.stats.compute.pdist import validate_estimator_keys
+        from mixle.stats.latent.mixture import MixtureEstimator
+        from mixle.stats.univariate.continuous.gaussian import GaussianEstimator
+
+        bad = MixtureEstimator([GaussianEstimator(keys=(None, "shared_var")), GaussianEstimator()])
+        with self.assertRaisesRegex(ValueError, "combinator convention"):
+            validate_estimator_keys(bad)
+        # tuple keys stay legal exactly where they are declared: combinator estimators
+        good = MixtureEstimator([GaussianEstimator(keys="s"), GaussianEstimator(keys="s")], keys=("w", "c"))
+        validate_estimator_keys(good)
+
     def test_tied_gaussian_mixture_reaches_the_analytic_pooled_fixed_point(self):
         from mixle.stats.compute.sequence import seq_estimate
         from mixle.stats.latent.mixture import MixtureEstimator

--- a/mixle/tests/keyed_protocol_sweep_test.py
+++ b/mixle/tests/keyed_protocol_sweep_test.py
@@ -1,0 +1,233 @@
+"""Every keys-bearing family obeys the pooling protocol -- swept over the full public catalog.
+
+The key_merge/key_replace protocol is hand-implemented per family, and that duplication produced
+FIVE distinct failure shapes before this sweep existed: pull-without-write-back (12 families kept
+only the first site's statistics -- 8 scalar families plus the 4 attention accumulators), dead
+keys (CTMC never inserted, so tying was a silent no-op), a reversed key_replace that pushed one
+site's statistics OVER the pool (Optional), a key_replace that crashed subscripting the pooled
+accumulator object (DiagonalGaussian), and combine/from_value adopting live array references so
+pooling mutated the DONOR accumulator (vMF, MVG, DG). Hand-picked per-family tests can't keep up
+with ~100 implementations, so this drives the protocol property over every distribution in the
+public catalog (the same one sampler_seed_test validates against ``stats.__all__``):
+
+    two accumulators sharing a key, fed DIFFERENT data, must both end holding the pool of ALL the
+    data -- exactly what an explicit ``combine`` of the two sites gives -- in either merge order.
+
+Families whose accumulators use a different keying convention (tuple/slot keys on combinators) or
+that cannot round-trip sample->encode->accumulate are skipped WITH a reason, a minimum-swept floor
+keeps silent skips from hollowing the test out, and the families from the 2026-07-14 pooling fixes
+are required by name. A family whose ``key_merge`` mentions ``self.keys`` but never registers the
+key FAILS as dead-keys (the CTMC shape) rather than skipping.
+"""
+
+import importlib.util
+import inspect
+import sys
+import unittest
+from pathlib import Path
+
+import numpy as np
+
+# the catalog lives in a sibling test module; mixle/tests is not a package, so load it by path
+_SEED_TEST = Path(__file__).with_name("sampler_seed_test.py")
+_spec = importlib.util.spec_from_file_location("_sampler_seed_catalog", _SEED_TEST)
+_mod = importlib.util.module_from_spec(_spec)
+sys.modules.setdefault("_sampler_seed_catalog", _mod)
+_spec.loader.exec_module(_mod)
+_CATALOG = dict(_mod._stats_public_distribution_catalog())
+
+# the nine families fixed in the 2026-07-14 pooling sweep: they must be SWEPT, never skipped
+_REQUIRED = (
+    "GaussianDistribution",
+    "ExponentialDistribution",
+    "GammaDistribution",
+    "GeometricDistribution",
+    "SkellamDistribution",
+    "HurdleDistribution",
+    "ZeroInflatedDistribution",
+    "InhomogeneousPoissonProcessDistribution",
+    "ContinuousTimeMarkovChainDistribution",
+)
+_MIN_SWEPT = 60  # coverage floor: silent skips must never hollow the sweep out
+
+
+def _flat(v):
+    out = []
+
+    def walk(u):
+        if isinstance(u, (tuple, list)):
+            for piece in u:
+                walk(piece)
+        elif isinstance(u, dict):
+            for k in sorted(u, key=repr):
+                walk(u[k])
+        elif isinstance(u, np.ndarray):
+            out.extend(np.asarray(u, dtype=np.float64).ravel().tolist())
+        elif isinstance(u, (int, float, np.integer, np.floating)):
+            out.append(float(u))
+        # non-numeric leaves (strings, None, objects) carry no poolable mass: ignored
+
+    walk(v)
+    return np.asarray(out)
+
+
+def _key_tree(root, depth):
+    """Key the top accumulator (depth=0) or also its DIRECT children (depth=1); return the keys.
+
+    Hybrid accumulators (Hurdle, ZeroInflated) manage their own key AND hold a child accumulator
+    whose statistics their key does not cover -- those need depth 1 to pool fully. But keying a
+    child TOGETHER with a parent whose key already covers the whole value (Composite) double-pools
+    through object aliasing, so depth 0 must be tried first and depth 1 only when the shallow
+    config leaves child statistics site-local. Deeper structures are out of scope on purpose:
+    their middle layers are site-local by design. Traversal order is deterministic (sorted
+    attribute names), so two accumulators from the same factory pool position by position.
+    """
+    assigned = []
+    counter = iter(range(10_000))
+
+    def key_one(obj):
+        if hasattr(obj, "key_merge") and hasattr(obj, "keys") and obj.keys is None:
+            key = f"k{next(counter)}"
+            obj.keys = key
+            assigned.append(key)
+            return True
+        return False
+
+    if key_one(root) and depth >= 1:
+        for _name, value in sorted(vars(root).items()):
+            candidates = value if isinstance(value, (list, tuple)) else [value]
+            for child in candidates:
+                if hasattr(child, "key_merge"):
+                    key_one(child)
+    return assigned
+
+
+def _accumulate(dist, fac, batches, depth):
+    acc = fac.make()
+    assigned = _key_tree(acc, depth)
+    enc = dist.dist_to_encoder()
+    for data in batches:
+        acc.seq_update(enc.seq_encode(data), np.ones(len(data), dtype=np.float64), dist)
+    return acc, assigned
+
+
+def _run_protocol(first, second):
+    stats_dict: dict = {}
+    first.key_merge(stats_dict)
+    second.key_merge(stats_dict)
+    first.key_replace(stats_dict)
+    second.key_replace(stats_dict)
+    return stats_dict
+
+
+class KeyedProtocolSweepTest(unittest.TestCase):
+    def test_every_scalar_keyed_family_pools_across_sites(self):
+        swept, skipped = [], {}
+        for name, dist in sorted(_CATALOG.items()):
+            with self.subTest(family=name):
+                outcome = self._check_family(name, dist)
+                if outcome is None:
+                    swept.append(name)
+                else:
+                    skipped[name] = outcome
+        missing = [n for n in _REQUIRED if n not in swept]
+        self.assertFalse(missing, f"required (previously broken) families were not swept: {missing}")
+        self.assertGreaterEqual(
+            len(swept),
+            _MIN_SWEPT,
+            f"only {len(swept)} families swept -- the skip list has hollowed the sweep out: {skipped}",
+        )
+
+    def _check_family(self, name, dist):
+        """Run the pooling property for one catalog entry; return a skip reason or None (=swept).
+
+        The oracle is COMBINE-based: after the protocol, both tied sites must hold exactly what an
+        explicit ``combine`` of the two sites' pre-protocol statistics gives. (An
+        accumulate-everything-at-one-site oracle is wrong for Monte-Carlo accumulators, whose
+        statistics depend on the rng path, and combine-vs-seq_update parity is its own protocol,
+        not the keying one.) Config fallback: the top-only keying regime is tried first; families
+        whose own key does not cover their child accumulator's statistics (Hurdle, ZeroInflated)
+        retry with direct children keyed too.
+        """
+        try:
+            est = dist.estimator()
+            fac = est.accumulator_factory()
+        except Exception as e:  # noqa: BLE001 -- estimator-less catalog entries skip with a reason
+            return f"no estimator/accumulator ({type(e).__name__})"
+        try:
+            data_a = list(dist.sampler(seed=101).sample(size=5))
+            data_b = list(dist.sampler(seed=202).sample(size=3))
+        except Exception as e:  # noqa: BLE001
+            return f"sampler unsupported ({type(e).__name__})"
+
+        last_err = None
+        for depth in (0, 1):
+            try:
+                outcome = self._check_config(name, dist, fac, data_a, data_b, depth)
+            except AssertionError as e:
+                last_err = e
+                continue
+            return outcome
+        raise last_err
+
+    def _check_config(self, name, dist, fac, data_a, data_b, depth):
+        try:
+            acc_a, assigned = _accumulate(dist, fac, [data_a], depth)
+            acc_b, _ = _accumulate(dist, fac, [data_b], depth)
+        except Exception as e:  # noqa: BLE001 -- families that can't round-trip sample->accumulate
+            return f"sample/encode/accumulate round-trip unsupported ({type(e).__name__})"
+        if not assigned:
+            return "no scalar keys attribute on the accumulator (tuple/slot keying convention)"
+
+        # the combine-based pool oracle, snapshotted BEFORE the protocol mutates either site
+        ref = fac.make()
+        ref.combine(acc_a.value())
+        ref.combine(acc_b.value())
+        expected = _flat(ref.value())
+
+        stats_dict = _run_protocol(acc_a, acc_b)
+        if not any(k in stats_dict for k in assigned):
+            # never registered: EITHER a different keying convention (fine) or the CTMC dead-keys
+            # bug shape. If this key_merge reads self.keys, it participates by design -- FAIL loud.
+            try:
+                src = inspect.getsource(type(acc_a).key_merge)
+            except (OSError, TypeError):
+                src = ""
+            self.assertNotIn(
+                "self.keys",
+                src,
+                f"{name}: key_merge reads self.keys but never registered any assigned key -- dead "
+                "keys (both protocol passes are silent no-ops, tied sites never pool)",
+            )
+            return "key_merge does not use the scalar keys attribute"
+
+        va, vb = _flat(acc_a.value()), _flat(acc_b.value())
+        if expected.size == 0 and va.size == 0:
+            return "stat-less accumulator (nothing numeric to pool)"
+        np.testing.assert_allclose(
+            va, vb, rtol=1e-9, atol=1e-12, err_msg=f"{name} (depth={depth}): tied sites diverge after replace"
+        )
+        np.testing.assert_allclose(
+            np.sort(va),
+            np.sort(expected),
+            rtol=1e-9,
+            atol=1e-12,
+            err_msg=f"{name} (depth={depth}): pooled statistics != combine of both sites",
+        )
+        # order invariance: merging (b, a) must give the same pool (sorted: list-carrying stats
+        # may concatenate in merge order without changing the multiset)
+        acc_a2, _ = _accumulate(dist, fac, [data_a], depth)
+        acc_b2, _ = _accumulate(dist, fac, [data_b], depth)
+        _run_protocol(acc_b2, acc_a2)
+        np.testing.assert_allclose(
+            np.sort(_flat(acc_a2.value())),
+            np.sort(va),
+            rtol=1e-9,
+            atol=1e-12,
+            err_msg=f"{name} (depth={depth}): pooling is merge-order dependent",
+        )
+        return None
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The all-family keying sweep promised in #441's follow-ups — and the seven additional broken families its first run immediately caught.

## The sweep (`keyed_protocol_sweep_test.py`)

One property driven over **every** distribution in the public catalog (the same catalog `sampler_seed_test` validates against `stats.__all__`): two accumulators sharing a key, fed different data, must both end holding the pool of ALL the data — exactly what an explicit `combine` of the two sites gives — in either merge order. 148 families sweep; skips carry a stated reason (tuple/slot keying conventions, estimator-less entries), a 60-family floor plus a by-name required list (the nine #441 fixes) keep skips from hollowing it out, and a family whose `key_merge` reads `self.keys` but never registers a key fails as dead-keys (the CTMC shape) instead of skipping.

Notable harness decisions: the oracle is **combine-based**, because accumulate-everything-at-once is wrong for Monte-Carlo accumulators (their statistics are rng-path-dependent — this initially looked like 4 more broken families and wasn't); and keying is depth-capped with a top-only-first fallback, because keying a child together with a parent whose key already covers the whole value double-pools through object aliasing.

## Seven more broken families (all pre-existing, all caught by the sweep's first run)

- **chained_attention, responsibility_attention, variational_embedding_attention, variational_multihop_attention** — pull-without-write-back, value flavor: the dict kept the first site's value; later sites' data silently discarded.
- **von_mises_fisher** — the object flavor: combined the dict-held accumulator into itself but left the dict pointing at the first site's accumulator.
- **optional** — `key_replace` ran *backwards*: it pushed `self.value()` over the pool instead of pulling, so the last site's stats overwrote the pool and no site ever received it.
- **diagonal_gaussian** — `key_replace` subscripted the pooled accumulator object: keyed use crashed with `TypeError` (never worked at all).

Plus one deeper defect the combine-based oracle surfaced: **vMF, MultivariateGaussian, and DiagonalGaussian `combine`/`from_value` adopted live array references** (`value()` hands out the underlying arrays), so combining a fresh accumulator from two sites mutated the first donor in place on the second combine — this corrupts any chunk-combining driver, not just keying. All three now copy on adopt (the CTMC `key_replace` precedent).

## Remaining #441 follow-ups closed

- `validate_estimator_keys` rejects keys whose shape contradicts the family's own ctor annotation: scalar families declare `keys: str | None` and use the value whole, so a tuple there (the combinator convention) never means what the caller intended. The annotation is the source of truth — no per-family churn; combinator tuple keys stay legal. Pinned in `keyed_pooling_test`.
- `best_of` forwards `fused_options` to every trial's `optimize` (`fit` already forwards `**kwargs`); pinned in `fused_options_test`.

## Testing

Full local gate green: 5,140 passed / 0 failed, 4,020 subtests (148 of them the sweep).
