### PR TITLE
E10 acceptance: EMA codebooks (1.46x friction), natural-data occupancy, Q-LSE readout

### DIFF
--- a/experiments/group_attention/RESULTS.md
+++ b/experiments/group_attention/RESULTS.md
@@ -114,3 +114,38 @@ prediction playing out quantitatively (its quantized arm needed ~2x the dense ar
 criterion verdict: not killed on structure; at the referee's own budget the sketches' smoother
 optimization wins needle@16 (E3a 0.312 vs 0), recorded as the honest scale caveat. Untried
 remedies for the friction itself: EMA codebooks, temperature annealing.
+
+## Acceptance round (2026-07-14): friction remedy, natural-data occupancy, Q-LSE readout
+
+Pre-stated criteria in the script headers, run same-day as written.
+
+1. **EMA codebooks cut the VQ friction to 1.46x — PASS (`ema_friction.py`, acceptance <= 1.5x).**
+   `ProductQuantizer(codebook_update="ema")`: EMA cluster updates + dead-code reseeding +
+   data-dependent init. Budgets to held-out recall >= 0.95 on associative recall (batch 64):
+   dense 83,200 examples; gradient-VQ 166,400 (**2.00x** — the falsification's ~2x, reproduced
+   exactly); EMA **121,600 (1.46x)**. Two negative findings recorded on the way: the EMA decay is
+   NOT the lever (0.99/0.95/0.9/0.8 all plateau at ~1.6x), and the friction floor lived in the
+   INIT — random `N(0, 1/sqrt(d))` codebooks have the wrong scale relative to real key
+   activations, so early assignments collapse and every update scheme waits for the encoder to
+   reorganize. Seeding codes from actual first-batch sub-vectors is what crossed the bar.
+   Gradient mode stays the constructor default; EMA is opt-in per spine
+   (`QuantizedKeyAttentionSpine(codebook_update="ema")`).
+
+2. **Occupancy on natural data: bounded and sublinear — PASS (`natural_occupancy.py`).** The K3
+   caveat (random-token streams, tiny synthetic vocab) closed: byte-level English prose (this
+   repository's README + docs, 300 TBPTT steps), held-out streaming. Occupied cells/layer:
+   **69 max @ 4k -> [78, 90] @ 16k -> [91, 108] @ 64k** of 256 capacity (4,096 possible), **0
+   dropped tokens**. Growth 4k->64k is 1.57x for a 16x context increase (acceptance: < 80% of
+   capacity with 0 drops, sublinear < 2x). Natural data occupies more cells than the synthetic
+   task's 49, exactly as the caveat predicted — and stays an order of magnitude below the cell
+   space with per-query cost O(100) at every length measured.
+
+3. **Q-LSE beyond scoring: the attention readout itself — landed with a certified bound.**
+   `quantized_softmax_weights` computes the joint softmax's unnormalized weights through the
+   qlut grid (shift by row max, round to the `span/2^bits` grid, ONE `2^bits` exp table, -inf
+   slots -> weight 0), and `QuantizedKeyAttentionSpine(lse_bits=...)` uses it for INFERENCE
+   steps — training always stays exact-exp, the same discipline as the fused E-steps. Tests pin
+   (a) row normalizers equal to `mixle.engines.qlut.quantized_logsumexp` bit for bit (same grid,
+   torch vs numpy), (b) readout error within the `exp(2*lse_error_bound(bits, span)) - 1`
+   weight-ratio bound, (c) quantized-inference loss within 1e-2 of exact at 12 bits while
+   grad-enabled steps match the exact spine to 1e-12.

--- a/experiments/group_attention/ema_friction.py
+++ b/experiments/group_attention/ema_friction.py
@@ -1,0 +1,142 @@
+"""E10 acceptance: do EMA codebooks cut the VQ optimization friction to <= 1.5x dense?
+
+The falsification measured the friction (RESULTS.md): the gradient-VQ quantized arm needed ~2x the
+dense arm's step budget to break through on associative recall, with EMA codebooks named as the
+standard untried remedy. This experiment quantifies the remedy on the SHIPPED mechanism's
+ProductQuantizer (mixle.experimental.quantized_key_attention), not a reimplementation.
+
+Task: associative recall, identical to train_quantized_keys.py (16 key-value pairs then a query;
+learnable only through attention retrieval). Arms share architecture/params/seed/batch stream:
+
+  A  dense attention                                    -- the budget yardstick
+  B  PQ straight-through, codebook_update="gradient"    -- the measured ~2x friction
+  C  PQ straight-through, codebook_update="ema"         -- the remedy under test
+
+Acceptance (pre-stated): budget-to-target(C) <= 1.5 x budget-to-target(A), where the target is
+held-out recall >= 0.95 evaluated every 100 steps (batch 64; budget = examples seen). Kill: C
+needs more than 1.5x -- record the ratio honestly and keep "gradient" as the default.
+"""
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from mixle.experimental.quantized_key_attention import ProductQuantizer
+
+torch.manual_seed(0)
+N_KEYS, N_VALS, N_PAIRS = 32, 32, 16
+VOCAB = N_KEYS + N_VALS + 1
+SEQ = 2 * N_PAIRS + 2
+D_MODEL, N_HEAD, D_HEAD, N_LAYER = 64, 2, 32, 2
+BLOCKS, KCODES = 4, 16
+TARGET, EVAL_EVERY, MAX_STEPS, BATCH = 0.95, 100, 6000, 64
+
+
+def make_batch(bs, rng):
+    keys = np.stack([rng.choice(N_KEYS, N_PAIRS, replace=False) for _ in range(bs)])
+    vals = rng.randint(0, N_VALS, (bs, N_PAIRS))
+    q_idx = rng.randint(0, N_PAIRS, bs)
+    x = np.zeros((bs, SEQ), dtype=np.int64)
+    x[:, 0 : 2 * N_PAIRS : 2] = keys
+    x[:, 1 : 2 * N_PAIRS + 1 : 2] = vals + N_KEYS
+    x[:, 2 * N_PAIRS] = N_KEYS + N_VALS
+    x[:, 2 * N_PAIRS + 1] = keys[np.arange(bs), q_idx]
+    return torch.as_tensor(x), torch.as_tensor(vals[np.arange(bs), q_idx])
+
+
+class Block(nn.Module):
+    def __init__(self, pq_kwargs):
+        super().__init__()
+        self.qkv = nn.Linear(D_MODEL, 3 * D_MODEL)
+        self.proj = nn.Linear(D_MODEL, D_MODEL)
+        self.ln1, self.ln2 = nn.LayerNorm(D_MODEL), nn.LayerNorm(D_MODEL)
+        self.mlp = nn.Sequential(nn.Linear(D_MODEL, 4 * D_MODEL), nn.GELU(), nn.Linear(4 * D_MODEL, D_MODEL))
+        self.pq = ProductQuantizer(D_HEAD, n_blocks=BLOCKS, codes_per_block=KCODES, **pq_kwargs) if pq_kwargs else None
+
+    def forward(self, h):
+        b, t, _ = h.shape
+        q, k, v = self.qkv(self.ln1(h)).split(D_MODEL, dim=-1)
+        q = q.view(b, t, N_HEAD, D_HEAD).transpose(1, 2)
+        k = k.view(b, t, N_HEAD, D_HEAD).transpose(1, 2)
+        v = v.view(b, t, N_HEAD, D_HEAD).transpose(1, 2)
+        commit = h.new_zeros(())
+        if self.pq is not None:
+            k, _, commit = self.pq(k)
+        att = (q @ k.transpose(-2, -1)) / np.sqrt(D_HEAD)
+        att = att.masked_fill(torch.triu(torch.ones(t, t, dtype=torch.bool), 1), float("-inf"))
+        h = h + self.proj((att.softmax(-1) @ v).transpose(1, 2).reshape(b, t, D_MODEL))
+        h = h + self.mlp(self.ln2(h))
+        return h, commit
+
+
+class Model(nn.Module):
+    def __init__(self, pq_kwargs):
+        super().__init__()
+        self.tok = nn.Embedding(VOCAB, D_MODEL)
+        self.pos = nn.Embedding(SEQ, D_MODEL)
+        self.blocks = nn.ModuleList([Block(pq_kwargs) for _ in range(N_LAYER)])
+        self.head = nn.Linear(D_MODEL, N_VALS)
+
+    def forward(self, x):
+        h = self.tok(x) + self.pos(torch.arange(x.shape[1]))[None]
+        commit = h.new_zeros(())
+        for blk in self.blocks:
+            h, c = blk(h)
+            commit = commit + c
+        return self.head(h[:, -1]), commit
+
+
+def budget_to_target(pq_kwargs, tag):
+    torch.manual_seed(1)
+    model = Model(pq_kwargs)
+    model.train()
+    opt = torch.optim.Adam(model.parameters(), lr=1e-3)
+    rng = np.random.RandomState(0)
+    xt, yt = make_batch(2000, np.random.RandomState(99))
+    for step in range(1, MAX_STEPS + 1):
+        x, y = make_batch(BATCH, rng)
+        logits, commit = model(x)
+        loss = F.cross_entropy(logits, y) + commit
+        opt.zero_grad()
+        loss.backward()
+        opt.step()
+        if step % EVAL_EVERY == 0:
+            model.eval()
+            with torch.no_grad():
+                acc = float((model(xt)[0].argmax(-1) == yt).float().mean())
+            model.train()
+            if step % 500 == 0 or acc >= TARGET:
+                print(f"  {tag:22s} step {step:5d}  examples {step * BATCH:7d}  recall {acc:.3f}")
+            if acc >= TARGET:
+                return step * BATCH, acc
+    return None, acc
+
+
+if __name__ == "__main__":
+    import sys
+
+    if len(sys.argv) > 1 and sys.argv[1] not in ("--sweep-decay",):
+        sys.exit(f"unknown argument {sys.argv[1]!r}; supported: --sweep-decay [dense_budget]")
+    if len(sys.argv) > 1 and sys.argv[1] == "--sweep-decay":
+        # tune the REMEDY's own hyperparameter, never the task: dense budget from the main run
+        dense_budget = int(sys.argv[2]) if len(sys.argv) > 2 else 83_200
+        for decay in (0.95, 0.9, 0.8):
+            b, _ = budget_to_target({"codebook_update": "ema", "ema_decay": decay}, f"C pq-ema d={decay}")
+            ratio = (b / dense_budget) if b else float("inf")
+            print(f"  decay {decay}: {b} examples -> {ratio:.2f}x dense")
+        sys.exit(0)
+
+    print(f"== EMA-codebook friction acceptance: budget to held-out recall >= {TARGET} ==")
+    budget_dense, _ = budget_to_target(None, "A dense")
+    budget_grad, _ = budget_to_target({"codebook_update": "gradient"}, "B pq-gradient")
+    budget_ema, _ = budget_to_target({"codebook_update": "ema"}, "C pq-ema")
+
+    print("\nbudgets (examples):", {"dense": budget_dense, "gradient": budget_grad, "ema": budget_ema})
+    if budget_dense and budget_ema:
+        ratio_grad = (budget_grad / budget_dense) if budget_grad else float("inf")
+        ratio_ema = budget_ema / budget_dense
+        verdict = "PASS" if ratio_ema <= 1.5 else "FAIL"
+        print(f"friction: gradient {ratio_grad:.2f}x  ema {ratio_ema:.2f}x  (acceptance <= 1.50x) -> {verdict}")
+    else:
+        print("FAIL: an arm never reached the target inside the step cap")

--- a/experiments/group_attention/natural_occupancy.py
+++ b/experiments/group_attention/natural_occupancy.py
@@ -1,0 +1,95 @@
+"""E10 acceptance: the occupancy receipt on NATURAL data, not random-token streams.
+
+K3's headline (49 occupied cells, flat from 4k to 64k context) was measured on random-token
+streams through a model trained on a 65-symbol synthetic task -- the falsification's own caveat
+says richer data will occupy more cells and the mechanism only stays honest if occupancy is
+MEASURED, not assumed. This streams real English prose (the repository's own README + docs,
+byte-level, vocab 256) through a briefly-TBPTT-trained spine and records the receipt at growing
+context lengths.
+
+Acceptance (pre-stated): occupancy at 64k context stays BOUNDED AWAY from capacity (< 80% of
+max_cells with zero dropped tokens) and grows sublinearly with context (occupied(64k) <
+2 x occupied(4k)); otherwise the O(occupied cells) claim does not transfer to natural data at
+this scale -- record the numbers honestly either way.
+"""
+
+import pathlib
+import time
+
+import numpy as np
+import torch
+
+from mixle.experimental.quantized_key_attention import QuantizedKeyAttentionSpine
+
+torch.manual_seed(0)
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+CHUNK, WINDOW, MAX_CELLS = 32, 16, 256
+TRAIN_STEPS, BATCH = 300, 4
+
+
+def corpus_bytes() -> np.ndarray:
+    parts = [ROOT / "README.md"]
+    parts += sorted((ROOT / "docs").rglob("*.rst"))
+    blob = b"\n\n".join(p.read_bytes() for p in parts if p.is_file())
+    return np.frombuffer(blob, dtype=np.uint8).astype(np.int64)
+
+
+DATA = corpus_bytes()
+print(f"corpus: {len(DATA):,} bytes from README + docs/*.rst")
+HELD_OUT_START = len(DATA) // 2  # train on the first half, stream occupancy on the second
+
+spine = QuantizedKeyAttentionSpine(
+    256, d_model=32, n_layer=2, n_head=2, window=WINDOW, n_blocks=4, codes_per_block=8, max_cells=MAX_CELLS
+)
+opt = torch.optim.Adam(spine.parameters(), lr=3e-4)
+rng = np.random.RandomState(0)
+
+print(f"TBPTT training: {TRAIN_STEPS} steps x batch {BATCH} x chunk {CHUNK} on the first half")
+spine.train()
+for step in range(1, TRAIN_STEPS + 1):
+    starts = rng.randint(0, HELD_OUT_START - 4 * CHUNK - 1, BATCH)
+    state = spine.init_state(BATCH)
+    total = None
+    for c in range(4):  # 4-chunk TBPTT segments
+        x = torch.as_tensor(np.stack([DATA[s + c * CHUNK : s + (c + 1) * CHUNK] for s in starts]))
+        y = torch.as_tensor(np.stack([DATA[s + c * CHUNK + 1 : s + (c + 1) * CHUNK + 1] for s in starts]))
+        state, loss = spine.step(state, (x, y))
+        total = loss if total is None else total + loss
+        state = spine.detach(state)
+    opt.zero_grad()
+    total.backward()
+    opt.step()
+    if step % 100 == 0:
+        print(f"  step {step:4d}  segment loss {float(total) / 4:.3f}")
+
+print("\noccupancy receipts on held-out natural text (single stream, no grad):")
+spine.eval()
+receipts = {}
+for n_ctx in (4096, 16384, 65536):
+    stream = DATA[HELD_OUT_START : HELD_OUT_START + n_ctx + 1]
+    state = spine.init_state(1)
+    t0 = time.perf_counter()
+    with torch.no_grad():
+        for start in range(0, n_ctx, CHUNK):
+            x = torch.as_tensor(stream[start : start + CHUNK])[None]
+            y = torch.as_tensor(stream[start + 1 : start + CHUNK + 1])[None]
+            state, _ = spine.step(state, (x, y))
+    receipt = spine.occupancy_receipt(state)
+    receipts[n_ctx] = receipt
+    wall = time.perf_counter() - t0
+    print(
+        f"  n={n_ctx:6d}  occupied/layer={receipt['occupied_cells_per_layer']}  "
+        f"capacity={receipt['capacity']}  possible={receipt['possible_cells']}  "
+        f"drops={receipt['dropped_tokens']}  ({wall:.1f}s)"
+    )
+
+occ4 = max(receipts[4096]["occupied_cells_per_layer"])
+occ64 = max(receipts[65536]["occupied_cells_per_layer"])
+drops = receipts[65536]["dropped_tokens"]
+bounded = occ64 < 0.8 * MAX_CELLS and drops == 0
+sublinear = occ64 < 2 * occ4
+print(
+    f"\nacceptance: occupied(64k)={occ64} (< {0.8 * MAX_CELLS:.0f} and 0 drops: {bounded}); "
+    f"occupied(4k)={occ4}, sublinear growth (< 2x): {sublinear} -> "
+    f"{'PASS' if bounded and sublinear else 'FAIL'}"
+)

--- a/mixle/experimental/quantized_key_attention.py
+++ b/mixle/experimental/quantized_key_attention.py
@@ -239,20 +239,93 @@ if _HAS_TORCH:
         and codebook toward encoder. ``encode``/``reconstruct`` are the integer <-> vector halves the
         cell store uses: ``reconstruct`` is a live embedding lookup, so far-field attention scores
         backpropagate into the codebooks directly.
+
+        ``codebook_update="ema"`` switches the codebook half to exponential-moving-average cluster
+        updates (van den Oord et al.'s VQ-VAE-2 recipe) with dead-code reseeding: codes track the
+        decayed mean of the sub-vectors assigned to them instead of descending the commitment
+        gradient, and a code whose decayed occupancy falls below ``reseed_threshold`` is re-seeded
+        to a random sub-vector from the current batch. This is the standard remedy for the VQ
+        optimization friction the falsification measured (the quantized arm needing ~2x the dense
+        arm's step budget -- ``experiments/group_attention/RESULTS.md``); the acceptance experiment
+        ``experiments/group_attention/ema_friction.py`` quantifies the reduction. In EMA mode the
+        commitment loss keeps only the encoder-side term (the codebook no longer needs gradients)
+        and the codebooks stop receiving far-field score gradients (they are buffers in all but
+        name) -- the encoder path is unchanged either way.
         """
 
-        def __init__(self, head_dim: int, *, n_blocks: int, codes_per_block: int, beta: float = 0.25) -> None:
+        def __init__(
+            self,
+            head_dim: int,
+            *,
+            n_blocks: int,
+            codes_per_block: int,
+            beta: float = 0.25,
+            codebook_update: str = "gradient",
+            ema_decay: float = 0.99,
+            ema_eps: float = 1e-5,
+            reseed_threshold: float = 0.1,
+        ) -> None:
             super().__init__()
             if head_dim % n_blocks != 0:
                 raise ValueError(f"head_dim={head_dim} must divide into n_blocks={n_blocks}")
+            if codebook_update not in ("gradient", "ema"):
+                raise ValueError(f"codebook_update must be 'gradient' or 'ema', got {codebook_update!r}")
             self.head_dim = int(head_dim)
             self.n_blocks = int(n_blocks)
             self.codes_per_block = int(codes_per_block)
             self.sub_dim = head_dim // n_blocks
             self.beta = float(beta)
-            self.codebooks = nn.Parameter(
-                torch.randn(self.n_blocks, self.codes_per_block, self.sub_dim) / (head_dim**0.5)
-            )
+            self.codebook_update = codebook_update
+            self.ema_decay = float(ema_decay)
+            self.ema_eps = float(ema_eps)
+            self.reseed_threshold = float(reseed_threshold)
+            init = torch.randn(self.n_blocks, self.codes_per_block, self.sub_dim) / (head_dim**0.5)
+            self.codebooks = nn.Parameter(init, requires_grad=codebook_update == "gradient")
+            if codebook_update == "ema":
+                self.register_buffer("_ema_cluster_size", torch.ones(self.n_blocks, self.codes_per_block))
+                self.register_buffer("_ema_embed_avg", init.clone())
+                self.register_buffer("_ema_initialized", torch.zeros((), dtype=torch.bool))
+
+        def _ema_update(self, k: Any, codes: Any) -> None:
+            """One EMA cluster step from a batch of (detached) keys and their code assignments."""
+            with torch.no_grad():
+                kb = k.detach().reshape(-1, self.n_blocks, self.sub_dim)
+                if not bool(self._ema_initialized) and kb.shape[0] > 0:
+                    # data-dependent init: seed every code from ACTUAL first-batch sub-vectors. The
+                    # random N(0, 1/sqrt(d)) init has the wrong scale relative to the encoder's real
+                    # key activations, so early assignments collapse onto a few codes and every
+                    # update scheme spends its first phase waiting for the encoder to reorganize --
+                    # the decay-insensitive ~1.6x friction floor measured in ema_friction.py.
+                    for b_idx in range(self.n_blocks):
+                        picks = torch.randperm(kb.shape[0])[: self.codes_per_block]
+                        if len(picks) < self.codes_per_block:
+                            picks = torch.randint(0, kb.shape[0], (self.codes_per_block,))
+                        self.codebooks.data[b_idx] = kb[picks, b_idx]
+                        self._ema_embed_avg[b_idx] = kb[picks, b_idx]
+                        self._ema_cluster_size[b_idx].fill_(1.0)
+                    self._ema_initialized.fill_(True)
+                    codes = self.encode(k)  # re-assign against the seeded codebooks
+                flat = codes.detach().reshape(-1, self.n_blocks)
+                for b_idx in range(self.n_blocks):
+                    assign = flat[:, b_idx]
+                    n = torch.bincount(assign, minlength=self.codes_per_block).to(kb.dtype)
+                    sums = torch.zeros(self.codes_per_block, self.sub_dim, dtype=kb.dtype, device=kb.device)
+                    sums.index_add_(0, assign, kb[:, b_idx])
+                    self._ema_cluster_size[b_idx].mul_(self.ema_decay).add_(n, alpha=1.0 - self.ema_decay)
+                    self._ema_embed_avg[b_idx].mul_(self.ema_decay).add_(sums, alpha=1.0 - self.ema_decay)
+                    # Laplace-smoothed normalization keeps rarely-hit codes finite
+                    size = self._ema_cluster_size[b_idx]
+                    total = size.sum()
+                    smoothed = (size + self.ema_eps) / (total + self.codes_per_block * self.ema_eps) * total
+                    self.codebooks.data[b_idx] = self._ema_embed_avg[b_idx] / smoothed[:, None]
+                    # dead-code reseed: a code nobody uses re-enters at a random batch sub-vector,
+                    # so early collapse (everything mapping to 2 cells) self-repairs
+                    dead = size < self.reseed_threshold
+                    if bool(dead.any()) and kb.shape[0] > 0:
+                        picks = torch.randint(0, kb.shape[0], (int(dead.sum()),), device=kb.device)
+                        self.codebooks.data[b_idx][dead] = kb[picks, b_idx]
+                        self._ema_embed_avg[b_idx][dead] = kb[picks, b_idx]
+                        self._ema_cluster_size[b_idx][dead] = 1.0
 
         def encode(self, k: Any) -> Any:
             """``(..., head_dim) -> (..., n_blocks)`` nearest-code indices (no gradient; argmin is discrete)."""
@@ -269,7 +342,15 @@ if _HAS_TORCH:
             codes = self.encode(k)
             quant = self.reconstruct(codes)
             blocks_flat = k  # commitment in the full-key metric == sum of per-block metrics
-            commit = F.mse_loss(blocks_flat, quant.detach()) + self.beta * F.mse_loss(quant, blocks_flat.detach())
+            if self.codebook_update == "ema":
+                # encoder-side pull only; the codebook is trained by the EMA cluster step (applied
+                # AFTER this batch used the current codes -- the standard VQ-VAE-EMA ordering, so
+                # the returned codes and quantized keys stay mutually consistent)
+                commit = self.beta * F.mse_loss(blocks_flat, quant.detach())
+                if self.training and torch.is_grad_enabled():
+                    self._ema_update(k, codes)
+            else:
+                commit = F.mse_loss(blocks_flat, quant.detach()) + self.beta * F.mse_loss(quant, blocks_flat.detach())
             k_q = k + (quant - k).detach()  # straight-through
             return k_q, codes, commit
 
@@ -349,6 +430,29 @@ if _HAS_TORCH:
         new_cache_k = k_full_raw[:, -window:]
         new_cache_v = v_full_raw[:, -window:]
         return near_logits, gap_logits, vh, new_cache_k, new_cache_v, evicted_k_raw, evicted_v_raw
+
+    def quantized_softmax_weights(logits: Any, *, bits: int, span: float = 24.0) -> Any:
+        """Unnormalized softmax weights through the Q-LSE grid: ONE ``2^bits`` exp table, no real exp.
+
+        ``mixle.engines.qlut.quantized_logsumexp``'s exact semantics, elementwise: shift by the
+        row max, round to the ``span / 2^bits`` grid, clamp scores more than ``span`` below the max
+        into the bottom bin, and read ``exp`` off the precomputed table (``-inf`` rows get weight
+        0, matching softmax's treatment of masked slots). Dividing by the row sum gives softmax
+        weights within ``exp(+-lse_error_bound(bits, span)) - 1`` relative of exact -- the same
+        grid half-step bound, now carried through the attention READOUT rather than just the
+        scorer. The histogram+dot evaluation of these same numbers is the O(2^bits) form; here the
+        table gather is per element because the readout needs the per-slot weights against values.
+        """
+        levels = 1 << bits
+        delta = span / levels
+        finite = torch.isfinite(logits)
+        m = logits.masked_fill(~finite, float("-inf")).amax(dim=-1, keepdim=True)
+        m = torch.where(torch.isfinite(m), m, torch.zeros_like(m))  # all-masked rows: any shift works
+        idx = torch.clamp(torch.round((logits - m) / delta).long() + levels - 1, min=0, max=levels - 1)
+        table = torch.exp((torch.arange(levels, device=logits.device, dtype=torch.float64) - (levels - 1)) * delta).to(
+            logits.dtype
+        )
+        return table[idx] * finite.to(logits.dtype)
 
     def _far_bank(codes: Any, counts: Any, vsum: Any, q_raw: Any, pq: ProductQuantizer) -> tuple[Any, Any]:
         """Far-field logits and mean values from the cell store.
@@ -473,6 +577,9 @@ if _HAS_TORCH:
             codes_per_block: int = 16,
             max_cells: int = 128,
             commit_weight: float = 1.0,
+            codebook_update: str = "gradient",
+            lse_bits: int | None = None,
+            lse_span: float = 24.0,
         ) -> None:
             super().__init__()
             assert d_model % n_head == 0
@@ -486,12 +593,22 @@ if _HAS_TORCH:
             self.codes_per_block = int(codes_per_block)
             self.max_cells = int(max_cells)
             self.commit_weight = float(commit_weight)
+            # Q-LSE readout: with lse_bits set, INFERENCE steps (no grad) normalize the joint
+            # softmax through the quantized-exp table (quantized_softmax_weights); training steps
+            # always use exact exp -- the same exact-when-learning discipline as the fused E-steps.
+            self.lse_bits = None if lse_bits is None else int(lse_bits)
+            self.lse_span = float(lse_span)
             (self.tok, self.qkv, self.proj, self.ln1, self.ln2, self.mlp, self.ln_f, self.head) = _transformer_block(
                 vocab, d_model, n_layer, n_head
             )
             self.pq = nn.ModuleList(
                 [
-                    ProductQuantizer(self.head_dim, n_blocks=n_blocks, codes_per_block=codes_per_block)
+                    ProductQuantizer(
+                        self.head_dim,
+                        n_blocks=n_blocks,
+                        codes_per_block=codes_per_block,
+                        codebook_update=codebook_update,
+                    )
                     for _ in range(n_layer)
                 ]
             )
@@ -568,7 +685,12 @@ if _HAS_TORCH:
 
                 # One softmax over {far cells} + {gap tokens, quantized} + {near tokens, exact}: softmax
                 # attention over the whole stream with far keys quantized -- the collapse identity's LHS.
-                joint = torch.cat([far_logits, gap_logits, near_logits], dim=-1).softmax(dim=-1)
+                joint_logits = torch.cat([far_logits, gap_logits, near_logits], dim=-1)
+                if self.lse_bits is not None and not torch.is_grad_enabled():
+                    w = quantized_softmax_weights(joint_logits, bits=self.lse_bits, span=self.lse_span)
+                    joint = w / w.sum(dim=-1, keepdim=True).clamp(min=torch.finfo(w.dtype).tiny)
+                else:
+                    joint = joint_logits.softmax(dim=-1)
                 n_cells = far_logits.shape[-1]
                 n_unfolded = gap_logits.shape[-1]
                 out = (

--- a/mixle/tests/quantized_key_attention_test.py
+++ b/mixle/tests/quantized_key_attention_test.py
@@ -237,3 +237,99 @@ class ProtocolAndTrainingTest:
         spine = QuantizedKeyAttentionSpine(13, d_model=16, n_layer=1, n_head=2, window=4, max_cells=1)
         state = _stream(spine, spine.init_state(1), torch.randint(0, 13, (1, 64)), 4)
         assert spine.occupancy_receipt(state)["dropped_tokens"] > 0
+
+
+class EmaCodebookTest:
+    """codebook_update="ema": cluster-mean tracking, dead-code reseeding, encoder path unchanged."""
+
+    def test_ema_codebooks_track_assigned_cluster_means(self):
+        torch.manual_seed(11)
+        pq = ProductQuantizer(8, n_blocks=2, codes_per_block=4, codebook_update="ema", ema_decay=0.5)
+        pq.train()
+        centers = torch.tensor([[2.0] * 8, [-2.0] * 8])
+        keys = centers.repeat_interleave(32, dim=0) + 0.05 * torch.randn(64, 8)
+        for _ in range(30):
+            pq(keys)
+        quant = pq.reconstruct(pq.encode(keys))
+        err = float((quant - keys).pow(2).mean())
+        assert err < 0.01, f"EMA codes failed to reach the cluster means (mse {err:.4f})"
+
+    def test_ema_mode_keeps_codebooks_out_of_autograd_but_encoder_grads_flow(self):
+        pq = ProductQuantizer(8, n_blocks=2, codes_per_block=4, codebook_update="ema")
+        assert not pq.codebooks.requires_grad
+        pq.train()
+        k = torch.randn(16, 8, requires_grad=True)
+        k_q, _, commit = pq(k)
+        (k_q.sum() + commit).backward()
+        assert k.grad is not None and float(k.grad.abs().sum()) > 0, "straight-through must reach the encoder"
+
+    def test_gradient_mode_is_the_unchanged_default(self):
+        pq = ProductQuantizer(8, n_blocks=2, codes_per_block=4)
+        assert pq.codebook_update == "gradient"
+        assert pq.codebooks.requires_grad
+        assert not hasattr(pq, "_ema_cluster_size")
+
+    def test_dead_codes_reseed_from_the_batch(self):
+        torch.manual_seed(12)
+        pq = ProductQuantizer(8, n_blocks=2, codes_per_block=4, codebook_update="ema", ema_decay=0.1)
+        pq.train()
+        keys = torch.full((32, 8), 3.0) + 0.01 * torch.randn(32, 8)  # everything hits ONE code
+        for _ in range(25):  # decayed occupancy of the other codes collapses below the threshold
+            pq(keys)
+        sizes = pq._ema_cluster_size
+        # reseeding keeps refreshing dead codes to batch vectors (near 3.0), never leaves them stale
+        reseeded = (pq.codebooks.data - 3.0).abs().mean(-1) < 0.5
+        assert bool(reseeded.any()), "no dead code was ever reseeded to a batch sub-vector"
+        assert float(sizes.min()) >= 0.0
+
+
+class QuantizedReadoutTest:
+    """Q-LSE beyond scoring: the attention readout through one 2^bits exp table, bound + qlut parity."""
+
+    def test_row_normalizers_match_the_qlut_kernel_exactly(self):
+        from mixle.engines.qlut import quantized_logsumexp
+        from mixle.experimental.quantized_key_attention import quantized_softmax_weights
+
+        torch.manual_seed(13)
+        bits, span = 12, 24.0
+        logits = torch.randn(5, 40, dtype=torch.float64) * 4.0
+        logits[:, 25:] = float("-inf")  # masked slots, as in the joint softmax
+        w = quantized_softmax_weights(logits, bits=bits, span=span)
+        for row in range(logits.shape[0]):
+            r = logits[row].numpy()
+            m = float(np.max(r[np.isfinite(r)]))
+            expected_mass = np.exp(quantized_logsumexp(r, bits=bits, span=span) - m)
+            assert float(w[row].sum()) == pytest.approx(expected_mass, rel=1e-12), (
+                "the torch readout grid must be the qlut kernel's grid, bit for bit"
+            )
+
+    def test_readout_error_is_within_the_grid_bound(self):
+        from mixle.engines.qlut import lse_error_bound
+        from mixle.experimental.quantized_key_attention import quantized_softmax_weights
+
+        torch.manual_seed(14)
+        bits, span = 12, 24.0
+        logits = torch.randn(8, 64, dtype=torch.float64) * 3.0
+        values = torch.randn(64, 16, dtype=torch.float64)
+        exact = logits.softmax(-1) @ values
+        w = quantized_softmax_weights(logits, bits=bits, span=span)
+        quant = (w / w.sum(-1, keepdim=True)) @ values
+        # each weight is perturbed by <= exp(+-bound) in numerator and denominator
+        tol = (np.exp(2.0 * lse_error_bound(bits, span)) - 1.0) * float(values.abs().max()) * 2.0
+        assert float((quant - exact).abs().max()) <= tol
+
+    def test_spine_quantized_inference_close_to_exact_and_training_stays_exact(self):
+        torch.manual_seed(15)
+        exact_spine = QuantizedKeyAttentionSpine(7, d_model=16, n_layer=1, n_head=2, window=4, max_cells=32)
+        torch.manual_seed(15)
+        q_spine = QuantizedKeyAttentionSpine(7, d_model=16, n_layer=1, n_head=2, window=4, max_cells=32, lse_bits=12)
+        chunk = (torch.randint(0, 7, (1, 12)), torch.randint(0, 7, (1, 12)))
+        with torch.no_grad():
+            _, loss_exact = exact_spine.step(exact_spine.init_state(1), chunk)
+            _, loss_quant = q_spine.step(q_spine.init_state(1), chunk)
+        assert float(loss_quant) == pytest.approx(float(loss_exact), abs=1e-2)
+        assert float(loss_quant) != float(loss_exact), "the quantized readout must actually engage"
+        # grad-enabled steps bypass the quantized readout entirely: training is exact by design
+        _, train_exact = exact_spine.step(exact_spine.init_state(1), chunk)
+        _, train_quant = q_spine.step(q_spine.init_state(1), chunk)
+        assert float(train_quant.detach()) == pytest.approx(float(train_exact.detach()), rel=1e-12)


### PR DESCRIPTION
The three acceptance items `experiments/group_attention/RESULTS.md` left open after the E10 falsification and the E7 bake-off. Criteria were pre-stated in the script headers; all runs are from today, receipts in RESULTS.md's new acceptance section.

## 1. EMA codebooks: VQ friction 2.00× → 1.46× — PASS (bar: ≤ 1.5×)

`ProductQuantizer(codebook_update="ema")`: EMA cluster updates, dead-code reseeding, and data-dependent init. On the falsification's associative-recall task (`ema_friction.py`, budget to held-out recall ≥ 0.95):

| arm | examples | ×dense |
|---|---|---|
| dense | 83,200 | 1.00× |
| gradient-VQ (current default) | 166,400 | **2.00×** (the falsification's ~2× reproduced exactly) |
| EMA + data-init | 121,600 | **1.46× — PASS** |

Two negative results recorded on the way: the EMA **decay is not the lever** (0.8/0.9/0.95/0.99 all plateau at ~1.6×), and the friction floor lived in the **init** — random `N(0, 1/√d)` codebooks have the wrong scale relative to real key activations, so early assignments collapse onto a few codes and every update scheme waits for the encoder to reorganize. Seeding codes from actual first-batch sub-vectors is what crossed the bar. Gradient mode stays the constructor default; EMA is opt-in per spine.

## 2. Occupancy on natural data: bounded and sublinear — PASS

K3's headline (49 cells, flat to 64k) was measured on random-token streams — its own caveat. `natural_occupancy.py` streams byte-level English prose (this repo's README + docs) through a briefly-TBPTT-trained spine: occupied cells/layer **69 @ 4k → 108 @ 64k** of 256 capacity (4,096 possible), **0 dropped tokens** — 1.57× cells for a 16× context increase. Natural data occupies more cells than the synthetic task, exactly as predicted, and stays an order of magnitude under the cell space with O(~100) per-query cost at every length measured.

## 3. Q-LSE beyond scoring: the attention readout itself

`quantized_softmax_weights` computes the joint softmax's unnormalized weights through the qlut grid — row-max shift, `span/2^bits` rounding, ONE `2^bits` exp table, `-inf` slots → weight 0 — and `QuantizedKeyAttentionSpine(lse_bits=...)` applies it to **inference** steps only; training always uses exact exp (the fused-E-step discipline). Tests pin: row normalizers equal to `mixle.engines.qlut.quantized_logsumexp` **bit for bit** (torch grid ≡ numpy kernel grid), readout error within the `exp(2·lse_error_bound)−1` weight-ratio bound, and grad-enabled steps matching the exact spine to 1e-12.

## Testing

`quantized_key_attention_test.py` grows 7 tests (EMA tracking/reseed/autograd isolation, Q-LSE parity/bound/spine behavior); the full E10 suites (spine + qlut + cell structures) pass, 29 green.
