### PR TITLE
Centralize the keyed protocol on the base accumulator; strip 166 hand-rolled copies

### DIFF
--- a/mixle/stats/bayes/dirichlet.py
+++ b/mixle/stats/bayes/dirichlet.py
@@ -761,36 +761,6 @@ class DirichletAccumulator(SequenceEncodableStatisticAccumulator):
             self.dim = len(x[1])
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Combine sufficient statistics with other accumulators sharing a matching key.
-
-        Args:
-            stats_dict (Dict[str, Any]): Dictionary mapping keys to accumulators.
-
-        Returns:
-            None.
-
-        """
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                stats_dict[self.keys].combine(self.value())
-            else:
-                stats_dict[self.keys] = self
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace sufficient statistics with values from stats_dict for a matching key.
-
-        Args:
-            stats_dict (Dict[str, Any]): Dictionary mapping keys to accumulators.
-
-        Returns:
-            None.
-
-        """
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                self.from_value(stats_dict[self.keys].value())
-
     def acc_to_encoder(self) -> "DirichletDataEncoder":
         """Create the encoder associated with this accumulator."""
         return DirichletDataEncoder()

--- a/mixle/stats/bayes/pitman_yor.py
+++ b/mixle/stats/bayes/pitman_yor.py
@@ -22,7 +22,6 @@ discount) factors exactly across partitions of arbitrary sizes.
 
 import math
 from collections.abc import Sequence
-from typing import Any
 
 import numpy as np
 from numpy.random import RandomState
@@ -252,19 +251,6 @@ class PitmanYorProcessAccumulator(SequenceEncodableStatisticAccumulator):
         """Restore the accumulator from serialized histogram statistics."""
         self.count, self.a_hist, self.b_hist, self.d_hist = x[0], dict(x[1]), dict(x[2]), dict(x[3])
         return self
-
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge this accumulator into a keyed statistics dictionary."""
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                stats_dict[self.keys].combine(self.value())
-            else:
-                stats_dict[self.keys] = self
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace this accumulator from a keyed statistics dictionary."""
-        if self.keys is not None and self.keys in stats_dict:
-            self.from_value(stats_dict[self.keys].value())
 
     def acc_to_encoder(self) -> "PitmanYorProcessDataEncoder":
         """Return an encoder that converts partitions to block-size arrays."""

--- a/mixle/stats/combinator/optional.py
+++ b/mixle/stats/combinator/optional.py
@@ -592,22 +592,23 @@ class OptionalEstimatorAccumulator(SequenceEncodableStatisticAccumulator):
         return self
 
     def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace this accumulator's state from the pooled keyed statistics when present."""
+        """Replace own + wrapped-child statistics from the pooled ``stats_dict`` (see key_merge)."""
         # The pull direction matters: this used to PUSH self.value() INTO the dict-held pool,
         # which overwrote the pooled statistics with the last site's own and left the site itself
         # untouched -- tied sites never received the pool (caught by the keyed-protocol sweep).
-        if self.keys is not None and self.keys in stats_dict:
-            pooled = stats_dict[self.keys]
-            if pooled is not self:
-                self.from_value(pooled.value())
+        super().key_replace(stats_dict)
+        self.accumulator.key_replace(stats_dict)
 
     def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge this accumulator into ``stats_dict`` under the configured key."""
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                stats_dict[self.keys].combine(self.value())
-            else:
-                stats_dict[self.keys] = self
+        """Merge own statistics under ``self.keys`` and DELEGATE to the wrapped child.
+
+        The delegation is the point of the override: without it, a keyed estimator nested under an
+        Optional never pooled at all (its key pass was unreachable -- the dead-keys shape the
+        keyed-protocol sweep hunts). The own-key pooling itself is the base-class canonical
+        protocol.
+        """
+        super().key_merge(stats_dict)
+        self.accumulator.key_merge(stats_dict)
 
     def acc_to_encoder(self) -> OptionalDataEncoder:
         """Return the optional encoder matching the wrapped child accumulator."""

--- a/mixle/stats/compute/pdist.py
+++ b/mixle/stats/compute/pdist.py
@@ -897,8 +897,23 @@ class StatisticAccumulator(ABC, Generic[SS]):
 
         The structural default implements the common single-key pattern: store the accumulator
         under ``self.keys`` the first time the key is seen, else ``combine`` into the one already
-        there. Accumulators with several named keys (e.g. an HMM's init/trans/state keys) or a
-        non-accumulator stats payload override this. A ``keys`` of ``None`` (the default) is a no-op.
+        there. Accumulators whose key does not cover their whole state (several named keys, a
+        wrapped child accumulator, a non-accumulator payload) override this -- and ONLY those:
+        as of 2026-07-14 every whole-state family uses this default, after a sweep found sixteen
+        hand-rolled copies that had drifted into three broken shapes. If you are tempted to
+        reimplement this per family, don't; extend the base or override with ``super()`` calls.
+        A ``keys`` of ``None`` (the default) is a no-op.
+
+        Why this exact shape is correct -- and the drifted shapes are not: the POOL must live in
+        the dict. Combining INTO the dict-held accumulator (below) mutates the pool in place, so
+        after all sites merge, the dict entry holds everyone's statistics and ``key_replace``
+        hands that pool to every site. The observed broken variants each violate one half:
+        pulling the dict's stats into ``self`` without writing back (the dict keeps the FIRST
+        site only -- later sites' data silently discarded); merging only when the key is already
+        present (nobody ever inserts: both passes are no-ops and tying does nothing); and
+        replacing by pushing ``self`` INTO the dict (the LAST site overwrites the pool). The
+        keyed-protocol sweep (`keyed_protocol_sweep_test.py`) enforces this behaviorally for
+        every catalog family.
         """
         keys = getattr(self, "keys", None)
         if keys is not None:

--- a/mixle/stats/directional/bingham.py
+++ b/mixle/stats/directional/bingham.py
@@ -215,19 +215,6 @@ class BinghamAccumulator(SequenceEncodableStatisticAccumulator):
         self.sum_xx = np.asarray(x[1], dtype=np.float64).copy()
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge this accumulator into ``stats_dict`` under its configured key."""
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                stats_dict[self.keys].combine(self.value())
-            else:
-                stats_dict[self.keys] = self
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace this accumulator's state from keyed statistics when present."""
-        if self.keys is not None and self.keys in stats_dict:
-            self.from_value(stats_dict[self.keys].value())
-
     def acc_to_encoder(self) -> "BinghamDataEncoder":
         """Return the encoder compatible with Bingham scatter statistics."""
         return BinghamDataEncoder()

--- a/mixle/stats/directional/kent.py
+++ b/mixle/stats/directional/kent.py
@@ -224,19 +224,6 @@ class KentAccumulator(SequenceEncodableStatisticAccumulator):
         self.sum_xx = np.asarray(x[2], dtype=np.float64).copy()
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge this accumulator into ``stats_dict`` under its configured key."""
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                stats_dict[self.keys].combine(self.value())
-            else:
-                stats_dict[self.keys] = self
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace this accumulator's state from keyed statistics when present."""
-        if self.keys is not None and self.keys in stats_dict:
-            self.from_value(stats_dict[self.keys].value())
-
     def acc_to_encoder(self) -> "KentDataEncoder":
         """Return the encoder compatible with Kent moment statistics."""
         return KentDataEncoder()

--- a/mixle/stats/directional/projected_normal.py
+++ b/mixle/stats/directional/projected_normal.py
@@ -264,19 +264,6 @@ class ProjectedNormalAccumulator(SequenceEncodableStatisticAccumulator):
         self.sum_x, self.sum_y, self.count = float(x[0]), float(x[1]), float(x[2])
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge keyed statistics into ``stats_dict`` when keys are configured."""
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                stats_dict[self.keys].combine(self.value())
-            else:
-                stats_dict[self.keys] = self
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace this accumulator from keyed statistics when available."""
-        if self.keys is not None and self.keys in stats_dict:
-            self.from_value(stats_dict[self.keys].value())
-
     def acc_to_encoder(self) -> "ProjectedNormalDataEncoder":
         """Return the encoder used by this accumulator."""
         return ProjectedNormalDataEncoder()

--- a/mixle/stats/directional/von_mises.py
+++ b/mixle/stats/directional/von_mises.py
@@ -337,19 +337,6 @@ class VonMisesAccumulator(SequenceEncodableStatisticAccumulator):
         self.count, self.sum_cos, self.sum_sin = x
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge keyed statistics into ``stats_dict`` when keys are configured."""
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                stats_dict[self.keys].combine(self.value())
-            else:
-                stats_dict[self.keys] = self
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace this accumulator from keyed statistics when available."""
-        if self.keys is not None and self.keys in stats_dict:
-            self.from_value(stats_dict[self.keys].value())
-
     def acc_to_encoder(self) -> "VonMisesDataEncoder":
         """Return the encoder used by this accumulator."""
         return VonMisesDataEncoder()

--- a/mixle/stats/directional/von_mises_fisher.py
+++ b/mixle/stats/directional/von_mises_fisher.py
@@ -604,40 +604,6 @@ class VonMisesFisherAccumulator(SequenceEncodableStatisticAccumulator):
         self.dim = None if self.ssum is None else len(self.ssum)
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge sufficient statistics from ``stats_dict`` when this accumulator's key is present.
-
-        Args:
-            stats_dict (Dict[str, Any]): Dict mapping keys to accumulators with shared sufficient statistics.
-
-        Returns:
-            None.
-
-        """
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                self.combine(stats_dict[self.keys].value())
-                # write the POOL back: the dict must end holding the pooled accumulator, else
-                # key_replace hands every tied site the FIRST site's statistics (later sites'
-                # data silently discarded -- caught by the keyed-protocol sweep)
-                stats_dict[self.keys] = self
-            else:
-                stats_dict[self.keys] = self
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace sufficient statistics from ``stats_dict`` when this accumulator's key is present.
-
-        Args:
-            stats_dict (Dict[str, Any]): Dict mapping keys to accumulators with shared sufficient statistics.
-
-        Returns:
-            None.
-
-        """
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                self.from_value(stats_dict[self.keys].value())
-
     def acc_to_encoder(self) -> "VonMisesFisherDataEncoder":
         """Return the encoder associated with this accumulator."""
         return VonMisesFisherDataEncoder()

--- a/mixle/stats/directional/watson.py
+++ b/mixle/stats/directional/watson.py
@@ -201,19 +201,6 @@ class WatsonAccumulator(SequenceEncodableStatisticAccumulator):
         self.dim = self.scatter.shape[0]
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge keyed statistics into ``stats_dict`` when keys are configured."""
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                stats_dict[self.keys].combine(self.value())
-            else:
-                stats_dict[self.keys] = self
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace this accumulator from keyed statistics when available."""
-        if self.keys is not None and self.keys in stats_dict:
-            self.from_value(stats_dict[self.keys].value())
-
     def acc_to_encoder(self) -> "WatsonDataEncoder":
         """Return the encoder used by this accumulator."""
         return WatsonDataEncoder()

--- a/mixle/stats/directional/wrapped_cauchy.py
+++ b/mixle/stats/directional/wrapped_cauchy.py
@@ -244,19 +244,6 @@ class WrappedCauchyAccumulator(SequenceEncodableStatisticAccumulator):
         self.sum_cos, self.sum_sin, self.count = float(x[0]), float(x[1]), float(x[2])
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge keyed statistics into ``stats_dict`` when keys are configured."""
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                stats_dict[self.keys].combine(self.value())
-            else:
-                stats_dict[self.keys] = self
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace this accumulator from keyed statistics when available."""
-        if self.keys is not None and self.keys in stats_dict:
-            self.from_value(stats_dict[self.keys].value())
-
     def acc_to_encoder(self) -> "WrappedCauchyDataEncoder":
         """Return the encoder used by this accumulator."""
         return WrappedCauchyDataEncoder()

--- a/mixle/stats/directional/wrapped_normal.py
+++ b/mixle/stats/directional/wrapped_normal.py
@@ -200,19 +200,6 @@ class WrappedNormalAccumulator(SequenceEncodableStatisticAccumulator):
         self.sum_cos, self.sum_sin, self.count = float(x[0]), float(x[1]), float(x[2])
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge keyed statistics into ``stats_dict`` when keys are configured."""
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                stats_dict[self.keys].combine(self.value())
-            else:
-                stats_dict[self.keys] = self
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace this accumulator from keyed statistics when available."""
-        if self.keys is not None and self.keys in stats_dict:
-            self.from_value(stats_dict[self.keys].value())
-
     def acc_to_encoder(self) -> "WrappedNormalDataEncoder":
         """Return the encoder used by this accumulator."""
         return WrappedNormalDataEncoder()

--- a/mixle/stats/graphs/erdos_renyi_graph.py
+++ b/mixle/stats/graphs/erdos_renyi_graph.py
@@ -331,19 +331,6 @@ class ErdosRenyiGraphAccumulator(SequenceEncodableStatisticAccumulator):
         self.edge_count = float(x[1])
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge tied edge-count statistics into ``stats_dict``."""
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                stats_dict[self.keys].combine(self.value())
-            else:
-                stats_dict[self.keys] = self
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace tied edge-count statistics from ``stats_dict``."""
-        if self.keys is not None and self.keys in stats_dict:
-            self.from_value(stats_dict[self.keys].value())
-
     def acc_to_encoder(self) -> GraphDataEncoder:
         """Return the encoder associated with this accumulator."""
         return GraphDataEncoder(directed=self.directed)

--- a/mixle/stats/graphs/knowledge_graph.py
+++ b/mixle/stats/graphs/knowledge_graph.py
@@ -285,19 +285,6 @@ class KnowledgeGraphAccumulator(SequenceEncodableStatisticAccumulator):
         self.weights = [np.asarray(x[2], dtype=float)] if len(x[1]) else []
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge this accumulator into ``stats_dict`` under its configured key."""
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                stats_dict[self.keys].combine(self.value())
-            else:
-                stats_dict[self.keys] = self
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace this accumulator's state from keyed statistics when present."""
-        if self.keys is not None and self.keys in stats_dict:
-            self.from_value(stats_dict[self.keys].value())
-
     def acc_to_encoder(self) -> "KnowledgeGraphDataEncoder":
         """Return the encoder compatible with stored triples."""
         return KnowledgeGraphDataEncoder()

--- a/mixle/stats/graphs/random_dot_product_graph.py
+++ b/mixle/stats/graphs/random_dot_product_graph.py
@@ -211,19 +211,6 @@ class RandomDotProductGraphAccumulator(SequenceEncodableStatisticAccumulator):
         self.count, self.adj_sum = x[0], (None if x[1] is None else np.asarray(x[1], dtype=float))
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge this accumulator into a keyed statistics dictionary."""
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                stats_dict[self.keys].combine(self.value())
-            else:
-                stats_dict[self.keys] = self
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace this accumulator from a keyed statistics dictionary."""
-        if self.keys is not None and self.keys in stats_dict:
-            self.from_value(stats_dict[self.keys].value())
-
     def acc_to_encoder(self) -> GraphDataEncoder:
         """Return the undirected graph encoder used by the accumulator."""
         return GraphDataEncoder(directed=False)

--- a/mixle/stats/graphs/stochastic_block_graph.py
+++ b/mixle/stats/graphs/stochastic_block_graph.py
@@ -495,19 +495,6 @@ class StochasticBlockGraphAccumulator(SequenceEncodableStatisticAccumulator):
         self.num_graphs = float(num_graphs)
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge tied SBM sufficient statistics into ``stats_dict``."""
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                stats_dict[self.keys].combine(self.value())
-            else:
-                stats_dict[self.keys] = self
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace tied SBM sufficient statistics from ``stats_dict``."""
-        if self.keys is not None and self.keys in stats_dict:
-            self.from_value(stats_dict[self.keys].value())
-
     def acc_to_encoder(self) -> GraphDataEncoder:
         """Return the encoder associated with this accumulator."""
         return GraphDataEncoder(directed=self.directed, fallback_assignments=self.block_assignments)

--- a/mixle/stats/latent/chained_attention.py
+++ b/mixle/stats/latent/chained_attention.py
@@ -266,23 +266,6 @@ class ChainedAttentionAccumulator(SequenceEncodableStatisticAccumulator):
         self.n = float(x[4])
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge this accumulator into ``stats_dict`` under its configured key."""
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                self.combine(stats_dict[self.keys])
-                # write the POOL back: without this the dict keeps the FIRST site's value and
-                # key_replace hands that truncated pool to every tied site (later sites' data
-                # silently discarded -- caught by the keyed-protocol sweep)
-                stats_dict[self.keys] = self.value()
-            else:
-                stats_dict[self.keys] = self.value()
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace this accumulator's state from keyed statistics when present."""
-        if self.keys is not None and self.keys in stats_dict:
-            self.from_value(stats_dict[self.keys])
-
     def acc_to_encoder(self) -> ChainedAttentionDataEncoder:
         """Return the encoder compatible with this accumulator."""
         return ChainedAttentionDataEncoder()

--- a/mixle/stats/latent/indian_buffet_process.py
+++ b/mixle/stats/latent/indian_buffet_process.py
@@ -493,19 +493,6 @@ class IndianBuffetProcessAccumulator(SequenceEncodableStatisticAccumulator):
         self.total_count *= c
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge this accumulator into ``stats_dict`` under its configured key."""
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                stats_dict[self.keys].combine(self.value())
-            else:
-                stats_dict[self.keys] = self
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace this accumulator's state from keyed statistics when present."""
-        if self.keys is not None and self.keys in stats_dict:
-            self.from_value(stats_dict[self.keys].value())
-
     def acc_to_encoder(self) -> "IndianBuffetProcessDataEncoder":
         """Return the encoder compatible with finite IBP sufficient statistics."""
         return IndianBuffetProcessDataEncoder(self.num_features, self.data_format)

--- a/mixle/stats/latent/probabilistic_pca.py
+++ b/mixle/stats/latent/probabilistic_pca.py
@@ -226,19 +226,6 @@ class ProbabilisticPCAAccumulator(SequenceEncodableStatisticAccumulator):
         self.dim = None if x[1] is None else len(x[1])
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge this accumulator into a keyed statistics dictionary."""
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                stats_dict[self.keys].combine(self.value())
-            else:
-                stats_dict[self.keys] = self
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace this accumulator from a keyed statistics dictionary."""
-        if self.keys is not None and self.keys in stats_dict:
-            self.from_value(stats_dict[self.keys].value())
-
     def acc_to_encoder(self) -> "ProbabilisticPCADataEncoder":
         """Return an encoder compatible with PPCA vector observations."""
         return ProbabilisticPCADataEncoder()

--- a/mixle/stats/latent/responsibility_attention.py
+++ b/mixle/stats/latent/responsibility_attention.py
@@ -285,23 +285,6 @@ class ResponsibilityAttentionAccumulator(SequenceEncodableStatisticAccumulator):
         self.query_sq = float(x[4])
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge this accumulator into ``stats_dict`` under its configured key."""
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                self.combine(stats_dict[self.keys])
-                # write the POOL back: without this the dict keeps the FIRST site's value and
-                # key_replace hands that truncated pool to every tied site (later sites' data
-                # silently discarded -- caught by the keyed-protocol sweep)
-                stats_dict[self.keys] = self.value()
-            else:
-                stats_dict[self.keys] = self.value()
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace this accumulator's state from keyed statistics when present."""
-        if self.keys is not None and self.keys in stats_dict:
-            self.from_value(stats_dict[self.keys])
-
     def acc_to_encoder(self) -> ResponsibilityAttentionDataEncoder:
         """Return the encoder compatible with this accumulator."""
         return ResponsibilityAttentionDataEncoder()

--- a/mixle/stats/latent/variational_embedding_attention.py
+++ b/mixle/stats/latent/variational_embedding_attention.py
@@ -291,23 +291,6 @@ class VariationalEmbeddingAttentionAccumulator(SequenceEncodableStatisticAccumul
         self.n = float(x[5])
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge this accumulator into ``stats_dict`` under its configured key."""
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                self.combine(stats_dict[self.keys])
-                # write the POOL back: without this the dict keeps the FIRST site's value and
-                # key_replace hands that truncated pool to every tied site (later sites' data
-                # silently discarded -- caught by the keyed-protocol sweep)
-                stats_dict[self.keys] = self.value()
-            else:
-                stats_dict[self.keys] = self.value()
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace this accumulator's state from keyed statistics when present."""
-        if self.keys is not None and self.keys in stats_dict:
-            self.from_value(stats_dict[self.keys])
-
     def acc_to_encoder(self) -> VariationalEmbeddingAttentionDataEncoder:
         """Return the encoder compatible with this accumulator."""
         return VariationalEmbeddingAttentionDataEncoder()

--- a/mixle/stats/latent/variational_multihop_attention.py
+++ b/mixle/stats/latent/variational_multihop_attention.py
@@ -250,23 +250,6 @@ class VariationalMultiHopAttentionAccumulator(SequenceEncodableStatisticAccumula
         self.n = float(x[4])
         return self
 
-    def key_merge(self, stats_dict) -> None:
-        """Merge this accumulator into ``stats_dict`` under its configured key."""
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                self.combine(stats_dict[self.keys])
-                # write the POOL back: without this the dict keeps the FIRST site's value and
-                # key_replace hands that truncated pool to every tied site (later sites' data
-                # silently discarded -- caught by the keyed-protocol sweep)
-                stats_dict[self.keys] = self.value()
-            else:
-                stats_dict[self.keys] = self.value()
-
-    def key_replace(self, stats_dict) -> None:
-        """Replace this accumulator's state from keyed statistics when present."""
-        if self.keys is not None and self.keys in stats_dict:
-            self.from_value(stats_dict[self.keys])
-
     def acc_to_encoder(self):
         """Return the encoder compatible with this attention accumulator."""
         return VariationalMultiHopAttentionDataEncoder()

--- a/mixle/stats/matrix/lkj.py
+++ b/mixle/stats/matrix/lkj.py
@@ -187,19 +187,6 @@ class LKJAccumulator(SequenceEncodableStatisticAccumulator):
         self.count, self.sum_log_det = float(x[0]), float(x[1])
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge this accumulator into a keyed statistics dictionary."""
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                stats_dict[self.keys].combine(self.value())
-            else:
-                stats_dict[self.keys] = self
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace this accumulator from a keyed statistics dictionary."""
-        if self.keys is not None and self.keys in stats_dict:
-            self.from_value(stats_dict[self.keys].value())
-
     def acc_to_encoder(self) -> "LKJDataEncoder":
         """Return an encoder that reduces correlation matrices to log determinants."""
         return LKJDataEncoder()

--- a/mixle/stats/matrix/matrix_normal.py
+++ b/mixle/stats/matrix/matrix_normal.py
@@ -19,7 +19,6 @@ Reference: Dawid, 'Some matrix-variate distribution theory', Biometrika (1981).
 
 import math
 from collections.abc import Sequence
-from typing import Any
 
 import numpy as np
 from numpy.random import RandomState
@@ -176,19 +175,6 @@ class MatrixNormalAccumulator(SequenceEncodableStatisticAccumulator):
         self.count = float(x[2])
         self.n, self.p = self.sum_x.shape
         return self
-
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge this accumulator into a keyed statistics dictionary."""
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                stats_dict[self.keys].combine(self.value())
-            else:
-                stats_dict[self.keys] = self
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace this accumulator from a keyed statistics dictionary."""
-        if self.keys is not None and self.keys in stats_dict:
-            self.from_value(stats_dict[self.keys].value())
 
     def acc_to_encoder(self) -> "MatrixNormalDataEncoder":
         """Return an encoder compatible with matrix-normal vectorized updates."""

--- a/mixle/stats/multivariate/_copula_common.py
+++ b/mixle/stats/multivariate/_copula_common.py
@@ -79,17 +79,6 @@ class BufferedUScoreAccumulator(SequenceEncodableStatisticAccumulator):
         self._w = [np.asarray(w, dtype=np.float64).ravel()] if len(u) else []
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                stats_dict[self.keys].combine(self.value())
-            else:
-                stats_dict[self.keys] = self
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        if self.keys is not None and self.keys in stats_dict:
-            self.from_value(stats_dict[self.keys].value())
-
     def acc_to_encoder(self) -> UScoreEncoder:
         return UScoreEncoder()
 

--- a/mixle/stats/multivariate/diagonal_gaussian.py
+++ b/mixle/stats/multivariate/diagonal_gaussian.py
@@ -609,42 +609,6 @@ class DiagonalGaussianAccumulator(SequenceEncodableStatisticAccumulator):
         self.count = x[2]
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Combine sufficient statistics with other accumulators sharing a matching key.
-
-        Args:
-            stats_dict (Dict[str, Any]): Dictionary mapping keys to aggregated statistics.
-
-        Returns:
-            None.
-
-        """
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                self.combine(stats_dict[self.keys].value())
-                # write the POOL back: the dict must end holding the pooled accumulator, else
-                # key_replace hands every tied site the FIRST site's statistics (later sites'
-                # data silently discarded -- caught by the keyed-protocol sweep)
-                stats_dict[self.keys] = self
-            else:
-                stats_dict[self.keys] = self
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace sufficient statistics with values from stats_dict for a matching key.
-
-        Args:
-            stats_dict (Dict[str, Any]): Dictionary mapping keys to aggregated statistics.
-
-        Returns:
-            None.
-
-        """
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                # the dict holds the pooled ACCUMULATOR (see key_merge); passing it whole made
-                # from_value subscript an accumulator object -- keyed use crashed with TypeError
-                self.from_value(stats_dict[self.keys].value())
-
     def acc_to_encoder(self) -> "DiagonalGaussianDataEncoder":
         """Return an encoder compatible with this accumulator's dimension."""
         return DiagonalGaussianDataEncoder(dim=self.dim)

--- a/mixle/stats/multivariate/dirichlet_multinomial.py
+++ b/mixle/stats/multivariate/dirichlet_multinomial.py
@@ -216,19 +216,6 @@ class DirichletMultinomialAccumulator(SequenceEncodableStatisticAccumulator):
         self.dim, self.n = self.c.shape[0], self.c.shape[1]
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge keyed statistics into ``stats_dict`` when keys are configured."""
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                stats_dict[self.keys].combine(self.value())
-            else:
-                stats_dict[self.keys] = self
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace this accumulator from keyed statistics when available."""
-        if self.keys is not None and self.keys in stats_dict:
-            self.from_value(stats_dict[self.keys].value())
-
     def acc_to_encoder(self) -> "DirichletMultinomialDataEncoder":
         """Return the encoder used by this accumulator."""
         return DirichletMultinomialDataEncoder()

--- a/mixle/stats/multivariate/gaussian_copula.py
+++ b/mixle/stats/multivariate/gaussian_copula.py
@@ -18,7 +18,6 @@ Reference: Nelsen, *An Introduction to Copulas* (2nd ed., Springer, 2006).
 
 import math
 from collections.abc import Sequence
-from typing import Any
 
 import numpy as np
 from numpy.random import RandomState
@@ -155,19 +154,6 @@ class GaussianCopulaAccumulator(SequenceEncodableStatisticAccumulator):
         self.count = float(x[2])
         self.dim = self.sum_z.shape[0]
         return self
-
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge this accumulator into a keyed statistics dictionary."""
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                stats_dict[self.keys].combine(self.value())
-            else:
-                stats_dict[self.keys] = self
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace this accumulator from a keyed statistics dictionary."""
-        if self.keys is not None and self.keys in stats_dict:
-            self.from_value(stats_dict[self.keys].value())
 
     def acc_to_encoder(self) -> "GaussianCopulaDataEncoder":
         """Return an encoder that produces normal-score observations."""

--- a/mixle/stats/multivariate/multivariate_gaussian.py
+++ b/mixle/stats/multivariate/multivariate_gaussian.py
@@ -726,36 +726,6 @@ class MultivariateGaussianAccumulator(SequenceEncodableStatisticAccumulator):
         self.count = x[2]
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Combine sufficient statistics with other accumulators sharing a matching key.
-
-        Args:
-            stats_dict (Dict[str, Any]): Dictionary mapping keys to aggregated statistics.
-
-        Returns:
-            None.
-
-        """
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                stats_dict[self.keys].combine(self.value())
-            else:
-                stats_dict[self.keys] = self
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace sufficient statistics with values from stats_dict for a matching key.
-
-        Args:
-            stats_dict (Dict[str, Any]): Dictionary mapping keys to aggregated statistics.
-
-        Returns:
-            None.
-
-        """
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                self.from_value(stats_dict[self.keys].value())
-
     def acc_to_encoder(self) -> "MultivariateGaussianDataEncoder":
         """Return an encoder compatible with this accumulator's dimension."""
         return MultivariateGaussianDataEncoder(dim=self.dim)

--- a/mixle/stats/multivariate/multivariate_student_t.py
+++ b/mixle/stats/multivariate/multivariate_student_t.py
@@ -391,19 +391,6 @@ class MultivariateStudentTAccumulator(SequenceEncodableStatisticAccumulator):
         self.dim = None if x[2] is None else len(x[2])
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge keyed statistics into ``stats_dict`` when keys are configured."""
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                stats_dict[self.keys].combine(self.value())
-            else:
-                stats_dict[self.keys] = self
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace this accumulator from keyed statistics when available."""
-        if self.keys is not None and self.keys in stats_dict:
-            self.from_value(stats_dict[self.keys].value())
-
     def acc_to_encoder(self) -> "MultivariateStudentTDataEncoder":
         """Return the encoder used by this accumulator."""
         return MultivariateStudentTDataEncoder()

--- a/mixle/stats/processes/birth_death.py
+++ b/mixle/stats/processes/birth_death.py
@@ -272,19 +272,6 @@ class BirthDeathSamplingAccumulator(SequenceEncodableStatisticAccumulator):
         self.horizon_sum *= c
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge this accumulator into a keyed statistics dictionary."""
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                stats_dict[self.keys].combine(self.value())
-            else:
-                stats_dict[self.keys] = self
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace this accumulator from a keyed statistics dictionary."""
-        if self.keys is not None and self.keys in stats_dict:
-            self.from_value(stats_dict[self.keys].value())
-
     def acc_to_encoder(self) -> "BirthDeathSamplingDataEncoder":
         """Return an encoder for trajectory sufficient statistics."""
         return BirthDeathSamplingDataEncoder()

--- a/mixle/stats/processes/chinese_restaurant_process.py
+++ b/mixle/stats/processes/chinese_restaurant_process.py
@@ -160,19 +160,6 @@ class ChineseRestaurantProcessAccumulator(SequenceEncodableStatisticAccumulator)
         self.sum_k, self.count = float(x[0]), float(x[1])
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge this accumulator into a keyed statistics dictionary."""
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                stats_dict[self.keys].combine(self.value())
-            else:
-                stats_dict[self.keys] = self
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace this accumulator from a keyed statistics dictionary."""
-        if self.keys is not None and self.keys in stats_dict:
-            self.from_value(stats_dict[self.keys].value())
-
     def acc_to_encoder(self) -> "ChineseRestaurantProcessDataEncoder":
         """Return an encoder for CRP partition label vectors."""
         return ChineseRestaurantProcessDataEncoder()

--- a/mixle/stats/processes/ctmc.py
+++ b/mixle/stats/processes/ctmc.py
@@ -215,23 +215,6 @@ class ContinuousTimeMarkovChainAccumulator(SequenceEncodableStatisticAccumulator
         self.dwell *= c
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge keyed transition and dwell statistics into ``stats_dict`` (the pool lives in the dict)."""
-        # Must INSERT when the key is absent: the old shape only merged when another site had already
-        # registered, but no site ever inserted -- so keyed CTMCs never pooled at all (key_merge and
-        # key_replace were both silent no-ops and every tied site kept its own statistics).
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                c, d = stats_dict[self.keys]
-                stats_dict[self.keys] = (c + self.counts, d + self.dwell)
-            else:
-                stats_dict[self.keys] = (self.counts.copy(), self.dwell.copy())
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace this accumulator's state from keyed statistics when present."""
-        if self.keys is not None and self.keys in stats_dict:
-            self.counts, self.dwell = (np.asarray(v, dtype=np.float64).copy() for v in stats_dict[self.keys])
-
     def acc_to_encoder(self) -> ContinuousTimeMarkovChainDataEncoder:
         """Return the encoder compatible with CTMC sufficient statistics."""
         return ContinuousTimeMarkovChainDataEncoder(self.num_states)

--- a/mixle/stats/processes/hawkes_process.py
+++ b/mixle/stats/processes/hawkes_process.py
@@ -357,19 +357,6 @@ class HawkesProcessAccumulator(SequenceEncodableStatisticAccumulator):
         self.total_window *= c
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge this accumulator into a keyed statistics dictionary."""
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                stats_dict[self.keys] = tuple(a + b for a, b in zip(stats_dict[self.keys], self.value()))
-            else:
-                stats_dict[self.keys] = self.value()
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace this accumulator from a keyed statistics dictionary."""
-        if self.keys is not None and self.keys in stats_dict:
-            self.from_value(stats_dict[self.keys])
-
     def acc_to_encoder(self) -> "HawkesProcessDataEncoder":
         """Return an encoder that pads event-time realizations for this window."""
         return HawkesProcessDataEncoder(self.window)

--- a/mixle/stats/processes/inhomogeneous_poisson.py
+++ b/mixle/stats/processes/inhomogeneous_poisson.py
@@ -259,28 +259,6 @@ class InhomogeneousPoissonProcessAccumulator(SequenceEncodableStatisticAccumulat
         self.n_realizations *= c
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge this accumulator into a keyed statistics dictionary."""
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                bc, nr = stats_dict[self.keys]
-                self.bin_counts += bc
-                self.n_realizations += nr
-                # write the POOL back: without this, the dict keeps the FIRST site's stats and
-                # key_replace hands every tied site that truncated pool -- later sites' data was
-                # silently discarded (order-dependent wrong fits; found by the compiler review's
-                # keyed-tying probe, present in 8 families vs the combine-into-dict families)
-                stats_dict[self.keys] = (self.bin_counts, self.n_realizations)
-            else:
-                stats_dict[self.keys] = (self.bin_counts.copy(), self.n_realizations)
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace this accumulator from a keyed statistics dictionary."""
-        if self.keys is not None and self.keys in stats_dict:
-            bc, nr = stats_dict[self.keys]
-            self.bin_counts = np.asarray(bc, dtype=np.float64).copy()
-            self.n_realizations = float(nr)
-
     def acc_to_encoder(self) -> "InhomogeneousPoissonProcessDataEncoder":
         """Return an encoder that bins event times on this accumulator's edges."""
         return InhomogeneousPoissonProcessDataEncoder(self.edges)

--- a/mixle/stats/processes/multivariate_hawkes.py
+++ b/mixle/stats/processes/multivariate_hawkes.py
@@ -312,19 +312,6 @@ class MultivariateHawkesProcessAccumulator(SequenceEncodableStatisticAccumulator
         self.total_window *= c
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge keyed statistics into ``stats_dict`` when keys are configured."""
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                stats_dict[self.keys].combine(self.value())
-            else:
-                stats_dict[self.keys] = self
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace this accumulator from keyed statistics when available."""
-        if self.keys is not None and self.keys in stats_dict:
-            self.from_value(stats_dict[self.keys].value())
-
     def acc_to_encoder(self) -> "MultivariateHawkesProcessDataEncoder":
         """Return the marked-event encoder used by this accumulator."""
         return MultivariateHawkesProcessDataEncoder(self.window, self.dim)

--- a/mixle/stats/processes/power_law_hawkes.py
+++ b/mixle/stats/processes/power_law_hawkes.py
@@ -265,21 +265,11 @@ class PowerLawHawkesAccumulator(SequenceEncodableStatisticAccumulator):
 
     def from_value(self, x):
         """Restore stored realizations, window, and alpha constraint."""
-        self.realizations, self.window, self.alpha_fixed = x
+        # copy on restore: assigning the pooled LIST reference would alias every tied site to one
+        # list, so a later in-place extend at any site mutates all of them (copy-on-adopt precedent)
+        self.realizations = list(x[0])
+        self.window, self.alpha_fixed = x[1], x[2]
         return self
-
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge stored realizations into ``stats_dict`` under the configured key."""
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                stats_dict[self.keys].realizations.extend(self.realizations)
-            else:
-                stats_dict[self.keys] = self
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace stored realizations from keyed statistics when present."""
-        if self.keys is not None and self.keys in stats_dict:
-            self.realizations = stats_dict[self.keys].realizations
 
     def acc_to_encoder(self):
         """Return the encoder compatible with raw Hawkes realizations."""

--- a/mixle/stats/rankings/bradley_terry.py
+++ b/mixle/stats/rankings/bradley_terry.py
@@ -194,19 +194,6 @@ class BradleyTerryAccumulator(SequenceEncodableStatisticAccumulator):
         self.dim = self.wins.shape[0]
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge this accumulator into ``stats_dict`` under its configured key."""
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                stats_dict[self.keys].combine(self.value())
-            else:
-                stats_dict[self.keys] = self
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace this accumulator's state from keyed statistics when present."""
-        if self.keys is not None and self.keys in stats_dict:
-            self.from_value(stats_dict[self.keys].value())
-
     def acc_to_encoder(self) -> BradleyTerryDataEncoder:
         """Return the encoder compatible with Bradley-Terry win-count statistics."""
         return BradleyTerryDataEncoder(dim=self.dim)

--- a/mixle/stats/rankings/ewens.py
+++ b/mixle/stats/rankings/ewens.py
@@ -208,16 +208,6 @@ class EwensAccumulator(SequenceEncodableStatisticAccumulator):
         self.cycle_sum, self.count = float(x[0]), float(x[1])
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge this accumulator into ``stats_dict`` under its configured key."""
-        if self.keys is not None:
-            stats_dict[self.keys] = stats_dict[self.keys].combine(self.value()) if self.keys in stats_dict else self
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace this accumulator's state from keyed statistics when present."""
-        if self.keys is not None and self.keys in stats_dict:
-            self.from_value(stats_dict[self.keys].value())
-
     def acc_to_encoder(self) -> EwensDataEncoder:
         """Return the encoder compatible with Ewens cycle-count statistics."""
         return EwensDataEncoder(dim=self.dim)

--- a/mixle/stats/rankings/generalized_mallows.py
+++ b/mixle/stats/rankings/generalized_mallows.py
@@ -499,19 +499,6 @@ class GeneralizedMallowsAccumulator(SequenceEncodableStatisticAccumulator):
         self._res_w = [float(w) for w in res_w]
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge this accumulator into ``stats_dict`` under its configured key."""
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                stats_dict[self.keys].combine(self.value())
-            else:
-                stats_dict[self.keys] = self
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace this accumulator's state from keyed statistics when present."""
-        if self.keys is not None and self.keys in stats_dict:
-            self.from_value(stats_dict[self.keys].value())
-
     def acc_to_encoder(self) -> GeneralizedMallowsDataEncoder:
         """Return the ranking encoder compatible with these sufficient statistics."""
         return GeneralizedMallowsDataEncoder(dim=self.dim)

--- a/mixle/stats/rankings/generalized_mallows_model.py
+++ b/mixle/stats/rankings/generalized_mallows_model.py
@@ -237,19 +237,6 @@ class GeneralizedMallowsModelAccumulator(SequenceEncodableStatisticAccumulator):
         self._res_w = [float(w) for w in res_w]
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge this accumulator into ``stats_dict`` under its configured key."""
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                stats_dict[self.keys].combine(self.value())
-            else:
-                stats_dict[self.keys] = self
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace this accumulator's state from keyed statistics when present."""
-        if self.keys is not None and self.keys in stats_dict:
-            self.from_value(stats_dict[self.keys].value())
-
     def acc_to_encoder(self) -> GeneralizedMallowsModelDataEncoder:
         """Return the encoder compatible with these sufficient statistics."""
         return GeneralizedMallowsModelDataEncoder(dim=self.dim)

--- a/mixle/stats/rankings/low_rank_permutation.py
+++ b/mixle/stats/rankings/low_rank_permutation.py
@@ -218,19 +218,6 @@ class LowRankPermutationAccumulator(SequenceEncodableStatisticAccumulator):
         self.dim = self.counts.shape[0]
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge this accumulator into ``stats_dict`` under its configured key."""
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                stats_dict[self.keys].combine(self.value())
-            else:
-                stats_dict[self.keys] = self
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace this accumulator's state from keyed statistics when present."""
-        if self.keys is not None and self.keys in stats_dict:
-            self.from_value(stats_dict[self.keys].value())
-
     def acc_to_encoder(self) -> LowRankPermutationDataEncoder:
         """Return the encoder compatible with item-by-rank sufficient statistics."""
         return LowRankPermutationDataEncoder(dim=self.dim)

--- a/mixle/stats/rankings/mallows.py
+++ b/mixle/stats/rankings/mallows.py
@@ -20,7 +20,6 @@ statistic) and fits theta by matching the mean Kendall distance to its closed-fo
 
 import math
 from collections.abc import Sequence
-from typing import Any
 
 import numpy as np
 from numpy.random import RandomState
@@ -298,19 +297,6 @@ class MallowsAccumulator(SequenceEncodableStatisticAccumulator):
         self.count, self.precede = x[0], np.asarray(x[1])
         self.dim = self.precede.shape[0]
         return self
-
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge this accumulator into a keyed statistics dictionary."""
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                stats_dict[self.keys].combine(self.value())
-            else:
-                stats_dict[self.keys] = self
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace this accumulator from a keyed statistics dictionary."""
-        if self.keys is not None and self.keys in stats_dict:
-            self.from_value(stats_dict[self.keys].value())
 
     def acc_to_encoder(self) -> "MallowsDataEncoder":
         """Return an encoder compatible with the accumulated ordering dimension."""

--- a/mixle/stats/rankings/matching.py
+++ b/mixle/stats/rankings/matching.py
@@ -19,7 +19,6 @@ log-weights.
 
 from collections.abc import Sequence
 from itertools import combinations
-from typing import Any
 
 import numpy as np
 from numpy.random import RandomState
@@ -267,19 +266,6 @@ class MatchingAccumulator(SequenceEncodableStatisticAccumulator):
         self.count, self.assign_counts = x[0], np.asarray(x[1])
         self.dim = self.assign_counts.shape[0]
         return self
-
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge this accumulator into a keyed statistics dictionary."""
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                stats_dict[self.keys].combine(self.value())
-            else:
-                stats_dict[self.keys] = self
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace this accumulator from a keyed statistics dictionary."""
-        if self.keys is not None and self.keys in stats_dict:
-            self.from_value(stats_dict[self.keys].value())
 
     def acc_to_encoder(self) -> "MatchingDataEncoder":
         """Return an encoder compatible with the accumulated matching dimension."""

--- a/mixle/stats/rankings/paired_comparison.py
+++ b/mixle/stats/rankings/paired_comparison.py
@@ -163,16 +163,6 @@ class PairWinAccumulator(SequenceEncodableStatisticAccumulator):
         self.dim = self.wins.shape[0]
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge tied win-count statistics into ``stats_dict``."""
-        if self.keys is not None:
-            stats_dict[self.keys] = stats_dict[self.keys].combine(self.value()) if self.keys in stats_dict else self
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace tied win-count statistics from ``stats_dict``."""
-        if self.keys is not None and self.keys in stats_dict:
-            self.from_value(stats_dict[self.keys].value())
-
     def acc_to_encoder(self) -> PairDataEncoder:
         """Return the encoder associated with this accumulator."""
         return PairDataEncoder(dim=self.dim)
@@ -314,16 +304,6 @@ class _TieAccumulator(SequenceEncodableStatisticAccumulator):
         self.count, self.wins, self.ties = x[0], np.asarray(x[1]), np.asarray(x[2])
         self.dim = self.wins.shape[0]
         return self
-
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge tied win-and-tie statistics into ``stats_dict``."""
-        if self.keys is not None:
-            stats_dict[self.keys] = stats_dict[self.keys].combine(self.value()) if self.keys in stats_dict else self
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace tied win-and-tie statistics from ``stats_dict``."""
-        if self.keys is not None and self.keys in stats_dict:
-            self.from_value(stats_dict[self.keys].value())
 
     def acc_to_encoder(self) -> _TieEncoder:
         """Return the encoder associated with this accumulator."""

--- a/mixle/stats/rankings/plackett_luce.py
+++ b/mixle/stats/rankings/plackett_luce.py
@@ -288,19 +288,6 @@ class PlackettLuceAccumulator(SequenceEncodableStatisticAccumulator):
         self.dim = len(self.num)
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge this accumulator into ``stats_dict`` under its configured key."""
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                stats_dict[self.keys].combine(self.value())
-            else:
-                stats_dict[self.keys] = self
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace this accumulator's state from ``stats_dict`` when its key is present."""
-        if self.keys is not None and self.keys in stats_dict:
-            self.from_value(stats_dict[self.keys].value())
-
     def acc_to_encoder(self) -> "PlackettLuceDataEncoder":
         """Return the full-ranking encoder compatible with these sufficient statistics."""
         return PlackettLuceDataEncoder(dim=self.dim)

--- a/mixle/stats/rankings/spearman_rho.py
+++ b/mixle/stats/rankings/spearman_rho.py
@@ -468,39 +468,6 @@ class SpearmanRankingAccumulator(SequenceEncodableStatisticAccumulator):
         self.count = x[0]
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge sufficient statistics from ``stats_dict`` when this accumulator's key is present.
-
-        Args:
-            stats_dict (Dict[str, Any]): Dict mapping keys to shared sufficient statistics.
-
-        Returns:
-            None.
-
-        """
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                vals = stats_dict[self.keys]
-                stats_dict[self.keys] = (vals[0] + self.count, vals[1] + self.sum)
-            else:
-                stats_dict[self.keys] = (self.count, self.sum)
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace sufficient statistics from ``stats_dict`` when this accumulator's key is present.
-
-        Args:
-            stats_dict (Dict[str, Any]): Dict mapping keys to shared sufficient statistics.
-
-        Returns:
-            None.
-
-        """
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                vals = stats_dict[self.keys]
-                self.count = vals[0]
-                self.sum = vals[1]
-
     def acc_to_encoder(self) -> "SpearmanRankingDataEncoder":
         """Return the encoder associated with this accumulator."""
         return SpearmanRankingDataEncoder()

--- a/mixle/stats/rankings/thurstone.py
+++ b/mixle/stats/rankings/thurstone.py
@@ -264,19 +264,6 @@ class ThurstoneAccumulator(SequenceEncodableStatisticAccumulator):
         self.dim = self.precede.shape[0]
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge this accumulator into ``stats_dict`` under its configured key."""
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                stats_dict[self.keys].combine(self.value())
-            else:
-                stats_dict[self.keys] = self
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace this accumulator's state from keyed statistics when present."""
-        if self.keys is not None and self.keys in stats_dict:
-            self.from_value(stats_dict[self.keys].value())
-
     def acc_to_encoder(self) -> ThurstoneDataEncoder:
         """Return the ranking encoder compatible with this accumulator."""
         return ThurstoneDataEncoder(dim=self.dim)

--- a/mixle/stats/sets/bernoulli_set.py
+++ b/mixle/stats/sets/bernoulli_set.py
@@ -664,30 +664,6 @@ class BernoulliSetAccumulator(SequenceEncodableStatisticAccumulator):
         self.tot_sum = x[1]
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge this accumulator's statistics into stats_dict under its key, if keyed.
-
-        Args:
-            stats_dict (Dict[str, Any]): Maps keys to merged accumulators or sufficient statistics.
-
-        """
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                stats_dict[self.keys].combine(self.value())
-            else:
-                stats_dict[self.keys] = self
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace this accumulator's statistics with the keyed statistics in stats_dict, if keyed.
-
-        Args:
-            stats_dict (Dict[str, Any]): Maps keys to merged accumulators or sufficient statistics.
-
-        """
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                self.from_value(stats_dict[self.keys].value())
-
     def acc_to_encoder(self) -> "BernoulliSetDataEncoder":
         """Return a data encoder for Bernoulli set observations."""
         return BernoulliSetDataEncoder()

--- a/mixle/stats/sets/integer_bernoulli_set.py
+++ b/mixle/stats/sets/integer_bernoulli_set.py
@@ -408,21 +408,6 @@ class IntegerBernoulliSetAccumulator(SequenceEncodableStatisticAccumulator):
         self.tot_sum *= c
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge this accumulator's state into ``stats_dict`` under its configured key."""
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                temp = stats_dict[self.keys]
-                stats_dict[self.keys] = (temp[0] + self.pcnt, temp[1] + self.tot_sum)
-            else:
-                stats_dict[self.keys] = (self.pcnt, self.tot_sum)
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace this accumulator's state from keyed statistics when present."""
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                self.pcnt, self.tot_sum = stats_dict[self.keys]
-
     def acc_to_encoder(self) -> "IntegerBernoulliSetDataEncoder":
         """Return the encoder compatible with Bernoulli-set sufficient statistics."""
         return IntegerBernoulliSetDataEncoder()

--- a/mixle/stats/trees/spanning_tree.py
+++ b/mixle/stats/trees/spanning_tree.py
@@ -18,7 +18,6 @@ n-1, keeps the spanning trees, and sorts them by fitted probability.
 """
 
 from collections.abc import Sequence
-from typing import Any
 
 import numpy as np
 from numpy.random import RandomState
@@ -285,19 +284,6 @@ class SpanningTreeAccumulator(SequenceEncodableStatisticAccumulator):
         self.count, self.edge_counts = x[0], np.asarray(x[1])
         self.dim = self.edge_counts.shape[0]
         return self
-
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge keyed statistics into ``stats_dict`` when keys are configured."""
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                stats_dict[self.keys].combine(self.value())
-            else:
-                stats_dict[self.keys] = self
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace this accumulator from keyed statistics when available."""
-        if self.keys is not None and self.keys in stats_dict:
-            self.from_value(stats_dict[self.keys].value())
 
     def acc_to_encoder(self) -> "SpanningTreeDataEncoder":
         """Return the encoder used by this accumulator."""

--- a/mixle/stats/univariate/continuous/beta.py
+++ b/mixle/stats/univariate/continuous/beta.py
@@ -364,19 +364,6 @@ class BetaAccumulator(SequenceEncodableStatisticAccumulator):
         self.sum2 = x[4]
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge keyed statistics into ``stats_dict`` when keys are configured."""
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                stats_dict[self.keys].combine(self.value())
-            else:
-                stats_dict[self.keys] = self
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace this accumulator from keyed statistics when available."""
-        if self.keys is not None and self.keys in stats_dict:
-            self.from_value(stats_dict[self.keys].value())
-
     def acc_to_encoder(self) -> "BetaDataEncoder":
         """Return the encoder used by this accumulator."""
         return BetaDataEncoder()

--- a/mixle/stats/univariate/continuous/exgaussian.py
+++ b/mixle/stats/univariate/continuous/exgaussian.py
@@ -276,19 +276,6 @@ class ExponentiallyModifiedGaussianAccumulator(SequenceEncodableStatisticAccumul
         self.m3 *= c
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge this accumulator into ``stats_dict`` under its configured key."""
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                stats_dict[self.keys].combine(self.value())
-            else:
-                stats_dict[self.keys] = self
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace this accumulator's state from keyed statistics when present."""
-        if self.keys is not None and self.keys in stats_dict:
-            self.from_value(stats_dict[self.keys].value())
-
     def acc_to_encoder(self) -> "ExponentiallyModifiedGaussianDataEncoder":
         """Return the encoder compatible with EMG moment statistics."""
         return ExponentiallyModifiedGaussianDataEncoder()

--- a/mixle/stats/univariate/continuous/exponential.py
+++ b/mixle/stats/univariate/continuous/exponential.py
@@ -483,47 +483,6 @@ class ExponentialAccumulator(SequenceEncodableStatisticAccumulator):
 
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merges ExponentialAccumulator sufficient statistics with sufficient statistics contained in suff_stat dict
-        that share the same key.
-
-        Args:
-            stats_dict (Dict[str, Any]): Dict containing 'key' string for ExponentialAccumulator
-                objects that represent the same distribution.
-
-        Returns:
-            None.
-
-        """
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                x0, x1 = stats_dict[self.keys]
-                self.count += x0
-                self.sum += x1
-                # write the POOL back: without this, the dict keeps the FIRST site's stats and
-                # key_replace hands every tied site that truncated pool -- later sites' data was
-                # silently discarded (order-dependent wrong fits; found by the compiler review's
-                # keyed-tying probe, present in 8 families vs the combine-into-dict families)
-                stats_dict[self.keys] = (self.count, self.sum)
-            else:
-                stats_dict[self.keys] = (self.count, self.sum)
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Set the sufficient statistics of ExponentialAccumulator to stats_key sufficient statistics if key is in
-            stats_dict.
-
-        Args:
-            stats_dict (Dict[str, Any]): Map key to sufficient statistics.
-
-        Returns:
-            None.
-
-        """
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                self.count = stats_dict[self.keys][0]
-                self.sum = stats_dict[self.keys][1]
-
     def acc_to_encoder(self) -> "ExponentialDataEncoder":
         """Return the encoder associated with this accumulator."""
         return ExponentialDataEncoder()

--- a/mixle/stats/univariate/continuous/gamma.py
+++ b/mixle/stats/univariate/continuous/gamma.py
@@ -542,48 +542,6 @@ class GammaAccumulator(SequenceEncodableStatisticAccumulator):
 
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge sufficient statistics from ``stats_dict`` when this accumulator's key is present.
-
-        Args:
-            stats_dict (Dict[str, Any]): Dict mapping keys to sufficient statistics.
-
-        Returns:
-            None.
-
-        """
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                x0, x1, x2 = stats_dict[self.keys]
-                self.count += x0
-                self.sum += x1
-                self.sum_of_logs += x2
-                # write the POOL back: without this, the dict keeps the FIRST site's stats and
-                # key_replace hands every tied site that truncated pool -- later sites' data was
-                # silently discarded (order-dependent wrong fits; found by the compiler review's
-                # keyed-tying probe, present in 8 families vs the combine-into-dict families)
-                stats_dict[self.keys] = (self.count, self.sum, self.sum_of_logs)
-
-            else:
-                stats_dict[self.keys] = (self.count, self.sum, self.sum_of_logs)
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace sufficient statistics from ``suff_stats`` when this accumulator's key is present.
-
-        Args:
-            stats_dict (Dict[str, Any]): Dict mapping keys to sufficient statistics.
-
-        Returns:
-            None.
-
-        """
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                x0, x1, x2 = stats_dict[self.keys]
-                self.count = x0
-                self.sum = x1
-                self.sum_of_logs = x2
-
     def acc_to_encoder(self) -> "GammaDataEncoder":
         """Return an encoder compatible with Gamma observations."""
         return GammaDataEncoder()

--- a/mixle/stats/univariate/continuous/gaussian.py
+++ b/mixle/stats/univariate/continuous/gaussian.py
@@ -655,46 +655,6 @@ class GaussianAccumulator(SequenceEncodableStatisticAccumulator):
 
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge sufficient statistics from ``stats_dict`` when this accumulator's key is present.
-
-        Args:
-            stats_dict (Dict[str, Any]): Dict mapping keys to sufficient statistics.
-
-        Returns:
-            None.
-
-        """
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                x0, x1, x2, x3 = stats_dict[self.keys]
-                self.sum += x0
-                self.sum2 += x1
-                self.count += x2
-                self.count2 += x3
-                # write the POOL back: without this, the dict keeps the FIRST site's stats and
-                # key_replace hands every tied site that truncated pool -- later sites' data was
-                # silently discarded (order-dependent wrong fits; found by the compiler review's
-                # keyed-tying probe, present in 8 families vs the combine-into-dict families)
-                stats_dict[self.keys] = (self.sum, self.sum2, self.count, self.count2)
-
-            else:
-                stats_dict[self.keys] = (self.sum, self.sum2, self.count, self.count2)
-
-    def key_replace(self, stats_dict: dict[str, "GaussianAccumulator"]) -> None:
-        """Replace sufficient statistics from ``suff_stats`` when this accumulator's key is present.
-
-        Args:
-            stats_dict (Dict[str, Any]): Dict mapping keys to sufficient statistics.
-
-        Returns:
-            None.
-
-        """
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                self.sum, self.sum2, self.count, self.count2 = stats_dict[self.keys]
-
     def acc_to_encoder(self) -> "GaussianDataEncoder":
         """Return an encoder compatible with Gaussian scalar observations."""
         return GaussianDataEncoder()

--- a/mixle/stats/univariate/continuous/generalized_extreme_value.py
+++ b/mixle/stats/univariate/continuous/generalized_extreme_value.py
@@ -327,19 +327,6 @@ class GeneralizedExtremeValueAccumulator(SequenceEncodableStatisticAccumulator):
         self.sum, self.sum2, self.sum3, self.count = float(x[0]), float(x[1]), float(x[2]), float(x[3])
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge keyed statistics into ``stats_dict`` when keys are configured."""
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                stats_dict[self.keys].combine(self.value())
-            else:
-                stats_dict[self.keys] = self
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace this accumulator from keyed statistics when available."""
-        if self.keys is not None and self.keys in stats_dict:
-            self.from_value(stats_dict[self.keys].value())
-
     def acc_to_encoder(self) -> "GeneralizedExtremeValueDataEncoder":
         """Return the encoder used by this accumulator."""
         return GeneralizedExtremeValueDataEncoder()

--- a/mixle/stats/univariate/continuous/generalized_gaussian.py
+++ b/mixle/stats/univariate/continuous/generalized_gaussian.py
@@ -226,19 +226,6 @@ class GeneralizedGaussianAccumulator(SequenceEncodableStatisticAccumulator):
         self.count, self.s1, self.s2, self.s3, self.s4 = (float(v) for v in x)
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge keyed statistics into ``stats_dict`` when keys are configured."""
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                stats_dict[self.keys].combine(self.value())
-            else:
-                stats_dict[self.keys] = self
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace this accumulator from keyed statistics when available."""
-        if self.keys is not None and self.keys in stats_dict:
-            self.from_value(stats_dict[self.keys].value())
-
     def acc_to_encoder(self) -> "GeneralizedGaussianDataEncoder":
         """Return the encoder used by this accumulator."""
         return GeneralizedGaussianDataEncoder()

--- a/mixle/stats/univariate/continuous/generalized_pareto.py
+++ b/mixle/stats/univariate/continuous/generalized_pareto.py
@@ -282,19 +282,6 @@ class GeneralizedParetoAccumulator(SequenceEncodableStatisticAccumulator):
         self.sum, self.sum2, self.count = float(x[0]), float(x[1]), float(x[2])
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge keyed statistics into ``stats_dict`` when keys are configured."""
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                stats_dict[self.keys].combine(self.value())
-            else:
-                stats_dict[self.keys] = self
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace this accumulator from keyed statistics when available."""
-        if self.keys is not None and self.keys in stats_dict:
-            self.from_value(stats_dict[self.keys].value())
-
     def acc_to_encoder(self) -> "GeneralizedParetoDataEncoder":
         """Return the encoder used by this accumulator."""
         return GeneralizedParetoDataEncoder()

--- a/mixle/stats/univariate/continuous/gumbel.py
+++ b/mixle/stats/univariate/continuous/gumbel.py
@@ -276,19 +276,6 @@ class GumbelAccumulator(SequenceEncodableStatisticAccumulator):
         self.sum, self.sum2, self.count = x
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge keyed statistics into ``stats_dict`` when keys are configured."""
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                stats_dict[self.keys].combine(self.value())
-            else:
-                stats_dict[self.keys] = self
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace this accumulator from keyed statistics when available."""
-        if self.keys is not None and self.keys in stats_dict:
-            self.from_value(stats_dict[self.keys].value())
-
     def acc_to_encoder(self) -> "GumbelDataEncoder":
         """Return the encoder used by this accumulator."""
         return GumbelDataEncoder()

--- a/mixle/stats/univariate/continuous/half_normal.py
+++ b/mixle/stats/univariate/continuous/half_normal.py
@@ -317,19 +317,6 @@ class HalfNormalAccumulator(SequenceEncodableStatisticAccumulator):
         self.sum2 = x[1]
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge keyed statistics into ``stats_dict`` when keys are configured."""
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                stats_dict[self.keys].combine(self.value())
-            else:
-                stats_dict[self.keys] = self
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace this accumulator from keyed statistics when available."""
-        if self.keys is not None and self.keys in stats_dict:
-            self.from_value(stats_dict[self.keys].value())
-
     def acc_to_encoder(self) -> "HalfNormalDataEncoder":
         """Return the encoder used by this accumulator."""
         return HalfNormalDataEncoder()

--- a/mixle/stats/univariate/continuous/inverse_gamma.py
+++ b/mixle/stats/univariate/continuous/inverse_gamma.py
@@ -336,19 +336,6 @@ class InverseGammaAccumulator(SequenceEncodableStatisticAccumulator):
         self.count, self.sum_inv, self.sum_neg_log = x
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge keyed statistics into ``stats_dict`` when keys are configured."""
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                stats_dict[self.keys].combine(self.value())
-            else:
-                stats_dict[self.keys] = self
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace this accumulator from keyed statistics when available."""
-        if self.keys is not None and self.keys in stats_dict:
-            self.from_value(stats_dict[self.keys].value())
-
     def acc_to_encoder(self) -> "InverseGammaDataEncoder":
         """Return the encoder used by this accumulator."""
         return InverseGammaDataEncoder()

--- a/mixle/stats/univariate/continuous/inverse_gaussian.py
+++ b/mixle/stats/univariate/continuous/inverse_gaussian.py
@@ -382,19 +382,6 @@ class InverseGaussianAccumulator(SequenceEncodableStatisticAccumulator):
         self.sum_inv = x[2]
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge keyed statistics into ``stats_dict`` when keys are configured."""
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                stats_dict[self.keys].combine(self.value())
-            else:
-                stats_dict[self.keys] = self
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace this accumulator from keyed statistics when available."""
-        if self.keys is not None and self.keys in stats_dict:
-            self.from_value(stats_dict[self.keys].value())
-
     def acc_to_encoder(self) -> "InverseGaussianDataEncoder":
         """Return the encoder used by this accumulator."""
         return InverseGaussianDataEncoder()

--- a/mixle/stats/univariate/continuous/laplace.py
+++ b/mixle/stats/univariate/continuous/laplace.py
@@ -257,19 +257,6 @@ class LaplaceAccumulator(SequenceEncodableStatisticAccumulator):
         self.weights = [np.asarray(w, dtype=np.float64) * c for w in self.weights]
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge keyed statistics into ``stats_dict`` when keys are configured."""
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                stats_dict[self.keys].combine(self.value())
-            else:
-                stats_dict[self.keys] = self
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace this accumulator from keyed statistics when available."""
-        if self.keys is not None and self.keys in stats_dict:
-            self.from_value(stats_dict[self.keys].value())
-
     def acc_to_encoder(self) -> "LaplaceDataEncoder":
         """Return the encoder used by this accumulator."""
         return LaplaceDataEncoder()

--- a/mixle/stats/univariate/continuous/log_gaussian.py
+++ b/mixle/stats/univariate/continuous/log_gaussian.py
@@ -581,40 +581,6 @@ class LogGaussianAccumulator(SequenceEncodableStatisticAccumulator):
 
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merges LogGaussianAccumulator sufficient statistics with sufficient statistics contained in suff_stat dict
-        that share the same key.
-
-        Args:
-            stats_dict (Dict[str, Any]): Dict containing 'key' string for LogGaussianAccumulator
-                objects to combine sufficient statistics.
-
-        Returns:
-            None.
-
-        """
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                stats_dict[self.keys].combine(self.value())
-            else:
-                stats_dict[self.keys] = self
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Set the sufficient statistics of LogGaussianAccumulator to stats_key sufficient statistics if key is in
-            stats_dict.
-
-        Args:
-            stats_dict (Dict[str, Any]): Dictionary mapping keys string ids to LogGaussianAccumulator
-                objects.
-
-        Returns:
-            None.
-
-        """
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                self.from_value(stats_dict[self.keys].value())
-
     def acc_to_encoder(self) -> "LogGaussianDataEncoder":
         """Return the encoder associated with this accumulator."""
         return LogGaussianDataEncoder()

--- a/mixle/stats/univariate/continuous/logistic.py
+++ b/mixle/stats/univariate/continuous/logistic.py
@@ -227,19 +227,6 @@ class LogisticAccumulator(SequenceEncodableStatisticAccumulator):
         self.count = x[2]
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge keyed statistics into ``stats_dict`` when keys are configured."""
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                stats_dict[self.keys].combine(self.value())
-            else:
-                stats_dict[self.keys] = self
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace this accumulator from keyed statistics when available."""
-        if self.keys is not None and self.keys in stats_dict:
-            self.from_value(stats_dict[self.keys].value())
-
     def acc_to_encoder(self) -> "LogisticDataEncoder":
         """Return the encoder used by this accumulator."""
         return LogisticDataEncoder()

--- a/mixle/stats/univariate/continuous/nakagami.py
+++ b/mixle/stats/univariate/continuous/nakagami.py
@@ -230,19 +230,6 @@ class NakagamiAccumulator(SequenceEncodableStatisticAccumulator):
         self.count, self.s2, self.s4 = float(x[0]), float(x[1]), float(x[2])
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge keyed statistics into ``stats_dict`` when keys are configured."""
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                stats_dict[self.keys].combine(self.value())
-            else:
-                stats_dict[self.keys] = self
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace this accumulator from keyed statistics when available."""
-        if self.keys is not None and self.keys in stats_dict:
-            self.from_value(stats_dict[self.keys].value())
-
     def acc_to_encoder(self) -> "NakagamiDataEncoder":
         """Return the encoder used by this accumulator."""
         return NakagamiDataEncoder()

--- a/mixle/stats/univariate/continuous/pareto.py
+++ b/mixle/stats/univariate/continuous/pareto.py
@@ -309,19 +309,6 @@ class ParetoAccumulator(SequenceEncodableStatisticAccumulator):
         self.sum_of_logs *= c
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge keyed statistics into ``stats_dict`` when keys are configured."""
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                stats_dict[self.keys].combine(self.value())
-            else:
-                stats_dict[self.keys] = self
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace this accumulator from keyed statistics when available."""
-        if self.keys is not None and self.keys in stats_dict:
-            self.from_value(stats_dict[self.keys].value())
-
     def acc_to_encoder(self) -> "ParetoDataEncoder":
         """Return the encoder used by this accumulator."""
         return ParetoDataEncoder()

--- a/mixle/stats/univariate/continuous/rayleigh.py
+++ b/mixle/stats/univariate/continuous/rayleigh.py
@@ -268,19 +268,6 @@ class RayleighAccumulator(SequenceEncodableStatisticAccumulator):
         self.sum2 = x[1]
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge keyed statistics into ``stats_dict`` when keys are configured."""
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                stats_dict[self.keys].combine(self.value())
-            else:
-                stats_dict[self.keys] = self
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace this accumulator from keyed statistics when available."""
-        if self.keys is not None and self.keys in stats_dict:
-            self.from_value(stats_dict[self.keys].value())
-
     def acc_to_encoder(self) -> "RayleighDataEncoder":
         """Return the encoder used by this accumulator."""
         return RayleighDataEncoder()

--- a/mixle/stats/univariate/continuous/rician.py
+++ b/mixle/stats/univariate/continuous/rician.py
@@ -256,19 +256,6 @@ class RicianAccumulator(SequenceEncodableStatisticAccumulator):
         self.count, self.s2, self.s4 = float(x[0]), float(x[1]), float(x[2])
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge keyed statistics into ``stats_dict`` when keys are configured."""
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                stats_dict[self.keys].combine(self.value())
-            else:
-                stats_dict[self.keys] = self
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace this accumulator from keyed statistics when available."""
-        if self.keys is not None and self.keys in stats_dict:
-            self.from_value(stats_dict[self.keys].value())
-
     def acc_to_encoder(self) -> "RicianDataEncoder":
         """Return the encoder used by this accumulator."""
         return RicianDataEncoder()

--- a/mixle/stats/univariate/continuous/skew_normal.py
+++ b/mixle/stats/univariate/continuous/skew_normal.py
@@ -245,19 +245,6 @@ class SkewNormalAccumulator(SequenceEncodableStatisticAccumulator):
         self.m3 *= c
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge keyed statistics into ``stats_dict`` when keys are configured."""
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                stats_dict[self.keys].combine(self.value())
-            else:
-                stats_dict[self.keys] = self
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace this accumulator from keyed statistics when available."""
-        if self.keys is not None and self.keys in stats_dict:
-            self.from_value(stats_dict[self.keys].value())
-
     def acc_to_encoder(self) -> "SkewNormalDataEncoder":
         """Return the encoder used by this accumulator."""
         return SkewNormalDataEncoder()

--- a/mixle/stats/univariate/continuous/student_t.py
+++ b/mixle/stats/univariate/continuous/student_t.py
@@ -243,19 +243,6 @@ class StudentTAccumulator(SequenceEncodableStatisticAccumulator):
         self.count = x[2]
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge keyed statistics into ``stats_dict`` when keys are configured."""
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                stats_dict[self.keys].combine(self.value())
-            else:
-                stats_dict[self.keys] = self
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace this accumulator from keyed statistics when available."""
-        if self.keys is not None and self.keys in stats_dict:
-            self.from_value(stats_dict[self.keys].value())
-
     def acc_to_encoder(self) -> "StudentTDataEncoder":
         """Return the encoder used by this accumulator."""
         return StudentTDataEncoder()

--- a/mixle/stats/univariate/continuous/uniform.py
+++ b/mixle/stats/univariate/continuous/uniform.py
@@ -251,19 +251,6 @@ class UniformAccumulator(SequenceEncodableStatisticAccumulator):
         self.count *= c
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge keyed statistics into ``stats_dict`` when keys are configured."""
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                stats_dict[self.keys].combine(self.value())
-            else:
-                stats_dict[self.keys] = self
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace this accumulator from keyed statistics when available."""
-        if self.keys is not None and self.keys in stats_dict:
-            self.from_value(stats_dict[self.keys].value())
-
     def acc_to_encoder(self) -> "UniformDataEncoder":
         """Return the encoder used by this accumulator."""
         return UniformDataEncoder()

--- a/mixle/stats/univariate/continuous/weibull.py
+++ b/mixle/stats/univariate/continuous/weibull.py
@@ -309,19 +309,6 @@ class WeibullAccumulator(SequenceEncodableStatisticAccumulator):
         self.count = x[2]
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge keyed statistics into ``stats_dict`` when keys are configured."""
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                stats_dict[self.keys].combine(self.value())
-            else:
-                stats_dict[self.keys] = self
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace this accumulator from keyed statistics when available."""
-        if self.keys is not None and self.keys in stats_dict:
-            self.from_value(stats_dict[self.keys].value())
-
     def acc_to_encoder(self) -> "WeibullDataEncoder":
         """Return the encoder used by this accumulator."""
         return WeibullDataEncoder()

--- a/mixle/stats/univariate/discrete/bernoulli.py
+++ b/mixle/stats/univariate/discrete/bernoulli.py
@@ -356,19 +356,6 @@ class BernoulliAccumulator(SequenceEncodableStatisticAccumulator):
         self.sum = x[1]
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge keyed statistics into ``stats_dict`` when keys are configured."""
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                stats_dict[self.keys].combine(self.value())
-            else:
-                stats_dict[self.keys] = self
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace this accumulator from keyed statistics when available."""
-        if self.keys is not None and self.keys in stats_dict:
-            self.from_value(stats_dict[self.keys].value())
-
     def acc_to_encoder(self) -> "BernoulliDataEncoder":
         """Return the encoder used by this accumulator."""
         return BernoulliDataEncoder()

--- a/mixle/stats/univariate/discrete/beta_binomial.py
+++ b/mixle/stats/univariate/discrete/beta_binomial.py
@@ -13,7 +13,6 @@ estimated by moments -- ``rho`` from the dispersion and the mean fixing ``a/(a+b
 
 import math
 from collections.abc import Sequence
-from typing import Any
 
 import numpy as np
 from numpy.random import RandomState
@@ -196,19 +195,6 @@ class BetaBinomialAccumulator(SequenceEncodableStatisticAccumulator):
         """Replace accumulator contents from a sufficient-statistic tuple."""
         self.sum, self.sum2, self.count = float(x[0]), float(x[1]), float(x[2])
         return self
-
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge keyed statistics into ``stats_dict`` when keys are configured."""
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                stats_dict[self.keys].combine(self.value())
-            else:
-                stats_dict[self.keys] = self
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace this accumulator from keyed statistics when available."""
-        if self.keys is not None and self.keys in stats_dict:
-            self.from_value(stats_dict[self.keys].value())
 
     def acc_to_encoder(self) -> "BetaBinomialDataEncoder":
         """Return the encoder used by this accumulator."""

--- a/mixle/stats/univariate/discrete/binomial.py
+++ b/mixle/stats/univariate/discrete/binomial.py
@@ -854,36 +854,6 @@ class BinomialAccumulator(SequenceEncodableStatisticAccumulator):
         self.sum *= c
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Combines the sufficient statistics of BinomialAccumulators that have the same key value.
-
-        Args:
-            stats_dict (Dict[str, Any]): Dictionary for mapping keys to BinomialAccumulators.
-
-        Returns:
-            None
-
-        """
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                stats_dict[self.keys].combine(self.value())
-            else:
-                stats_dict[self.keys] = self
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace sufficient statistics when matching keyed statistics are present.
-
-        Args:
-            stats_dict (Dict[str, Any]): Maps member variable key to BinomialAccumualator with same key.
-
-        Returns:
-            None
-
-        """
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                self.from_value(stats_dict[self.keys].value())
-
     def acc_to_encoder(self) -> "BinomialDataEncoder":
         """Create the encoder for binomial observations.
 

--- a/mixle/stats/univariate/discrete/categorical.py
+++ b/mixle/stats/univariate/discrete/categorical.py
@@ -722,34 +722,6 @@ class CategoricalAccumulator(SequenceEncodableStatisticAccumulator):
 
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Combines the sufficient statistics of CategoricalAccumulators that have the same key value.
-
-        Args:
-            stats_dict (Dict[str, Any]): Dictionary for mapping keys to CategoricalAccumulators.
-
-        Returns:
-            None
-
-        """
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                stats_dict[self.keys].combine(self.value())
-
-            else:
-                stats_dict[self.keys] = self
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace sufficient statistics from another accumulator with the same key.
-
-        Args:
-            stats_dict: Mapping from merge keys to categorical accumulators.
-
-        """
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                self.from_value(stats_dict[self.keys].value())
-
     def acc_to_encoder(self) -> "CategoricalDataEncoder":
         """Return an encoder compatible with categorical observations."""
         return CategoricalDataEncoder()

--- a/mixle/stats/univariate/discrete/geometric.py
+++ b/mixle/stats/univariate/discrete/geometric.py
@@ -583,44 +583,6 @@ class GeometricAccumulator(SequenceEncodableStatisticAccumulator):
 
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge sufficient statistics from ``stats_dict`` when this accumulator's key is present.
-
-        Args:
-            stats_dict (Dict[str, Any]): Dict mapping keys to sufficient statistics.
-
-        Returns:
-            None.
-
-        """
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                x0, x1 = stats_dict[self.keys]
-                self.count += x0
-                self.sum += x1
-                # write the POOL back: without this, the dict keeps the FIRST site's stats and
-                # key_replace hands every tied site that truncated pool -- later sites' data was
-                # silently discarded (order-dependent wrong fits; found by the compiler review's
-                # keyed-tying probe, present in 8 families vs the combine-into-dict families)
-                stats_dict[self.keys] = (self.count, self.sum)
-
-            else:
-                stats_dict[self.keys] = (self.count, self.sum)
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace sufficient statistics from ``stats_dict`` when this accumulator's key is present.
-
-        Args:
-            stats_dict (Dict[str, Any]): Dict mapping keys to sufficient statistics.
-
-        Returns:
-            None.
-
-        """
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                self.count, self.sum = stats_dict[self.keys]
-
     def acc_to_encoder(self) -> "GeometricDataEncoder":
         """Return the encoder associated with this accumulator."""
         return GeometricDataEncoder()

--- a/mixle/stats/univariate/discrete/integer_categorical.py
+++ b/mixle/stats/univariate/discrete/integer_categorical.py
@@ -712,37 +712,6 @@ class IntegerCategoricalAccumulator(SequenceEncodableStatisticAccumulator):
             self.count_vec *= c
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Aggregate member sufficient statistics with sufficient statistics of objects with matching keys.
-
-        Args:
-            stats_dict (Dict[str, Any]): Dict mapping keys to corresponding sufficient stats.
-
-        Returns:
-            None.
-
-        """
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                stats_dict[self.keys].combine(self.value())
-
-            else:
-                stats_dict[self.keys] = self
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Set member sufficient statistics to suff stats with matching keys.
-
-        Args:
-            stats_dict (Dict[str, Any]): Dict mapping keys to corresponding sufficient stats.
-
-        Returns:
-            None.
-
-        """
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                self.from_value(stats_dict[self.keys].value())
-
     def acc_to_encoder(self) -> "IntegerCategoricalDataEncoder":
         """Return the encoder associated with this accumulator."""
         return IntegerCategoricalDataEncoder()

--- a/mixle/stats/univariate/discrete/integer_uniform_spike.py
+++ b/mixle/stats/univariate/discrete/integer_uniform_spike.py
@@ -584,20 +584,6 @@ class IntegerUniformSpikeAccumulator(SequenceEncodableStatisticAccumulator):
         self.count *= c
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge this accumulator's sufficient statistics into stats_dict under its key."""
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                stats_dict[self.keys].combine(self.value())
-            else:
-                stats_dict[self.keys] = self
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace this accumulator's sufficient statistics from stats_dict under its key."""
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                self.from_value(stats_dict[self.keys].value())
-
     def acc_to_encoder(self) -> "IntegerUniformSpikeDataEncoder":
         """Returns an IntegerUniformSpikeDataEncoder for encoding sequences of iid integer observations."""
         return IntegerUniformSpikeDataEncoder()

--- a/mixle/stats/univariate/discrete/logseries.py
+++ b/mixle/stats/univariate/discrete/logseries.py
@@ -343,19 +343,6 @@ class LogSeriesAccumulator(SequenceEncodableStatisticAccumulator):
         self.count, self.sum = x
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge keyed statistics into ``stats_dict`` when keys are configured."""
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                stats_dict[self.keys].combine(self.value())
-            else:
-                stats_dict[self.keys] = self
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace this accumulator from keyed statistics when available."""
-        if self.keys is not None and self.keys in stats_dict:
-            self.from_value(stats_dict[self.keys].value())
-
     def acc_to_encoder(self) -> "LogSeriesDataEncoder":
         """Return the encoder used by this accumulator."""
         return LogSeriesDataEncoder()

--- a/mixle/stats/univariate/discrete/negative_binomial.py
+++ b/mixle/stats/univariate/discrete/negative_binomial.py
@@ -382,19 +382,6 @@ class NegativeBinomialAccumulator(SequenceEncodableStatisticAccumulator):
         self.histogram = {int(k): float(w) for k, w in x[2].items()} if len(x) > 2 and x[2] else {}
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge keyed statistics into ``stats_dict`` when keys are configured."""
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                stats_dict[self.keys].combine(self.value())
-            else:
-                stats_dict[self.keys] = self
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace this accumulator from keyed statistics when available."""
-        if self.keys is not None and self.keys in stats_dict:
-            self.from_value(stats_dict[self.keys].value())
-
     def acc_to_encoder(self) -> "NegativeBinomialDataEncoder":
         """Return the encoder used by this accumulator."""
         return NegativeBinomialDataEncoder()

--- a/mixle/stats/univariate/discrete/poisson.py
+++ b/mixle/stats/univariate/discrete/poisson.py
@@ -626,30 +626,6 @@ class PoissonAccumulator(SequenceEncodableStatisticAccumulator):
 
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge this accumulator into ``stats_dict`` under its configured key.
-
-        Args:
-            stats_dict: Mapping from merge keys to Poisson accumulators.
-
-        """
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                stats_dict[self.keys].combine(self.value())
-            else:
-                stats_dict[self.keys] = self
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace sufficient statistics from ``stats_dict`` when this accumulator's key is present.
-
-        Args:
-            stats_dict: Mapping from keys to compatible sufficient statistics.
-
-        """
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                self.from_value(stats_dict[self.keys].value())
-
     def acc_to_encoder(self) -> "PoissonDataEncoder":
         """Return an encoder compatible with Poisson observations."""
         return PoissonDataEncoder()

--- a/mixle/stats/univariate/discrete/skellam.py
+++ b/mixle/stats/univariate/discrete/skellam.py
@@ -308,27 +308,6 @@ class SkellamAccumulator(SequenceEncodableStatisticAccumulator):
         self.sum2 *= c
         return self
 
-    def key_merge(self, stats_dict: dict[str, Any]) -> None:
-        """Merge keyed statistics into ``stats_dict`` when keys are configured."""
-        if self.keys is not None:
-            if self.keys in stats_dict:
-                c, s, s2 = stats_dict[self.keys]
-                self.count += c
-                self.sum += s
-                self.sum2 += s2
-                # write the POOL back: without this, the dict keeps the FIRST site's stats and
-                # key_replace hands every tied site that truncated pool -- later sites' data was
-                # silently discarded (order-dependent wrong fits; found by the compiler review's
-                # keyed-tying probe, present in 8 families vs the combine-into-dict families)
-                stats_dict[self.keys] = (self.count, self.sum, self.sum2)
-            else:
-                stats_dict[self.keys] = (self.count, self.sum, self.sum2)
-
-    def key_replace(self, stats_dict: dict[str, Any]) -> None:
-        """Replace this accumulator from keyed statistics when available."""
-        if self.keys is not None and self.keys in stats_dict:
-            self.count, self.sum, self.sum2 = stats_dict[self.keys]
-
     def acc_to_encoder(self) -> "SkellamDataEncoder":
         """Return the encoder used by this accumulator."""
         return SkellamDataEncoder()

--- a/mixle/tests/keyed_pooling_test.py
+++ b/mixle/tests/keyed_pooling_test.py
@@ -144,3 +144,51 @@ class KeyedPoolingProtocolTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class BaseProtocolAdoptionTest(unittest.TestCase):
+    """Families normalized onto the base-class canonical protocol (2026-07-14 centralization)."""
+
+    def test_power_law_hawkes_pools_through_the_base_protocol_without_aliasing(self):
+        # Previously pooled by ALIASING (stored itself; key_replace assigned the pool's list
+        # reference to every site). Now the base protocol + a copying from_value: sites hold
+        # independent copies of the pooled realizations.
+        from mixle.stats.processes.power_law_hawkes import PowerLawHawkesAccumulator
+
+        acc_a = PowerLawHawkesAccumulator(window=10.0, alpha_fixed=None, keys="h")
+        acc_b = PowerLawHawkesAccumulator(window=10.0, alpha_fixed=None, keys="h")
+        acc_a.realizations.extend([[0.1, 0.5], [1.0, 2.0]])
+        acc_b.realizations.extend([[3.0, 4.0]])
+        stats: dict = {}
+        acc_a.key_merge(stats)
+        acc_b.key_merge(stats)
+        acc_a.key_replace(stats)
+        acc_b.key_replace(stats)
+        self.assertEqual(len(acc_a.realizations), 3)
+        self.assertEqual(len(acc_b.realizations), 3)
+        self.assertIsNot(acc_a.realizations, acc_b.realizations, "tied sites must not share one list")
+        acc_a.realizations.append([9.9])  # mutating one site must not leak into the other
+        self.assertEqual(len(acc_b.realizations), 3)
+
+    def test_optional_delegates_the_key_pass_to_its_wrapped_child(self):
+        # A keyed estimator nested under an Optional never pooled: Optional's key pass did not
+        # delegate to the wrapped child accumulator (the dead-keys shape, combinator edition).
+        from mixle.stats.combinator.optional import OptionalEstimator
+        from mixle.stats.univariate.continuous.gaussian import GaussianEstimator
+
+        def site(data):
+            est = OptionalEstimator(estimator=GaussianEstimator(keys="inner"))
+            acc = est.accumulator_factory().make()
+            enc = acc.acc_to_encoder()
+            acc.seq_update(enc.seq_encode(data), np.ones(len(data)), None)
+            return acc
+
+        acc_a, acc_b = site([1.0, 2.0, 3.0]), site([10.0, 20.0])
+        stats: dict = {}
+        acc_a.key_merge(stats)
+        acc_b.key_merge(stats)
+        acc_a.key_replace(stats)
+        acc_b.key_replace(stats)
+        self.assertIn("inner", stats, "the wrapped child's key must reach the stats dict")
+        np.testing.assert_allclose(_flat(acc_a.accumulator.value()), _flat(acc_b.accumulator.value()), rtol=1e-12)
+        self.assertAlmostEqual(float(acc_a.accumulator.count), 5.0, places=12)


### PR DESCRIPTION
The two items deferred from the keying work, now commissioned: centralize the protocol so the bug class is unrepresentable, and normalize power_law_hawkes off pool-by-aliasing.

## The insight: the base class was right all along

`StatisticAccumulator` has always shipped a correct canonical `key_merge`/`key_replace` (store the accumulator under the key the first time, else `combine` into the dict-held one; replace pulls from it). Every one of the sixteen broken families found this week had **overridden a correct default with a hand-rolled drift** into one of three wrong shapes. The durable fix is deletion, not more copies.

## What changed

- **166 `key_merge`/`key_replace` overrides removed from 83 accumulator classes** (82 files, net −1,361 lines). Eligibility was **behavioral, not textual**: a class was stripped only if the keyed-protocol sweep proves its pooling whole-state under top-level keying, AND its methods neither delegate to child accumulators nor touch slot keys (`init_key`/`trans_key`/…). The 8 delegating/slot-key classes (Composite, Sequence, MarkovChain + Integer variant, Multinomial variants, ChowLiuTree, IntegerBernoulliEdit) keep their overrides, as do partial-coverage hybrids (Hurdle, ZeroInflated).
- **The base default now documents *why* its exact shape is correct** and names the three observed broken variants (pull-without-write-back, never-inserts, push-over-pool), so the next reader extends the base instead of reimplementing it.
- **Optional gained the delegation its key pass was missing**: a keyed estimator nested under an `OptionalEstimator` never pooled at all — the dead-keys shape, combinator edition, caught while classifying overrides. Its own-key handling now defers to the base via `super()`; the override exists only to delegate to the wrapped child, mirroring Hurdle.
- **power_law_hawkes normalized**: overrides deleted (the base protocol covers it) and `from_value` copies the realizations list, so tied sites no longer share one mutable list (the copy-on-adopt precedent).

## Testing

- `keyed_pooling_test` grows the PowerLawHawkes no-aliasing case and the Optional child-delegation case.
- The 148-family protocol sweep passes unchanged over the stripped tree — it is the behavioral guard that makes this deletion safe and keeps it safe.
- Full local gate: 5,154 passed. Two local-only failures are pre-existing on the pristine base commit (verified by stash/re-run twice): a leaf-hotswap GradLeaf-plateau test that fails deterministically on this machine's py3.14 while CI (3.11/3.12) passes it, and one known xdist-contention flake that passes single-process. Neither is touched by this diff.
