### PR TITLE
E5: Wire the orphaned language_bridge

### DIFF
--- a/mixle/reason/posterior_protocol.py
+++ b/mixle/reason/posterior_protocol.py
@@ -1,0 +1,59 @@
+"""IC-1 -- the shared `Posterior` protocol (frozen; work-plan Sec.5).
+
+The single subsurface-posterior type both a core `mixle` distribution and a `mixle_pde` field posterior satisfy, so
+the spine (E1-E11), the stochastic optimizer (H4), and the valuation (J2) all consume one structural type. `samples`
+is a METHOD returning an ``(n, d)`` draw matrix (NOTE the plural -- `mixle_pde.latent.PosteriorField3D.sample` is
+singular today; E1 adds the plural alias). `cov` returns a dense array for small problems or a `LinearOperator` for
+survey-scale ones (never materialised -- work-plan Sec.C2). `derived_quantity` maps a pushforward ``fn`` over posterior
+draws into a `DerivedQuantity` that carries the samples, a credible interval, AND the honesty flag `prior_dominated`
+(work-plan A2): a driller-facing number is never emitted without it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Protocol, runtime_checkable
+
+import numpy as np
+from scipy.sparse.linalg import LinearOperator
+
+
+@runtime_checkable
+class DerivedQuantity(Protocol):
+    """A pushforward of the posterior through a functional: draws + interval + the prior-dominated honesty flag."""
+
+    samples: np.ndarray  # (n,) or (n, k) draws of the derived quantity, physical units
+    prior_dominated: bool  # True when the regulariser, not the data, sets the width (work-plan A2)
+
+    def credible_interval(self, level: float) -> tuple[np.ndarray, np.ndarray]:
+        """Central ``level`` interval (e.g. 0.9) of the derived quantity."""
+        ...
+
+
+@runtime_checkable
+class Posterior(Protocol):
+    """The frozen subsurface-posterior protocol. Signatures are fixed; only implementations vary."""
+
+    def samples(self, n: int, rng: np.random.Generator) -> np.ndarray:
+        """Draw ``n`` samples in physical units; shape ``(n, d)``."""
+        ...
+
+    @property
+    def mean(self) -> np.ndarray:
+        """Posterior mean, shape ``(d,)``, physical units."""
+        ...
+
+    @property
+    def cov(self) -> np.ndarray | LinearOperator:
+        """Covariance: a dense ``(d, d)`` array, or a matrix-free ``LinearOperator`` at survey scale."""
+        ...
+
+    def credible_interval(self, level: float) -> tuple[np.ndarray, np.ndarray]:
+        """Per-component central credible interval covering ``level`` mass; ``(lo, hi)`` each shape ``(d,)``."""
+        ...
+
+    def derived_quantity(
+        self, fn: Callable[[np.ndarray], np.ndarray], n: int, rng: np.random.Generator
+    ) -> DerivedQuantity:
+        """Pushforward ``fn`` over ``n`` posterior draws into a `DerivedQuantity` (samples + CI + prior_dominated)."""
+        ...

--- a/mixle/tests/posterior_protocol_test.py
+++ b/mixle/tests/posterior_protocol_test.py
@@ -1,0 +1,59 @@
+"""IC-1 -- the shared `Posterior` protocol (frozen conformance check; work-plan Sec.5).
+
+Named with the repo's own `*_test.py` suffix convention (``pyproject.toml``'s
+``[tool.pytest.ini_options] python_files``), not the ``test_*.py`` prefix contracts.md's copy-paste
+stub illustrates -- content is otherwise the frozen conformance test verbatim.
+"""
+
+import inspect
+
+import numpy as np
+
+from mixle.reason.posterior_protocol import DerivedQuantity, Posterior
+
+
+class _DQ:
+    def __init__(self, s):
+        self.samples = np.asarray(s, float)
+        self.prior_dominated = False
+
+    def credible_interval(self, level):
+        a = (1.0 - level) / 2.0
+        return np.quantile(self.samples, a, 0), np.quantile(self.samples, 1 - a, 0)
+
+
+class _Conforming:
+    def samples(self, n, rng):
+        return rng.standard_normal((n, 3))
+
+    @property
+    def mean(self):
+        return np.zeros(3)
+
+    @property
+    def cov(self):
+        return np.eye(3)
+
+    def credible_interval(self, level):
+        return -np.ones(3), np.ones(3)
+
+    def derived_quantity(self, fn, n, rng):
+        return _DQ(fn(self.samples(n, rng)))
+
+
+def test_protocols_are_runtime_checkable():
+    assert isinstance(_Conforming(), Posterior)
+    assert isinstance(_DQ([1.0, 2.0]), DerivedQuantity)
+
+
+def test_frozen_signatures():
+    assert list(inspect.signature(Posterior.samples).parameters) == ["self", "n", "rng"]
+    assert list(inspect.signature(Posterior.credible_interval).parameters) == ["self", "level"]
+    assert list(inspect.signature(Posterior.derived_quantity).parameters) == ["self", "fn", "n", "rng"]
+
+
+def test_derived_quantity_carries_flag_and_interval():
+    p = _Conforming()
+    dq = p.derived_quantity(lambda m: m.sum(1), 128, np.random.default_rng(0))
+    lo, hi = dq.credible_interval(0.9)
+    assert dq.prior_dominated is False and np.all(lo <= hi)


### PR DESCRIPTION
## Worklist item

**Item:** E5

## Summary

From `notes/exploration-e2e-work-plan.md` (the post-0.7 capability-expansion worklist, commissioned directly by the maintainer) and `notes/exec/workstream-E.md` -- not the original 0.8.0 stability worklist; this is new, explicitly authorized capability work.

E5's own Files list places the actual `language_bridge` wiring in `mixle-pde` (a `describe_posterior` helper in `reasoning.py`) and `mixle-mlops` (a new `POST /v1/interpret` route) -- companion PRs gmboquet/mixle-pde#26 and gmboquet/mixle-mlops#9. `mixle/mixle/reason/language_bridge.py` itself needed no changes here (E5 imports it unchanged, per the work order).

This PR's contribution to core `mixle` is landing IC-1 -- `mixle/mixle/reason/posterior_protocol.py`, the frozen `Posterior`/`DerivedQuantity` protocol from `notes/exec/contracts.md` -- a Wave-0 prerequisite that E5 (and E1/E3/E4/E10/H4/J2) all build against, which had not yet landed on `release/0.8.0`. Added verbatim from the contract, plus its conformance test.

## Public API impact

- [x] This PR does **not** change any public `__all__`. (`posterior_protocol.py` is a new module, not re-exported from `reason/__init__.py` -- the same "imported by nothing from the package `__init__`" pattern the work order documents for `language_bridge.py` itself; `python scripts/gen_api_manifest.py` produces no diff against the committed `api_manifest.json`.)

## Claims impact

- [x] No public claim (README, docs, benchmarks) is affected.

## Evidence

```
PYTHONPATH=$MX/mixle $MX/.venv/bin/python -m pytest mixle/tests/posterior_protocol_test.py -q
-> 3 passed
```

## Checklist

- [x] Tests added/updated and passing; `ruff check` + `ruff format --check` clean.
- [x] Consumer suites for any edited module pass. (No existing consumers of this new module in this repo yet -- the consumers are the companion mixle-pde/mixle-mlops PRs above.)
- [x] I am not merging this PR myself, and I have not enabled auto-merge.

## Notes

- This PR only lands the IC-1 prerequisite. The IC-1 test is named `posterior_protocol_test.py` (this repo's own `*_test.py` `pyproject.toml` convention) rather than contracts.md's illustrative `test_posterior_protocol.py`, so it's actually collected by a plain `pytest -q` run; content is the frozen conformance test verbatim.
- The real `language_bridge` wiring (the `describe_posterior` helper and the `/v1/interpret` route) is in the companion mixle-pde/mixle-mlops PRs linked above, since E5's own Files list places that code in those sibling repos, not here.