### PR TITLE
E7: Cross-chain provenance receipt

### DIFF
--- a/mixle/reason/receipt.py
+++ b/mixle/reason/receipt.py
@@ -1,0 +1,245 @@
+"""E7 — cross-chain provenance receipt (work-plan §5, IC-2 / IC-5 / IC-13).
+
+``decision_receipt`` walks a data -> posterior -> claim -> decision chain and emits an
+:mod:`mixle.task.trace_record` (IC-5) whose every step carries a content hash for its own output and
+its parent's hash as ``result["parent_hash"]`` -- a hashed, re-derivable lineage edge from raw data
+through an inversion, an interpretation, and a decision. The posterior is *ingested* into a
+:class:`~mixle.substrate.core.Substrate` (via :func:`~mixle.substrate.ingest.ingest_artifacts`) rather
+than copied: the substrate item's payload references the artifact (an IC-13-shaped
+``{artifact_ref, schema, grid, crs, units}`` record), the array bytes stay wherever the IC-2 artifact
+already lives.
+
+Repo-boundary note (see the PR body for the full explanation): this PR only touches the core ``mixle``
+repository. ``mixle-pde`` (E2's ``io/artifacts.py`` -- IC-2) and ``mixle-mlops`` (E3/E4/E5) had not
+landed on ``release/0.8.0`` as of this PR, so ``decision_receipt`` does not import either package.
+Instead it accepts already-content-hashed ``*_ref`` handles (the same opaque-string convention IC-3's
+``run_inversion``/``query_posterior`` use) and, when ``posterior_ref`` names an on-disk IC-2 artifact
+(a ``{posterior_ref}.json`` sibling exists, carrying the frozen ``HEADER_KEYS``), reads that header
+directly (plain ``json.load`` -- no ``mixle_pde`` import) rather than depending on a real
+``load_posterior``. ``claim``/``decision`` accept a plain dict, any dataclass, or an ad hoc object
+(e.g. a ``mixle.reason.language_bridge.Claim``); each is normalized to a dict before hashing.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import re
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+from mixle.data.hashing import dataset_hash
+from mixle.inference.production.provenance import build_header
+from mixle.substrate.core import Substrate
+from mixle.substrate.ingest import ingest_artifacts
+from mixle.task.trace_record import validate_trace_record
+
+__all__ = ["decision_receipt", "content_edge_hash"]
+
+_HEX64 = re.compile(r"^[0-9a-f]{64}$")
+
+# Fallback schema tag used only when the posterior artifact carries no header of its own (e.g. a bare
+# in-memory reference in a test/demo chain, with no IC-2 `{path}.json` sibling to read).
+_FALLBACK_ARTIFACT_SCHEMA = "mixle_pde.field_posterior/v1"
+
+
+def content_edge_hash(value: Any) -> str:
+    """The hash for one lineage edge: pass an already-hashed hex digest through unchanged (the IC-2/IC-3
+    ``*_ref`` convention), else fingerprint ``value`` with :func:`mixle.data.hashing.dataset_hash` (a
+    stable sha256 over a canonical byte encoding) so the edge is deterministic and independently
+    re-derivable from the same inline payload."""
+    if isinstance(value, str) and _HEX64.match(value):
+        return value
+    return dataset_hash([value])
+
+
+def _stringify_ref(ref: Any) -> str:
+    if isinstance(ref, str):
+        return ref
+    return json.dumps(ref, sort_keys=True, default=str)
+
+
+def _to_plain(value: Any) -> dict[str, Any]:
+    """Normalize a claim/decision payload into a JSON-friendly dict so it can be hashed and embedded."""
+    if isinstance(value, dict):
+        return dict(value)
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
+        out = dict(dataclasses.asdict(value))
+        text_fn = getattr(value, "text", None)
+        if callable(text_fn):
+            try:
+                out.setdefault("text", text_fn())
+            except Exception:  # noqa: BLE001 - best-effort text surface only
+                pass
+        return out
+    if hasattr(value, "__dict__"):
+        return dict(vars(value))
+    return {"value": value}
+
+
+def _posterior_reference(posterior_ref: Any) -> tuple[str, dict[str, Any]]:
+    """Resolve ``posterior_ref`` (a bare string/path/hash, an IC-2-header-shaped dict, or an ad hoc
+    object) into ``(ref_str, header_meta)``. When ``posterior_ref`` is a path with an on-disk IC-2
+    sibling ``{posterior_ref}.json``, that header (frozen ``HEADER_KEYS``: schema/content_hash/crs/
+    grid/units/provenance/created) is read directly -- no ``mixle_pde`` import required."""
+    if isinstance(posterior_ref, dict):
+        ref = (
+            posterior_ref.get("artifact_ref")
+            or posterior_ref.get("ref")
+            or posterior_ref.get("path")
+            or posterior_ref.get("content_hash")
+        )
+        return (str(ref) if ref is not None else _stringify_ref(posterior_ref)), dict(posterior_ref)
+    if isinstance(posterior_ref, str):
+        header_path = Path(f"{posterior_ref}.json")
+        if header_path.is_file():
+            try:
+                meta = json.loads(header_path.read_text())
+            except Exception:  # noqa: BLE001 - an unreadable/corrupt header falls back to a bare ref
+                meta = {}
+            if isinstance(meta, dict):
+                return posterior_ref, meta
+        return posterior_ref, {}
+    meta = {
+        k: getattr(posterior_ref, k)
+        for k in ("schema", "grid", "crs", "units", "content_hash", "provenance")
+        if hasattr(posterior_ref, k)
+    }
+    ref = getattr(posterior_ref, "path", None) or getattr(posterior_ref, "ref", None) or posterior_ref
+    return _stringify_ref(ref), meta
+
+
+def _registry_dir_for(substrate: Substrate, digest: str) -> Path:
+    """A stable, per-digest micro-directory to host one ``manifest.json`` for `ingest_artifacts` --
+    under the substrate's own root when it has one (persistent), else a shared scratch location. Never
+    holds array bytes: only the small JSON manifest referencing the real artifact."""
+    base = substrate.root if substrate.root is not None else Path(tempfile.gettempdir()) / "mixle_receipt_registry"
+    d = Path(base) / "field_posterior" / digest[:16]
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _ingest_posterior(
+    substrate: Substrate, ref_str: str, meta: dict[str, Any], digest: str
+) -> tuple[str, dict[str, Any]]:
+    """Ingest a reference to the posterior artifact via :func:`ingest_artifacts` (arrays stay behind the
+    ref); returns ``(substrate_item_id, artifact_record)`` where ``artifact_record`` is the IC-13-shaped
+    ``{artifact_ref, schema, grid, crs, units, content_hash}`` payload."""
+    record = {
+        "artifact_ref": ref_str,
+        "schema": meta.get("schema", _FALLBACK_ARTIFACT_SCHEMA),
+        "grid": meta.get("grid"),
+        "crs": meta.get("crs"),
+        "units": meta.get("units"),
+        "content_hash": digest,
+    }
+    registry_dir = _registry_dir_for(substrate, digest)
+    manifest = {
+        "mixle_artifact": "field_posterior",
+        "kind": "field_posterior",
+        "parent": meta.get("provenance", {}).get("parent") if isinstance(meta.get("provenance"), dict) else None,
+        "meta": record,
+    }
+    (registry_dir / "manifest.json").write_text(json.dumps(manifest))
+    ids = ingest_artifacts(substrate, str(registry_dir))
+    item_id = ids[0] if ids else ""
+    return item_id, record
+
+
+def decision_receipt(
+    *, dataset_ref: Any, posterior_ref: Any, claim: Any, decision: Any, substrate: Substrate
+) -> dict[str, Any]:
+    """Build an IC-5 trace record for one data -> posterior -> claim -> decision chain.
+
+    ``dataset_ref`` / ``posterior_ref`` are content-hashed handles (the IC-2/IC-3 ``*_ref`` convention;
+    a bare string is treated as already-hashed, anything else is fingerprinted). ``claim`` / ``decision``
+    are the interpretation/decision payloads (a dict, a dataclass, or an ad hoc object such as a
+    ``language_bridge.Claim``), normalized to a dict before hashing. The posterior is ingested into
+    ``substrate`` as a referenced (not copied) artifact.
+
+    Returns a dict that satisfies :func:`mixle.task.trace_record.validate_trace_record`: every scalar
+    output (the posterior, the claim, the decision) resolves to a hashed lineage edge whose ``content_hash``
+    is independently re-derivable via :func:`content_edge_hash`, and whose ``parent_hash`` chains back to
+    the previous edge.
+    """
+    data_hash = content_edge_hash(dataset_ref)
+
+    ref_str, posterior_meta = _posterior_reference(posterior_ref)
+    posterior_hash = posterior_meta.get("content_hash") or content_edge_hash(
+        {"ref": ref_str, **{k: v for k, v in posterior_meta.items() if k != "content_hash"}}
+    )
+    substrate_item_id, artifact_record = _ingest_posterior(substrate, ref_str, posterior_meta, posterior_hash)
+
+    claim_record = _to_plain(claim)
+    claim_hash = content_edge_hash(claim_record)
+
+    decision_record = _to_plain(decision)
+    decision_hash = content_edge_hash(decision_record)
+
+    lineage = [
+        {"stage": "data", "content_hash": data_hash, "parent_hash": None},
+        {
+            "stage": "posterior",
+            "content_hash": posterior_hash,
+            "parent_hash": data_hash,
+            "substrate_item_id": substrate_item_id,
+            "artifact": artifact_record,
+        },
+        {"stage": "claim", "content_hash": claim_hash, "parent_hash": posterior_hash},
+        {"stage": "decision", "content_hash": decision_hash, "parent_hash": claim_hash},
+    ]
+
+    header = build_header(decision_record, [data_hash, posterior_hash, claim_hash, decision_hash], final_loglik=None)
+
+    steps: list[dict[str, Any]] = [
+        {
+            "tool": "dataset",
+            "args": {"dataset_ref": _stringify_ref(dataset_ref)},
+            "result": {"content_hash": data_hash},
+            "model": None,
+            "verdict": None,
+        },
+        {
+            "tool": "run_inversion",
+            "args": {"dataset_ref": _stringify_ref(dataset_ref)},
+            "result": {
+                "content_hash": posterior_hash,
+                "parent_hash": data_hash,
+                "posterior_ref": ref_str,
+                "substrate_item_id": substrate_item_id,
+                **artifact_record,
+            },
+            "model": posterior_meta.get("model"),
+            "verdict": None,
+        },
+        {
+            "tool": "interpret",
+            "args": {"posterior_ref": ref_str},
+            "result": {"content_hash": claim_hash, "parent_hash": posterior_hash, "claim": claim_record},
+            "model": claim_record.get("model"),
+            "verdict": None,
+        },
+        {
+            "tool": "decide",
+            "args": {"claim_hash": claim_hash},
+            "result": {"content_hash": decision_hash, "parent_hash": claim_hash, "decision": decision_record},
+            "model": decision_record.get("model"),
+            "verdict": None,
+        },
+    ]
+
+    receipt: dict[str, Any] = {
+        "prompt": f"decision receipt for posterior {ref_str}",
+        "steps": steps,
+        "outcome": decision_record,
+        "provenance": {
+            "lineage": lineage,
+            "header": header.to_dict(),
+            "posterior_substrate_item": substrate_item_id,
+            "created_at": time.time(),
+        },
+    }
+    validate_trace_record(receipt)
+    return receipt

--- a/mixle/task/trace_record.py
+++ b/mixle/task/trace_record.py
@@ -1,0 +1,50 @@
+"""IC-5 — the frozen trace/receipt envelope the dataset foundry (M4) mines (work-plan §5, DR-ALG M4).
+
+Frozen top-level keys: ``prompt, steps, outcome, provenance``; each step: ``tool, args, result, model, verdict``.
+``validate_trace_record`` enforces the names so a producer (executor/gateway/receipt) and the consumer (M4 trace
+miner) never drift. ``from_execution_trace`` lifts a core ``mixle.task.replay.ExecutionTrace`` into the envelope.
+
+This module was specified (frozen) in ``notes/exec/contracts.md`` §IC-5 as a Wave-0 deliverable, but had not
+actually landed in this repository yet -- E7 (cross-chain provenance receipt) requires ``validate_trace_record``
+to shape its lineage receipt, so this lands the frozen stub verbatim. Only ``from_execution_trace``'s body
+remains a stub: that lift is M4a's job, not E7's.
+"""
+
+from __future__ import annotations
+
+from typing import Any, TypedDict
+
+
+class TraceStepRecord(TypedDict, total=False):
+    tool: str
+    args: dict[str, Any]
+    result: Any
+    model: str | None
+    verdict: dict[str, Any] | None  # an IC-6 Verdict as a dict, when the step was verified
+
+
+class TraceRecord(TypedDict, total=False):
+    prompt: str
+    steps: list[TraceStepRecord]
+    outcome: Any
+    provenance: dict[str, Any]
+
+
+TRACE_KEYS = ("prompt", "steps", "outcome", "provenance")
+STEP_KEYS = ("tool", "args", "result", "model", "verdict")
+
+
+def validate_trace_record(d: dict[str, Any]) -> None:
+    """Raise ``ValueError`` if ``d`` is missing a frozen top-level key or any step lacks ``tool``/``args``/``result``."""
+    missing = [k for k in TRACE_KEYS if k not in d]
+    if missing:
+        raise ValueError(f"trace record missing frozen keys: {missing}")
+    for i, s in enumerate(d.get("steps") or []):
+        for k in ("tool", "args", "result"):
+            if k not in s:
+                raise ValueError(f"step {i} missing frozen key {k!r}")
+
+
+def from_execution_trace(trace: Any, *, outcome: Any = None, provenance: dict[str, Any] | None = None) -> TraceRecord:
+    """Lift a `mixle.task.replay.ExecutionTrace` into the frozen envelope (fills ``model``/``verdict`` as None)."""
+    raise NotImplementedError("M4a")

--- a/mixle/tests/test_e7_provenance.py
+++ b/mixle/tests/test_e7_provenance.py
@@ -1,0 +1,108 @@
+"""E7 -- cross-chain provenance receipt.
+
+Repo-boundary note: the work order's literal DoD command targets
+``$MX/mixle-mlops/tests/test_e7_provenance.py`` (a different repository, gmboquet/mixle-mlops), which
+had not landed E3/E4/E5 on ``release/0.8.0`` as of this PR and is out of scope for a PR against
+``gmboquet/mixle``. This test exercises the exact DoD scenario -- a synthetic data -> invert ->
+interpret -> decide chain, every scalar resolving to a hashed, re-derivable lineage edge, and
+``validate_trace_record`` passing -- entirely with core-``mixle`` fixtures (a real
+``mixle.reason.language_bridge.Claim`` for the interpretation step, a hand-built IC-2-header-shaped
+dict for the posterior step, standing in for the not-yet-landed ``mixle_pde`` artifact).
+"""
+
+import hashlib
+import json
+
+from mixle.reason.language_bridge import Claim
+from mixle.reason.receipt import content_edge_hash, decision_receipt
+from mixle.substrate.core import Substrate
+from mixle.task.trace_record import STEP_KEYS, validate_trace_record
+
+
+def _synthetic_dataset_ref():
+    return {"kind": "gravity", "n_stations": 5, "values": [1.1, 2.2, 3.3, 4.4, 5.5]}
+
+
+def _synthetic_posterior_header(tmp_path):
+    """A hand-built header shaped exactly like IC-2's frozen ``{schema, content_hash, crs, grid, units,
+    provenance, created}`` so `decision_receipt` reads it as an on-disk artifact sibling, the same way
+    it would read a real `mixle_pde.io.artifacts.save_posterior` output."""
+    array_digest = hashlib.sha256(b"mean|cov|synthetic-field-posterior-arrays").hexdigest()
+    header = {
+        "schema": "mixle_pde.field_posterior/v1",
+        "content_hash": array_digest,
+        "crs": "EPSG:32611",
+        "grid": {"shape": [4, 4, 4], "origin": [0.0, 0.0, 0.0], "spacing": [10.0, 10.0, 10.0]},
+        "units": "kg/m^3",
+        "provenance": {"modality": "gravity", "prior": "smooth"},
+        "created": "2026-07-14T00:00:00Z",
+    }
+    path_prefix = tmp_path / "posterior_run_001"
+    (tmp_path / "posterior_run_001.json").write_text(json.dumps(header))
+    return str(path_prefix), array_digest
+
+
+def test_decision_receipt_chain_is_hashed_and_validates(tmp_path):
+    substrate = Substrate()
+
+    dataset_ref = _synthetic_dataset_ref()
+    posterior_ref, array_digest = _synthetic_posterior_header(tmp_path)
+    claim = Claim(field="density", lo=2650.0, hi=2800.0)
+    decision = {"action": "drill", "region": "target-7", "tonnage_ci": [120_000.0, 180_000.0]}
+
+    receipt = decision_receipt(
+        dataset_ref=dataset_ref, posterior_ref=posterior_ref, claim=claim, decision=decision, substrate=substrate
+    )
+
+    # the record shape is IC-5-valid
+    validate_trace_record(receipt)
+    assert len(receipt["steps"]) == 4
+    for step in receipt["steps"]:
+        assert set(STEP_KEYS) <= set(step)
+
+    lineage = {edge["stage"]: edge for edge in receipt["provenance"]["lineage"]}
+    assert set(lineage) == {"data", "posterior", "claim", "decision"}
+
+    # every edge carries a content_hash, and it is re-derivable: re-running the exact same chain
+    # yields byte-identical hashes at every stage (determinism, not just presence).
+    for edge in lineage.values():
+        assert isinstance(edge["content_hash"], str) and len(edge["content_hash"]) == 64
+
+    receipt_again = decision_receipt(
+        dataset_ref=dataset_ref, posterior_ref=posterior_ref, claim=claim, decision=decision, substrate=Substrate()
+    )
+    lineage_again = {edge["stage"]: edge for edge in receipt_again["provenance"]["lineage"]}
+    for stage in ("data", "posterior", "claim", "decision"):
+        assert lineage[stage]["content_hash"] == lineage_again[stage]["content_hash"]
+
+    # the data hash is directly re-derivable from the raw input via the public helper
+    assert lineage["data"]["content_hash"] == content_edge_hash(dataset_ref)
+
+    # the posterior's IC-2 array digest is PRESERVED as the artifact digest, never recomputed
+    assert lineage["posterior"]["content_hash"] == array_digest
+
+    # each edge's parent_hash chains to the previous edge -- data -> posterior -> claim -> decision
+    assert lineage["data"]["parent_hash"] is None
+    assert lineage["posterior"]["parent_hash"] == lineage["data"]["content_hash"]
+    assert lineage["claim"]["parent_hash"] == lineage["posterior"]["content_hash"]
+    assert lineage["decision"]["parent_hash"] == lineage["claim"]["content_hash"]
+
+    # the posterior was ingested into the substrate (referenced, not copied): the substrate item exists,
+    # is a structured IC-13-shaped {artifact_ref, schema, grid, crs, units} record, and carries no raw
+    # arrays -- only the reference and metadata.
+    item_id = receipt["provenance"]["posterior_substrate_item"]
+    item = substrate.get(item_id)
+    assert item is not None and item.kind == "artifact"
+    meta = item.payload["manifest"]["meta"]
+    assert meta["artifact_ref"] == posterior_ref
+    assert meta["content_hash"] == array_digest
+    assert meta["crs"] == "EPSG:32611"
+    assert meta["grid"]["shape"] == [4, 4, 4]
+    assert "mean" not in meta and "cov" not in meta and "samples" not in meta
+
+    # the receipt carries a content-hash header (reused from inference.production.provenance.build_header)
+    header = receipt["provenance"]["header"]
+    assert isinstance(header["dataset_hash"], str) and len(header["dataset_hash"]) == 64
+
+    # the outcome is the decision itself
+    assert receipt["outcome"]["action"] == "drill"

--- a/mixle/tests/test_ic_trace_record.py
+++ b/mixle/tests/test_ic_trace_record.py
@@ -1,0 +1,30 @@
+"""IC-5 conformance: the frozen trace/receipt envelope (notes/exec/contracts.md).
+
+Landed alongside E7 (cross-chain provenance receipt), which is the first real consumer of
+``validate_trace_record`` in this repository.
+"""
+
+import pytest
+
+from mixle.task.trace_record import STEP_KEYS, TRACE_KEYS, validate_trace_record
+
+
+def test_frozen_keys():
+    assert TRACE_KEYS == ("prompt", "steps", "outcome", "provenance")
+    assert STEP_KEYS == ("tool", "args", "result", "model", "verdict")
+
+
+def test_validate_accepts_a_minimal_record():
+    validate_trace_record(
+        {"prompt": "p", "steps": [{"tool": "t", "args": {}, "result": 1}], "outcome": "ok", "provenance": {}}
+    )
+
+
+def test_validate_rejects_missing_top_key():
+    with pytest.raises(ValueError):
+        validate_trace_record({"prompt": "p", "steps": [], "outcome": None})
+
+
+def test_validate_rejects_bad_step():
+    with pytest.raises(ValueError):
+        validate_trace_record({"prompt": "p", "steps": [{"tool": "t"}], "outcome": None, "provenance": {}})


### PR DESCRIPTION
## Worklist item

**Item:** E7

From `notes/exploration-e2e-work-plan.md` (the post-0.7 capability-expansion worklist, commissioned
directly by the maintainer) and `notes/exec/workstream-E.md` — not the original 0.8.0 stability
worklist; this is new, explicitly authorized capability work.

## Summary

Implements the E7 cross-chain provenance receipt: `mixle.reason.receipt.decision_receipt(*,
dataset_ref, posterior_ref, claim, decision, substrate) -> dict`, which walks a data -> posterior ->
claim -> decision chain and emits a receipt whose every edge carries a content hash (independently
re-derivable via the new `content_edge_hash` helper) and whose `parent_hash` chains back to the
previous edge. The posterior is ingested into `mixle.substrate` via the existing `ingest_artifacts`
helper as an IC-13-shaped `{artifact_ref, schema, grid, crs, units}` reference record (arrays are
never copied), and the whole receipt is validated against the frozen IC-5 `validate_trace_record`.
`mixle.inference.production.provenance.build_header` is reused to attach a content-hash header
(environment + a combined `dataset_hash` over the four lineage hashes) to the receipt's provenance.

Also lands `mixle/task/trace_record.py` (IC-5), which had not actually landed in this repository yet
(see Notes #2) even though it is a frozen Wave-0 contract other Workstream-E tasks assume is already
present.

## Notes (judgment calls / deviations)

1. **Repo scope.** E7's work order spans core `mixle` + `mixle-pde` + `mixle-mlops`. This PR is
   scoped to `gmboquet/mixle` only (this task's fixed repo assignment). The `mixle-pde/mixle_pde/latent.py`
   provenance-serialization change (serialising the Field3D `provenance` dict) is out of scope for this
   PR — different repository/remote — and is left for a mixle-pde-scoped task.
2. **E2 (IC-2, `mixle_pde/io/artifacts.py`) had not landed** on `mixle-pde`'s `release/0.8.0` as of
   this PR (confirmed: the file does not exist there). So `decision_receipt` does not import
   `mixle_pde`. It treats `posterior_ref` as an opaque content-hashed handle (the same `*_ref`
   convention IC-3's `run_inversion`/`query_posterior` already use) and, when a real on-disk artifact
   header exists (a `{posterior_ref}.json` sibling matching IC-2's frozen `HEADER_KEYS`), reads it
   directly via `json.load` — a format-level dependency on the frozen contract, not a functional import
   of the unlanded module. When the header carries a `content_hash`, that value is PRESERVED as the
   posterior's lineage digest (never recomputed), per the work order's "preserve the IC-2 array digest"
   instruction.
3. **IC-5 (`mixle/task/trace_record.py`) had not landed either** — confirmed absent anywhere in this
   repo's git history, despite `notes/exec/contracts.md` describing it as an already-landed Wave-0
   stub. Landed the frozen stub verbatim (not a redesign — only `from_execution_trace` remains
   `NotImplementedError("M4a")`, exactly as frozen) since E7 needs `validate_trace_record` to build
   against. Also added `mixle/tests/test_ic_trace_record.py`, the IC-5 conformance test from
   contracts.md, verbatim.
4. **DoD test repo mismatch.** The work order's literal DoD command is `pytest
   $MX/mixle-mlops/tests/test_e7_provenance.py -q` — a different repository (`gmboquet/mixle-mlops`,
   which had not landed E3/E4/E5 as of this PR) out of scope for a PR against `gmboquet/mixle`. Added an
   equivalent test at `mixle/tests/test_e7_provenance.py` in this repo that exercises the identical DoD
   scenario (a synthetic data -> invert -> interpret -> decide chain; every scalar resolves to a hashed,
   re-derivable lineage edge; `validate_trace_record` passes) using core-`mixle` fixtures: a real
   `mixle.reason.language_bridge.Claim` for the interpretation step and a hand-built IC-2-header-shaped
   artifact standing in for the not-yet-landed `mixle_pde` posterior.
5. **`mixle/reason/__init__.py` left untouched.** `decision_receipt` is not re-exported through
   `mixle.reason`'s `__all__`, mirroring the existing precedent for `mixle.reason.language_bridge` (per
   E5's own notes: "imported by nothing... not in reason/__init__.py"). No package `__all__` changed, so
   `api_manifest.json` needs no regeneration (verified by inspection of `scripts/gen_api_manifest.py`,
   which only scans `__init__.py` files declaring `__all__`).
6. Ran this repo's documented single-file invocation (`pytest <file> -n0 -m ""`) instead of the bare
   `pytest <file> -q` from the DoD template, since `pyproject.toml`'s `addopts` defaults to `-n auto -m
   fast` — this repo's own comment in `pyproject.toml` recommends `-n0 -m ""` for a single serial file
   run.

## Public API impact

- [x] This PR does **not** change any public `__all__`.
- [ ] It changes the public surface, and I regenerated the manifest (`python scripts/gen_api_manifest.py`) and committed `api_manifest.json`.
- [ ] It adds public surface: a written exception is recorded in the release decision log.

## Claims impact

- [x] No public claim (README, docs, benchmarks) is affected.
- [ ] A claim is affected and the relevant docs / claim-evidence ledger are updated with evidence at the required grade.

## Evidence

DoD-equivalent test (see Notes #4 for why this repo hosts it instead of `mixle-mlops`):

```
PYTHONPATH=/Users/grantboquet/mixle/mixle python -m pytest mixle/tests/test_e7_provenance.py -q -n0 -m ""
-> 1 passed in 461.18s
```

IC-5 conformance + broader regression suite over every module this PR touches or reuses
(`mixle.task.trace_record`, `mixle.substrate.ingest`/`.core`, `mixle.inference.production.provenance`,
`mixle.reason.language_bridge`, `mixle.data.hashing`, `mixle.task.replay`/traces):

```
PYTHONPATH=/Users/grantboquet/mixle/mixle python -m pytest \
  mixle/tests/test_ic_trace_record.py mixle/tests/substrate_test.py mixle/tests/provenance_test.py \
  mixle/tests/language_bridge_test.py mixle/tests/ingest_file_test.py mixle/tests/task_traces_test.py \
  -q -n0 -m ""
-> 55 passed, 6 warnings in 57.85s
```

(The 6 warnings are pre-existing `ResourceWarning`s from unrelated tests leaving temp files open;
unaffected by this PR.)

`ruff format --check` / `ruff check` on all four changed files: clean.

## Checklist

- [x] Tests added/updated and passing; `ruff check` + `ruff format --check` clean.
- [x] Consumer suites for any edited module pass.
- [x] I am not merging this PR myself, and I have not enabled auto-merge.
