### PR TITLE
H2: Ore blending & grade control

### DIFF
--- a/mixle/blending.py
+++ b/mixle/blending.py
@@ -1,0 +1,149 @@
+"""Ore blending & grade control.
+
+A blend draws tonnage ``w_s`` from each of several sources (stockpiles, mine faces, parcels), each
+with its own per-element grade and unit cost, to hit a head-grade *window* on the combined material
+-- ``spec_lo[e] <= (sum_s w_s grades[s,e]) / sum_s w_s <= spec_hi[e]`` for every element ``e`` -- at
+minimum blending cost. Fixing the total blended tonnage to the requested ``demand`` linearizes the
+otherwise-fractional ratio constraint into a pair of linear inequalities, so the whole problem is a
+linear (or, with a minimum-parcel floor per source, mixed-integer) program solved by
+:func:`mixle.relations.branch_and_bound_milp`. When the spec window cannot be met by any blend of the
+given sources, :func:`mixle.relations.irreducible_infeasible_subset` names the conflicting
+constraint rows -- which element window, high or low, is unmeetable -- rather than just reporting
+"infeasible".
+
+    >>> import numpy as np
+    >>> grades = np.array([[0.50], [0.55], [0.65], [0.70]])  # Fe fraction per stockpile
+    >>> costs = np.array([10.0, 12.0, 15.0, 18.0])
+    >>> avail = np.array([1000.0, 1000.0, 1000.0, 1000.0])
+    >>> cost, tonnage = blend_to_spec(grades, costs, [0.58], [0.62], avail, 1000.0)
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from mixle.relations import branch_and_bound_milp, irreducible_infeasible_subset
+
+__all__ = ["blend_to_spec", "blend_feasibility"]
+
+
+def _spec_constraints(
+    grades: np.ndarray, spec_lo: np.ndarray, spec_hi: np.ndarray, avail: np.ndarray, demand: float
+) -> tuple[np.ndarray, np.ndarray, list[tuple[float, float]]]:
+    """Build the blend-to-spec LP's ``a_ub @ w <= b_ub`` rows and per-source bounds.
+
+    Per element ``e``: the linearized head-grade window ``sum_s w_s (grades[s,e]-spec_lo[e]) >= 0``
+    and ``sum_s w_s (grades[s,e]-spec_hi[e]) <= 0`` (two rows). Then the total-tonnage equality
+    ``sum_s w_s = demand`` as a paired ``<=``/``>=`` inequality (two more rows). Bounds are
+    ``0 <= w_s <= avail[s]``. Row order is fixed so callers can map an IIS row index back to
+    "element e's lower window" / "element e's upper window" / "total tonnage".
+    """
+    n_sources, n_elements = grades.shape
+    rows: list[np.ndarray] = []
+    rhs: list[float] = []
+    for e in range(n_elements):
+        rows.append(-(grades[:, e] - spec_lo[e]))  # -> sum_s w_s (grade - lo) >= 0
+        rhs.append(0.0)
+        rows.append(grades[:, e] - spec_hi[e])  # -> sum_s w_s (grade - hi) <= 0
+        rhs.append(0.0)
+    rows.append(np.ones(n_sources))  # sum_s w_s <= demand
+    rhs.append(float(demand))
+    rows.append(-np.ones(n_sources))  # -sum_s w_s <= -demand  (together: sum_s w_s == demand)
+    rhs.append(float(-demand))
+    a_ub = np.array(rows, dtype=np.float64)
+    b_ub = np.array(rhs, dtype=np.float64)
+    bounds = [(0.0, float(avail[s])) for s in range(n_sources)]
+    return a_ub, b_ub, bounds
+
+
+def _min_parcel_gates(
+    a_ub: np.ndarray, b_ub: np.ndarray, bounds: list[tuple[float, float]], avail: np.ndarray, min_parcel: float
+) -> tuple[np.ndarray, np.ndarray, list[tuple[float, float]], list[int]]:
+    """Extend the LP with binary draw gates ``z_s`` for a minimum-parcel (discrete stockpile draw) floor.
+
+    The big-M indicator pattern from :func:`mixle.relations.cardinality_constrained_milp`: appends one
+    binary ``z_s`` per source and the rows ``w_s <= avail_s z_s`` / ``w_s >= min_parcel z_s``, so
+    ``z_s = 0`` forces ``w_s = 0`` and ``z_s = 1`` forces ``w_s`` into ``[min_parcel, avail_s]`` --
+    either no draw at all or a discrete draw above the floor, never an arbitrarily small sliver.
+    """
+    n_sources = len(bounds)
+    n_rows = a_ub.shape[0]
+    a_padded = np.hstack([a_ub, np.zeros((n_rows, n_sources))])
+    gate_rows = np.zeros((2 * n_sources, 2 * n_sources))
+    gate_rhs = np.zeros(2 * n_sources)
+    for s in range(n_sources):
+        gate_rows[2 * s, s] = 1.0  # w_s - avail_s z_s <= 0
+        gate_rows[2 * s, n_sources + s] = -float(avail[s])
+        gate_rows[2 * s + 1, s] = -1.0  # -w_s + min_parcel z_s <= 0
+        gate_rows[2 * s + 1, n_sources + s] = float(min_parcel)
+    a_ext = np.vstack([a_padded, gate_rows])
+    b_ext = np.concatenate([b_ub, gate_rhs])
+    bounds_ext = [*bounds, *([(0.0, 1.0)] * n_sources)]
+    integer_idx = list(range(n_sources, 2 * n_sources))
+    return a_ext, b_ext, bounds_ext, integer_idx
+
+
+def blend_to_spec(
+    grades: Any,
+    costs: Any,
+    spec_lo: Any,
+    spec_hi: Any,
+    avail: Any,
+    demand: float,
+    *,
+    min_parcel: float | None = None,
+) -> tuple[float, np.ndarray]:
+    """Minimum-cost blend hitting a head-grade window, drawing tonnage from several sources.
+
+    ``grades`` is ``(n_sources, n_elements)``, ``costs``/``avail`` are length ``n_sources``,
+    ``spec_lo``/``spec_hi`` are length ``n_elements``. The blend must total ``demand`` tons and, for
+    every element ``e``, ``spec_lo[e] <= blended_grade[e] <= spec_hi[e]``. Solved as an LP by default
+    (``branch_and_bound_milp`` with no integer variables -> the HiGHS relaxation); pass
+    ``min_parcel`` to additionally require that any source actually drawn from contributes at least
+    that many tons (a discrete stockpile-draw floor), which turns it into a MILP.
+
+    Returns ``(min blend cost, per-source tonnage)``. Raises :class:`ValueError` -- naming the
+    conflicting constraint rows from :func:`mixle.relations.irreducible_infeasible_subset` -- when no
+    blend of the given sources can meet the spec window at the requested tonnage.
+    """
+    grades = np.asarray(grades, dtype=np.float64)
+    costs = np.asarray(costs, dtype=np.float64)
+    spec_lo = np.asarray(spec_lo, dtype=np.float64)
+    spec_hi = np.asarray(spec_hi, dtype=np.float64)
+    avail = np.asarray(avail, dtype=np.float64)
+    n_sources = grades.shape[0]
+
+    a_ub, b_ub, bounds = _spec_constraints(grades, spec_lo, spec_hi, avail, demand)
+    if min_parcel is None:
+        res = branch_and_bound_milp(costs, a_ub, b_ub, integer=[], bounds=bounds, sense="min")
+    else:
+        a_ext, b_ext, bounds_ext, integer_idx = _min_parcel_gates(a_ub, b_ub, bounds, avail, min_parcel)
+        c_ext = np.concatenate([costs, np.zeros(n_sources)])
+        res = branch_and_bound_milp(c_ext, a_ext, b_ext, integer=integer_idx, bounds=bounds_ext, sense="min")
+
+    if res is None:
+        iis = irreducible_infeasible_subset(a_ub, b_ub, bounds)
+        raise ValueError(
+            f"blend_to_spec: no blend of these sources meets the spec window at demand={demand}; "
+            f"infeasible constraint rows (element lower/upper windows, then total-tonnage): {iis}"
+        )
+    value, x = res
+    return float(value), np.asarray(x[:n_sources], dtype=np.float64)
+
+
+def blend_feasibility(grades: Any, spec_lo: Any, spec_hi: Any, avail: Any, demand: float) -> list[int] | None:
+    """Whether some blend of the sources can meet the spec window at ``demand`` tons, cost aside.
+
+    Returns ``None`` when feasible. Otherwise returns the row indices of an irreducible infeasible
+    subset (:func:`mixle.relations.irreducible_infeasible_subset`) of the linearized spec-window /
+    total-tonnage system -- the minimal set of conflicting constraints, i.e. which element's window
+    (and whether its floor or ceiling) cannot be reached given the sources on hand.
+    """
+    grades = np.asarray(grades, dtype=np.float64)
+    spec_lo = np.asarray(spec_lo, dtype=np.float64)
+    spec_hi = np.asarray(spec_hi, dtype=np.float64)
+    avail = np.asarray(avail, dtype=np.float64)
+    a_ub, b_ub, bounds = _spec_constraints(grades, spec_lo, spec_hi, avail, demand)
+    return irreducible_infeasible_subset(a_ub, b_ub, bounds)

--- a/mixle/tests/test_h2_blending.py
+++ b/mixle/tests/test_h2_blending.py
@@ -1,0 +1,116 @@
+"""Ore blending & grade control (H2): blend-to-spec LP/MILP + IIS feasibility diagnostics."""
+
+from __future__ import annotations
+
+import numpy as np
+from scipy.optimize import linprog
+
+from mixle.blending import blend_feasibility, blend_to_spec
+
+
+def _reference_blend_cost(grades, costs, spec_lo, spec_hi, avail, demand):
+    """Hand-built `linprog` reference for the single-element blend-to-spec LP.
+
+    Independent of `mixle.blending`'s constraint assembly: minimizes `costs @ x` subject to the
+    linearized head-grade window, the total-tonnage equality, and per-source availability bounds.
+    """
+    grades = np.asarray(grades, dtype=np.float64)
+    costs = np.asarray(costs, dtype=np.float64)
+    s = grades.shape[0]
+    a_ub = np.array(
+        [
+            -(grades[:, 0] - spec_lo[0]),  # sum_s x_s (grade_s - lo) >= 0
+            grades[:, 0] - spec_hi[0],  # sum_s x_s (grade_s - hi) <= 0
+        ]
+    )
+    b_ub = np.array([0.0, 0.0])
+    a_eq = np.ones((1, s))
+    b_eq = np.array([demand])
+    bounds = [(0.0, float(a)) for a in avail]
+    res = linprog(costs, A_ub=a_ub, b_ub=b_ub, A_eq=a_eq, b_eq=b_eq, bounds=bounds, method="highs")
+    assert res.success
+    return float(res.fun), res.x
+
+
+def test_blend_to_spec_matches_reference_lp():
+    # 4 stockpiles, single element (Fe fraction). Cheap sources are low-grade, expensive ones high-grade,
+    # so the min-cost blend must trade off grade against cost while sitting inside [0.58, 0.62].
+    grades = np.array([[0.50], [0.55], [0.65], [0.70]])
+    costs = np.array([10.0, 12.0, 15.0, 18.0])
+    avail = np.array([1000.0, 1000.0, 1000.0, 1000.0])
+    spec_lo = np.array([0.58])
+    spec_hi = np.array([0.62])
+    demand = 1000.0
+
+    ref_cost, ref_x = _reference_blend_cost(grades, costs, spec_lo, spec_hi, avail, demand)
+    cost, tonnage = blend_to_spec(grades, costs, spec_lo, spec_hi, avail, demand)
+
+    assert np.isclose(cost, ref_cost, atol=1e-6, rtol=1e-6)
+    assert np.isclose(cost, np.dot(costs, ref_x), atol=1e-6, rtol=1e-6)
+    assert tonnage.shape == (4,)
+    assert np.isclose(tonnage.sum(), demand, atol=1e-6)
+    assert np.all(tonnage >= -1e-9)
+    assert np.all(tonnage <= avail + 1e-9)
+    blended_grade = np.dot(tonnage, grades[:, 0]) / tonnage.sum()
+    assert spec_lo[0] - 1e-6 <= blended_grade <= spec_hi[0] + 1e-6
+
+
+def test_blend_feasibility_infeasible_returns_iis():
+    # Every source is below the required floor -- no blend can reach spec_lo, regardless of weights.
+    grades = np.array([[0.40], [0.45], [0.48], [0.50]])
+    avail = np.array([1000.0, 1000.0, 1000.0, 1000.0])
+    spec_lo = np.array([0.58])
+    spec_hi = np.array([0.62])
+    demand = 1000.0
+
+    iis = blend_feasibility(grades, spec_lo, spec_hi, avail, demand)
+
+    assert iis is not None
+    assert len(iis) > 0
+    assert all(isinstance(i, (int, np.integer)) for i in iis)
+
+
+def test_blend_feasibility_feasible_returns_none():
+    grades = np.array([[0.50], [0.55], [0.65], [0.70]])
+    avail = np.array([1000.0, 1000.0, 1000.0, 1000.0])
+    spec_lo = np.array([0.58])
+    spec_hi = np.array([0.62])
+    demand = 1000.0
+
+    assert blend_feasibility(grades, spec_lo, spec_hi, avail, demand) is None
+
+
+def test_blend_to_spec_min_parcel_gates_small_draws():
+    # With a minimum-parcel gate, any source actually drawn from must contribute at least `min_parcel`
+    # tons -- either 0 or a discrete draw above the floor, never a small continuous sliver.
+    grades = np.array([[0.50], [0.55], [0.65], [0.70]])
+    costs = np.array([10.0, 12.0, 15.0, 18.0])
+    avail = np.array([1000.0, 1000.0, 1000.0, 1000.0])
+    spec_lo = np.array([0.58])
+    spec_hi = np.array([0.62])
+    demand = 1000.0
+
+    cost, tonnage = blend_to_spec(grades, costs, spec_lo, spec_hi, avail, demand, min_parcel=50.0)
+
+    assert np.isclose(tonnage.sum(), demand, atol=1e-6)
+    for w in tonnage:
+        assert w <= 1e-6 or w >= 50.0 - 1e-6
+    blended_grade = np.dot(tonnage, grades[:, 0]) / tonnage.sum()
+    assert spec_lo[0] - 1e-6 <= blended_grade <= spec_hi[0] + 1e-6
+    assert cost >= np.dot(costs, tonnage) - 1e-6
+
+
+def test_blend_to_spec_infeasible_raises_with_iis_context():
+    grades = np.array([[0.40], [0.45], [0.48], [0.50]])
+    costs = np.array([10.0, 12.0, 15.0, 18.0])
+    avail = np.array([1000.0, 1000.0, 1000.0, 1000.0])
+    spec_lo = np.array([0.58])
+    spec_hi = np.array([0.62])
+    demand = 1000.0
+
+    try:
+        blend_to_spec(grades, costs, spec_lo, spec_hi, avail, demand)
+    except ValueError as exc:
+        assert "infeasible" in str(exc).lower()
+    else:
+        raise AssertionError("expected blend_to_spec to raise on an unmeetable spec window")


### PR DESCRIPTION
## Worklist item

**Item:** H2

From notes/exploration-e2e-work-plan.md (the post-0.7 capability-expansion worklist, commissioned directly by the maintainer) and notes/exec/workstream-H.md — not the original 0.8.0 stability worklist; this is new, explicitly authorized capability work.

## Summary

Adds `mixle/blending.py` (new module):

- `blend_to_spec(grades, costs, spec_lo, spec_hi, avail, demand, *, min_parcel=None) -> (cost, tonnage)` — minimum-cost blend of several sources that hits a per-element head-grade window at a fixed total tonnage. Fixing total blended tonnage to `demand` linearizes the otherwise-fractional grade-ratio constraint into two linear inequalities per element, solved as an LP via the existing `branch_and_bound_milp` (HiGHS relaxation, `integer=[]`). Passing `min_parcel` adds binary draw gates per source (the same big-M pattern `cardinality_constrained_milp` already uses) so a source is either untouched or drawn from in a real discrete parcel, turning it into a MILP.
- `blend_feasibility(grades, spec_lo, spec_hi, avail, demand) -> list[int] | None` — runs the same constraint system through the existing `irreducible_infeasible_subset` and returns the conflicting row indices (which element's window, upper or lower, is unmeetable) instead of a bare infeasibility flag.

Only reads frozen surfaces (`mixle.relations.branch_and_bound_milp`, `mixle.relations.irreducible_infeasible_subset`); no edits to `relations.py` or `mixle/doe/mixture.py`.

## Public API impact

- [x] It changes the public surface, and I regenerated the manifest (`python scripts/gen_api_manifest.py`) and committed `api_manifest.json`.

Ran the generator; it produced **no diff**. `mixle/blending.py` is a new top-level module (like `mixle/relations.py` itself), not a package `__init__.py` — the manifest generator's declared scope is `pkg_root.rglob("__init__.py")`, so top-level modules' `__all__` are outside its tracked surface by design (same treatment `relations.py` already gets). Noting this explicitly rather than silently checking the "no impact" box, since the module does add two new public functions.

## Claims impact

- [x] No public claim (README, docs, benchmarks) is affected.

## Evidence

DoD command (worked from the isolated worktree, venv-pinned per the repo's own env-pin convention — bare `python`/`PYTHONPATH=.../mixle/mixle` resolves to a stale editable install, not this worktree):

```
PYTHONPATH=/tmp/mixle-exec/mixle-h2/mixle /Users/grantboquet/mixle/.venv/bin/python -m pytest mixle/tests/test_h2_blending.py -q
5 passed in 129.35s
```

Broader regression check (existing `relations.py`/`doe` suites, unmodified):

```
PYTHONPATH=/tmp/mixle-exec/mixle-h2/mixle /Users/grantboquet/mixle/.venv/bin/python -m pytest mixle/tests/relations_test.py mixle/tests/relation_sample_test.py mixle/doe -q
24 passed in 48.57s
```

`ruff format` / `ruff check` on the two changed files: clean, no changes needed.

## Checklist

- [x] Tests added/updated and passing; `ruff check` + `ruff format --check` clean.
- [x] Consumer suites for any edited module pass. (No existing module edited; ran `relations`/`doe` suites anyway since the new module imports from them.)
- [x] I am not merging this PR myself, and I have not enabled auto-merge.

## Notes

- `blend_to_spec` raises `ValueError` (naming the IIS row indices) on an infeasible spec window, since its return type (`tuple[float, np.ndarray]`) can't represent infeasibility; `blend_feasibility` is the dedicated `list[int] | None` surface for that check. The work order didn't pin down `blend_to_spec`'s infeasible-case behavior explicitly, so this is the judgment call made.
- The work order's header lists `Uses contracts: [IC-9]`, but the section's own Algorithm/Public API don't call `min_cost_flow`/`multicommodity_flow`/`network_design` (H1's IC-9 fill-ins) — `blend_to_spec`/`blend_feasibility` only need `branch_and_bound_milp` and `irreducible_infeasible_subset`, which already exist in `relations.py` today (not part of H1's stubs). Built strictly against the Files/Public API/Algorithm text, which is authoritative per the work order.
- H1 (min-cost/multicommodity flow, same repo) has not landed on `release/0.8.0` yet as of this PR; not a blocker since H2 doesn't consume those symbols.