### PR TITLE
E2: registrable field-posterior kind for the local model registry

### DIFF
--- a/mixle/reason/posterior_protocol.py
+++ b/mixle/reason/posterior_protocol.py
@@ -1,0 +1,59 @@
+"""IC-1 -- the shared `Posterior` protocol (frozen; work-plan Sec.5).
+
+The single subsurface-posterior type both a core `mixle` distribution and a `mixle_pde` field posterior satisfy, so
+the spine (E1-E11), the stochastic optimizer (H4), and the valuation (J2) all consume one structural type. `samples`
+is a METHOD returning an ``(n, d)`` draw matrix (NOTE the plural -- `mixle_pde.latent.PosteriorField3D.sample` is
+singular today; E1 adds the plural alias). `cov` returns a dense array for small problems or a `LinearOperator` for
+survey-scale ones (never materialised -- work-plan Sec.C2). `derived_quantity` maps a pushforward ``fn`` over posterior
+draws into a `DerivedQuantity` that carries the samples, a credible interval, AND the honesty flag `prior_dominated`
+(work-plan A2): a driller-facing number is never emitted without it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Protocol, runtime_checkable
+
+import numpy as np
+from scipy.sparse.linalg import LinearOperator
+
+
+@runtime_checkable
+class DerivedQuantity(Protocol):
+    """A pushforward of the posterior through a functional: draws + interval + the prior-dominated honesty flag."""
+
+    samples: np.ndarray  # (n,) or (n, k) draws of the derived quantity, physical units
+    prior_dominated: bool  # True when the regulariser, not the data, sets the width (work-plan A2)
+
+    def credible_interval(self, level: float) -> tuple[np.ndarray, np.ndarray]:
+        """Central ``level`` interval (e.g. 0.9) of the derived quantity."""
+        ...
+
+
+@runtime_checkable
+class Posterior(Protocol):
+    """The frozen subsurface-posterior protocol. Signatures are fixed; only implementations vary."""
+
+    def samples(self, n: int, rng: np.random.Generator) -> np.ndarray:
+        """Draw ``n`` samples in physical units; shape ``(n, d)``."""
+        ...
+
+    @property
+    def mean(self) -> np.ndarray:
+        """Posterior mean, shape ``(d,)``, physical units."""
+        ...
+
+    @property
+    def cov(self) -> np.ndarray | LinearOperator:
+        """Covariance: a dense ``(d, d)`` array, or a matrix-free ``LinearOperator`` at survey scale."""
+        ...
+
+    def credible_interval(self, level: float) -> tuple[np.ndarray, np.ndarray]:
+        """Per-component central credible interval covering ``level`` mass; ``(lo, hi)`` each shape ``(d,)``."""
+        ...
+
+    def derived_quantity(
+        self, fn: Callable[[np.ndarray], np.ndarray], n: int, rng: np.random.Generator
+    ) -> DerivedQuantity:
+        """Pushforward ``fn`` over ``n`` posterior draws into a `DerivedQuantity` (samples + CI + prior_dominated)."""
+        ...

--- a/mixle/registry.py
+++ b/mixle/registry.py
@@ -3,12 +3,14 @@
 The registry is the local library catalog that orchestrators, routers, capture
 flows, and accumulation workflows can read from or write into. Deliberately a
 directory plus a JSON index, not a server: every entry is a saved
-:class:`~mixle.task.model.TaskModel` or :class:`~mixle.task.calibrate.CalibratedTaskModel` artifact directory
-(see :mod:`mixle.task.artifact`) plus a small index record naming its capabilities, task fingerprint
-(:func:`~mixle.task.edge.task_fingerprint`), and capture profile. ``find_for`` answers "do I already have
-something for this task"; ``tier_stack`` turns a matching capability into an ascending-cost tier list -- the
-shape :class:`~mixle.task.router.Router` consumes directly (``Router(tiers=stack)``), with the frontier
-appended last as the router's own fallback tier.
+:class:`~mixle.task.model.TaskModel`, :class:`~mixle.task.calibrate.CalibratedTaskModel`, or an IC-1
+``Posterior``-conforming field-posterior artifact directory (see :mod:`mixle.task.artifact` for the
+first two; the third is written/read through ``mixle_pde.io.artifacts`` -- IC-2 -- lazily imported so
+this module never hard-depends on the ``mixle_pde`` plugin). A small index record names each entry's
+capabilities, task fingerprint (:func:`~mixle.task.edge.task_fingerprint`), and capture profile.
+``find_for`` answers "do I already have something for this task"; ``tier_stack`` turns a matching
+capability into an ascending-cost tier list -- the shape :class:`~mixle.task.router.Router` consumes
+directly (``Router(tiers=stack)``), with the frontier appended last as the router's own fallback tier.
 """
 
 from __future__ import annotations
@@ -27,13 +29,58 @@ from mixle.task.model import TaskModel
 _INDEX_NAME = "index.json"
 
 
+def _is_field_posterior(model: Any) -> bool:
+    """True when ``model`` is a ``mixle_pde`` field posterior (the "field_posterior" `Registry` kind, IC-2).
+
+    Checks the concrete ``mixle_pde.latent.PosteriorField3D`` type rather than the abstract IC-1
+    ``Posterior`` protocol so this keeps working whether or not the field posterior has picked up the
+    ``samples``-method rename the protocol freezes -- this module only cares which artifact I/O to call,
+    not full protocol conformance. Returns ``False`` (never raises) when ``mixle_pde`` isn't installed, so
+    a bare `mixle` checkout never fails ``isinstance``/``TypeError`` dispatch for a class it can't see.
+    """
+    try:
+        from mixle_pde.latent import PosteriorField3D
+    except ImportError:
+        return False
+    return isinstance(model, PosteriorField3D)
+
+
+def _save_field_posterior(model: Any, path: str) -> None:
+    """Delegate to ``mixle_pde.io.artifacts.save_posterior`` (IC-2), imported lazily.
+
+    ``mixle_pde`` depends on ``mixle``, never the reverse (see ``mixle_pde``'s package docstring), so this
+    module never imports it at module scope -- only here, when a caller actually registers a field
+    posterior.
+    """
+    try:
+        from mixle_pde.io.artifacts import save_posterior
+    except ImportError as exc:
+        raise ImportError(
+            "registering a field_posterior kind requires the mixle_pde package "
+            "(install mixle_pde, or add its checkout to PYTHONPATH)"
+        ) from exc
+    save_posterior(model, path)
+
+
+def _load_field_posterior(path: str) -> Any:
+    """Delegate to ``mixle_pde.io.artifacts.load_posterior`` (IC-2), imported lazily (see `_save_field_posterior`)."""
+    try:
+        from mixle_pde.io.artifacts import load_posterior
+    except ImportError as exc:
+        raise ImportError(
+            "loading a field_posterior kind requires the mixle_pde package "
+            "(install mixle_pde, or add its checkout to PYTHONPATH)"
+        ) from exc
+    return load_posterior(path)
+
+
 @dataclass
 class RegistryEntry:
     """One catalog record: where the artifact lives, what it's registered under, and how much it costs to run."""
 
     entry_id: str
     path: str
-    kind: str  # "task" or "calibrated" -- which class reloads the artifact at ``path``
+    kind: str  # "task", "calibrated", or "field_posterior" -- which loader reloads the artifact at ``path``
     capabilities: list[str] = field(default_factory=list)
     fingerprint: list[float] | None = None
     profile: dict[str, Any] = field(default_factory=dict)
@@ -89,7 +136,7 @@ class Registry:
 
     def register(
         self,
-        model: TaskModel | CalibratedTaskModel,
+        model: TaskModel | CalibratedTaskModel | Any,
         *,
         capabilities: Sequence[str],
         fingerprint: Sequence[float] | None = None,
@@ -99,10 +146,11 @@ class Registry:
     ) -> RegistryEntry:
         """Save ``model``'s artifact under ``dir`` and add its index entry; return the entry.
 
-        ``model`` is a fitted :class:`~mixle.task.model.TaskModel` or
-        :class:`~mixle.task.calibrate.CalibratedTaskModel` -- the two artifact-saveable task model kinds.
-        ``capabilities`` names what this model answers (matched by :meth:`find_for`); ``fingerprint`` is
-        typically :func:`~mixle.task.edge.task_fingerprint`'s vector for the training data; ``profile`` is
+        ``model`` is a fitted :class:`~mixle.task.model.TaskModel`, a
+        :class:`~mixle.task.calibrate.CalibratedTaskModel`, or a ``mixle_pde`` field posterior (a
+        "field_posterior" kind, IC-2) -- the three artifact-saveable model kinds. ``capabilities`` names
+        what this model answers (matched by :meth:`find_for`); ``fingerprint`` is typically
+        :func:`~mixle.task.edge.task_fingerprint`'s vector for the training data; ``profile`` is
         free-form (e.g. a :func:`~mixle.task.capability.capture_profile` dict); ``cost`` is the per-request
         cost used to order :meth:`tier_stack`. An explicit ``entry_id`` that already exists (in the index
         or as an artifact directory) raises rather than duplicating the index row and silently
@@ -112,8 +160,12 @@ class Registry:
             kind = "calibrated"
         elif isinstance(model, TaskModel):
             kind = "task"
+        elif _is_field_posterior(model):
+            kind = "field_posterior"
         else:
-            raise TypeError(f"Registry only stores TaskModel/CalibratedTaskModel, got {type(model)!r}")
+            raise TypeError(
+                f"Registry only stores TaskModel/CalibratedTaskModel/field-posterior artifacts, got {type(model)!r}"
+            )
         taken = {e.entry_id for e in self._entries}
         if entry_id is not None:
             if entry_id in taken or os.path.exists(os.path.join(self.dir, entry_id)):
@@ -126,7 +178,10 @@ class Registry:
                 i += 1
             entry_id = f"entry_{i:04d}"
         path = os.path.join(self.dir, entry_id)
-        model.save(path)
+        if kind == "field_posterior":
+            _save_field_posterior(model, path)
+        else:
+            model.save(path)
         entry = RegistryEntry(
             entry_id=entry_id,
             path=path,
@@ -140,9 +195,11 @@ class Registry:
         self._write_index()
         return entry
 
-    def load(self, entry_id: str) -> TaskModel | CalibratedTaskModel:
+    def load(self, entry_id: str) -> TaskModel | CalibratedTaskModel | Any:
         """Reload a registered model by ``entry_id`` (round-trips through the artifact on disk)."""
         entry = self._get(entry_id)
+        if entry.kind == "field_posterior":
+            return _load_field_posterior(entry.path)
         cls = CalibratedTaskModel if entry.kind == "calibrated" else TaskModel
         return cls.load(entry.path)
 

--- a/mixle/tests/posterior_protocol_test.py
+++ b/mixle/tests/posterior_protocol_test.py
@@ -1,0 +1,59 @@
+"""IC-1 -- the shared `Posterior` protocol (frozen conformance check; work-plan Sec.5).
+
+Named with the repo's own `*_test.py` suffix convention (``pyproject.toml``'s
+``[tool.pytest.ini_options] python_files``), not the ``test_*.py`` prefix contracts.md's copy-paste
+stub illustrates -- content is otherwise the frozen conformance test verbatim.
+"""
+
+import inspect
+
+import numpy as np
+
+from mixle.reason.posterior_protocol import DerivedQuantity, Posterior
+
+
+class _DQ:
+    def __init__(self, s):
+        self.samples = np.asarray(s, float)
+        self.prior_dominated = False
+
+    def credible_interval(self, level):
+        a = (1.0 - level) / 2.0
+        return np.quantile(self.samples, a, 0), np.quantile(self.samples, 1 - a, 0)
+
+
+class _Conforming:
+    def samples(self, n, rng):
+        return rng.standard_normal((n, 3))
+
+    @property
+    def mean(self):
+        return np.zeros(3)
+
+    @property
+    def cov(self):
+        return np.eye(3)
+
+    def credible_interval(self, level):
+        return -np.ones(3), np.ones(3)
+
+    def derived_quantity(self, fn, n, rng):
+        return _DQ(fn(self.samples(n, rng)))
+
+
+def test_protocols_are_runtime_checkable():
+    assert isinstance(_Conforming(), Posterior)
+    assert isinstance(_DQ([1.0, 2.0]), DerivedQuantity)
+
+
+def test_frozen_signatures():
+    assert list(inspect.signature(Posterior.samples).parameters) == ["self", "n", "rng"]
+    assert list(inspect.signature(Posterior.credible_interval).parameters) == ["self", "level"]
+    assert list(inspect.signature(Posterior.derived_quantity).parameters) == ["self", "fn", "n", "rng"]
+
+
+def test_derived_quantity_carries_flag_and_interval():
+    p = _Conforming()
+    dq = p.derived_quantity(lambda m: m.sum(1), 128, np.random.default_rng(0))
+    lo, hi = dq.credible_interval(0.9)
+    assert dq.prior_dominated is False and np.all(lo <= hi)


### PR DESCRIPTION
## Summary

Companion to gmboquet/mixle-pde#TBD (the E2 work order's primary deliverable). A fitted field posterior
had no way into the local model `Registry` alongside the existing `TaskModel`/`CalibratedTaskModel`
kinds, so this teaches `Registry.register`/`Registry.load` a third `"field_posterior"` kind that
dispatches to `mixle_pde.io.artifacts.save_posterior`/`load_posterior` (IC-2), imported lazily inside the
two call sites so `mixle.registry` keeps zero import-time dependency on the `mixle_pde` plugin
(`mixle_pde` depends on `mixle`, never the reverse). A bare `mixle` checkout with no `mixle_pde` on the
path still works fine for the task/calibrated kinds and only raises a clear `ImportError` if something
actually tries to register/load a field posterior without `mixle_pde` installed.

Also lands `mixle/reason/posterior_protocol.py` -- the frozen IC-1 `Posterior`/`DerivedQuantity`
protocol. It hadn't actually landed on `release/0.8.0` despite being a Wave-0 prerequisite several
workstream-E tasks (this one included) type against; `mixle_pde.io.artifacts` imports it directly, and
without it this PR's companion mixle-pde change can't import. (PR #446, already open, lands the
identical file for the same reason from the E5 side -- the two should merge cleanly since the content is
copied verbatim from the same frozen contract text; whichever lands first, the other is a no-op add.)

## Why

The E2 work order ("PDE artifact I/O + registrable model kind") spans two repos by design: the artifact
I/O lives in mixle-pde, but the shared local catalog (`Registry`) lives here. Without this half, a saved
field posterior has a working on-disk artifact but no way to show up in the same registry orchestrators
and routers already query for task/calibrated models.

## Test plan

- `PYTHONPATH=<this-worktree>:<mixle-pde-worktree> python -m pytest mixle/tests/registry_test.py mixle/tests/posterior_protocol_test.py mixle/tests/dpo_and_registry_hardening_test.py mixle/tests/maturity_registry_test.py -q` -- 20 passed.
- The mixle-pde-side DoD (`test_e2_artifacts.py`, including `test_registry_register_then_load_round_trips`) passes against this branch -- see the companion PR for the exact command and result.
- `ruff format` / `ruff check` clean on `mixle/registry.py`, `mixle/reason/posterior_protocol.py`, `mixle/tests/posterior_protocol_test.py`.

## Notes

- `mixle/reason/posterior_protocol.py` should have landed as a standalone Wave-0 stub PR per
  `notes/exec/contracts.md`'s ownership table but hadn't reached `release/0.8.0`; re-landing it here
  (copied verbatim from the frozen contract text, identical to PR #446's copy) is the pragmatic
  unblock rather than redesigning anything.
- The registry's `_is_field_posterior` check dispatches on the concrete `mixle_pde.latent.PosteriorField3D`
  type rather than `isinstance(model, Posterior)` (the abstract IC-1 protocol), so it doesn't depend on
  whichever Wave-1 task (E1) lands the `.samples()` plural-method rename that full protocol conformance
  needs -- this module only needs to know which artifact I/O to call.