### PR TITLE
H4: Stochastic / robust optimization under grade uncertainty  ⚗

### DIFF
--- a/mixle/stochastic_opt.py
+++ b/mixle/stochastic_opt.py
@@ -1,0 +1,150 @@
+"""H4 — stochastic / robust optimization under grade uncertainty (work-plan §7-H).
+
+Bridges a calibrated grade `Posterior` (IC-1, `.samples(n, rng)`) into a single-period ore/waste
+extraction decision. Rather than optimizing against one point-estimate grade, `two_stage_stochastic_plan`
+draws `k_scenarios` grade realizations and solves a two-stage scenario program: one shared first-stage
+extraction decision `x_b in {0, 1}` per block, with per-scenario recourse value
+``v_k(x) = sum_b x_b * (price * g[k, b] - block_cost[b])``. The objective trades expected value against
+downside risk via ``CVaR_alpha(-v_k(x))`` (Rockafellar–Uryasev), so a block whose *average* grade looks
+profitable but whose scenario-conditional downside is large (grade uncertainty / ore-waste
+misclassification risk) is priced correctly instead of naively included on its mean alone.
+
+`cvar_epigraph` is the reusable LP-representable epigraph of CVaR: given ``losses[k] = L_k(x)`` as a
+linear map of the (as yet undetermined) decision vector — an ``(K, n)`` coefficient matrix, not realized
+numbers — it emits the extra ``eta`` (Value-at-Risk) / ``u_k`` (excess-loss) variable block plus the
+``a_ub`` rows enforcing ``u_k >= L_k(x) - eta``, ``u_k >= 0``, ready to be concatenated onto any existing
+MILP built on :func:`mixle.relations.branch_and_bound_milp`.
+
+Repo-boundary note (see the PR body for the full explanation): H1 (`min_cost_flow` et al., IC-9) and H3
+(`mixle.mine_planning`) had not landed on ``release/0.8.0`` as of this PR. Neither this task's frozen
+Public API nor its Algorithm section actually calls into either module directly — the scenario program
+here is built entirely on the already-landed :mod:`mixle.reason.posterior_protocol` (IC-1) and
+:func:`mixle.relations.branch_and_bound_milp` — so this module imports neither `mixle.relations`' new
+flow surface nor `mixle.mine_planning`.
+"""
+
+from __future__ import annotations
+
+from typing import Any, NamedTuple
+
+import numpy as np
+
+from mixle.reason.posterior_protocol import Posterior
+from mixle.relations import branch_and_bound_milp
+
+__all__ = ["StochasticPlan", "cvar_epigraph", "two_stage_stochastic_plan"]
+
+# Risk-aversion weight lambda in ``maximize E[v] - _CVAR_LAMBDA * CVaR_alpha(-v)`` (work-plan §7-H step
+# 3). Not exposed on the frozen public signature (only posterior/block_cost/price/k_scenarios/alpha/rng
+# are); fixed at 1.0 so the expected-value term and the CVaR term are weighted equally by default.
+_CVAR_LAMBDA = 1.0
+
+
+class StochasticPlan(NamedTuple):
+    """A two-stage scenario-optimal extraction plan: which blocks, and its risk profile.
+
+    ``extract`` is the boolean per-block decision; ``expected_value`` is ``E_k[v_k(extract)]`` over the
+    scenarios the plan was optimized against; ``cvar`` is ``CVaR_alpha(-v_k(extract))`` (a more negative
+    value is safer — the tail is still profitable; a less negative or positive value is riskier);
+    ``scenarios`` is the raw ``(K, n_blocks)`` grade draws used for planning.
+    """
+
+    extract: np.ndarray
+    expected_value: float
+    cvar: float
+    scenarios: np.ndarray
+
+
+def cvar_epigraph(losses: Any, alpha: float) -> tuple[np.ndarray, np.ndarray, np.ndarray, int]:
+    """Rockafellar–Uryasev LP epigraph of ``CVaR_alpha`` for a loss that is *linear in the decision*.
+
+    ``losses`` is a ``(K, n)`` matrix such that scenario ``k``'s loss is ``losses[k] @ x`` for the
+    not-yet-fixed length-``n`` decision vector ``x`` — e.g. ``losses[k, b] = -(price * g[k, b] -
+    block_cost[b])``, the negated per-scenario recourse value. Returns the pieces of::
+
+        CVaR_alpha(L(x)) = min_{eta, u >= 0}  eta + (1 / ((1 - alpha) * K)) * sum_k u_k
+                            s.t.  u_k >= losses[k] @ x - eta
+
+    embeddable alongside any existing constraints/variables on ``x``:
+
+    - ``c_add``: length ``n + 1 + K`` objective row over ``[x, eta, u]`` giving the CVaR value itself
+      (``eta``'s coefficient is 1, each ``u_k``'s coefficient is ``1 / ((1 - alpha) * K)``, zero on
+      ``x``) — combine with an expected-value objective as ``c_ev_padded - lam * c_add`` for a
+      ``sense="max"`` solve of ``E[v] - lam * CVaR_alpha(-v)``.
+    - ``a_ub_rows``: ``(K, n + 1 + K)`` rows encoding ``losses[k] @ x - eta - u_k <= 0``.
+    - ``b_ub``: length-``K`` zeros, the right-hand side of ``a_ub_rows``.
+    - ``var_index``: the column index of ``eta`` in the ``[x, eta, u]`` layout (``= n``); ``u_k`` sits
+      at ``var_index + 1 + k``. Give ``eta`` bounds ``(-inf, inf)`` and each ``u_k`` bounds ``(0, inf)``.
+    """
+    loss = np.asarray(losses, dtype=np.float64)
+    if loss.ndim != 2:
+        raise ValueError("losses must be a (K, n) matrix: scenario loss as a linear map of the decision")
+    if not (0.0 < alpha < 1.0):
+        raise ValueError("alpha must be in (0, 1)")
+    k_scenarios, n = loss.shape
+    coef = 1.0 / ((1.0 - alpha) * k_scenarios)
+    var_index = n
+    width = n + 1 + k_scenarios
+
+    c_add = np.zeros(width, dtype=np.float64)
+    c_add[var_index] = 1.0
+    c_add[var_index + 1 :] = coef
+
+    a_ub_rows = np.zeros((k_scenarios, width), dtype=np.float64)
+    a_ub_rows[:, :n] = loss
+    a_ub_rows[:, var_index] = -1.0
+    a_ub_rows[np.arange(k_scenarios), var_index + 1 + np.arange(k_scenarios)] = -1.0
+    b_ub = np.zeros(k_scenarios, dtype=np.float64)
+    return c_add, a_ub_rows, b_ub, var_index
+
+
+def two_stage_stochastic_plan(
+    posterior: Posterior,
+    block_cost: Any,
+    price: float,
+    *,
+    k_scenarios: int = 50,
+    alpha: float = 0.9,
+    rng: np.random.Generator,
+) -> StochasticPlan:
+    """Two-stage scenario program: extract blocks to maximize ``E[v] - lambda * CVaR_alpha(-v)``.
+
+    Draws ``g = posterior.samples(k_scenarios, rng)`` (IC-1) as the calibrated grade scenarios, forms
+    the per-scenario recourse value ``v_k(x) = sum_b x_b * (price * g[k, b] - block_cost[b])``, and
+    solves the joint MILP — binary ``x`` plus the free ``eta``/``u_k >= 0`` block from
+    :func:`cvar_epigraph` — via :func:`mixle.relations.branch_and_bound_milp`.
+    """
+    cost = np.asarray(block_cost, dtype=np.float64)
+    n_blocks = cost.size
+
+    g = np.asarray(posterior.samples(k_scenarios, rng), dtype=np.float64)
+    if g.shape != (k_scenarios, n_blocks):
+        raise ValueError(f"posterior.samples returned shape {g.shape}, expected {(k_scenarios, n_blocks)}")
+
+    profit = price * g - cost[None, :]  # (K, n_blocks): v_k(x) = profit[k] @ x
+    mean_profit = profit.mean(axis=0)
+    losses = -profit  # L_k(x) = -v_k(x)
+
+    c_add, a_ub_rows, b_ub, var_index = cvar_epigraph(losses, alpha)
+    width = a_ub_rows.shape[1]
+
+    c_ev = np.zeros(width, dtype=np.float64)
+    c_ev[:n_blocks] = mean_profit
+    objective = c_ev - _CVAR_LAMBDA * c_add  # maximize E[v] - lambda * CVaR(-v)
+
+    bounds = [(0.0, 1.0)] * n_blocks + [(-np.inf, np.inf)] + [(0.0, np.inf)] * k_scenarios
+    integer = list(range(n_blocks))
+
+    solved = branch_and_bound_milp(objective, a_ub_rows, b_ub, integer=integer, bounds=bounds, sense="max")
+    if solved is None:
+        raise ValueError("two_stage_stochastic_plan: MILP infeasible for the given blocks/scenarios")
+    _, x_full = solved
+
+    extract = np.round(x_full[:n_blocks]).astype(bool)
+    eta_star = float(x_full[var_index])
+    u_star = x_full[var_index + 1 :]
+    coef = 1.0 / ((1.0 - alpha) * k_scenarios)
+    cvar = eta_star + coef * float(u_star.sum())
+    expected_value = float(mean_profit @ extract.astype(np.float64))
+
+    return StochasticPlan(extract=extract, expected_value=expected_value, cvar=cvar, scenarios=g)

--- a/mixle/tests/test_h4_stochastic.py
+++ b/mixle/tests/test_h4_stochastic.py
@@ -1,0 +1,160 @@
+"""H4 DoD — stochastic / robust optimization under grade uncertainty (notes/exec/workstream-H.md).
+
+Synthetic blocks with a *known* truth grade and a posterior stub whose ``.samples`` returns noisy
+draws around it. Three groups: a few blocks that are always clearly profitable ("safe good"), a few
+that are always clearly unprofitable ("safe bad"), and one "risky" block whose baseline grade is
+mildly profitable but which carries a low-probability catastrophic grade shock (an ore/waste
+misclassification tail). The risky block's *true* mean profit (computed from the exact mixture, no
+sampling) is slightly negative — it is a true loser — but the specific fixed-seed 50-scenario draw
+used for planning happens to under-realize the shock, so a plain point-estimate/expected-value-only
+optimizer (the "deterministic-mean plan": threshold each block on the sample-mean profit of that same
+draw, no risk term) is fooled into keeping it.
+
+``two_stage_stochastic_plan``'s CVaR term looks at the *distribution* of the same 50 draws rather than
+just their average, so it excludes the risky block: on a large held-out sample drawn from the true
+generative process, this yields both a higher expected value (the risky block really was a net loser)
+and a strictly better (lower) CVaR (its excluded tail risk).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from mixle.reason.posterior_protocol import Posterior
+from mixle.stochastic_opt import StochasticPlan, cvar_epigraph, two_stage_stochastic_plan
+
+PRICE = 1.0
+N_SAFE_GOOD = 3
+N_SAFE_BAD = 3
+N_BLOCKS = N_SAFE_GOOD + N_SAFE_BAD + 1  # + one risky block
+SAFE_GOOD_GRADE = 3.0
+SAFE_BAD_GRADE = 0.3
+RISKY_MEAN = 1.06
+RISKY_STD = 0.08
+RISKY_SHOCK_PROB = 0.07
+RISKY_SHOCK_GRADE = 0.1
+
+
+class _BlockGradePosterior:
+    """A minimal IC-1 `Posterior` over per-block ore grade: three known-truth groups (good/bad/risky)."""
+
+    def samples(self, n: int, rng: np.random.Generator) -> np.ndarray:
+        out = np.zeros((n, N_BLOCKS))
+        out[:, :N_SAFE_GOOD] = SAFE_GOOD_GRADE + rng.normal(0.0, 0.02, size=(n, N_SAFE_GOOD))
+        out[:, N_SAFE_GOOD : N_SAFE_GOOD + N_SAFE_BAD] = SAFE_BAD_GRADE + rng.normal(0.0, 0.02, size=(n, N_SAFE_BAD))
+        base = RISKY_MEAN + rng.normal(0.0, RISKY_STD, size=n)
+        shocked = rng.random(n) < RISKY_SHOCK_PROB
+        out[:, -1] = np.where(shocked, RISKY_SHOCK_GRADE, base)
+        return np.clip(out, 0.0, None)
+
+    @property
+    def mean(self) -> np.ndarray:
+        m = np.zeros(N_BLOCKS)
+        m[:N_SAFE_GOOD] = SAFE_GOOD_GRADE
+        m[N_SAFE_GOOD : N_SAFE_GOOD + N_SAFE_BAD] = SAFE_BAD_GRADE
+        m[-1] = (1 - RISKY_SHOCK_PROB) * RISKY_MEAN + RISKY_SHOCK_PROB * RISKY_SHOCK_GRADE
+        return m
+
+    @property
+    def cov(self) -> np.ndarray:
+        return np.eye(N_BLOCKS)
+
+    def credible_interval(self, level: float) -> tuple[np.ndarray, np.ndarray]:
+        return self.mean - 1.0, self.mean + 1.0
+
+    def derived_quantity(self, fn, n, rng):
+        s = fn(self.samples(n, rng))
+
+        class _DQ:
+            samples = s
+            prior_dominated = False
+
+            def credible_interval(self, level):
+                a = (1.0 - level) / 2.0
+                return np.quantile(self.samples, a, axis=0), np.quantile(self.samples, 1 - a, axis=0)
+
+        return _DQ()
+
+
+def _held_out_cvar_and_ev(posterior, extract, cost, *, alpha=0.9, n_truth=200_000, seed=12345):
+    """Empirical expected value + CVaR of a fixed extraction plan on a large held-out truth sample."""
+    g_truth = posterior.samples(n_truth, np.random.default_rng(seed))
+    profit = (PRICE * g_truth - cost[None, :]) @ extract.astype(np.float64)
+    ev = float(profit.mean())
+    loss = -profit
+    n_tail = max(1, int(np.ceil((1.0 - alpha) * loss.size)))
+    cvar = float(np.sort(loss)[::-1][:n_tail].mean())
+    return ev, cvar
+
+
+def test_posterior_stub_conforms_to_ic1():
+    assert isinstance(_BlockGradePosterior(), Posterior)
+
+
+def test_stochastic_plan_shape_and_types():
+    posterior = _BlockGradePosterior()
+    cost = np.ones(N_BLOCKS)
+    plan = two_stage_stochastic_plan(posterior, cost, PRICE, k_scenarios=50, alpha=0.9, rng=np.random.default_rng(0))
+    assert isinstance(plan, StochasticPlan)
+    assert plan.extract.shape == (N_BLOCKS,)
+    assert plan.extract.dtype == np.bool_
+    assert plan.scenarios.shape == (50, N_BLOCKS)
+    assert isinstance(plan.expected_value, float)
+    assert isinstance(plan.cvar, float)
+
+
+def test_stochastic_plan_beats_deterministic_mean_plan_on_held_out_truth():
+    posterior = _BlockGradePosterior()
+    cost = np.ones(N_BLOCKS)
+
+    plan = two_stage_stochastic_plan(posterior, cost, PRICE, k_scenarios=50, alpha=0.9, rng=np.random.default_rng(0))
+
+    # Safe blocks are always correctly classified: good ones extracted, bad ones not.
+    assert bool(plan.extract[:N_SAFE_GOOD].all())
+    assert not bool(plan.extract[N_SAFE_GOOD : N_SAFE_GOOD + N_SAFE_BAD].any())
+
+    # The deterministic-mean plan: threshold each block on the sample-mean profit of the very same
+    # 50-scenario draw the stochastic plan saw, ignoring the distribution around that mean entirely.
+    sample_mean_profit = PRICE * plan.scenarios.mean(axis=0) - cost
+    det_extract = sample_mean_profit > 0.0
+
+    # The fixed-seed draw fools the naive mean-only plan into keeping the (truly losing) risky block,
+    # while the CVaR-aware plan — looking at the tail, not just the average — excludes it.
+    assert bool(det_extract[-1]) is True
+    assert bool(plan.extract[-1]) is False
+
+    ev_stochastic, cvar_stochastic = _held_out_cvar_and_ev(posterior, plan.extract, cost)
+    ev_det, cvar_det = _held_out_cvar_and_ev(posterior, det_extract, cost)
+
+    assert ev_stochastic >= ev_det - 1e-9
+    assert cvar_stochastic < cvar_det
+
+
+def test_cvar_epigraph_shapes_and_constraint():
+    rng = np.random.default_rng(1)
+    losses = rng.normal(size=(20, 4))
+    alpha = 0.9
+    c_add, a_ub_rows, b_ub, var_index = cvar_epigraph(losses, alpha)
+
+    n, k = 4, 20
+    assert var_index == n
+    assert c_add.shape == (n + 1 + k,)
+    assert a_ub_rows.shape == (k, n + 1 + k)
+    assert b_ub.shape == (k,)
+    assert c_add[var_index] == pytest.approx(1.0)
+    assert np.allclose(c_add[var_index + 1 :], 1.0 / ((1.0 - alpha) * k))
+
+    # For any x, the row for scenario m must encode losses[m] @ x - eta - u_m <= 0.
+    x = rng.normal(size=n)
+    eta = 0.3
+    u = np.maximum(0.0, losses @ x - eta)
+    full = np.concatenate([x, [eta], u])
+    assert np.all(a_ub_rows @ full <= b_ub + 1e-9)
+
+
+def test_cvar_epigraph_rejects_bad_alpha():
+    with pytest.raises(ValueError):
+        cvar_epigraph(np.zeros((3, 2)), 1.5)
+    with pytest.raises(ValueError):
+        cvar_epigraph(np.zeros((3, 2)), 0.0)


### PR DESCRIPTION
## Worklist item

**Item:** H4

## Summary

From notes/exploration-e2e-work-plan.md (the post-0.7 capability-expansion worklist, commissioned directly by the maintainer) and notes/exec/workstream-H.md — not the original 0.8.0 stability worklist; this is new, explicitly authorized capability work.

Adds `mixle/stochastic_opt.py`: a two-stage scenario program that bridges an IC-1 `Posterior`'s calibrated grade draws into a single-period ore/waste extraction decision, trading expected value against downside risk via a CVaR (Rockafellar–Uryasev) term instead of optimizing a single point-estimate grade.

- `cvar_epigraph(losses, alpha)` — the reusable LP epigraph of `CVaR_alpha` for a loss linear in a decision vector: emits the `eta`/`u_k` variable block and `a_ub` rows, ready to concatenate onto any MILP built on `mixle.relations.branch_and_bound_milp`.
- `two_stage_stochastic_plan(posterior, block_cost, price, *, k_scenarios=50, alpha=0.9, rng)` — draws `K` grade scenarios via `posterior.samples`, forms the per-scenario recourse value, and solves the joint MILP (binary extraction `x` + the CVaR epigraph) to return a `StochasticPlan(extract, expected_value, cvar, scenarios)`.

## Public API impact

- [x] It changes the public surface, and I regenerated the manifest (`python scripts/gen_api_manifest.py`) and committed `api_manifest.json`.

Note: `mixle/stochastic_opt.py` is a new module (not a package `__init__.py`), so `scripts/gen_api_manifest.py` — which only scans package `__init__.py` files with `__all__` — produced **no diff** when run (same as `mixle/relations.py`'s own `__all__` additions, which are likewise untracked by the manifest). Nothing to commit there; noted here for the record instead of checking the "no public surface change" box, since `mixle.stochastic_opt.{StochasticPlan, cvar_epigraph, two_stage_stochastic_plan}` are genuinely new importable public names.

## Claims impact

- [x] No public claim (README, docs, benchmarks) is affected.

## Evidence

```
PYTHONPATH=/Users/grantboquet/mixle/mixle python -m pytest mixle/tests/test_h4_stochastic.py -q
-> 5 passed

PYTHONPATH=/Users/grantboquet/mixle/mixle python -m pytest mixle/tests/relations_test.py mixle/tests/relation_sample_test.py mixle/tests/posterior_protocol_test.py -q
-> 24 + 3 passed (no regressions in the relations/posterior surfaces this module builds on)

ruff format --check + ruff check mixle/stochastic_opt.py mixle/tests/test_h4_stochastic.py -> clean
```

## Notes (judgment calls)

- **H1/H3 not yet on `release/0.8.0`.** At this branch point neither H1's `min_cost_flow`/`multicommodity_flow`/`network_design` (IC-9 fill-in) nor H3's `mixle/mine_planning.py` had landed. Re-reading H4's own frozen Public API and Algorithm text, neither is actually called: the algorithm only needs the IC-1 `Posterior.samples` contract (already landed) and `mixle.relations.branch_and_bound_milp` (already present pre-H1). So this module imports neither the new flow surface nor `mine_planning`, and the DoD test builds its own synthetic blocks rather than depending on H3's block model.
- **CVaR weight `lambda` is not on the frozen signature.** The Algorithm section's objective `E[v] - λ·CVaR_α(-v)` doesn't expose `λ` as a parameter of `two_stage_stochastic_plan` (only `k_scenarios`/`alpha`/`rng` are frozen). Fixed it as an internal module constant `_CVAR_LAMBDA = 1.0` (documented in the module docstring) rather than silently dropping the risk term or inventing an extra kwarg not in the contract.
- **`cvar_epigraph`'s `losses` argument is a coefficient matrix, not realized numbers.** Since CVaR has to be embedded in the same MILP as the (not-yet-solved) decision `x`, `losses` is the `(K, n)` linear map `L_k(x) = losses[k] @ x`, not a vector of already-computed scalar losses — documented explicitly in the docstring since the work-order text is compatible with either reading.
- **DoD test design.** Built three block groups (always-profitable, always-unprofitable, and one "risky" block with a low-probability correlated grade shock whose true mean profit is negative but whose fixed-seed 50-draw sample mean is fooled positive) so the assertions are exact and reproducible under `np.random.default_rng(0)`, per the DoD text's own framing ("known truth grade", "posterior stub", "fixed-seed rng"). The "deterministic-mean plan" baseline (not part of the public API) is defined in the test as a per-block sample-mean threshold on the same training draws — the natural point-estimate-only contrast to the CVaR-aware plan.