### PR TITLE
H1: Min-cost & multi-commodity network flow + capacitated network design

### DIFF
--- a/mixle/relations.py
+++ b/mixle/relations.py
@@ -52,9 +52,14 @@ __all__ = [
     "BestSubsetRegression",
     "branch_and_bound_milp",
     "cardinality_constrained_milp",
+    "Design",
     "EditDistance",
+    "Flow",
     "graph_coloring",
     "irreducible_infeasible_subset",
+    "min_cost_flow",
+    "multicommodity_flow",
+    "network_design",
     "Relation",
     "RelationSampler",
     "ShortestPath",
@@ -324,6 +329,279 @@ def min_cut(capacity: Any, source: int, sink: int) -> tuple[float, list[int], li
     cut_edges = [(u, v) for u in reachable for v in range(n) if v not in reachable and cap[u, v] > 0.0]
     cut_capacity = float(sum(cap[u, v] for u, v in cut_edges))
     return cut_capacity, sorted(reachable), cut_edges
+
+
+# ---------------------------------------------------------------------------
+# Minimum-cost flow, multicommodity flow, and capacitated network design
+# ---------------------------------------------------------------------------
+class Flow(NamedTuple):
+    """A resolved flow: ``value`` (total/objective cost) and ``flow[u, v]`` per-arc, like `max_flow`'s output."""
+
+    value: float
+    flow: np.ndarray
+
+
+class Design(NamedTuple):
+    """A network-design solution: ``cost`` (total), ``open`` (opened-arc/facility mask), and the induced ``flow``."""
+
+    cost: float
+    open: np.ndarray
+    flow: np.ndarray
+
+
+def min_cost_flow(cap: Any, cost: Any, supply: Any) -> Flow:
+    """Min-cost feasible flow meeting node ``supply`` (positive = source) under arc ``cap``/``cost``.
+
+    Successive-shortest-path with node potentials: a super-source feeds every ``supply > 0`` node and
+    every ``supply < 0`` node feeds a super-sink (arc capacity ``|supply|``, cost 0), then the residual
+    super-source -> super-sink path of least *reduced* cost is repeatedly augmented (Dijkstra, since the
+    potentials keep every reduced cost non-negative) until the super-sink is unreachable. Potentials are
+    seeded with a Bellman-Ford pass so arbitrary-sign ``cost`` entries are handled, then updated by the
+    per-round Dijkstra distances (the standard Johnson's-algorithm maintenance). ``cap``/``cost`` are
+    ``n x n`` arc matrices; ``supply`` is length ``n`` and must sum to (approximately) zero. Returns
+    `Flow(value=total cost, flow=(n, n) arc flows)`; raises :class:`ValueError` if the supply cannot be
+    fully routed under the given capacities.
+    """
+    cap = np.asarray(cap, dtype=np.float64)
+    cost = np.asarray(cost, dtype=np.float64)
+    supply = np.asarray(supply, dtype=np.float64)
+    n = supply.shape[0]
+    if cap.shape != (n, n) or cost.shape != (n, n):
+        raise ValueError("cap/cost must be (n, n), matching supply's length n")
+    assert abs(float(supply.sum())) < 1.0e-6, "supply must sum to (approximately) zero"
+
+    ss, tt, m = n, n + 1, n + 2  # super-source, super-sink, extended node count
+    big_cap = np.zeros((m, m))
+    big_cap[:n, :n] = cap
+    big_cost = np.zeros((m, m))
+    big_cost[:n, :n] = cost
+    total_supply = 0.0
+    for i in range(n):
+        if supply[i] > 1.0e-12:
+            big_cap[ss, i] = supply[i]
+            total_supply += float(supply[i])
+        elif supply[i] < -1.0e-12:
+            big_cap[i, tt] = -float(supply[i])
+
+    residual = big_cap.copy()
+    flow = np.zeros((m, m))
+
+    def bellman_ford_from_source() -> np.ndarray:
+        dist = np.full(m, np.inf)
+        dist[ss] = 0.0
+        for _ in range(m - 1):
+            changed = False
+            for u in range(m):
+                if not np.isfinite(dist[u]):
+                    continue
+                for v in range(m):
+                    if residual[u, v] > 1.0e-12 and dist[u] + big_cost[u, v] < dist[v] - 1.0e-9:
+                        dist[v] = dist[u] + big_cost[u, v]
+                        changed = True
+            if not changed:
+                break
+        return np.where(np.isfinite(dist), dist, 0.0)
+
+    pot = bellman_ford_from_source()  # seeds potentials so Dijkstra sees non-negative reduced costs
+    routed = 0.0
+    while routed < total_supply - 1.0e-9:
+        reduced = big_cost + pot[:, None] - pot[None, :]
+        dist = np.full(m, np.inf)
+        dist[ss] = 0.0
+        prev = np.full(m, -1, dtype=int)
+        visited = np.zeros(m, dtype=bool)
+        heap: list[tuple[float, int]] = [(0.0, ss)]
+        while heap:
+            d, u = heapq.heappop(heap)
+            if visited[u]:
+                continue
+            visited[u] = True
+            for v in range(m):
+                if not visited[v] and residual[u, v] > 1.0e-12:
+                    nd = d + reduced[u, v]
+                    if nd < dist[v] - 1.0e-12:
+                        dist[v] = nd
+                        prev[v] = u
+                        heapq.heappush(heap, (nd, v))
+        if not visited[tt]:
+            break  # super-sink unreachable: no more augmenting paths
+        for v in range(m):
+            if visited[v] and np.isfinite(dist[v]):
+                pot[v] += dist[v]  # Johnson's-algorithm potential maintenance
+
+        bottleneck = total_supply - routed
+        path: list[tuple[int, int]] = []
+        v = tt
+        while v != ss:
+            u = prev[v]
+            bottleneck = min(bottleneck, residual[u, v])
+            path.append((u, v))
+            v = u
+        for u, v in path:
+            residual[u, v] -= bottleneck
+            residual[v, u] += bottleneck
+            cancel = min(bottleneck, flow[v, u])  # undo previously-pushed flow on the reverse arc first
+            flow[v, u] -= cancel
+            if bottleneck - cancel > 1.0e-15:
+                flow[u, v] += bottleneck - cancel
+        routed += bottleneck
+
+    if routed < total_supply - 1.0e-6:
+        raise ValueError("min_cost_flow: infeasible -- supply cannot be fully routed under the given capacities")
+
+    value = float((flow[:n, :n] * cost).sum())
+    return Flow(value=value, flow=flow[:n, :n])
+
+
+def multicommodity_flow(cap: Any, cost: Any, demands: Any) -> Flow:
+    """Multi-commodity min-cost flow (different products/grades share arc ``cap``) via LP relaxation.
+
+    ``cap``/``cost`` are ``n x n`` arc matrices (an arc exists where ``cap > 0``); ``demands`` lists
+    ``(source, sink, amount)`` rows, one per commodity. Each commodity gets its own flow variables with
+    its own conservation constraints (per-commodity supply at its source, demand at its sink, balance
+    elsewhere); every arc's *combined* commodity flow is capped at ``cap[u, v]``. Solved as a single LP
+    (``scipy.optimize.linprog``, HiGHS) over the stacked per-commodity arc variables. Returns `Flow` with
+    the aggregate cost and the summed arc flows (``flow = sum_k x_k``); raises :class:`ValueError` if the
+    demands cannot be met under the shared capacities.
+    """
+    from scipy.optimize import linprog
+
+    cap = np.asarray(cap, dtype=np.float64)
+    cost = np.asarray(cost, dtype=np.float64)
+    demands = np.atleast_2d(np.asarray(demands, dtype=np.float64))
+    n = cap.shape[0]
+    if cap.shape != (n, n) or cost.shape != (n, n):
+        raise ValueError("cap/cost must be square (n, n) arc matrices")
+    k = demands.shape[0]
+    arcs = [(u, v) for u in range(n) for v in range(n) if cap[u, v] > 0.0]
+    n_arcs = len(arcs)
+
+    def var(kk: int, ai: int) -> int:
+        return kk * n_arcs + ai
+
+    n_vars = k * n_arcs
+    c = np.zeros(n_vars)
+    for kk in range(k):
+        for ai, (u, v) in enumerate(arcs):
+            c[var(kk, ai)] = cost[u, v]
+
+    a_eq_rows: list[np.ndarray] = []
+    b_eq: list[float] = []
+    for kk in range(k):
+        src, snk, qty = int(demands[kk, 0]), int(demands[kk, 1]), float(demands[kk, 2])
+        for node in range(n):
+            row = np.zeros(n_vars)
+            for ai, (u, v) in enumerate(arcs):
+                if u == node:
+                    row[var(kk, ai)] += 1.0
+                if v == node:
+                    row[var(kk, ai)] -= 1.0
+            rhs = qty if node == src else (-qty if node == snk else 0.0)
+            a_eq_rows.append(row)
+            b_eq.append(rhs)
+
+    a_ub_rows: list[np.ndarray] = []
+    b_ub: list[float] = []
+    for ai, (u, v) in enumerate(arcs):
+        row = np.zeros(n_vars)
+        for kk in range(k):
+            row[var(kk, ai)] = 1.0
+        a_ub_rows.append(row)
+        b_ub.append(cap[u, v])
+
+    res = linprog(
+        c,
+        A_ub=np.array(a_ub_rows) if a_ub_rows else None,
+        b_ub=np.array(b_ub) if b_ub else None,
+        A_eq=np.array(a_eq_rows) if a_eq_rows else None,
+        b_eq=np.array(b_eq) if b_eq else None,
+        bounds=[(0.0, None)] * n_vars,
+        method="highs",
+    )
+    if not res.success:
+        raise ValueError("multicommodity_flow: infeasible -- demands cannot be met under the shared capacities")
+
+    flow = np.zeros((n, n))
+    for kk in range(k):
+        for ai, (u, v) in enumerate(arcs):
+            flow[u, v] += res.x[var(kk, ai)]
+    return Flow(value=float(res.fun), flow=flow)
+
+
+def network_design(nodes: Sequence[int], arcs: Sequence[tuple[int, int]], fixed_costs: Any, demands: Any) -> Design:
+    """Capacitated fixed-charge network design (which arcs/facilities to open) via big-M MILP.
+
+    ``nodes`` lists node ids; ``arcs`` lists candidate directed arcs (``fixed_costs[i]`` is the cost of
+    opening ``arcs[i]``); ``demands`` is a length-``len(nodes)`` net supply/demand vector aligned with
+    ``nodes`` (positive = supply, negative = demand, summing to zero) -- the same convention as
+    :func:`min_cost_flow`'s ``supply``. Continuous flow ``x[arc] >= 0`` is big-M-linked to the binary
+    open/closed decision ``y[arc]`` (``x[arc] <= M * y[arc]``, ``M`` sized from the total demand so it
+    never binds a genuinely open arc); flow balance ``A x = demands`` is encoded as the paired
+    inequalities ``A x <= demands`` and ``-A x <= -demands`` (:func:`branch_and_bound_milp` exposes only
+    ``a_ub``/``b_ub``). The frozen signature carries no per-unit routing cost, so the objective is the
+    total opening cost ``fixed_costs @ y`` (the classic uncapacitated-routing fixed-charge network design:
+    which arcs to build so the demand vector is routable at minimum build cost). Returns
+    ``Design(cost, open, flow)`` where ``open`` is the boolean opened-arc mask and ``flow`` is the induced
+    ``(n, n)`` arc flow; raises :class:`ValueError` if no arc-opening choice can route the demands.
+    """
+    node_list = list(nodes)
+    n = len(node_list)
+    index = {node: i for i, node in enumerate(node_list)}
+    arc_list = list(arcs)
+    n_arcs = len(arc_list)
+    fixed = np.asarray(fixed_costs, dtype=np.float64)
+    demand = np.asarray(demands, dtype=np.float64)
+    if fixed.shape != (n_arcs,):
+        raise ValueError("fixed_costs must align with arcs, one entry per candidate arc")
+    if demand.shape != (n,):
+        raise ValueError("demands must align with nodes, one net supply/demand entry per node")
+    if abs(float(demand.sum())) > 1.0e-6:
+        raise ValueError("network_design: demands must sum to (approximately) zero")
+
+    big_m = float(np.abs(demand).sum()) or 1.0  # a non-binding capacity once an arc is opened
+    n_vars = 2 * n_arcs  # [x_0..x_{n_arcs-1}, y_0..y_{n_arcs-1}]
+
+    def x_idx(a: int) -> int:
+        return a
+
+    def y_idx(a: int) -> int:
+        return n_arcs + a
+
+    c = np.zeros(n_vars)
+    c[n_arcs:] = fixed  # objective: total opening cost (no per-unit routing cost in the frozen signature)
+
+    rows: list[np.ndarray] = []
+    rhs: list[float] = []
+    for a in range(n_arcs):  # big-M link: x[a] - M * y[a] <= 0
+        row = np.zeros(n_vars)
+        row[x_idx(a)] = 1.0
+        row[y_idx(a)] = -big_m
+        rows.append(row)
+        rhs.append(0.0)
+
+    balance = np.zeros((n, n_vars))
+    for a, (u, v) in enumerate(arc_list):
+        balance[index[u], x_idx(a)] += 1.0
+        balance[index[v], x_idx(a)] -= 1.0
+    for node_row, b in zip(balance, demand, strict=True):  # A x = b as paired A x <= b, -A x <= -b
+        rows.append(node_row.copy())
+        rhs.append(float(b))
+        rows.append(-node_row)
+        rhs.append(-float(b))
+
+    bounds = [(0.0, big_m)] * n_arcs + [(0.0, 1.0)] * n_arcs
+    result = branch_and_bound_milp(
+        c, np.array(rows), np.array(rhs), integer=list(range(n_arcs, n_vars)), bounds=bounds, sense="min"
+    )
+    if result is None:
+        raise ValueError("network_design: infeasible -- no arc-opening choice routes the given demands")
+    value, sol = result
+    opened = np.round(sol[n_arcs:]).astype(bool)
+    x = sol[:n_arcs]
+    flow_matrix = np.zeros((n, n))
+    for a, (u, v) in enumerate(arc_list):
+        flow_matrix[index[u], index[v]] = x[a]
+    return Design(cost=float(value), open=opened, flow=flow_matrix)
 
 
 # ---------------------------------------------------------------------------

--- a/mixle/tests/test_h1_flows.py
+++ b/mixle/tests/test_h1_flows.py
@@ -1,0 +1,157 @@
+"""Min-cost & multi-commodity network flow + capacitated network design (H1: IC-9 implementation)."""
+
+from __future__ import annotations
+
+import numpy as np
+from scipy.optimize import linprog
+
+from mixle.relations import Design, Flow, min_cost_flow, multicommodity_flow, network_design
+
+# Nodes: 0-2 mines, 3-4 plants, 5-8 customers.
+N = 9
+MINES = (0, 1, 2)
+PLANTS = (3, 4)
+CUSTOMERS = (5, 6, 7, 8)
+
+
+def _base_network():
+    """3-mine / 2-plant / 4-customer network. Plant 3 is capacity-bottlenecked: mines 0+1 push more
+    supply into it (40) than its "native" customers 5+6 demand (30), so 10 units must detour through
+    the expensive direct arc 3->7 in the absence of an inter-plant transfer arc."""
+    cap = np.zeros((N, N))
+    cost = np.zeros((N, N))
+
+    def arc(u, v, c, w):
+        cap[u, v] = c
+        cost[u, v] = w
+
+    arc(0, 3, 25, 2)  # mine0 -> plant3
+    arc(1, 3, 25, 2)  # mine1 -> plant3
+    arc(2, 4, 25, 2)  # mine2 -> plant4
+    arc(3, 5, 20, 1)  # plant3 -> customer5
+    arc(3, 6, 20, 1)  # plant3 -> customer6
+    arc(3, 7, 20, 6)  # plant3 -> customer7 (expensive long-haul fallback)
+    arc(4, 7, 20, 1)  # plant4 -> customer7
+    arc(4, 8, 20, 1)  # plant4 -> customer8
+
+    supply = np.zeros(N)
+    supply[0], supply[1], supply[2] = 20.0, 20.0, 20.0
+    supply[5], supply[6], supply[7], supply[8] = -15.0, -15.0, -15.0, -15.0
+    return cap, cost, supply
+
+
+def _reference_min_cost_flow(cap, cost, supply):
+    """Hand-built linprog reference: one variable per existing arc, node-arc incidence for A_eq."""
+    n = cap.shape[0]
+    arcs = [(u, v) for u in range(n) for v in range(n) if cap[u, v] > 0.0]
+    incidence = np.zeros((n, len(arcs)))
+    c = np.zeros(len(arcs))
+    bounds = []
+    for j, (u, v) in enumerate(arcs):
+        incidence[u, j] = 1.0
+        incidence[v, j] = -1.0
+        c[j] = cost[u, v]
+        bounds.append((0.0, cap[u, v]))
+    res = linprog(c, A_eq=incidence, b_eq=supply, bounds=bounds, method="highs")
+    assert res.success
+    return res.fun
+
+
+def test_min_cost_flow_matches_linprog_reference():
+    cap, cost, supply = _base_network()
+    result = min_cost_flow(cap, cost, supply)
+    assert isinstance(result, Flow)
+    reference = _reference_min_cost_flow(cap, cost, supply)
+    assert abs(result.value - reference) < 1.0e-6
+
+    # flow conservation at every transship/customer node
+    net = result.flow.sum(axis=1) - result.flow.sum(axis=0)
+    assert np.allclose(net, supply, atol=1.0e-6)
+    assert np.all(result.flow <= cap + 1.0e-6)
+    assert np.all(result.flow >= -1.0e-9)
+
+
+def test_inter_plant_transfer_arc_strictly_lowers_cost():
+    cap, cost, supply = _base_network()
+    base_value = min_cost_flow(cap, cost, supply).value
+
+    cap2 = cap.copy()
+    cost2 = cost.copy()
+    cap2[3, 4] = 50.0  # open a cheap inter-plant transfer arc
+    cost2[3, 4] = 0.2
+    transfer_value = min_cost_flow(cap2, cost2, supply).value
+
+    assert transfer_value < base_value - 1.0e-9
+
+    # matches the hand-solved optimum: the transfer arc entirely displaces the expensive 3->7 fallback
+    assert abs(transfer_value - 182.0) < 1.0e-6
+    assert abs(base_value - 230.0) < 1.0e-6
+
+
+def test_min_cost_flow_infeasible_raises():
+    cap = np.array([[0.0, 1.0], [0.0, 0.0]])
+    cost = np.array([[0.0, 1.0], [0.0, 0.0]])
+    supply = np.array([5.0, -5.0])  # arc capacity (1) below required supply (5)
+    try:
+        min_cost_flow(cap, cost, supply)
+        raise AssertionError("expected ValueError for an infeasible instance")
+    except ValueError:
+        pass
+
+
+def test_multicommodity_flow_respects_shared_capacity_and_cost():
+    # nodes: 0 srcA, 1 srcB, 2 trunk-in, 3 trunk-out, 4 sinkA, 5 sinkB
+    n = 6
+    cap = np.zeros((n, n))
+    cost = np.zeros((n, n))
+    cap[0, 2], cost[0, 2] = 100.0, 1.0
+    cap[1, 2], cost[1, 2] = 100.0, 1.0
+    cap[2, 3], cost[2, 3] = 15.0, 0.0  # shared bottleneck trunk arc
+    cap[3, 4], cost[3, 4] = 100.0, 1.0
+    cap[3, 5], cost[3, 5] = 100.0, 1.0
+
+    demands = np.array([[0, 4, 7.0], [1, 5, 7.0]])  # commodity A: 0->4 qty 7; commodity B: 1->5 qty 7
+    result = multicommodity_flow(cap, cost, demands)
+    assert isinstance(result, Flow)
+    assert abs(result.value - 28.0) < 1.0e-6  # each commodity pays (1 + 0 + 1) * 7 = 14
+    assert result.flow[2, 3] <= cap[2, 3] + 1.0e-6  # shared trunk capacity respected
+    assert abs(result.flow[2, 3] - 14.0) < 1.0e-6
+
+
+def test_multicommodity_flow_infeasible_raises():
+    cap = np.array([[0.0, 1.0], [0.0, 0.0]])
+    cost = np.array([[0.0, 1.0], [0.0, 0.0]])
+    demands = np.array([[0, 1, 5.0]])  # needs 5 units through a capacity-1 arc
+    try:
+        multicommodity_flow(cap, cost, demands)
+        raise AssertionError("expected ValueError for an infeasible instance")
+    except ValueError:
+        pass
+
+
+def test_network_design_opens_cheaper_two_hop_path():
+    nodes = [0, 1, 2]
+    arcs = [(0, 1), (1, 2), (0, 2)]
+    fixed_costs = np.array([5.0, 5.0, 100.0])  # direct arc is expensive to open; the two-hop route is cheap
+    demands = np.array([10.0, 0.0, -10.0])
+
+    result = network_design(nodes, arcs, fixed_costs, demands)
+    assert isinstance(result, Design)
+    assert abs(result.cost - 10.0) < 1.0e-6
+    assert bool(result.open[0]) is True  # 0 -> 1 opened
+    assert bool(result.open[1]) is True  # 1 -> 2 opened
+    assert bool(result.open[2]) is False  # the expensive direct arc stays closed
+    assert abs(result.flow[0, 1] - 10.0) < 1.0e-6
+    assert abs(result.flow[1, 2] - 10.0) < 1.0e-6
+
+
+def test_network_design_infeasible_raises():
+    nodes = [0, 1, 2]
+    arcs = [(0, 1)]  # node 2 has no arc at all, so its -10 demand can never be met
+    fixed_costs = np.array([1.0])
+    demands = np.array([10.0, 0.0, -10.0])
+    try:
+        network_design(nodes, arcs, fixed_costs, demands)
+        raise AssertionError("expected ValueError for an infeasible instance")
+    except ValueError:
+        pass


### PR DESCRIPTION
## Worklist item

**Item:** H1

From notes/exploration-e2e-work-plan.md (the post-0.7 capability-expansion worklist, commissioned directly by the maintainer) and notes/exec/workstream-H.md -- not the original 0.8.0 stability worklist; this is new, explicitly authorized capability work.

## Summary

Implements IC-9's three network-flow functions in `mixle/relations.py`:

- `min_cost_flow(cap, cost, supply)` -- successive-shortest-path min-cost flow. Adds a super-source/super-sink around the supply/demand nodes, seeds node potentials with Bellman-Ford (so arbitrary-sign costs are handled), then repeatedly augments along the least-reduced-cost residual path via Dijkstra, maintaining potentials the standard Johnson's-algorithm way. Raises `ValueError` if the supply can't be fully routed.
- `multicommodity_flow(cap, cost, demands)` -- per-commodity LP relaxation (`scipy.optimize.linprog`, HiGHS) with per-commodity flow-conservation equalities and a shared arc-capacity coupling inequality across commodities.
- `network_design(nodes, arcs, fixed_costs, demands)` -- capacitated fixed-charge network design via big-M MILP over the existing `branch_and_bound_milp`: binary open/close per candidate arc, big-M-linked continuous flow, paired-inequality flow balance.

Also adds the `Flow`/`Design` NamedTuples and extends `__all__` with all five new names. No existing symbol in `relations.py` was touched.

## Public API impact

- [x] It adds public surface: `Flow`, `Design`, `min_cost_flow`, `multicommodity_flow`, `network_design` are new entries in `mixle.relations.__all__`.
- Ran `python scripts/gen_api_manifest.py`: **no diff**. `api_manifest.json` only tracks package `__init__.py` files with their own `__all__`, and `mixle/relations.py` is a standalone module (not a package `__init__.py`), so this addition isn't in the manifest's scope. Nothing to commit there.

## Claims impact

- [x] No public claim (README, docs, benchmarks) is affected.

## Evidence

DoD command (verbatim from the work order):

```
PYTHONPATH=/Users/grantboquet/mixle/mixle python -m pytest mixle/tests/test_h1_flows.py -q
-> 7 passed
```

Broader regression check on touched/adjacent surfaces:

```
PYTHONPATH=<worktree> python -m pytest mixle/tests/relations_test.py mixle/tests/max_flow_test.py mixle/tests/relation_sample_test.py mixle/tests/test_h2_blending.py -q
-> 32 passed, 60 subtests passed

PYTHONPATH=<worktree> python -m pytest mixle/tests/public_api_manifest_test.py -q
-> 2 passed
```

`ruff format` / `ruff check` on the changed files: clean.

## Notes (judgment calls)

- **`network_design`'s frozen signature carries no per-unit routing cost or arc capacity array** (only `nodes, arcs, fixed_costs, demands`), while the algorithm prose in workstream-H.md references `cost·x` and "capacitated." Per rule 4 I kept the frozen signature exactly and adapted the implementation: the objective is `fixed_costs @ y` only (no variable routing cost term, since none was supplied), and the "capacity" once an arc is opened is a data-derived big-M (`sum(|demands|)`) rather than an explicit per-arc cap -- i.e. this realizes the classic *uncapacitated-routing* fixed-charge network design problem (which arcs to build so the demand vector becomes routable, at minimum build cost). `demands` is interpreted as a single-commodity net supply/demand vector aligned with `nodes` (same sign convention as `min_cost_flow`'s `supply`), matching the algorithm's single flow-balance system `Ax = b` rather than a per-commodity structure.
- The H1 Definition-of-Done text only specifies a concrete test scenario for `min_cost_flow`; I added companion tests for `multicommodity_flow` and `network_design` in the same `test_h1_flows.py` file (capacity-coupling respected, infeasibility raises, a hand-verifiable cheaper-two-hop-path case) since they're part of the same frozen Public API surface, but these are supplementary, not separately mandated by the DoD line.
- `mixle/tests/test_h2_blending.py` was already present on `release/0.8.0` (H2 landed independently, since it only depends on `branch_and_bound_milp`/`irreducible_infeasible_subset`, not on the new IC-9 symbols) -- included in the regression run above purely as a nearby-module sanity check, not because this PR touches it.