### PR TITLE
L1: Emissions / carbon accounting

### DIFF
--- a/api_manifest.json
+++ b/api_manifest.json
@@ -21,6 +21,8 @@
     "what_supports"
   ],
   "mixle.analysis": [
+    "EmissionFactors",
+    "Footprint",
     "GPDFit",
     "KDE",
     "LedoitWolfEstimator",
@@ -37,6 +39,7 @@
     "chao2",
     "copeland",
     "cost_curve",
+    "emissions_footprint",
     "empirical_variogram",
     "endpoint_estimator",
     "fit_smith_maxstable",

--- a/mixle/analysis/__init__.py
+++ b/mixle/analysis/__init__.py
@@ -20,6 +20,7 @@ from mixle.analysis.coverage import (
     rarefaction_curve,
     turing_coverage,
 )
+from mixle.analysis.emissions import EmissionFactors, Footprint, emissions_footprint
 from mixle.analysis.extreme import (
     GPDFit,
     endpoint_estimator,
@@ -113,4 +114,8 @@ __all__ = [
     # mine economics: cost curves and capex/opex roll-up
     "cost_curve",
     "capex_opex",
+    # emissions / carbon accounting (Scope 1/2/3 GHG footprint)
+    "EmissionFactors",
+    "Footprint",
+    "emissions_footprint",
 ]

--- a/mixle/analysis/emissions.py
+++ b/mixle/analysis/emissions.py
@@ -1,0 +1,152 @@
+"""Scope 1/2/3 GHG (carbon) accounting for an operation's production activity.
+
+Maps a production ``activity`` schedule -- direct fuel combustion and blasting, purchased-grid
+electricity draw, and upstream reagents / downstream haulage -- onto CO2e emissions via
+GHG-Protocol-style :class:`EmissionFactors`.
+
+  * :func:`emissions_footprint` -- Scope 1 (direct combustion/blasting) + Scope 2 (purchased
+    electricity) + Scope 3 (upstream reagents / downstream transport) totals, with an optional
+    Monte-Carlo 90% credible interval when per-factor uncertainties (:attr:`EmissionFactors.sigma`)
+    are supplied, and a content-addressed ``activity_content_hash`` in the returned
+    :class:`Footprint`'s provenance so every number traces back to the exact activity schedule that
+    produced it.
+
+Emission factors are always supplied by the caller (or an upstream knowledge store) -- this module
+vendors no lifecycle-inventory database; see the work-plan Non-goals for L1. Carbon *pricing* (turning
+a footprint into a cost/NPV term) is out of scope here too -- see :mod:`mixle.analysis.emissions`'s
+``transition_risk`` (L3) and ``climate_terms`` (L6), which build on :class:`Footprint`.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+
+import numpy as np
+
+from mixle.data.hashing import _canonical
+
+_VALID_SCOPES = (1, 2, 3)
+
+
+@dataclass
+class EmissionFactors:
+    """Per-activity-key CO2e emission factors, one dict per GHG-Protocol scope.
+
+    ``scope1``/``scope2``/``scope3`` map an activity key (e.g. ``"diesel_L"``, ``"grid_kWh"``,
+    ``"explosives_kg"``, ``"transport_t_km"``) to a CO2e factor expressed per unit of that activity
+    (e.g. kg CO2e per litre of diesel). A key absent from a scope's dict simply does not contribute to
+    that scope. ``sigma`` optionally gives the standard deviation of each *factor* (not the activity
+    quantity itself), keyed the same way across all three scopes, for Monte-Carlo uncertainty
+    propagation in :func:`emissions_footprint`; a key with no entry in ``sigma`` is treated as exactly
+    known (std 0).
+    """
+
+    scope1: dict[str, float]
+    scope2: dict[str, float]
+    scope3: dict[str, float]
+    sigma: dict[str, float] | None = None
+
+
+@dataclass
+class Footprint:
+    """A Scope 1/2/3 CO2e footprint with an optional 90% credible interval and full provenance.
+
+    ``scope1``/``scope2``/``scope3``/``total`` are in the same physical CO2e units as the emission
+    factors (typically kg CO2e). ``ci`` is the ``(lo, hi)`` 90% Monte-Carlo interval on ``total`` when
+    factor uncertainties were propagated, else ``None``. ``provenance`` carries ``factor_source``,
+    the 64-hex ``activity_content_hash`` (sha256 of the canonical activity encoding, the same hashing
+    convention IC-2 uses for field artifacts), and the ``scopes`` actually included in ``total``.
+    """
+
+    scope1: float
+    scope2: float
+    scope3: float
+    total: float
+    ci: tuple[float, float] | None
+    provenance: dict
+
+
+def _scope_dict(factors: EmissionFactors, scope: int) -> dict[str, float]:
+    if scope == 1:
+        return factors.scope1
+    if scope == 2:
+        return factors.scope2
+    if scope == 3:
+        return factors.scope3
+    raise ValueError(f"scope must be one of {_VALID_SCOPES}, got {scope!r}")
+
+
+def _scope_total(activity: dict[str, float], scope_factors: dict[str, float]) -> float:
+    """Sum ``factor * activity[key]`` over the keys the scope's factor dict knows about."""
+    return float(sum(factor * activity.get(key, 0.0) for key, factor in scope_factors.items()))
+
+
+def _activity_content_hash(activity: dict[str, float]) -> str:
+    """sha256 hex digest of the canonical byte encoding of ``activity`` (IC-2 hashing convention:
+    a deterministic, key-order-independent encoding of the record so the same activity numbers
+    always hash the same, and any change to a key or a value changes the hash)."""
+    return hashlib.sha256(_canonical(dict(activity))).hexdigest()
+
+
+def emissions_footprint(
+    activity: dict[str, float],
+    factors: EmissionFactors,
+    *,
+    scopes: tuple[int, ...] = (1, 2, 3),
+    n: int = 0,
+    rng: np.random.Generator | None = None,
+) -> Footprint:
+    """Scope 1/2/3 CO2e footprint of a production ``activity`` schedule.
+
+    Each ``activity`` key (e.g. ``diesel_L``, ``grid_kWh``, ``explosives_kg``, ``transport_t_km``) is
+    priced by the corresponding factor in whichever of ``factors.scope1/scope2/scope3`` includes that
+    key: Scope 1 is direct combustion/blasting, Scope 2 is purchased electricity, Scope 3 is upstream
+    reagents plus downstream transport. ``scopes`` selects which of the three scopes are actually
+    included in the returned footprint (a scope not requested reports ``0.0`` and does not contribute
+    to ``total`` -- e.g. ``scopes=(1, 2)`` for a Scope-1/2-only disclosure).
+
+    If ``n > 0`` and ``factors.sigma`` is supplied, each priced factor is treated as
+    ``Normal(mean=factor, std=sigma.get(key, 0.0))`` and resampled ``n`` times (factors with no
+    ``sigma`` entry stay fixed); the resulting distribution of ``total`` yields a 90% credible interval
+    in ``ci``. Without both a positive ``n`` and a non-empty ``sigma``, ``ci`` is ``None`` -- the point
+    total is still returned, just without an uncertainty band.
+
+    ``provenance`` always carries ``activity_content_hash`` (a 64-hex sha256 fingerprint of the
+    activity dict, IC-2's hashing convention) so a downstream carbon-cost or transition-risk term
+    (L3/L6) can always be traced back to the exact activity schedule it was computed from.
+    """
+    for s in scopes:
+        if s not in _VALID_SCOPES:
+            raise ValueError(f"scopes must be a subset of {_VALID_SCOPES}, got {scopes!r}")
+
+    scope_values = {s: (_scope_total(activity, _scope_dict(factors, s)) if s in scopes else 0.0) for s in _VALID_SCOPES}
+    total = float(sum(scope_values.values()))
+
+    ci: tuple[float, float] | None = None
+    if n > 0 and factors.sigma:
+        gen = np.random.default_rng() if rng is None else rng
+        totals = np.zeros(n)
+        for s in scopes:
+            for key, mean in _scope_dict(factors, s).items():
+                qty = activity.get(key, 0.0)
+                std = float(factors.sigma.get(key, 0.0))
+                draws = gen.normal(mean, std, size=n) if std > 0 else np.full(n, mean)
+                totals += draws * qty
+        lo, hi = np.quantile(totals, [0.05, 0.95])
+        ci = (float(lo), float(hi))
+
+    provenance = {
+        "factor_source": "caller_supplied",
+        "activity_content_hash": _activity_content_hash(activity),
+        "scopes": tuple(scopes),
+    }
+
+    return Footprint(
+        scope1=scope_values[1],
+        scope2=scope_values[2],
+        scope3=scope_values[3],
+        total=total,
+        ci=ci,
+        provenance=provenance,
+    )

--- a/mixle/tests/test_emissions.py
+++ b/mixle/tests/test_emissions.py
@@ -1,0 +1,90 @@
+"""L1 DoD -- emissions / carbon accounting (notes/exec/workstream-L.md).
+
+A synthetic production activity schedule (diesel combustion, purchased grid electricity, blasting
+explosives, downstream haulage) run through `emissions_footprint` against hand-computed Scope 1/2/3
+GHG-Protocol totals, with a Monte-Carlo 90% CI when factor uncertainties are supplied and a
+content-addressed activity hash (IC-2 hashing convention) for provenance.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from mixle.analysis.emissions import EmissionFactors, Footprint, emissions_footprint
+
+ACTIVITY = {
+    "diesel_L": 5_000.0,
+    "grid_kWh": 20_000.0,
+    "explosives_kg": 800.0,
+    "transport_t_km": 15_000.0,
+}
+
+# Scope 1: direct combustion (diesel) + blasting (explosives).
+# Scope 2: purchased grid electricity.
+# Scope 3: downstream haulage.
+FACTORS = EmissionFactors(
+    scope1={"diesel_L": 2.68, "explosives_kg": 0.20},
+    scope2={"grid_kWh": 0.42},
+    scope3={"transport_t_km": 0.12},
+    sigma={"diesel_L": 0.05, "grid_kWh": 0.01, "explosives_kg": 0.02, "transport_t_km": 0.01},
+)
+
+# Hand-computed reference (kg CO2e).
+REF_SCOPE1 = 5_000.0 * 2.68 + 800.0 * 0.20  # 13560.0
+REF_SCOPE2 = 20_000.0 * 0.42  # 8400.0
+REF_SCOPE3 = 15_000.0 * 0.12  # 1800.0
+REF_TOTAL = REF_SCOPE1 + REF_SCOPE2 + REF_SCOPE3  # 23760.0
+
+
+def test_schedule_yields_scoped_footprint():
+    fp = emissions_footprint(ACTIVITY, FACTORS)
+
+    assert isinstance(fp, Footprint)
+    assert fp.scope1 == pytest.approx(REF_SCOPE1)
+    assert fp.scope2 == pytest.approx(REF_SCOPE2)
+    assert fp.scope3 == pytest.approx(REF_SCOPE3)
+    assert fp.total == pytest.approx(REF_TOTAL)
+    assert fp.ci is None  # n=0 by default: no sampling requested
+
+    ah = fp.provenance["activity_content_hash"]
+    assert isinstance(ah, str) and len(ah) == 64
+    assert all(c in "0123456789abcdef" for c in ah)
+    assert fp.provenance["scopes"] == (1, 2, 3)
+
+    # Deterministic: the same activity numbers always hash the same.
+    fp2 = emissions_footprint(dict(ACTIVITY), FACTORS)
+    assert fp2.provenance["activity_content_hash"] == ah
+
+    # A different activity schedule hashes differently.
+    other = dict(ACTIVITY, diesel_L=5_001.0)
+    fp3 = emissions_footprint(other, FACTORS)
+    assert fp3.provenance["activity_content_hash"] != ah
+
+
+def test_ci_present_when_sigma_and_n_given():
+    fp = emissions_footprint(ACTIVITY, FACTORS, n=5_000, rng=np.random.default_rng(0))
+    assert fp.ci is not None
+    lo, hi = fp.ci
+    assert lo < REF_TOTAL < hi
+    # 90% CI should be reasonably tight around the reference mean for these small factor sigmas.
+    assert (hi - lo) < 0.5 * REF_TOTAL
+
+
+def test_no_ci_without_sigma():
+    factors_no_sigma = EmissionFactors(scope1=FACTORS.scope1, scope2=FACTORS.scope2, scope3=FACTORS.scope3)
+    fp = emissions_footprint(ACTIVITY, factors_no_sigma, n=1_000, rng=np.random.default_rng(0))
+    assert fp.ci is None
+
+
+def test_scopes_subset_excludes_unrequested_scope():
+    fp = emissions_footprint(ACTIVITY, FACTORS, scopes=(1, 2))
+    assert fp.scope1 == pytest.approx(REF_SCOPE1)
+    assert fp.scope2 == pytest.approx(REF_SCOPE2)
+    assert fp.scope3 == 0.0
+    assert fp.total == pytest.approx(REF_SCOPE1 + REF_SCOPE2)
+
+
+def test_invalid_scope_raises():
+    with pytest.raises(ValueError):
+        emissions_footprint(ACTIVITY, FACTORS, scopes=(1, 4))


### PR DESCRIPTION
## Worklist item

**Item:** L1

From `notes/exploration-e2e-work-plan.md` (the post-0.7 capability-expansion worklist, commissioned directly by the maintainer) and `notes/exec/workstream-L.md` — not the original 0.8.0 stability worklist; this is new, explicitly authorized capability work.

## Summary

Adds `mixle/analysis/emissions.py`: Scope 1/2/3 GHG-Protocol carbon accounting for a production activity schedule (fuel combustion, blasting, purchased grid electricity, downstream haulage).

- `EmissionFactors` — per-activity-key CO2e factors, one dict per scope, plus an optional per-factor `sigma` for uncertainty propagation.
- `Footprint` — `scope1`/`scope2`/`scope3`/`total` CO2e, an optional 90% Monte-Carlo credible interval (`ci`), and `provenance` carrying a 64-hex `activity_content_hash` (IC-2's sha256-of-canonical-encoding convention) plus `factor_source` and the `scopes` actually included.
- `emissions_footprint(activity, factors, *, scopes=(1,2,3), n=0, rng=None) -> Footprint` — prices each activity key by whichever scope's factor dict includes it; when `n > 0` and `factors.sigma` is supplied, resamples each priced factor as `Normal(factor, sigma)` to build the CI.

`emissions_footprint` takes a plain `activity: dict[str, float]` — no runtime dependency on the H1 production-schedule solver, so this lands and tests standalone (synthetic-first, per the work order's parallel-safety note). `EmissionFactors`/`Footprint`/`emissions_footprint` are exported from `mixle/analysis/__init__.py` and `api_manifest.json` is regenerated to match.

## Public API impact

- [x] It changes the public surface, and I regenerated the manifest (`python scripts/gen_api_manifest.py`) and committed `api_manifest.json`.

Added: `EmissionFactors`, `Footprint`, `emissions_footprint` to `mixle.analysis.__all__`.

## Claims impact

- [x] No public claim (README, docs, benchmarks) is affected.

## Evidence

Test plan / DoD command (run inside an isolated worktree, path adjusted from the work order's generic template to this worktree's actual root — same file, same test):

```
$ PYTHONPATH=<worktree> python -m pytest mixle/tests/test_emissions.py::test_schedule_yields_scoped_footprint -q
1 passed in 183.59s
```

Full new test file (5 tests: hand-computed Scope 1/2/3 totals + hash provenance, CI-with-sigma, no-CI-without-sigma, scopes subset, invalid-scope error):

```
$ PYTHONPATH=<worktree> python -m pytest mixle/tests/test_emissions.py -q
5 passed in 64.80s
```

Broader regression sweep (analysis-package siblings + api-consistency/naming-alias tests, to check the new `__init__.py` export and manifest regen didn't disturb anything):

```
$ PYTHONPATH=<worktree> python -m pytest mixle/tests/test_emissions.py mixle/tests/api_naming_aliases_test.py \
    mixle/tests/api_consistency_test.py mixle/tests/max_stable_test.py mixle/tests/enumerator_coverage_test.py \
    mixle/tests/extreme_value_test.py mixle/tests/glossary_coverage_test.py mixle/tests/kde_test.py \
    mixle/tests/kriging_test.py mixle/tests/automatic_generalized_extreme_value_test.py \
    mixle/tests/coverage_estimation_test.py mixle/tests/cdf_coverage_test.py mixle/tests/rank_aggregation_test.py \
    mixle/tests/covariance_shrinkage_test.py mixle/tests/generalized_extreme_value_test.py -q
146 passed, 40 subtests passed in 407.46s
```

`ruff format` / `ruff check` clean on all changed files; `lint-imports` (import-linter) reports all 3 architecture contracts kept.

## Notes (judgment calls)

- The work order's algorithm step 4 says `provenance = {factor_source, activity_content_hash, scopes}` but `factor_source` isn't threaded through any parameter of the frozen `emissions_footprint` signature, and the Non-goals explicitly rule out a vendored factor database. I set `provenance["factor_source"] = "caller_supplied"` as a fixed literal documenting that factors always come from the caller/knowledge layer, rather than inventing an extra parameter not in the frozen Public API.
- `activity_content_hash` reuses the existing canonical-encoding hasher in `mixle/data/hashing.py` (`_canonical`, already used for `dataset_hash`/`model_hash`) rather than reimplementing a second canonical-JSON encoder, so the hashing convention referenced by IC-2 stays singly-sourced in the codebase.
- `scopes` filtering: a scope not requested reports `0.0` in that `Footprint` field and does not contribute to `total`, rather than being computed-but-excluded-from-total-only — simpler semantics for a Scope-1/2-only disclosure use case, and not constrained differently by the frozen signature.