### PR TITLE
M0b: Core substrate → IC-13 bundle compatibility bridge

### DIFF
--- a/mixle/substrate/context.py
+++ b/mixle/substrate/context.py
@@ -12,11 +12,186 @@ event records the budget, usage, and number of selected items.
 
 from __future__ import annotations
 
+import hashlib
+import json
 from collections.abc import Sequence
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from typing import Any
 
 from mixle.substrate.core import Substrate, SubstrateItem
+
+# --- IC-13 compatibility bridge (M0b) --------------------------------------------------------------
+#
+# Core substrate items are dependency-free dataclasses; `mixle_knowledge.contracts.KnowledgeItem` /
+# `KnowledgeBundle` (IC-13) are the frozen, validated wire shapes the rest of the platform (mixle-knowledge,
+# mixle-mlops, tools, models) exchanges. `substrate_item_to_knowledge_dict` and
+# `ContextPacket.to_knowledge_bundle_dict` translate one into the other as PLAIN, JSON-native dicts --
+# core never imports `mixle_knowledge`, so constructing/validating the pydantic model is the receiving
+# package's (or a test's) responsibility.
+
+GENERIC_KNOWLEDGE_SCHEMA = "mixle://schema/substrate-item/1"
+PROPERTY_GRAPH_SCHEMA = "mixle://schema/property-graph/1"
+TYPED_TABLE_SCHEMA = "mixle://schema/typed-table/1"
+SPATIAL_MEDIA_SCHEMA = "mixle://schema/spatial-media/1"
+
+# substrate kind -> (IC-13 ResourceKind value, IC-13 Modality value). An unmapped/future kind falls back
+# to a generic artifact/structured pair rather than raising, so the bridge degrades instead of breaking.
+_RESOURCE_KIND_BY_SUBSTRATE_KIND: dict[str, tuple[str, str]] = {
+    "text": ("document", "text"),
+    "record": ("table", "table"),
+    "image": ("image", "image"),
+    "signal": ("timeseries", "timeseries"),
+    "graph": ("artifact", "graph"),
+    "field": ("geospatial_layer", "raster"),
+    "event_stream": ("dataset", "timeseries"),
+    "artifact": ("artifact", "structured"),
+    "trace": ("trace", "structured"),
+    "context": ("context_packet", "structured"),
+}
+
+
+def _canonical_json(obj: Any) -> str:
+    """A stable JSON encoding (sorted keys, no incidental whitespace) so equal content hashes equal."""
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"), default=str)
+
+
+def _canonical_item_hash(
+    *,
+    schema_uri: str,
+    schema_version: str,
+    payload: Any,
+    artifact_ref: str | None,
+    metadata: dict[str, Any],
+) -> str:
+    """IC-13's frozen ``content_hash`` recipe: sha256 over ``{schema_uri,schema_version,payload,
+    artifact_ref,metadata}`` -- never over a text summary alone, so structurally-equal items dedupe and
+    silent drift is detectable. A separate artifact-byte digest (see :func:`_provenance_refs`/metadata)
+    verifies the referenced bytes independently and is never substituted for this hash."""
+    envelope = {
+        "schema_uri": schema_uri,
+        "schema_version": schema_version,
+        "payload": payload,
+        "artifact_ref": artifact_ref,
+        "metadata": metadata,
+    }
+    return hashlib.sha256(_canonical_json(envelope).encode("utf-8")).hexdigest()
+
+
+def _as_artifact_ref(ref: Any) -> str:
+    """Make a bare path/id URI-like (``artifact_ref`` convention); an already-URI value passes through."""
+    text = str(ref)
+    return text if "://" in text else f"substrate://artifact/{text.lstrip('/')}"
+
+
+def _looks_like_typed_table(payload: dict[str, Any]) -> bool:
+    return {"primary_key", "columns"} <= set(payload)
+
+
+def _infer_schema_uri(item: SubstrateItem, raw_payload: dict[str, Any]) -> str:
+    """Best-effort default schema for an item with no explicit override (a heuristic bridge, not a
+    validator -- core does not check the payload actually conforms; the receiving package does)."""
+    if item.kind == "graph":
+        return PROPERTY_GRAPH_SCHEMA
+    if item.kind in ("image", "field"):
+        return SPATIAL_MEDIA_SCHEMA
+    if item.kind == "record" and _looks_like_typed_table(raw_payload):
+        return TYPED_TABLE_SCHEMA
+    return GENERIC_KNOWLEDGE_SCHEMA
+
+
+def _access_policy_dict(scope: str) -> dict[str, Any]:
+    """``SubstrateItem.scope`` is ``"local"`` or a team id; IC-13's ``AccessPolicy`` names an explicit scope."""
+    if scope == "local":
+        return {"scope": "private"}
+    return {"scope": "team", "teams": [scope]}
+
+
+def _provenance_refs(item: SubstrateItem) -> list[dict[str, Any]]:
+    """Summarize ``item.provenance`` as one IC-13 ``SourceRef``-shaped dict (``uri`` is the only
+    required field there). The substrate's own file-byte digest (``provenance["content_hash"]``, a
+    truncated sha256 -- see ``freshness.content_hash``) is NOT put in ``sha256`` here: that field is
+    64-hex only, while the substrate's is a 32-hex digest of different provenance; it is preserved
+    verbatim in ``metadata["substrate_provenance"]`` instead so it is never lost nor misrepresented."""
+    prov = item.provenance or {}
+    uri = prov.get("source") or prov.get("path") or prov.get("uri") or f"substrate:{item.id}"
+    ref: dict[str, Any] = {"uri": str(uri)}
+    if prov.get("media_type"):
+        ref["media_type"] = prov["media_type"]
+    if prov.get("version") is not None:
+        ref["version"] = str(prov["version"])
+    if prov.get("license"):
+        ref["license"] = prov["license"]
+    return [ref]
+
+
+def _iso(epoch_seconds: float) -> str:
+    return datetime.fromtimestamp(float(epoch_seconds), tz=UTC).isoformat()
+
+
+def substrate_item_to_knowledge_dict(item: SubstrateItem, *, schema_uri: str | None = None) -> dict[str, Any]:
+    """Bridge one :class:`SubstrateItem` to an IC-13 ``KnowledgeItem``-shaped dict (M0b).
+
+    Core never imports ``mixle_knowledge``: this returns a plain, JSON-native dict with exactly the
+    frozen field names, so a caller (or test) can validate it with
+    ``mixle_knowledge.contracts.KnowledgeItem.model_validate`` without core depending on that package.
+
+    ``item.payload`` is the canonical structured payload UNLESS it carries a ``"ref"``/``"path"``
+    pointer (the substrate's own artifact convention -- see ``ingest_artifacts``), in which case that
+    pointer becomes ``artifact_ref`` and any remaining payload keys (e.g. spatial metadata) stay in
+    ``payload``. ``schema_uri`` defaults from ``item.kind`` (and, for a ``record`` item whose payload
+    already looks like a typed table, from its shape) but an explicit override always wins. The item
+    hash is always computed fresh over the canonical envelope; it never hashes ``item.text`` alone.
+    """
+    raw_payload: dict[str, Any] = dict(item.payload) if item.payload else {}
+    resolved_schema_uri = schema_uri or _infer_schema_uri(item, raw_payload)
+
+    payload_out: dict[str, Any] | None = dict(raw_payload)
+    artifact_ref: str | None = None
+    for ref_key in ("ref", "path"):
+        if ref_key in payload_out:
+            artifact_ref = _as_artifact_ref(payload_out.pop(ref_key))
+            break
+    if not payload_out and artifact_ref is not None:
+        payload_out = None
+    if payload_out is None and artifact_ref is None:
+        payload_out = {}  # IC-13 requires payload or artifact_ref; an empty canonical payload satisfies it
+
+    resource_kind, modality = _RESOURCE_KIND_BY_SUBSTRATE_KIND.get(item.kind, ("artifact", "structured"))
+
+    metadata: dict[str, Any] = {"tags": list(item.tags)}
+    if item.provenance:
+        metadata["substrate_provenance"] = dict(item.provenance)
+
+    schema_version = "1.0.0"
+    item_hash = _canonical_item_hash(
+        schema_uri=resolved_schema_uri,
+        schema_version=schema_version,
+        payload=payload_out,
+        artifact_ref=artifact_ref,
+        metadata=metadata,
+    )
+
+    return {
+        "id": item.id,
+        "kind": resource_kind,
+        "modality": modality,
+        "schema_uri": resolved_schema_uri,
+        "schema_version": schema_version,
+        "media_type": None,
+        "content_hash": item_hash,
+        "payload": payload_out,
+        "artifact_ref": artifact_ref,
+        "text_surface": item.text or None,
+        "provenance": _provenance_refs(item),
+        "relations": [{"predicate": "related_to", "target_id": link} for link in item.links],
+        "uncertainty": None,
+        "metadata": metadata,
+        "access": _access_policy_dict(item.scope),
+        "revision": 1,
+        "supersedes": [],
+        "created_at": _iso(item.created_at),
+    }
 
 
 @dataclass
@@ -146,6 +321,56 @@ class ContextPacket:
             "citations": citations,
             "expected_output_schema": expected_output_schema or {},
             "payload": payload,
+        }
+
+    def to_knowledge_bundle_dict(
+        self,
+        *,
+        id: str,  # noqa: A002 - matches the mixle-knowledge KnowledgeBundle field name exactly
+        project_id: str,
+        target_kind: str,
+        target_id: str | None = None,
+        expected_output_schema: dict[str, Any] | None = None,
+        gaps: list[dict[str, Any]] | None = None,
+    ) -> dict[str, Any]:
+        """Return a plain dict shaped like ``mixle_knowledge.contracts.KnowledgeBundle`` (IC-13, M0b).
+
+        Unlike :meth:`to_knowledge_dict` (kept, unchanged, as a deprecated compatibility view -- M1c
+        must never use it as canonical state), this bridge carries each selected item's OWN canonical
+        structured payload/artifact_ref/relations (:func:`substrate_item_to_knowledge_dict`) instead of
+        flattening everything into one rendered text string: a graph stays a graph, a typed table stays
+        a typed table, an image keeps its artifact ref. ``self.render()`` and the compression receipt
+        are only a disposable legacy view, kept under ``renderings["legacy_text"]``; they may be
+        recomputed or dropped at will without touching any item's canonical payload or hash.
+
+        As with :func:`substrate_item_to_knowledge_dict`, core never imports ``mixle_knowledge`` --
+        the caller validates the result (e.g. with ``KnowledgeBundle.model_validate``).
+        """
+        citations = [{"uri": p["source"] or f"substrate:{p['id']}", "media_type": p["kind"]} for p in self.provenance()]
+        return {
+            "id": id,
+            "project_id": project_id,
+            "task": self.task,
+            "target_kind": target_kind,
+            "target_id": target_id,
+            "revision": 1,
+            "items": [substrate_item_to_knowledge_dict(item) for item in self.items],
+            "gaps": gaps or [],
+            "constraints": [],
+            "citations": citations,
+            "expected_output_schema": expected_output_schema or {},
+            "token_budget": None,
+            "byte_budget": self.budget.max_chars,
+            "lineage": [],
+            "renderings": {
+                "legacy_text": {
+                    "text": self.render(),
+                    "shape": self.budget.shape,
+                    "compressed": self.compressed,
+                    "compression_ratio": self.compression_ratio,
+                    "preservation": self.preservation(),
+                }
+            },
         }
 
     def __len__(self) -> int:

--- a/mixle/tests/test_substrate_knowledge_bundle.py
+++ b/mixle/tests/test_substrate_knowledge_bundle.py
@@ -1,0 +1,189 @@
+"""M0b: core substrate -> IC-13 bundle compatibility bridge (notes/exec/workstream-M.md).
+
+Exercises `substrate_item_to_knowledge_dict` and `ContextPacket.to_knowledge_bundle_dict` against
+`mixle_knowledge.contracts.KnowledgeBundle` (IC-13). Core itself never imports `mixle_knowledge` --
+only this test does, to validate the dependency-free dicts the bridge produces.
+"""
+
+import pytest
+
+pydantic = pytest.importorskip("pydantic")
+from pydantic import ValidationError  # noqa: E402
+
+knowledge_contracts = pytest.importorskip("mixle_knowledge.contracts")
+KnowledgeBundle = knowledge_contracts.KnowledgeBundle
+
+from mixle.substrate.context import (  # noqa: E402
+    PROPERTY_GRAPH_SCHEMA,
+    SPATIAL_MEDIA_SCHEMA,
+    TYPED_TABLE_SCHEMA,
+    ContextPacket,
+    substrate_item_to_knowledge_dict,
+)
+from mixle.substrate.core import SubstrateItem  # noqa: E402
+
+
+def _graph_item():
+    return SubstrateItem(
+        id="graph-1",
+        kind="graph",
+        text="deposit graph",
+        payload={
+            "nodes": [{"id": "n1", "type": "deposit"}, {"id": "n2", "type": "assay"}],
+            "edges": [{"id": "e1", "source": "n1", "target": "n2", "type": "refines"}],
+        },
+        provenance={"source": "geo-model"},
+        scope="local",
+        tags=["geology"],
+        links=["table-1"],
+    )
+
+
+def _table_item():
+    return SubstrateItem(
+        id="table-1",
+        kind="record",
+        text="assay table",
+        payload={
+            "primary_key": ["sample_id"],
+            "columns": [
+                {"name": "sample_id", "type": "string"},
+                {"name": "cu_pct", "type": "float", "unit": "%"},
+            ],
+            "rows": [{"sample_id": "A-1", "cu_pct": 1.8}],
+        },
+        provenance={"source": "lab"},
+        scope="team-geo",
+        tags=["assay"],
+        links=["graph-1"],
+    )
+
+
+def _image_item():
+    return SubstrateItem(
+        id="image-1",
+        kind="image",
+        text="site raster",
+        payload={
+            "ref": "blob/sha256/" + "3" * 64,
+            "crs": "EPSG:32611",
+            "extent": [500000, 4100000, 501000, 4101000],
+            "pixel_to_crs": [1, 0, 500000, 0, -1, 4101000],
+        },
+        provenance={"source": "survey"},
+        scope="local",
+        tags=[],
+        links=[],
+    )
+
+
+def test_graph_item_round_trips_through_knowledge_item_validation():
+    d = substrate_item_to_knowledge_dict(_graph_item())
+    assert d["schema_uri"] == PROPERTY_GRAPH_SCHEMA
+    assert d["kind"] == "artifact" and d["modality"] == "graph"
+    item = knowledge_contracts.KnowledgeItem.model_validate(d)
+    assert item.payload == _graph_item().payload
+    assert item.relations[0].target_id == "table-1"
+    assert item.access.scope == "private"
+    assert len(item.content_hash) == 64
+
+
+def test_table_item_infers_typed_table_schema_from_shape():
+    d = substrate_item_to_knowledge_dict(_table_item())
+    assert d["schema_uri"] == TYPED_TABLE_SCHEMA
+    item = knowledge_contracts.KnowledgeItem.model_validate(d)
+    assert item.payload["rows"][0]["cu_pct"] == 1.8
+    assert item.access.scope == "team" and item.access.teams == ["team-geo"]
+
+
+def test_image_item_splits_ref_into_artifact_ref_and_keeps_spatial_payload():
+    d = substrate_item_to_knowledge_dict(_image_item())
+    assert d["schema_uri"] == SPATIAL_MEDIA_SCHEMA
+    assert d["artifact_ref"] == "substrate://artifact/blob/sha256/" + "3" * 64
+    assert "ref" not in d["payload"]
+    item = knowledge_contracts.KnowledgeItem.model_validate(d)
+    assert item.payload["crs"] == "EPSG:32611"
+    assert item.artifact_ref == d["artifact_ref"]
+
+
+def test_explicit_schema_uri_override_wins():
+    d = substrate_item_to_knowledge_dict(_graph_item(), schema_uri="mixle://schema/substrate-item/1")
+    assert d["schema_uri"] == "mixle://schema/substrate-item/1"
+
+
+def test_bundle_round_trips_graph_table_image_without_flattening():
+    packet = ContextPacket(
+        task="rank targets",
+        items=[_graph_item(), _table_item(), _image_item()],
+        scores=[0.9, 0.8, 0.7],
+    )
+    gap = {
+        "id": "gap-assay",
+        "question": "Find the missing Cu assay for A-2",
+        "required_schema": {"type": "number"},
+        "acceptance_criteria": ["verified lab result"],
+    }
+    bundle_dict = packet.to_knowledge_bundle_dict(
+        id="bundle-1",
+        project_id="p",
+        target_kind="model",
+        target_id="model-a",
+        expected_output_schema={"type": "object"},
+        gaps=[gap],
+    )
+
+    bundle = KnowledgeBundle.model_validate(bundle_dict)
+    assert len(bundle.items) == 3
+    by_id = {item.id: item for item in bundle.items}
+
+    # exact payload/links/scope preserved -- nothing flattened into rendered text
+    assert by_id["graph-1"].payload["edges"][0]["id"] == "e1"
+    assert by_id["graph-1"].relations[0].target_id == "table-1"
+    assert by_id["table-1"].payload["columns"][1]["type"] == "float"
+    assert by_id["table-1"].access.teams == ["team-geo"]
+    assert by_id["image-1"].artifact_ref.endswith("3" * 64)
+    assert by_id["image-1"].payload["extent"] == [500000, 4100000, 501000, 4101000]
+
+    assert bundle.gaps[0].id == "gap-assay"
+    assert bundle.gaps[0].status.value == "open"
+
+    # renderings carry the legacy text view only -- it may differ freely without moving item hashes
+    hashes_before = {item.id: item.content_hash for item in bundle.items}
+    legacy_text_first = bundle.renderings["legacy_text"]["text"]
+    bundle_dict_again = packet.to_knowledge_bundle_dict(
+        id="bundle-1", project_id="p", target_kind="model", target_id="model-a"
+    )
+    bundle_again = KnowledgeBundle.model_validate(bundle_dict_again)
+    hashes_after = {item.id: item.content_hash for item in bundle_again.items}
+    assert hashes_after == hashes_before
+    assert isinstance(legacy_text_first, str) and legacy_text_first
+
+
+def test_bundle_omits_legacy_to_knowledge_dict_from_canonical_items():
+    # to_knowledge_dict (legacy) stays available and unchanged, but is not what feeds the bundle.
+    packet = ContextPacket(task="t", items=[_graph_item()], scores=[1.0])
+    legacy = packet.to_knowledge_dict(id="x", project_id="p", target_kind="model")
+    assert "items" not in legacy  # the flattened legacy view has no canonical per-item structure
+    bundle_dict = packet.to_knowledge_bundle_dict(id="x", project_id="p", target_kind="model")
+    assert bundle_dict["items"][0]["payload"]["nodes"][0]["id"] == "n1"
+
+
+def test_item_with_neither_payload_nor_ref_still_validates_with_empty_payload():
+    item = SubstrateItem(id="bare", kind="text", text="just text", payload={})
+    d = substrate_item_to_knowledge_dict(item)
+    assert d["payload"] == {} and d["artifact_ref"] is None
+    knowledge_contracts.KnowledgeItem.model_validate(d)  # does not raise
+
+
+def test_bad_graph_payload_fails_downstream_validation_not_silently():
+    item = SubstrateItem(
+        id="bad-graph",
+        kind="graph",
+        payload={
+            "nodes": [{"id": "n1", "type": "deposit"}],
+            "edges": [{"id": "e", "source": "n1", "target": "missing", "type": "near"}],
+        },
+    )
+    d = substrate_item_to_knowledge_dict(item)
+    with pytest.raises(ValidationError):
+        knowledge_contracts.KnowledgeItem.model_validate(d)


### PR DESCRIPTION
## Worklist item

**Item:** M0b

From notes/exploration-e2e-work-plan.md (the post-0.7 capability-expansion worklist, commissioned directly by the maintainer) and notes/exec/workstream-M.md -- not the original 0.8.0 stability worklist; this is new, explicitly authorized capability work.

## Summary

Adds the core-substrate side of the IC-13 structured-knowledge-exchange bridge (workstream M, "the meta-brain"). Today `ContextPacket.to_knowledge_dict` is the only export path from the substrate, and it flattens every item down to one rendered text blob plus a citations list -- fine for a plain-text RAG prompt, but it throws away exactly what IC-13 exists to carry (a graph's nodes/edges, a table's typed columns, an image's georeference) before `mixle-knowledge` or `mixle-mlops` ever see it.

This PR adds a second, additive export path in `mixle/mixle/substrate/context.py` that preserves that structure:

- `substrate_item_to_knowledge_dict(item, *, schema_uri=None)` maps one `SubstrateItem` to an IC-13 `KnowledgeItem`-shaped dict: kind/modality inferred from the substrate kind, canonical payload kept intact (an artifact `"ref"`/`"path"` pointer is split out into `artifact_ref`), `links` -> `relations`, `scope` -> `access` policy, and a `content_hash` computed over the canonical envelope (`schema_uri, schema_version, payload, artifact_ref, metadata`) exactly per the frozen semantics in `notes/exec/contracts.md`.
- `ContextPacket.to_knowledge_bundle_dict(...)` builds a `KnowledgeBundle`-shaped dict for a full packet using the above per item, and keeps the old rendered text only as a disposable `renderings["legacy_text"]` view.

Core still never imports `mixle_knowledge` -- both return plain, JSON-native dicts; validating them against the real pydantic models is the caller's (or a test's) job. `to_knowledge_dict` is untouched and stays as the deprecated compatibility view (M1c must not use it as canonical state).

## Public API impact

- [x] This PR does **not** change any public `__all__`.
- [ ] It changes the public surface, and I regenerated the manifest (`python scripts/gen_api_manifest.py`) and committed `api_manifest.json`.
- [ ] It adds public surface: a written exception is recorded in the release decision log (freeze rule -- a change adding more public surface than it removes needs one).

(`substrate_item_to_knowledge_dict` and `ContextPacket.to_knowledge_bundle_dict` are new public names in `mixle.substrate.context`, but neither is added to `mixle/substrate/__init__.py`'s `__all__`, so the AST-based manifest generator sees no change -- confirmed by running it and diffing `api_manifest.json`, which is byte-identical to the committed baseline.)

## Claims impact

- [x] No public claim (README, docs, benchmarks) is affected.

## Evidence

```
PYTHONPATH=/Users/grantboquet/mixle/mixle:/Users/grantboquet/mixle/mixle-knowledge .venv/bin/python -m pytest mixle/tests/test_substrate_knowledge_bundle.py -q
8 passed

PYTHONPATH=/Users/grantboquet/mixle/mixle:/Users/grantboquet/mixle/mixle-knowledge .venv/bin/python -m pytest mixle/tests/test_substrate_knowledge_bundle.py mixle/tests/context_test.py mixle/tests/substrate_test.py -q
36 passed

ruff check mixle/substrate/context.py mixle/tests/test_substrate_knowledge_bundle.py -> All checks passed!
ruff format --check mixle/substrate/context.py mixle/tests/test_substrate_knowledge_bundle.py -> 2 files already formatted
```

## Notes (judgment calls)

- M0's IC-13 contract (`mixle-knowledge/mixle_knowledge/contracts.py`) has already merged to `mixle-knowledge`'s `release/0.8.0` (PR #2, `work/m0-freeze-the-structured-knowledge-exchange`), so the DoD test imports and validates against it directly rather than re-deriving the schema locally.
- `schema_uri` inference (`_infer_schema_uri`) is a best-effort default from the substrate item's `kind` (graph -> property-graph, image/field -> spatial-media, a `record` only gets the typed-table schema when its payload already looks like one by shape), not a conformance guarantee -- core does not validate the payload itself, so a malformed item still fails at `KnowledgeItem` construction downstream, which matches the contract's "never silently coerce" invariant. An explicit `schema_uri=` argument always overrides the inference.
- `KnowledgeRelation.predicate` has no substrate-side equivalent (`SubstrateItem.links` is untyped id list), so every derived relation uses the generic predicate `"related_to"`; a richer predicate vocabulary is out of scope for this bridge task.
- `AccessPolicy.scope` mapping: substrate `scope="local"` -> `access.scope="private"`; any other scope string (team id) -> `access.scope="team", teams=[scope]`. No substrate item scope maps to `"project"`/`"public"` today.

## Checklist

- [x] Tests added/updated and passing; `ruff check` + `ruff format --check` clean.
- [x] Consumer suites for any edited module pass (`context_test.py`, `substrate_test.py`).
- [x] I am not merging this PR myself, and I have not enabled auto-merge.
