### PR TITLE
M3: Problem decomposition & tool/model routing ⚗

### DIFF
--- a/mixle/task/catalog_router.py
+++ b/mixle/task/catalog_router.py
@@ -1,0 +1,86 @@
+"""IC-10 tool/model catalog -> :class:`~mixle.task.router.Router` wiring (M3-core).
+
+Every routable capability -- a physics forward, an economic model, a climate projection, an
+external domain model (IC-7) -- registers with the same uniform shape (:class:`CatalogEntry`, IC-10)
+so a decomposer/router never special-cases a tool family. :func:`build_catalog_router` turns a flat
+list of entries into one calibrated :class:`~mixle.task.router.Router` tier per entry (cheapest first),
+falling through to a frontier/teacher callable exactly the way :class:`~mixle.task.cascade.Cascade`
+already escalates uncertain calls.
+
+Local convention (not part of the frozen IC-10 shape, documented here because M3 owns the wiring):
+``CatalogEntry.schema`` is a plain ``dict[str, Any]`` (IC-10 imposes no further shape on it), so a
+registrant MAY stash two optional, well-known keys on it: ``"output"`` (the JSON-schema of what this
+entry produces, used for schema-compatibility matching in :mod:`mixle.task.knowledge_routing`) and
+``"invoke"`` (a ``Callable[[dict], Any]`` that actually runs the tool/model given a gap dict). Neither
+key is required; an entry with no ``"invoke"`` is still routable but can never produce a canonical
+result on its own -- see :mod:`mixle.task.knowledge_routing` for how an unresolved gap is handled.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from mixle.task.calibrate import ESCALATE
+from mixle.task.router import Router
+
+__all__ = ["CatalogEntry", "build_catalog_router"]
+
+
+@dataclass(frozen=True)
+class CatalogEntry:
+    """A routable capability: identity, its JSON `schema`, owning subsystem, `cost`, prior
+    `reliability`, and an optional verifier (the IC-10 tuple).
+
+    IC-10 (``notes/exec/contracts.md``) freezes ``verifier`` as ``str | None`` -- the *name* of the
+    IC-6 verifier kind that gates this entry's output. M3's own algorithm (step 5: "attach each
+    verifier; verified item ids resolve gaps") needs to actually CALL a verifier, not just look one up
+    by name, so this field is typed ``Any | None`` here and accepts either an IC-10-style string tag
+    or a live IC-6 ``Verifier``-shaped object (anything exposing ``.verify(claim, context)``) -- a
+    thin, additive shim over the frozen contract, not a rename of it. Field names/order/defaults are
+    otherwise identical to the frozen stub.
+    """
+
+    id: str
+    schema: dict[str, Any]
+    owner: str  # "physics" | "economic" | "climate" | "external" | ...
+    cost: float = 0.0
+    reliability: float = 1.0
+    verifier: Any | None = None
+
+
+class _ReliabilityGate:
+    """Adapts one :class:`CatalogEntry` into a :class:`~mixle.task.router.Router` tier.
+
+    ``decide(x)`` answers with this entry's own id when ``x`` names a domain this entry does not
+    disagree with and the entry's prior reliability clears ``min_reliability``; otherwise it escalates
+    to the next (costlier) tier, exactly like a calibrated task model's ``decide``.
+    """
+
+    def __init__(self, entry: CatalogEntry, *, min_reliability: float = 0.5) -> None:
+        self.entry = entry
+        self.min_reliability = float(min_reliability)
+
+    def decide(self, x: Any) -> Any:
+        domain = x.get("domain") if isinstance(x, dict) else None
+        if domain is not None and domain != self.entry.owner:
+            return ESCALATE
+        if self.entry.reliability < self.min_reliability:
+            return ESCALATE
+        return self.entry.id
+
+
+def build_catalog_router(catalog: list[CatalogEntry], teacher: Any) -> Router:
+    """Build one ``(id, adapter, cost)`` tier per catalog entry, ascending cost, teacher last.
+
+    ``teacher`` is the frontier fallback -- a BATCHED callable (``texts -> [labels]``, the same shape
+    :class:`~mixle.task.router.Router`'s final tier already expects). Its per-request cost is not
+    supplied by the caller (IC-10 entries carry the only costs this function knows about), so it is
+    set just above the priciest registered entry -- the frontier is a last resort, never competitive
+    with a cheaper registered tool on cost alone.
+    """
+    ordered = sorted(catalog, key=lambda e: (e.cost, e.id))
+    tiers: list[tuple[str, Any, float]] = [(entry.id, _ReliabilityGate(entry), float(entry.cost)) for entry in ordered]
+    frontier_cost = max((e.cost for e in ordered), default=0.0) + 1.0
+    tiers.append(("frontier", teacher, frontier_cost))
+    return Router(tiers)

--- a/mixle/task/knowledge_routing.py
+++ b/mixle/task/knowledge_routing.py
@@ -1,0 +1,342 @@
+"""M3 -- problem decomposition & tool/model routing over the IC-10 catalog (M3-core wiring).
+
+``route_task`` turns one compound question into ordered sub-tasks and explicit, typed prerequisite
+gaps -- never hidden prose intermediates -- matches each gap against the IC-10 catalog by declared
+domain/schema, and drives the existing :func:`~mixle.task.orchestrate.orchestrate` loop to resolve
+what it can. Every tool result is normalized into an IC-13-shaped ``KnowledgeItem``/``KnowledgeDelta``
+dict with model/tool attribution and a receipt; nothing free-form ever becomes a canonical delta. Core
+never imports ``mixle_knowledge`` -- everything here is a plain, dependency-free dict envelope shaped
+to the frozen IC-13 contract (``notes/exec/contracts.md``), so M1c/M2a can validate and persist it.
+
+This module reuses, rather than reinvents, three pieces of existing machinery:
+
+* :class:`~mixle.task.task_decomposition.DecompositionProposer` -- an outcome-trained proposer over
+  ordered sub-task sequences; ``proposer.plan_model.sample(rng)`` gives the decomposition order.
+* :func:`~mixle.task.orchestrate.orchestrate` -- the step/re-plan/stop controller loop; this module
+  supplies a trivial sequential plan model plus a :class:`~mixle.task.orchestrate.World` that resolves
+  one gap per step.
+* :class:`~mixle.scientist.ResearchProposal` -- the existing "here is how to find out" abstention
+  output; :func:`research_proposal_to_gap` folds it into the same IC-13 gap shape rather than
+  maintaining a second missing-knowledge lifecycle.
+
+Pre-M5, the decomposition itself is heuristic/seeded (``proposer`` is fit on a seed corpus, not
+learned online) -- that is an explicit non-goal here, deferred to M5.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+from mixle.task.catalog_router import CatalogEntry
+from mixle.task.orchestrate import orchestrate
+
+if TYPE_CHECKING:
+    from mixle.scientist import ResearchProposal
+    from mixle.task.task_decomposition import DecompositionProposer
+
+__all__ = ["KnowledgeOrchestrationResult", "research_proposal_to_gap", "route_task"]
+
+
+@dataclass
+class KnowledgeOrchestrationResult:
+    """An IC-13-shaped, dependency-free dict envelope: the answer, the IC-5 trace, an aggregate
+    IC-13 ``KnowledgeDelta``-shaped dict, and the gaps still open after this call. M1c/M2a validate
+    and persist ``delta``/``remaining_gaps`` against the real ``mixle_knowledge`` contracts; core
+    never imports that package itself."""
+
+    answer: Any
+    trace: dict[str, Any]
+    delta: dict[str, Any]
+    remaining_gaps: list[dict[str, Any]]
+
+
+def _stable_seed(question: str) -> int:
+    """A deterministic RNG seed derived from the question text, so the same compound query always
+    proposes the same sub-task order (no hidden global-RNG dependence)."""
+    return int(hashlib.sha256(question.encode("utf-8")).hexdigest()[:8], 16)
+
+
+def _dedupe_preserve_order(xs: list[str]) -> list[str]:
+    seen: set[str] = set()
+    out: list[str] = []
+    for x in xs:
+        if x and x not in seen:
+            seen.add(x)
+            out.append(x)
+    return out
+
+
+def _new_gap(question: str, domain: str, *, index: int) -> dict[str, Any]:
+    """A typed prerequisite gap for one sub-task, IC-13 ``KnowledgeGap``-shaped: an explicit
+    ``required_schema``/``acceptance_criteria`` pair the decomposer emits instead of a hidden prose
+    intermediate."""
+    return {
+        "id": f"gap-{index}-{domain}",
+        "question": f"{question} :: requires {domain} evidence",
+        "required_schema": {"type": "object", "domain": domain},
+        "acceptance_criteria": [f"a verified {domain} item resolves this gap"],
+        "status": "open",
+        "priority": 50,
+        "owner": None,
+        "attempts": [],
+        "resolved_by_item_ids": [],
+    }
+
+
+def research_proposal_to_gap(proposal: ResearchProposal, *, gap_id: str) -> dict[str, Any]:
+    """Map an existing :class:`~mixle.scientist.ResearchProposal` (an abstention's "here is how to
+    find out") into the frozen IC-13 gap shape, rather than maintaining a second missing-knowledge
+    lifecycle alongside it. ``ResearchProposal`` carries no structured schema for the missing evidence,
+    so ``required_schema`` is a best-effort description; ``acceptance_criteria`` is the proposal's own
+    ranked acquisition options (mirroring :meth:`~mixle.scientist.ResearchProposal.render`'s top-4
+    slice). ``nearest_knowledge``/``note`` have no home in the frozen ``KnowledgeGap`` fields and are
+    intentionally dropped rather than smuggled in as ad hoc extra keys."""
+    criteria = [str(opt["how"]) for opt in (proposal.options or [])[:4] if opt.get("how")]
+    return {
+        "id": gap_id,
+        "question": proposal.question,
+        "required_schema": {"type": "object", "description": proposal.missing},
+        "acceptance_criteria": criteria,
+        "status": "open",
+        "priority": 50,
+        "owner": None,
+        "attempts": [],
+        "resolved_by_item_ids": [],
+    }
+
+
+def _output_properties(entry: CatalogEntry) -> set[str]:
+    schema = entry.schema or {}
+    out = schema.get("output", schema)
+    return set((out or {}).get("properties") or {})
+
+
+def _candidates_for_gap(gap: dict[str, Any], catalog: list[CatalogEntry]) -> list[CatalogEntry]:
+    """Match a gap's ``required_schema`` against the catalog's declared domain/output schemas and
+    return compatible entries cheapest-and-most-reliable first. Only entries carrying a verifier are
+    eligible: an un-verifiable tool's output can never resolve a gap on its own (step 5 of the M3
+    algorithm), so it is not a routing candidate here at all."""
+    required = gap.get("required_schema") or {}
+    domain = required.get("domain")
+    candidates = [e for e in catalog if e.verifier is not None and e.reliability > 0]
+    if domain is not None:
+        candidates = [e for e in candidates if e.owner == domain]
+    req_props = set(required.get("properties") or {})
+    if req_props:
+        candidates = [e for e in candidates if req_props <= _output_properties(e)]
+    return sorted(candidates, key=lambda e: (e.cost, -e.reliability, e.id))
+
+
+def _match_existing_item(gap: dict[str, Any], known_items: list[dict[str, Any]]) -> dict[str, Any] | None:
+    """A gap is already answerable if the input bundle carries an item whose declared domain matches
+    -- no tool call needed; the bundle's own evidence resolves it directly."""
+    domain = (gap.get("required_schema") or {}).get("domain")
+    if domain is None:
+        return None
+    for item in known_items:
+        if (item.get("metadata") or {}).get("domain") == domain:
+            return item
+    return None
+
+
+def _canonical_hash(payload: dict[str, Any]) -> str:
+    blob = json.dumps(payload, sort_keys=True, default=str).encode("utf-8")
+    return hashlib.sha256(blob).hexdigest()
+
+
+def _to_knowledge_item(gap: dict[str, Any], entry: CatalogEntry, raw: Any) -> dict[str, Any]:
+    """Normalize a raw tool result into an IC-13-shaped ``KnowledgeItem`` dict -- never the raw
+    unstructured result itself."""
+    payload = raw if isinstance(raw, dict) else {"value": raw}
+    schema = entry.schema or {}
+    return {
+        "id": f"item-{gap['id']}-{entry.id}",
+        "kind": "artifact",
+        "modality": "structured",
+        "schema_uri": schema.get("schema_uri", "mixle://schema/catalog-result/1"),
+        "schema_version": "1.0.0",
+        "content_hash": _canonical_hash(payload),
+        "payload": payload,
+        "provenance": [{"tool_or_model": entry.id, "kind": "tool"}],
+        "metadata": {"domain": entry.owner, "gap_id": gap["id"]},
+    }
+
+
+def _verdict_passed(verdict: Any) -> bool:
+    if verdict is None:
+        return False
+    if isinstance(verdict, dict):
+        return bool(verdict.get("passed"))
+    return bool(getattr(verdict, "passed", False))
+
+
+def _attempt(*, tool_or_model: str | None, query: str, status: str, produced_item_ids: list[str]) -> dict[str, Any]:
+    return {
+        "actor": "mixle.task.knowledge_routing.route_task",
+        "query": query,
+        "tool_or_model": tool_or_model,
+        "status": status,
+        "produced_item_ids": produced_item_ids,
+    }
+
+
+def _resolve_gap(gap: dict[str, Any], known_items: list[dict[str, Any]], catalog: list[CatalogEntry]) -> dict[str, Any]:
+    """Resolve one gap: prefer evidence already in the bundle, else route to the cheapest matching,
+    reliable, verifiable catalog entry and verify its result before ever treating it as canonical."""
+    existing = _match_existing_item(gap, known_items)
+    if existing is not None:
+        return {"resolved": True, "item_ids": [existing["id"]], "item": None, "attempt": None}
+
+    candidates = _candidates_for_gap(gap, catalog)
+    if not candidates:
+        return {
+            "resolved": False,
+            "item_ids": [],
+            "item": None,
+            "attempt": _attempt(
+                tool_or_model=None, query=gap["question"], status="no_matching_tool", produced_item_ids=[]
+            ),
+        }
+
+    entry = candidates[0]
+    invoke = (entry.schema or {}).get("invoke")
+    if invoke is None:
+        return {
+            "resolved": False,
+            "item_ids": [],
+            "item": None,
+            "attempt": _attempt(
+                tool_or_model=entry.id, query=gap["question"], status="no_executor", produced_item_ids=[]
+            ),
+        }
+
+    raw = invoke(gap)
+    item = _to_knowledge_item(gap, entry, raw)
+    verdict = entry.verifier.verify(claim={"payload": item["payload"]}, context={"gap": gap, "entry": entry.id})
+    if _verdict_passed(verdict):
+        return {
+            "resolved": True,
+            "item_ids": [item["id"]],
+            "item": item,
+            "attempt": _attempt(
+                tool_or_model=entry.id, query=gap["question"], status="resolved", produced_item_ids=[item["id"]]
+            ),
+        }
+    return {
+        "resolved": False,
+        "item_ids": [],
+        "item": None,
+        "attempt": _attempt(tool_or_model=entry.id, query=gap["question"], status="failed", produced_item_ids=[]),
+    }
+
+
+@dataclass
+class _RoutingWorld:
+    """The :class:`~mixle.task.orchestrate.World` this module drives ``orchestrate`` against: one
+    step resolves one gap. Never mutates the caller's input bundle -- ``known_items`` is read-only;
+    newly produced items accumulate separately in ``add_items``."""
+
+    gaps: list[dict[str, Any]]
+    known_items: list[dict[str, Any]]
+    catalog: list[CatalogEntry]
+    add_items: list[dict[str, Any]] = field(default_factory=list)
+    gap_updates: list[dict[str, Any]] = field(default_factory=list)
+    tried_catalog_ids: set[str] = field(default_factory=set)
+    _cursor: int = 0
+
+    @property
+    def done(self) -> bool:
+        return self._cursor >= len(self.gaps)
+
+    def step(self, action: dict[str, Any]) -> Any:
+        idx = int(action["args"]["index"])
+        gap = self.gaps[idx]
+        self._cursor += 1
+        outcome = _resolve_gap(gap, self.known_items + self.add_items, self.catalog)
+        attempt = outcome["attempt"]
+        if attempt is not None and attempt.get("tool_or_model"):
+            self.tried_catalog_ids.add(attempt["tool_or_model"])
+        if outcome["resolved"]:
+            gap["status"] = "resolved"
+            gap["resolved_by_item_ids"] = outcome["item_ids"]
+            if outcome["item"] is not None:
+                self.add_items.append(outcome["item"])
+            self.gap_updates.append(
+                {"gap_id": gap["id"], "status": "resolved", "resolved_by_item_ids": outcome["item_ids"]}
+            )
+        elif attempt is not None:
+            gap["attempts"].append(attempt)
+        return outcome
+
+    def score(self) -> dict[str, Any]:
+        n_resolved = sum(1 for g in self.gaps if g["status"] == "resolved")
+        return {"resolved": n_resolved, "total": len(self.gaps)}
+
+
+def _sequential_plan(n_gaps: int):
+    """A trivial plan model: resolve gap 0, 1, 2, ... in order, then STOP -- the decomposition order
+    was already decided by the proposer; ``orchestrate`` just needs a step/stop signal per gap."""
+
+    def plan(_question: str, history: list[dict[str, Any]]) -> dict[str, Any] | None:
+        i = len(history)
+        if i >= n_gaps:
+            return None
+        return {"tool": "resolve_gap", "args": {"index": i}}
+
+    return plan
+
+
+def route_task(
+    question: str,
+    catalog: list[CatalogEntry],
+    *,
+    proposer: DecompositionProposer,
+    budget: int,
+    bundle: dict[str, Any] | None = None,
+) -> KnowledgeOrchestrationResult:
+    """Decompose ``question`` into ordered sub-tasks and explicit prerequisite gaps, route each gap
+    to the cheapest reliable/verifiable catalog entry (or an item already in ``bundle``), drive
+    :func:`~mixle.task.orchestrate.orchestrate` to resolve what it can, and return an IC-13-shaped
+    answer/trace/delta/remaining-gaps envelope. Core emits plain dicts and never imports
+    ``mixle_knowledge``; M1c/M2a validate and persist this envelope against the real contracts."""
+    bundle = dict(bundle or {})
+    known_items = list(bundle.get("items") or [])
+    seed_gaps = list(bundle.get("gaps") or [])
+
+    rng = np.random.RandomState(_stable_seed(question))
+    sampled = proposer.plan_model.sample(rng)
+    domains = _dedupe_preserve_order(sampled) or sorted({e.owner for e in catalog})
+    new_gaps = [_new_gap(question, domain, index=i) for i, domain in enumerate(domains)]
+    all_gaps = seed_gaps + new_gaps
+
+    world = _RoutingWorld(gaps=all_gaps, known_items=known_items, catalog=list(catalog))
+    result = orchestrate(question, _sequential_plan(len(all_gaps)), world, budget=max(int(budget), len(all_gaps)))
+
+    remaining = [g for g in world.gaps if g["status"] != "resolved"]
+    delta = {
+        "base_bundle_id": bundle.get("id", ""),
+        "base_revision": int(bundle.get("revision", 1)),
+        "produced_by": "mixle.task.knowledge_routing.route_task",
+        "model_version": None,
+        "add_items": world.add_items,
+        "add_gaps": new_gaps,
+        "supersede_item_ids": [],
+        "gap_updates": world.gap_updates,
+        "provenance": [{"tool_or_model": "route_task", "note": f"{len(all_gaps)} sub-task gaps"}],
+    }
+    answer = {
+        "resolved_gap_ids": [g["id"] for g in world.gaps if g["status"] == "resolved"],
+        "unresolved_gap_ids": [g["id"] for g in remaining],
+        "catalog_ids_considered": sorted(world.tried_catalog_ids),
+    }
+    return KnowledgeOrchestrationResult(
+        answer=answer,
+        trace=result.trace.to_json(),
+        delta=delta,
+        remaining_gaps=remaining,
+    )

--- a/mixle/tests/task/test_catalog_router.py
+++ b/mixle/tests/task/test_catalog_router.py
@@ -1,0 +1,78 @@
+"""M3 DoD: IC-10 catalog entries wire into one calibrated Router tier per entry, ascending cost,
+teacher/frontier last -- and a low-reliability entry escalates rather than answering."""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from mixle.task.catalog_router import CatalogEntry, build_catalog_router
+
+
+class _StubVerifier:
+    def verify(self, claim, context):
+        return {"passed": True, "score": 1.0, "reasons": [], "kind": "exact"}
+
+
+def _catalog() -> list[CatalogEntry]:
+    return [
+        CatalogEntry(
+            id="physics_survey", schema={}, owner="physics", cost=0.2, reliability=0.9, verifier=_StubVerifier()
+        ),
+        CatalogEntry(
+            id="economic_model", schema={}, owner="economic", cost=0.1, reliability=0.85, verifier=_StubVerifier()
+        ),
+        CatalogEntry(
+            id="climate_projection", schema={}, owner="climate", cost=0.3, reliability=0.2, verifier=_StubVerifier()
+        ),
+    ]
+
+
+def _teacher(texts):
+    return [{"domain": "frontier", "for": (t.get("domain") if isinstance(t, dict) else t)} for t in texts]
+
+
+def test_entry_fields_match_ic10_names_and_order():
+    names = [f.name for f in dataclasses.fields(CatalogEntry)]
+    assert names == ["id", "schema", "owner", "cost", "reliability", "verifier"]
+
+
+def test_entry_is_immutable():
+    entry = CatalogEntry(id="x", schema={}, owner="external")
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        entry.cost = 2.0
+
+
+def test_one_tier_per_entry_ascending_cost_teacher_last():
+    router = build_catalog_router(_catalog(), _teacher)
+    assert len(router.tiers) == len(_catalog()) + 1
+
+    costs = [cost for _, _, cost in router.tiers[:-1]]
+    assert costs == sorted(costs)
+    assert [name for name, _, _ in router.tiers[:-1]] == ["economic_model", "physics_survey", "climate_projection"]
+
+    name, model, cost = router.tiers[-1]
+    assert name == "frontier"
+    assert model is _teacher
+    assert cost > max(costs)
+
+
+def test_matching_reliable_entry_answers_without_escalating():
+    router = build_catalog_router(_catalog(), _teacher)
+    label = router({"domain": "physics"})
+    assert label == "physics_survey"
+
+    tier_by_name = {t["tier"]: t["answered"] for t in router.report()["tiers"]}
+    assert tier_by_name["physics_survey"] == 1
+    assert tier_by_name["economic_model"] == 0
+    assert tier_by_name["climate_projection"] == 0
+
+
+def test_low_reliability_entry_escalates_to_frontier():
+    router = build_catalog_router(_catalog(), _teacher)
+    result = router({"domain": "climate"})
+    # climate_projection's reliability (0.2) is below the adapter's gate -- it must escalate rather
+    # than answer, and the frontier teacher gets the whole request (batched, per Router.__call__).
+    assert result == {"domain": "frontier", "for": "climate"}
+    assert router.report()["harvested_labels"] == 1

--- a/mixle/tests/task/test_knowledge_routing.py
+++ b/mixle/tests/task/test_knowledge_routing.py
@@ -1,0 +1,196 @@
+"""M3 DoD: a compound query decomposes into typed prerequisite gaps across >=3 catalog domains,
+resolves seeded-answerable gaps with real item ids, leaves unmatched/unverified gaps open and
+explicit, and never lets a tool's free text become a canonical delta item."""
+
+from __future__ import annotations
+
+from mixle.task.catalog_router import CatalogEntry
+from mixle.task.knowledge_routing import research_proposal_to_gap, route_task
+from mixle.task.task_decomposition import init_decomposition_proposer
+
+QUESTION = "What is the projected copper tonnage under baseline economics and RCP4.5 climate?"
+
+
+class _PassVerifier:
+    def verify(self, claim, context):
+        return {"passed": True, "score": 1.0, "reasons": ["matches expected structure"], "kind": "physical"}
+
+
+class _FailVerifier:
+    def verify(self, claim, context):
+        return {"passed": False, "score": 0.0, "reasons": ["implausible free text"], "kind": "physical"}
+
+
+def _physics_tool(gap):
+    return {"tonnage_mt": 12.5, "units": "Mt"}
+
+
+def _economic_tool(gap):
+    return {"npv_usd": 4.2e7}
+
+
+def _climate_tool(gap):
+    return {"precip_delta_pct": -8.0}
+
+
+def _rumor_tool(gap):
+    return "probably fine, trust me"  # free-form prose -- must never become canonical
+
+
+def _catalog() -> list[CatalogEntry]:
+    return [
+        CatalogEntry(
+            id="physics_survey",
+            schema={"invoke": _physics_tool, "output": {"properties": {"tonnage_mt": {"type": "number"}}}},
+            owner="physics",
+            cost=0.2,
+            reliability=0.9,
+            verifier=_PassVerifier(),
+        ),
+        CatalogEntry(
+            id="economic_model",
+            schema={"invoke": _economic_tool, "output": {"properties": {"npv_usd": {"type": "number"}}}},
+            owner="economic",
+            cost=0.1,
+            reliability=0.85,
+            verifier=_PassVerifier(),
+        ),
+        CatalogEntry(
+            id="climate_projection",
+            schema={"invoke": _climate_tool, "output": {"properties": {"precip_delta_pct": {"type": "number"}}}},
+            owner="climate",
+            cost=0.3,
+            reliability=0.8,
+            verifier=_PassVerifier(),
+        ),
+        CatalogEntry(
+            id="rumor_mill",
+            schema={"invoke": _rumor_tool},
+            owner="rumor",
+            cost=0.05,
+            reliability=0.99,
+            verifier=_FailVerifier(),
+        ),
+    ]
+
+
+def _proposer():
+    # Seeded/heuristic decomposition (pre-M5, per the M3 non-goals): a repeated seed corpus so the
+    # fitted Markov chain reliably proposes the same ordered sub-task domains for this question.
+    seed_decompositions = [["physics", "economic", "climate"]] * 20
+    return init_decomposition_proposer(seed_decompositions)
+
+
+def test_compound_query_routes_at_least_three_catalog_ids_and_creates_typed_gaps():
+    result = route_task(QUESTION, _catalog(), proposer=_proposer(), budget=8)
+
+    assert len(result.answer["catalog_ids_considered"]) >= 3
+    assert {"physics_survey", "economic_model", "climate_projection"} <= set(result.answer["catalog_ids_considered"])
+
+    add_gaps = result.delta["add_gaps"]
+    assert len(add_gaps) >= 3
+    for gap in add_gaps:
+        assert gap["required_schema"].get("domain")  # typed, not a hidden prose intermediate
+        assert gap["acceptance_criteria"]
+
+    resolved_ids = set(result.answer["resolved_gap_ids"])
+    assert len(resolved_ids) >= 3
+    assert result.delta["add_items"]
+    for item in result.delta["add_items"]:
+        assert item["content_hash"]
+        assert isinstance(item["payload"], dict)
+
+
+def test_seeded_bundle_item_resolves_its_gap_without_a_tool_call():
+    seeded_item = {
+        "id": "geo-report-1",
+        "kind": "artifact",
+        "modality": "structured",
+        "schema_uri": "mixle://schema/typed-table/1",
+        "content_hash": "a" * 64,
+        "payload": {"assay": "cu"},
+        "metadata": {"domain": "geology"},
+    }
+    seed_gap = {
+        "id": "gap-seed-geology",
+        "question": "what is the historical assay grade",
+        "required_schema": {"type": "object", "domain": "geology"},
+        "acceptance_criteria": ["a verified geology item resolves this gap"],
+        "status": "open",
+        "priority": 50,
+        "owner": None,
+        "attempts": [],
+        "resolved_by_item_ids": [],
+    }
+    bundle = {"id": "bundle-1", "revision": 3, "items": [seeded_item], "gaps": [seed_gap]}
+
+    result = route_task(QUESTION, _catalog(), proposer=_proposer(), budget=8, bundle=bundle)
+
+    assert "gap-seed-geology" in result.answer["resolved_gap_ids"]
+    seed_updates = [u for u in result.delta["gap_updates"] if u["gap_id"] == "gap-seed-geology"]
+    assert seed_updates and seed_updates[0]["resolved_by_item_ids"] == ["geo-report-1"]
+    # the pre-existing bundle item resolved it directly -- no new item was manufactured for it
+    assert not any("gap-seed-geology" in item["id"] for item in result.delta["add_items"])
+
+
+def test_unmatched_and_unverified_gaps_remain_open_and_free_text_never_becomes_a_delta():
+    bundle = {
+        "gaps": [
+            {
+                "id": "gap-seed-hydrology",
+                "question": "what is the water table depth",
+                "required_schema": {"type": "object", "domain": "hydrology"},
+                "acceptance_criteria": ["a verified hydrology item resolves this gap"],
+                "status": "open",
+                "priority": 50,
+                "owner": None,
+                "attempts": [],
+                "resolved_by_item_ids": [],
+            },
+            {
+                "id": "gap-seed-rumor",
+                "question": "any word on the permit?",
+                "required_schema": {"type": "object", "domain": "rumor"},
+                "acceptance_criteria": ["a verified rumor item resolves this gap"],
+                "status": "open",
+                "priority": 50,
+                "owner": None,
+                "attempts": [],
+                "resolved_by_item_ids": [],
+            },
+        ]
+    }
+
+    result = route_task(QUESTION, _catalog(), proposer=_proposer(), budget=8, bundle=bundle)
+
+    unresolved_ids = {g["id"] for g in result.remaining_gaps}
+    assert {"gap-seed-hydrology", "gap-seed-rumor"} <= unresolved_ids
+
+    hydrology_gap = next(g for g in result.remaining_gaps if g["id"] == "gap-seed-hydrology")
+    assert hydrology_gap["attempts"][-1]["status"] == "no_matching_tool"  # no catalog entry for this domain
+
+    rumor_gap = next(g for g in result.remaining_gaps if g["id"] == "gap-seed-rumor")
+    assert rumor_gap["attempts"][-1]["status"] == "failed"  # tool ran, but its verifier rejected the output
+
+    # the rumor tool's free-form prose result never became a canonical item/delta entry
+    assert not any(item.get("metadata", {}).get("domain") == "rumor" for item in result.delta["add_items"])
+    assert not any(isinstance(item["payload"], str) for item in result.delta["add_items"])
+
+
+def test_research_proposal_to_gap_maps_into_the_frozen_gap_shape():
+    from mixle.scientist import ResearchProposal
+
+    proposal = ResearchProposal(
+        question="how permeable is the tailings facility foundation?",
+        missing="foundation permeability",
+        nearest_knowledge=[{"score": 0.4, "text": "nearby borehole log"}],
+        options=[{"how": "run a falling-head permeability test", "cost": 500.0}],
+    )
+    gap = research_proposal_to_gap(proposal, gap_id="gap-from-proposal-1")
+
+    assert gap["id"] == "gap-from-proposal-1"
+    assert gap["question"] == proposal.question
+    assert gap["required_schema"]["description"] == "foundation permeability"
+    assert gap["acceptance_criteria"] == ["run a falling-head permeability test"]
+    assert gap["status"] == "open"
+    assert gap["resolved_by_item_ids"] == []


### PR DESCRIPTION
## Worklist item

**Item:** M3

From `notes/exec/exploration-e2e-work-plan.md` (the post-0.7 capability-expansion worklist, commissioned directly by the maintainer) and `notes/exec/workstream-M.md` — not the original 0.8.0 stability worklist; this is new, explicitly authorized capability work.

## Summary

Wires the existing decomposition/routing primitives (`Router`, `orchestrate`, `DecompositionProposer`) to an IC-10 tool/model catalog, entirely in core and dependency-free (no `mixle_knowledge` import):

- `mixle/mixle/task/catalog_router.py` — the IC-10 `CatalogEntry` shape plus `build_catalog_router(catalog, teacher)`, which builds one `Router` tier per catalog entry (ascending cost), teacher/frontier last, gated by a reliability threshold per tier.
- `mixle/mixle/task/knowledge_routing.py` — `route_task(question, catalog, *, proposer, budget, bundle=None)`, which decomposes a compound question into ordered sub-tasks via the existing `DecompositionProposer`, turns each into an explicit, typed IC-13 gap (`{question, required_schema, acceptance_criteria}` — never a hidden prose intermediate), matches each gap against the catalog by domain/schema, drives the existing `orchestrate` loop to resolve what it can, and returns an IC-13-shaped `KnowledgeOrchestrationResult{answer, trace, delta, remaining_gaps}` dict envelope for M1c/M2a to validate and persist. `research_proposal_to_gap` folds the existing `ResearchProposal` abstention output into the same gap shape instead of keeping a second missing-knowledge lifecycle alive.

Every tool result is normalized into a canonical `KnowledgeItem` dict and passed through its catalog entry's verifier before it can resolve a gap; free-form/unverified output never becomes a delta item.

## Public API impact

- [x] This PR does **not** change any public `__all__` tracked in `api_manifest.json` — the two new modules declare their own `__all__` but neither is re-exported from any package `__init__.py`, so `python scripts/gen_api_manifest.py` produces a byte-identical manifest (verified; no diff, not committed).

## Claims impact

- [x] No public claim (README, docs, benchmarks) is affected.

## Evidence

```
PYTHONPATH=/Users/grantboquet/mixle/mixle .venv/bin/python -m pytest mixle/tests/task/test_catalog_router.py mixle/tests/task/test_knowledge_routing.py -q
-> 9 passed

Regression check (existing router/orchestrate/decomposition suites, read-only in this PR):
pytest mixle/tests/task_router_test.py mixle/tests/task_orchestrate_test.py mixle/tests/task_decomposition_test.py mixle/tests/outcome_decomposer_test.py mixle/tests/decomposition_test.py mixle/tests/router_harvest_test.py -q
-> 32 passed

ruff format + ruff check on the four changed/added files: clean.
```

## Checklist

- [x] Tests added/updated and passing; `ruff check` + `ruff format --check` clean.
- [x] Consumer suites for any edited module pass (router/orchestrate/decomposition suites above — this PR only reads those modules, never edits them).
- [x] I am not merging this PR myself, and I have not enabled auto-merge.

## Notes (judgment calls)

- **IC-10 `verifier` field type.** The frozen IC-10 stub in `notes/exec/contracts.md` types `CatalogEntry.verifier` as `str | None` (a verifier-*kind* tag). M3's own algorithm (step 5: "attach each verifier; verified item ids resolve gaps") needs to actually *call* a verifier, not just look one up by name. `catalog_router.CatalogEntry.verifier` is typed `Any | None` and accepts either an IC-10-style string tag or a live IC-6 `Verifier`-shaped object (anything exposing `.verify(claim, context)`). Field names/order/defaults are unchanged from the frozen stub; this is documented as a shim in the module docstring, not a redesign of IC-10.
- **`mixle/mixle/task/catalog.py` (the IC-10 module itself) does not exist yet** in this branch (no Wave-0/E4 PR has landed it), and M3's own Files list only asks for `catalog_router.py` + `knowledge_routing.py` — not `catalog.py`. `CatalogEntry` is therefore defined locally in `catalog_router.py`, matching the frozen IC-10 field names/order/defaults exactly, rather than importing a module that isn't there. When `mixle.task.catalog` lands, reconciling the two (or re-exporting from one) is a follow-up, not a redesign of either.
- **Executor hook on `CatalogEntry.schema`.** IC-10 types `schema` as a plain `dict[str, Any]` with no execution hook. Since `route_task` must actually drive `orchestrate` against real catalog entries, this PR uses two additive, optional, well-known keys on that dict — `"output"` (declared output JSON-schema, used for schema-compatibility matching) and `"invoke"` (a `Callable[[dict], Any]` that runs the tool) — documented in the `catalog_router` module docstring. Neither key is required by IC-10 or contradicts it; an entry without `"invoke"` is still routable but can never resolve a gap unassisted.
- **Decomposition is heuristic/seeded**, per the task's own non-goals (learned decomposition is M5). `route_task` derives a deterministic RNG seed from the question text so the same compound query reliably proposes the same sub-task order from a given seeded `DecompositionProposer`.