### PR TITLE
H6: Demand forecasting + distribution routing/dispatch

### DIFF
--- a/mixle/distribution.py
+++ b/mixle/distribution.py
@@ -1,0 +1,145 @@
+"""Demand forecasting + distribution routing/dispatch.
+
+Two steps, chained: forecast tomorrow's demand honestly, then route today's supply to meet it at
+minimum cost.
+
+:func:`forecast_demand` fits a small regime-switching (Gaussian-emission HMM) model directly from a
+raw history series and calls the existing :func:`mixle.inference.forecast.forecast` front door for
+the exact state-marginal / Monte-Carlo-emission predictive band, then recalibrates that band with
+:func:`mixle.inference.conformal.split_conformal` on a held-out tail of the SAME history so the
+returned interval holds its nominal coverage even when the underlying HMM is mis-specified (few
+states, short history, non-Gaussian residuals, ...) -- conformal calibration is model-agnostic and
+only assumes exchangeability of the calibration residuals.
+
+:func:`route_distribution` then turns that forecast into a network flow problem: the forecast mean
+is the per-node demand, ``supply_nodes - demand`` is the net supply IC-9's :func:`min_cost_flow`
+consumes directly (H1's already-solved minimum-cost network flow), giving the min-cost dispatch that
+meets the forecast at once.
+
+    >>> history = [50.0 + 10 * ((-1) ** (t // 12)) for t in range(60)]
+    >>> f = forecast_demand(history, horizon=4, level=0.9, seed=0)
+    >>> f.mean.shape
+    (4,)
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from mixle.inference.conformal import split_conformal
+from mixle.inference.forecast import Forecast, forecast
+from mixle.relations import Flow, min_cost_flow
+
+__all__ = ["forecast_demand", "route_distribution"]
+
+_N_STATES = 2  # low/high demand regimes -- matches the two-state precedent in forecast()'s own tests
+_CAL_FRAC = 0.35  # fraction of history reserved as the conformal calibration tail
+_MAX_ITS = 50
+
+
+def _fit_demand_hmm(values: np.ndarray, *, seed: int) -> Any:
+    """Fit a small Gaussian-emission HMM to a univariate demand series (EM, quantile-seeded init).
+
+    A cold/random EM init on a single continuous sequence is prone to a degenerate collapse (a state
+    grabbing zero mass and its variance flooring to ~0); seeding from the calibration-set's own lower/
+    upper quartiles as two well-separated regimes (with a mildly sticky transition prior) gives EM a
+    basin that converges to a genuine two-regime fit instead.
+    """
+    from mixle.inference.estimation import optimize
+    from mixle.stats import GaussianDistribution, GaussianEstimator, HiddenMarkovModelDistribution
+    from mixle.stats.latent.hidden_markov import HiddenMarkovEstimator
+
+    lo_q, hi_q = np.quantile(values, [0.25, 0.75])
+    var0 = max(float(values.std()) ** 2, 1.0e-6)
+    init = HiddenMarkovModelDistribution(
+        [GaussianDistribution(float(lo_q), var0), GaussianDistribution(float(hi_q), var0)],
+        [0.5, 0.5],
+        [[0.8, 0.2], [0.2, 0.8]],
+    )
+    estimator = HiddenMarkovEstimator([GaussianEstimator() for _ in range(_N_STATES)], pseudo_count=(1.0, 1.0))
+    return optimize([values.tolist()], estimator, max_its=_MAX_ITS, prev_estimate=init, structure="off")
+
+
+def forecast_demand(history: Any, horizon: int, *, level: float = 0.9, seed: int = 0) -> Forecast:
+    """Forecast ``horizon`` steps of demand beyond ``history``, with a conformally-calibrated band.
+
+    Fits a 2-state Gaussian-emission HMM to ``history`` and calls :func:`mixle.inference.forecast.forecast`
+    for the exact state-marginal / Monte-Carlo predictive mean and band; the raw band is then
+    recalibrated by :func:`mixle.inference.conformal.split_conformal`: a model fit on everything but
+    the last ``~35%`` of ``history`` is used to forecast that held-out tail, the (prediction, actual)
+    pairs there calibrate a constant additive half-width at the nominal ``level``, and that half-width
+    is added around the mean of a *second* model refit on the full ``history`` -- so the returned
+    interval holds close to ``level`` coverage even though the HMM itself is a simplification (few
+    states, short series, whatever residual shape the demand series actually has).
+
+    Args:
+        history: past demand observations (one univariate series).
+        horizon: number of future periods to forecast.
+        level: central-interval mass (0.9 -> a calibrated ~90% band).
+        seed: reproducibility (both the HMM's EM/MC internals and the calibration split).
+
+    Returns:
+        A :class:`mixle.inference.forecast.Forecast` (`.mean`, `.lo`, `.hi`, `.level`, `.state_probs`).
+    """
+    if horizon < 1:
+        raise ValueError("horizon must be >= 1")
+    if not 0.0 < level < 1.0:
+        raise ValueError("level must be in (0, 1)")
+    hist = np.asarray(history, dtype=np.float64)
+    if hist.ndim != 1:
+        raise ValueError("history must be a 1-D demand series")
+    n = hist.shape[0]
+    if n < 8:
+        raise ValueError("forecast_demand needs at least 8 history points to hold out a calibration tail")
+
+    k = max(horizon, int(round(_CAL_FRAC * n)))
+    k = min(k, n - 4)  # leave at least 4 points to fit the calibration-split model itself
+    train, cal_actual = hist[:-k], hist[-k:]
+
+    cal_model = _fit_demand_hmm(train, seed=seed)
+    cal_forecast = forecast(cal_model, train.tolist(), horizon=k, level=level, seed=seed)
+    cal_pred = np.asarray(cal_forecast.mean, dtype=np.float64)
+
+    alpha = 1.0 - level
+    _lo_adj, hi_adj = split_conformal(cal_pred, cal_actual, cal_pred, alpha=alpha, side="two-sided")
+    half_width = float(np.mean(hi_adj - cal_pred))  # split_conformal's two-sided q is a single constant
+
+    final_model = _fit_demand_hmm(hist, seed=seed)
+    final_forecast = forecast(final_model, hist.tolist(), horizon=horizon, level=level, seed=seed)
+    mean = np.asarray(final_forecast.mean, dtype=np.float64)
+
+    return Forecast(
+        mean=mean,
+        lo=mean - half_width,
+        hi=mean + half_width,
+        level=level,
+        state_probs=final_forecast.state_probs,
+        samples=final_forecast.samples,
+    )
+
+
+def route_distribution(supply_nodes: Any, demand_forecast: Forecast, cost: Any, cap: Any) -> Flow:
+    """Route supply to meet forecast demand at minimum cost (H1/IC-9's :func:`min_cost_flow`).
+
+    ``supply_nodes`` and ``demand_forecast.mean`` align one-to-one, per node (a plant/depot/customer
+    per forecast horizon step); ``supply = supply_nodes - demand_forecast.mean`` is the net node
+    supply :func:`min_cost_flow` consumes directly under the given ``(n, n)`` arc ``cap``/``cost``.
+
+    Args:
+        supply_nodes: length-``n`` available supply per node.
+        demand_forecast: a :class:`Forecast` (from :func:`forecast_demand` or
+            :func:`mixle.inference.forecast.forecast`) whose ``.mean`` is length ``n``.
+        cost: ``(n, n)`` per-unit arc routing cost.
+        cap: ``(n, n)`` arc capacity.
+
+    Returns:
+        The resolved :class:`mixle.relations.Flow` (``value`` = total routing cost, ``flow`` = arcs).
+    """
+    supply_nodes = np.asarray(supply_nodes, dtype=np.float64)
+    demand = np.asarray(demand_forecast.mean, dtype=np.float64)
+    if supply_nodes.shape != demand.shape:
+        raise ValueError("supply_nodes and demand_forecast.mean must align, one entry per node")
+    supply = supply_nodes - demand
+    return min_cost_flow(cap, cost, supply)

--- a/mixle/tests/test_h6_distribution.py
+++ b/mixle/tests/test_h6_distribution.py
@@ -1,0 +1,91 @@
+"""H6 DoD: forecast_demand's calibrated coverage, and route_distribution vs a min_cost_flow reference."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from mixle.distribution import forecast_demand, route_distribution
+from mixle.inference.forecast import Forecast
+from mixle.relations import min_cost_flow
+
+
+def _simulate_regime_series(n: int, seed: int) -> np.ndarray:
+    """A synthetic two-regime demand series (low/high mean, sticky Markov switching + Gaussian noise)."""
+    rng = np.random.RandomState(seed)
+    means = (40.0, 60.0)
+    trans = np.array([[0.9, 0.1], [0.15, 0.85]])
+    state = 0
+    out = np.empty(n)
+    for t in range(n):
+        out[t] = rng.normal(means[state], 4.0)
+        state = rng.choice(2, p=trans[state])
+    return out
+
+
+def test_forecast_demand_held_out_coverage_matches_nominal_level():
+    level = 0.9
+    horizon = 8
+    n_history = 70
+    n_trials = 25
+
+    hits = 0
+    total = 0
+    for trial in range(n_trials):
+        series = _simulate_regime_series(n_history + horizon, seed=1000 + trial)
+        history, future = series[:n_history], series[n_history : n_history + horizon]
+
+        f = forecast_demand(history, horizon, level=level, seed=trial)
+        assert f.mean.shape == (horizon,)
+        assert np.all(f.hi >= f.lo)
+
+        hits += int(np.sum((future >= f.lo) & (future <= f.hi)))
+        total += horizon
+
+    coverage = hits / total
+    assert abs(coverage - level) <= 0.05, f"coverage {coverage} not within 0.05 of level {level}"
+
+
+def test_route_distribution_cost_matches_min_cost_flow_reference():
+    # 2 plants feeding 3 distribution hubs, each hub's forecast demand net against its own supply.
+    rng = np.random.RandomState(0)
+    history = 50.0 + 10.0 * np.sin(2 * np.pi * np.arange(60) / 12.0) + rng.normal(0.0, 2.0, size=60)
+    demand_forecast = forecast_demand(history.tolist(), horizon=3, level=0.9, seed=0)
+
+    # supply_nodes = forecast mean + a zero-sum surplus/deficit pattern, so net supply is exactly
+    # routable (min_cost_flow requires supply to sum to zero) regardless of the forecast's own mean.
+    demand_mean = np.asarray(demand_forecast.mean)
+    surplus_deficit = np.array([5.0, -8.0, 3.0])
+    supply_nodes = demand_mean + surplus_deficit
+    n = supply_nodes.shape[0]
+    cap = np.full((n, n), 100.0)
+    np.fill_diagonal(cap, 0.0)
+    cost = np.array(
+        [
+            [0.0, 2.0, 5.0],
+            [3.0, 0.0, 1.0],
+            [4.0, 2.0, 0.0],
+        ]
+    )
+
+    result = route_distribution(supply_nodes, demand_forecast, cost, cap)
+
+    reference_supply = supply_nodes - np.asarray(demand_forecast.mean)
+    reference = min_cost_flow(cap, cost, reference_supply)
+
+    assert result.value == reference.value
+    np.testing.assert_allclose(result.flow, reference.flow)
+
+
+def test_route_distribution_rejects_misaligned_shapes():
+    f = Forecast(
+        mean=np.array([1.0, 2.0]),
+        lo=np.array([0.0, 1.0]),
+        hi=np.array([2.0, 3.0]),
+        level=0.9,
+        state_probs=np.zeros((2, 2)),
+    )
+    try:
+        route_distribution(np.array([1.0, 2.0, 3.0]), f, np.zeros((3, 3)), np.zeros((3, 3)))
+        raise AssertionError("expected a ValueError for misaligned supply_nodes/demand shapes")
+    except ValueError:
+        pass


### PR DESCRIPTION
## Worklist item

**Item:** H6

From notes/exploration-e2e-work-plan.md (the post-0.7 capability-expansion worklist, commissioned directly by the maintainer) and notes/exec/workstream-H.md — not the original 0.8.0 stability worklist; this is new, explicitly authorized capability work.

## Summary

Adds `mixle/distribution.py` (new module):

- `forecast_demand(history, horizon, *, level=0.9, seed=0) -> Forecast` — fits a small 2-state Gaussian-emission HMM directly from the raw demand history (quantile-seeded EM init, to avoid the degenerate single-sequence collapse a cold/random init is prone to), calls the existing `mixle.inference.forecast.forecast` front door for the exact state-marginal / Monte-Carlo predictive band, then recalibrates that band with `mixle.inference.conformal.split_conformal` on a held-out tail of the same history (a model fit on everything but the last ~35% forecasts that tail; the (prediction, actual) pairs there calibrate a constant additive half-width at `level`, applied around the mean of a second model refit on the full history). This keeps the returned interval close to nominal coverage even though the HMM itself is a simplification.
- `route_distribution(supply_nodes, demand_forecast, cost, cap) -> Flow` — `supply = supply_nodes - demand_forecast.mean`, routed via the existing (H1/IC-9) `min_cost_flow`.

Only reads frozen surfaces (`mixle.inference.forecast.forecast`, `mixle.inference.conformal.split_conformal`, `mixle.relations.{Flow, min_cost_flow}`); no edits to `relations.py` or `inference/forecast.py`.

## Public API impact

- [x] It changes the public surface, and I regenerated the manifest (`python scripts/gen_api_manifest.py`) and committed `api_manifest.json`.

Ran the generator; it produced **no diff** (confirmed with `git status`/`git diff --stat api_manifest.json`, both empty). `mixle/distribution.py` is a new top-level module (like `mixle/relations.py`, `mixle/blending.py`), not a package `__init__.py` — the manifest generator's declared scope is `pkg_root.rglob("__init__.py")`, so top-level modules' `__all__` are outside its tracked surface by design. Noting this explicitly (same treatment H2's `blending.py` got) rather than silently checking the "no impact" box, since the module does add two new public functions.

## Claims impact

- [x] No public claim (README, docs, benchmarks) is affected.

## Evidence

DoD command (run from the isolated worktree, venv-pinned per the repo's own env-pin convention — the literal `PYTHONPATH=/Users/grantboquet/mixle/mixle` in the work order resolves to a stale editable install, not this worktree):

```
PYTHONPATH=/tmp/mixle-exec/mixle-h6/mixle /Users/grantboquet/mixle/.venv/bin/python -m pytest mixle/tests/test_h6_distribution.py -q
3 passed in 192.95s
```

(the coverage test alone runs 25 fixed-seed trials of a synthetic two-regime demand series and checks aggregate held-out coverage against `level=0.9`; the routing test checks `route_distribution`'s cost against a hand-built `min_cost_flow` reference on the same instance.)

Broader regression check (existing `forecast`/`conformal` suites this module reads from, unmodified):

```
PYTHONPATH=/tmp/mixle-exec/mixle-h6/mixle /Users/grantboquet/mixle/.venv/bin/python -m pytest mixle/tests/forecast_test.py mixle/tests/conformal_test.py mixle/tests/conformal_array_test.py -q
16 passed in 88.10s
```

`ruff format` / `ruff check` on the two changed files: clean (format made one whitespace-only pass on the test file; both clean on recheck).

## Checklist

- [x] Tests added/updated and passing; `ruff check` + `ruff format --check` clean.
- [x] Consumer suites for any edited module pass. (No existing module edited; ran `forecast`/`conformal` suites anyway since the new module reads from them.)
- [x] I am not merging this PR myself, and I have not enabled auto-merge.

## Notes

- **H1 dependency (not yet merged):** `route_distribution` calls `mixle.relations.min_cost_flow`, which is H1's IC-9 fill-in. H1 (PR #451, same repo) has **not landed on `release/0.8.0` yet** as of this PR — `origin/release/0.8.0` today has no `min_cost_flow`/`Flow` in `relations.py` at all (not even a stub). I verified this PR's DoD test green by temporarily overlaying H1's branch (`origin/work/h1-min-cost-multi-commodity-network-flow`) on top of my worktree's `relations.py`, running the test, then restoring `relations.py` to the `release/0.8.0` baseline before committing — so this PR's diff is exactly the two new files above, nothing from H1. Until #451 merges, `mixle/tests/test_h6_distribution.py` will fail at collection with an `ImportError` on a bare `release/0.8.0` checkout; it passes as soon as H1 lands (verified). Sequencing H1 before H6 in merge order resolves this with no further changes needed here.
- **Fitting the HMM from a bare history (no `model` argument):** the frozen Public API signature `forecast_demand(history, horizon, *, level=0.9, seed=0)` takes no fitted model, but `mixle.inference.forecast.forecast` requires one. `forecast_demand` fits a 2-state Gaussian HMM internally via `mixle.inference.estimation.optimize`, seeded from the history's own lower/upper quartiles (a plain random/cold EM init on a single continuous sequence reliably collapsed to a degenerate one-state fit in testing — near-zero variance, zero transition mass). This is a judgment call: the work order's Algorithm text describes calling `forecast(model, ...)` without saying how `model` is obtained when the Public API omits it.
- **Node alignment for `route_distribution`:** read `supply_nodes` and `demand_forecast.mean` as aligned 1:1 per node (one supply figure and one forecast horizon-step per node), matching the Algorithm text `supply = supply_nodes − demand` literally (elementwise, not a concatenation of two disjoint node sets).
- Did not add extra public symbols wrapping `ShortestPath`/`Assignment`/`tsp_held_karp` (mentioned under "Files"/"Algorithm" as available for last-mile tours / depot-customer matching / haul paths) — the frozen "Public API" section for H6 lists exactly `forecast_demand` and `route_distribution`, and the DoD doesn't exercise the others; kept the surface to what's specified.
