### PR TITLE
H8: Digital-twin simulation of the pipeline

### DIFF
--- a/mixle/pipeline_twin.py
+++ b/mixle/pipeline_twin.py
@@ -1,0 +1,269 @@
+"""Digital-twin simulation of the mine -> plant -> distribution pipeline (H8).
+
+A :class:`PipelineTwin` is a period-stepped re-solve of the production network's flow: each period
+it re-runs :func:`mixle.relations.min_cost_flow` (IC-9) under the current arc capacities/costs and a
+draw of stochastic arrivals, then accumulates queue/bottleneck diagnostics as state. It is wrapped
+as a :class:`mixle.inference.simulate.Simulator` so the per-period stochastic draws come from the
+same ``.sampler(seed=...)`` surface every other simulated model in the codebase uses, and named
+interventions are registered through the same :class:`~mixle.inference.simulate.Scenario` bookkeeping
+the simulate module already exposes -- though, unlike a learned Bayesian network, a deterministic
+flow network has no ``do``-operator to route through, so interventions here are applied directly as
+arc/capacity/supply overrides (see :meth:`PipelineTwin._apply_interventions`).
+
+Network capacities can be tightened by H5 (``mixle_pde.material_transport``) transport-physics
+numbers -- those arrive as a plain ``{(u, v): capacity}`` mapping (no cross-plugin import) and are
+combined with the network's nameplate capacities in :func:`build_twin`.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from mixle.inference.simulate import Scenario, Simulator
+from mixle.relations import min_cost_flow
+
+__all__ = ["build_twin", "PipelineTwin"]
+
+# Penalty terms for the slack node that keeps every period's flow problem feasible even when the
+# real subnetwork cannot fully satisfy conservation (a saturated arc, a plant outage, ...). Slack
+# capacity is large enough to never itself bind; slack cost is large enough to never be preferred
+# over any real route, so it only carries what the real network genuinely could not.
+_SLACK_CAPACITY = 1.0e6
+_SLACK_COST = 1.0e4
+
+
+class _ArrivalModel:
+    """Minimal ``.sampler(seed=...)`` surface -- the twin's stochastic-arrivals source, so the twin
+    can be packaged as a :class:`mixle.inference.simulate.Simulator` like any other fitted model."""
+
+    def __init__(self, n_supply: int, noise_scale: float) -> None:
+        self.n_supply = n_supply
+        self.noise_scale = noise_scale
+
+    def sampler(self, seed: int = 0) -> _ArrivalSampler:
+        return _ArrivalSampler(self.n_supply, self.noise_scale, seed)
+
+
+class _ArrivalSampler:
+    """Draws one perturbation vector (over supply nodes) per simulated period."""
+
+    def __init__(self, n_supply: int, noise_scale: float, seed: int) -> None:
+        self._rng = np.random.default_rng(seed)
+        self._n_supply = n_supply
+        self._noise_scale = noise_scale
+
+    def sample(self, n_draws: int) -> list[np.ndarray]:
+        if self._noise_scale <= 0.0:
+            return [np.zeros(self._n_supply) for _ in range(int(n_draws))]
+        return [self._rng.normal(0.0, self._noise_scale, size=self._n_supply) for _ in range(int(n_draws))]
+
+
+def _augment_with_slack(
+    cap: np.ndarray, cost: np.ndarray, supply: np.ndarray
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Add one universal slack node so ``min_cost_flow`` is always feasible for a period's draw.
+
+    The slack node supplies whatever a deficit node is short, and absorbs whatever a surplus node
+    cannot push through the real arcs, at a heavy per-unit penalty -- so real capacity is always
+    preferred, and only the genuinely-unroutable remainder ever touches it.
+    """
+    n = cap.shape[0]
+    cap_ext = np.zeros((n + 1, n + 1))
+    cost_ext = np.zeros((n + 1, n + 1))
+    cap_ext[:n, :n] = cap
+    cost_ext[:n, :n] = cost
+    cap_ext[:n, n] = _SLACK_CAPACITY
+    cap_ext[n, :n] = _SLACK_CAPACITY
+    cost_ext[:n, n] = _SLACK_COST
+    cost_ext[n, :n] = _SLACK_COST
+    supply_ext = np.append(supply, -float(supply.sum()))
+    return cap_ext, cost_ext, supply_ext
+
+
+class PipelineTwin:
+    """A period-stepped digital twin of the production network's flow.
+
+    Each :meth:`run` re-solves ``min_cost_flow`` per period under the twin's (possibly
+    scenario-modified) capacities/costs and a draw of stochastic arrivals on the supply nodes,
+    tracking per-period throughput/queue/bottleneck-arc diagnostics.
+    """
+
+    def __init__(
+        self,
+        cap: np.ndarray,
+        cost: np.ndarray,
+        supply: np.ndarray,
+        *,
+        supply_nodes: list[int],
+        demand_nodes: list[int],
+        seed: int = 0,
+        arrival_noise: float = 0.0,
+        interventions: dict[str, dict[str, Any]] | None = None,
+    ) -> None:
+        self._cap = np.array(cap, dtype=float)
+        self._cost = np.array(cost, dtype=float)
+        self._supply = np.array(supply, dtype=float)
+        self._supply_nodes = list(supply_nodes)
+        self._demand_nodes = list(demand_nodes)
+        self._seed = seed
+        self._arrival_noise = arrival_noise
+        self._interventions: dict[str, dict[str, Any]] = dict(interventions or {})
+        self._simulator = Simulator(_ArrivalModel(len(self._supply_nodes), arrival_noise))
+        for name, iv in self._interventions.items():
+            self._simulator.scenarios[name] = Scenario(name, {})
+
+    def scenario(self, name: str, interventions: dict[str, Any]) -> PipelineTwin:
+        """Register a named intervention (plant-down / grade-shift / demand-spike / new arc / ...).
+
+        Returns a new twin sharing this one's network and seed but with ``name`` available to
+        :meth:`run` via its ``scenario=`` argument -- the base twin (and any other scenario already
+        registered on it) is left untouched.
+        """
+        merged = dict(self._interventions)
+        merged[name] = dict(interventions)
+        return PipelineTwin(
+            self._cap,
+            self._cost,
+            self._supply,
+            supply_nodes=self._supply_nodes,
+            demand_nodes=self._demand_nodes,
+            seed=self._seed,
+            arrival_noise=self._arrival_noise,
+            interventions=merged,
+        )
+
+    def _apply_interventions(
+        self, cap: np.ndarray, cost: np.ndarray, supply: np.ndarray, interventions: dict[str, Any]
+    ) -> None:
+        """Apply a scenario's interventions in place onto this period's cap/cost/supply arrays."""
+        for kind, spec in interventions.items():
+            if kind == "add_arc":
+                # {(u, v): (capacity, cost)} -- e.g. an inter-plant transfer arc.
+                for (u, v), (c, w) in spec.items():
+                    cap[u, v] = float(c)
+                    cost[u, v] = float(w)
+            elif kind == "zero_capacity_node":
+                # plant-down: knock out every arc touching the given node(s).
+                nodes = spec if isinstance(spec, (list, tuple, set)) else [spec]
+                for node in nodes:
+                    cap[node, :] = 0.0
+                    cap[:, node] = 0.0
+            elif kind == "grade_shift":
+                # {node: multiplier} -- perturb a mine's effective usable feed grade/tonnage.
+                for node, mult in spec.items():
+                    supply[node] *= float(mult)
+            elif kind == "demand_delta":
+                # {node: additive delta} -- demand-spike (or relief) at a customer node.
+                for node, delta in spec.items():
+                    supply[node] += float(delta)
+            else:
+                raise KeyError(f"unknown intervention kind {kind!r}")
+
+    def run(self, n_periods: int, *, scenario: str | None = None) -> dict:
+        """Step the twin ``n_periods`` periods, re-solving the flow each period.
+
+        Returns a dict of per-period diagnostics: ``throughput`` (delivered per period),
+        ``queue`` (cumulative unmet demand), ``utilization`` (per-period ``(n, n)`` arc
+        flow/capacity ratios), ``bottleneck_arc`` (the ``(u, v)`` with highest utilization in the
+        final period), and ``bottleneck_utilization`` (that arc's utilization series).
+        """
+        cap = self._cap.copy()
+        cost = self._cost.copy()
+        supply = self._supply.copy()
+        if scenario is not None:
+            if scenario not in self._interventions:
+                raise KeyError(f"no scenario named {scenario!r}; register it with .scenario(...) first")
+            self._apply_interventions(cap, cost, supply, self._interventions[scenario])
+
+        n = cap.shape[0]
+        arc_mask = cap > 0.0
+        noises = self._simulator.run(int(n_periods), seed=self._seed)
+
+        nominal_demand = -supply[self._demand_nodes]
+
+        throughput_series: list[float] = []
+        queue_series: list[float] = []
+        utilization_series: list[np.ndarray] = []
+        bottleneck_arcs: list[tuple[int, int] | None] = []
+        bottleneck_utils: list[float] = []
+        queue_total = 0.0
+
+        for t in range(int(n_periods)):
+            period_supply = supply.copy()
+            noise = noises[t]
+            for i, node in enumerate(self._supply_nodes):
+                period_supply[node] += float(noise[i])
+
+            cap_ext, cost_ext, supply_ext = _augment_with_slack(cap, cost, period_supply)
+            result = min_cost_flow(cap_ext, cost_ext, supply_ext)
+            flow = result.flow[:n, :n]
+
+            delivered = flow[:, self._demand_nodes].sum(axis=0)
+            shortfall = float(np.clip(nominal_demand - delivered, 0.0, None).sum())
+            queue_total += shortfall
+
+            util = np.zeros_like(cap)
+            util[arc_mask] = flow[arc_mask] / cap[arc_mask]
+
+            if arc_mask.any():
+                masked = np.where(arc_mask, util, -np.inf)
+                u, v = (int(x) for x in np.unravel_index(np.argmax(masked), masked.shape))
+                bottleneck_arcs.append((u, v))
+                bottleneck_utils.append(float(util[u, v]))
+            else:
+                bottleneck_arcs.append(None)
+                bottleneck_utils.append(0.0)
+
+            throughput_series.append(float(delivered.sum()))
+            queue_series.append(queue_total)
+            utilization_series.append(util)
+
+        return {
+            "throughput": np.array(throughput_series),
+            "queue": np.array(queue_series),
+            "utilization": np.array(utilization_series),
+            "bottleneck_arc": bottleneck_arcs[-1],
+            "bottleneck_utilization": np.array(bottleneck_utils),
+        }
+
+
+def build_twin(network: dict, transport: dict, *, seed: int = 0) -> PipelineTwin:
+    """Build a :class:`PipelineTwin` from a network spec and (optionally empty) H5 transport caps.
+
+    ``network`` keys: ``cap``/``cost`` (``(n, n)`` arc matrices), ``supply`` (length ``n``, positive
+    = mine/source, negative = customer/demand), ``supply_nodes``/``demand_nodes`` (node-index lists;
+    inferred from the sign of ``supply`` if omitted), and an optional ``arrival_noise`` std-dev for
+    the per-period stochastic-arrivals draw (default 0, deterministic).
+
+    ``transport`` is a plain ``{(u, v): capacity}`` mapping of H5 (``mixle_pde.material_transport``)
+    derived real-world throughput ceilings (slurry line / conveyor limits, etc.) -- these are combined
+    with ``network``'s nameplate arc capacities via ``min`` (no cross-plugin import: the twin only
+    ever sees the resulting plain numbers).
+    """
+    cap = np.array(network["cap"], dtype=float)
+    cost = np.array(network["cost"], dtype=float)
+    supply = np.array(network["supply"], dtype=float)
+
+    supply_nodes = network.get("supply_nodes")
+    if supply_nodes is None:
+        supply_nodes = [i for i, s in enumerate(supply) if s > 0.0]
+    demand_nodes = network.get("demand_nodes")
+    if demand_nodes is None:
+        demand_nodes = [i for i, s in enumerate(supply) if s < 0.0]
+
+    for (u, v), capacity in (transport or {}).items():
+        cap[u, v] = min(cap[u, v], float(capacity)) if cap[u, v] > 0.0 else float(capacity)
+
+    arrival_noise = float(network.get("arrival_noise", 0.0))
+
+    return PipelineTwin(
+        cap,
+        cost,
+        supply,
+        supply_nodes=list(supply_nodes),
+        demand_nodes=list(demand_nodes),
+        seed=seed,
+        arrival_noise=arrival_noise,
+    )

--- a/mixle/relations.py
+++ b/mixle/relations.py
@@ -52,9 +52,14 @@ __all__ = [
     "BestSubsetRegression",
     "branch_and_bound_milp",
     "cardinality_constrained_milp",
+    "Design",
     "EditDistance",
+    "Flow",
     "graph_coloring",
     "irreducible_infeasible_subset",
+    "min_cost_flow",
+    "multicommodity_flow",
+    "network_design",
     "Relation",
     "RelationSampler",
     "ShortestPath",
@@ -324,6 +329,279 @@ def min_cut(capacity: Any, source: int, sink: int) -> tuple[float, list[int], li
     cut_edges = [(u, v) for u in reachable for v in range(n) if v not in reachable and cap[u, v] > 0.0]
     cut_capacity = float(sum(cap[u, v] for u, v in cut_edges))
     return cut_capacity, sorted(reachable), cut_edges
+
+
+# ---------------------------------------------------------------------------
+# Minimum-cost flow, multicommodity flow, and capacitated network design
+# ---------------------------------------------------------------------------
+class Flow(NamedTuple):
+    """A resolved flow: ``value`` (total/objective cost) and ``flow[u, v]`` per-arc, like `max_flow`'s output."""
+
+    value: float
+    flow: np.ndarray
+
+
+class Design(NamedTuple):
+    """A network-design solution: ``cost`` (total), ``open`` (opened-arc/facility mask), and the induced ``flow``."""
+
+    cost: float
+    open: np.ndarray
+    flow: np.ndarray
+
+
+def min_cost_flow(cap: Any, cost: Any, supply: Any) -> Flow:
+    """Min-cost feasible flow meeting node ``supply`` (positive = source) under arc ``cap``/``cost``.
+
+    Successive-shortest-path with node potentials: a super-source feeds every ``supply > 0`` node and
+    every ``supply < 0`` node feeds a super-sink (arc capacity ``|supply|``, cost 0), then the residual
+    super-source -> super-sink path of least *reduced* cost is repeatedly augmented (Dijkstra, since the
+    potentials keep every reduced cost non-negative) until the super-sink is unreachable. Potentials are
+    seeded with a Bellman-Ford pass so arbitrary-sign ``cost`` entries are handled, then updated by the
+    per-round Dijkstra distances (the standard Johnson's-algorithm maintenance). ``cap``/``cost`` are
+    ``n x n`` arc matrices; ``supply`` is length ``n`` and must sum to (approximately) zero. Returns
+    `Flow(value=total cost, flow=(n, n) arc flows)`; raises :class:`ValueError` if the supply cannot be
+    fully routed under the given capacities.
+    """
+    cap = np.asarray(cap, dtype=np.float64)
+    cost = np.asarray(cost, dtype=np.float64)
+    supply = np.asarray(supply, dtype=np.float64)
+    n = supply.shape[0]
+    if cap.shape != (n, n) or cost.shape != (n, n):
+        raise ValueError("cap/cost must be (n, n), matching supply's length n")
+    assert abs(float(supply.sum())) < 1.0e-6, "supply must sum to (approximately) zero"
+
+    ss, tt, m = n, n + 1, n + 2  # super-source, super-sink, extended node count
+    big_cap = np.zeros((m, m))
+    big_cap[:n, :n] = cap
+    big_cost = np.zeros((m, m))
+    big_cost[:n, :n] = cost
+    total_supply = 0.0
+    for i in range(n):
+        if supply[i] > 1.0e-12:
+            big_cap[ss, i] = supply[i]
+            total_supply += float(supply[i])
+        elif supply[i] < -1.0e-12:
+            big_cap[i, tt] = -float(supply[i])
+
+    residual = big_cap.copy()
+    flow = np.zeros((m, m))
+
+    def bellman_ford_from_source() -> np.ndarray:
+        dist = np.full(m, np.inf)
+        dist[ss] = 0.0
+        for _ in range(m - 1):
+            changed = False
+            for u in range(m):
+                if not np.isfinite(dist[u]):
+                    continue
+                for v in range(m):
+                    if residual[u, v] > 1.0e-12 and dist[u] + big_cost[u, v] < dist[v] - 1.0e-9:
+                        dist[v] = dist[u] + big_cost[u, v]
+                        changed = True
+            if not changed:
+                break
+        return np.where(np.isfinite(dist), dist, 0.0)
+
+    pot = bellman_ford_from_source()  # seeds potentials so Dijkstra sees non-negative reduced costs
+    routed = 0.0
+    while routed < total_supply - 1.0e-9:
+        reduced = big_cost + pot[:, None] - pot[None, :]
+        dist = np.full(m, np.inf)
+        dist[ss] = 0.0
+        prev = np.full(m, -1, dtype=int)
+        visited = np.zeros(m, dtype=bool)
+        heap: list[tuple[float, int]] = [(0.0, ss)]
+        while heap:
+            d, u = heapq.heappop(heap)
+            if visited[u]:
+                continue
+            visited[u] = True
+            for v in range(m):
+                if not visited[v] and residual[u, v] > 1.0e-12:
+                    nd = d + reduced[u, v]
+                    if nd < dist[v] - 1.0e-12:
+                        dist[v] = nd
+                        prev[v] = u
+                        heapq.heappush(heap, (nd, v))
+        if not visited[tt]:
+            break  # super-sink unreachable: no more augmenting paths
+        for v in range(m):
+            if visited[v] and np.isfinite(dist[v]):
+                pot[v] += dist[v]  # Johnson's-algorithm potential maintenance
+
+        bottleneck = total_supply - routed
+        path: list[tuple[int, int]] = []
+        v = tt
+        while v != ss:
+            u = prev[v]
+            bottleneck = min(bottleneck, residual[u, v])
+            path.append((u, v))
+            v = u
+        for u, v in path:
+            residual[u, v] -= bottleneck
+            residual[v, u] += bottleneck
+            cancel = min(bottleneck, flow[v, u])  # undo previously-pushed flow on the reverse arc first
+            flow[v, u] -= cancel
+            if bottleneck - cancel > 1.0e-15:
+                flow[u, v] += bottleneck - cancel
+        routed += bottleneck
+
+    if routed < total_supply - 1.0e-6:
+        raise ValueError("min_cost_flow: infeasible -- supply cannot be fully routed under the given capacities")
+
+    value = float((flow[:n, :n] * cost).sum())
+    return Flow(value=value, flow=flow[:n, :n])
+
+
+def multicommodity_flow(cap: Any, cost: Any, demands: Any) -> Flow:
+    """Multi-commodity min-cost flow (different products/grades share arc ``cap``) via LP relaxation.
+
+    ``cap``/``cost`` are ``n x n`` arc matrices (an arc exists where ``cap > 0``); ``demands`` lists
+    ``(source, sink, amount)`` rows, one per commodity. Each commodity gets its own flow variables with
+    its own conservation constraints (per-commodity supply at its source, demand at its sink, balance
+    elsewhere); every arc's *combined* commodity flow is capped at ``cap[u, v]``. Solved as a single LP
+    (``scipy.optimize.linprog``, HiGHS) over the stacked per-commodity arc variables. Returns `Flow` with
+    the aggregate cost and the summed arc flows (``flow = sum_k x_k``); raises :class:`ValueError` if the
+    demands cannot be met under the shared capacities.
+    """
+    from scipy.optimize import linprog
+
+    cap = np.asarray(cap, dtype=np.float64)
+    cost = np.asarray(cost, dtype=np.float64)
+    demands = np.atleast_2d(np.asarray(demands, dtype=np.float64))
+    n = cap.shape[0]
+    if cap.shape != (n, n) or cost.shape != (n, n):
+        raise ValueError("cap/cost must be square (n, n) arc matrices")
+    k = demands.shape[0]
+    arcs = [(u, v) for u in range(n) for v in range(n) if cap[u, v] > 0.0]
+    n_arcs = len(arcs)
+
+    def var(kk: int, ai: int) -> int:
+        return kk * n_arcs + ai
+
+    n_vars = k * n_arcs
+    c = np.zeros(n_vars)
+    for kk in range(k):
+        for ai, (u, v) in enumerate(arcs):
+            c[var(kk, ai)] = cost[u, v]
+
+    a_eq_rows: list[np.ndarray] = []
+    b_eq: list[float] = []
+    for kk in range(k):
+        src, snk, qty = int(demands[kk, 0]), int(demands[kk, 1]), float(demands[kk, 2])
+        for node in range(n):
+            row = np.zeros(n_vars)
+            for ai, (u, v) in enumerate(arcs):
+                if u == node:
+                    row[var(kk, ai)] += 1.0
+                if v == node:
+                    row[var(kk, ai)] -= 1.0
+            rhs = qty if node == src else (-qty if node == snk else 0.0)
+            a_eq_rows.append(row)
+            b_eq.append(rhs)
+
+    a_ub_rows: list[np.ndarray] = []
+    b_ub: list[float] = []
+    for ai, (u, v) in enumerate(arcs):
+        row = np.zeros(n_vars)
+        for kk in range(k):
+            row[var(kk, ai)] = 1.0
+        a_ub_rows.append(row)
+        b_ub.append(cap[u, v])
+
+    res = linprog(
+        c,
+        A_ub=np.array(a_ub_rows) if a_ub_rows else None,
+        b_ub=np.array(b_ub) if b_ub else None,
+        A_eq=np.array(a_eq_rows) if a_eq_rows else None,
+        b_eq=np.array(b_eq) if b_eq else None,
+        bounds=[(0.0, None)] * n_vars,
+        method="highs",
+    )
+    if not res.success:
+        raise ValueError("multicommodity_flow: infeasible -- demands cannot be met under the shared capacities")
+
+    flow = np.zeros((n, n))
+    for kk in range(k):
+        for ai, (u, v) in enumerate(arcs):
+            flow[u, v] += res.x[var(kk, ai)]
+    return Flow(value=float(res.fun), flow=flow)
+
+
+def network_design(nodes: Sequence[int], arcs: Sequence[tuple[int, int]], fixed_costs: Any, demands: Any) -> Design:
+    """Capacitated fixed-charge network design (which arcs/facilities to open) via big-M MILP.
+
+    ``nodes`` lists node ids; ``arcs`` lists candidate directed arcs (``fixed_costs[i]`` is the cost of
+    opening ``arcs[i]``); ``demands`` is a length-``len(nodes)`` net supply/demand vector aligned with
+    ``nodes`` (positive = supply, negative = demand, summing to zero) -- the same convention as
+    :func:`min_cost_flow`'s ``supply``. Continuous flow ``x[arc] >= 0`` is big-M-linked to the binary
+    open/closed decision ``y[arc]`` (``x[arc] <= M * y[arc]``, ``M`` sized from the total demand so it
+    never binds a genuinely open arc); flow balance ``A x = demands`` is encoded as the paired
+    inequalities ``A x <= demands`` and ``-A x <= -demands`` (:func:`branch_and_bound_milp` exposes only
+    ``a_ub``/``b_ub``). The frozen signature carries no per-unit routing cost, so the objective is the
+    total opening cost ``fixed_costs @ y`` (the classic uncapacitated-routing fixed-charge network design:
+    which arcs to build so the demand vector is routable at minimum build cost). Returns
+    ``Design(cost, open, flow)`` where ``open`` is the boolean opened-arc mask and ``flow`` is the induced
+    ``(n, n)`` arc flow; raises :class:`ValueError` if no arc-opening choice can route the demands.
+    """
+    node_list = list(nodes)
+    n = len(node_list)
+    index = {node: i for i, node in enumerate(node_list)}
+    arc_list = list(arcs)
+    n_arcs = len(arc_list)
+    fixed = np.asarray(fixed_costs, dtype=np.float64)
+    demand = np.asarray(demands, dtype=np.float64)
+    if fixed.shape != (n_arcs,):
+        raise ValueError("fixed_costs must align with arcs, one entry per candidate arc")
+    if demand.shape != (n,):
+        raise ValueError("demands must align with nodes, one net supply/demand entry per node")
+    if abs(float(demand.sum())) > 1.0e-6:
+        raise ValueError("network_design: demands must sum to (approximately) zero")
+
+    big_m = float(np.abs(demand).sum()) or 1.0  # a non-binding capacity once an arc is opened
+    n_vars = 2 * n_arcs  # [x_0..x_{n_arcs-1}, y_0..y_{n_arcs-1}]
+
+    def x_idx(a: int) -> int:
+        return a
+
+    def y_idx(a: int) -> int:
+        return n_arcs + a
+
+    c = np.zeros(n_vars)
+    c[n_arcs:] = fixed  # objective: total opening cost (no per-unit routing cost in the frozen signature)
+
+    rows: list[np.ndarray] = []
+    rhs: list[float] = []
+    for a in range(n_arcs):  # big-M link: x[a] - M * y[a] <= 0
+        row = np.zeros(n_vars)
+        row[x_idx(a)] = 1.0
+        row[y_idx(a)] = -big_m
+        rows.append(row)
+        rhs.append(0.0)
+
+    balance = np.zeros((n, n_vars))
+    for a, (u, v) in enumerate(arc_list):
+        balance[index[u], x_idx(a)] += 1.0
+        balance[index[v], x_idx(a)] -= 1.0
+    for node_row, b in zip(balance, demand, strict=True):  # A x = b as paired A x <= b, -A x <= -b
+        rows.append(node_row.copy())
+        rhs.append(float(b))
+        rows.append(-node_row)
+        rhs.append(-float(b))
+
+    bounds = [(0.0, big_m)] * n_arcs + [(0.0, 1.0)] * n_arcs
+    result = branch_and_bound_milp(
+        c, np.array(rows), np.array(rhs), integer=list(range(n_arcs, n_vars)), bounds=bounds, sense="min"
+    )
+    if result is None:
+        raise ValueError("network_design: infeasible -- no arc-opening choice routes the given demands")
+    value, sol = result
+    opened = np.round(sol[n_arcs:]).astype(bool)
+    x = sol[:n_arcs]
+    flow_matrix = np.zeros((n, n))
+    for a, (u, v) in enumerate(arc_list):
+        flow_matrix[index[u], index[v]] = x[a]
+    return Design(cost=float(value), open=opened, flow=flow_matrix)
 
 
 # ---------------------------------------------------------------------------

--- a/mixle/tests/test_h1_flows.py
+++ b/mixle/tests/test_h1_flows.py
@@ -1,0 +1,157 @@
+"""Min-cost & multi-commodity network flow + capacitated network design (H1: IC-9 implementation)."""
+
+from __future__ import annotations
+
+import numpy as np
+from scipy.optimize import linprog
+
+from mixle.relations import Design, Flow, min_cost_flow, multicommodity_flow, network_design
+
+# Nodes: 0-2 mines, 3-4 plants, 5-8 customers.
+N = 9
+MINES = (0, 1, 2)
+PLANTS = (3, 4)
+CUSTOMERS = (5, 6, 7, 8)
+
+
+def _base_network():
+    """3-mine / 2-plant / 4-customer network. Plant 3 is capacity-bottlenecked: mines 0+1 push more
+    supply into it (40) than its "native" customers 5+6 demand (30), so 10 units must detour through
+    the expensive direct arc 3->7 in the absence of an inter-plant transfer arc."""
+    cap = np.zeros((N, N))
+    cost = np.zeros((N, N))
+
+    def arc(u, v, c, w):
+        cap[u, v] = c
+        cost[u, v] = w
+
+    arc(0, 3, 25, 2)  # mine0 -> plant3
+    arc(1, 3, 25, 2)  # mine1 -> plant3
+    arc(2, 4, 25, 2)  # mine2 -> plant4
+    arc(3, 5, 20, 1)  # plant3 -> customer5
+    arc(3, 6, 20, 1)  # plant3 -> customer6
+    arc(3, 7, 20, 6)  # plant3 -> customer7 (expensive long-haul fallback)
+    arc(4, 7, 20, 1)  # plant4 -> customer7
+    arc(4, 8, 20, 1)  # plant4 -> customer8
+
+    supply = np.zeros(N)
+    supply[0], supply[1], supply[2] = 20.0, 20.0, 20.0
+    supply[5], supply[6], supply[7], supply[8] = -15.0, -15.0, -15.0, -15.0
+    return cap, cost, supply
+
+
+def _reference_min_cost_flow(cap, cost, supply):
+    """Hand-built linprog reference: one variable per existing arc, node-arc incidence for A_eq."""
+    n = cap.shape[0]
+    arcs = [(u, v) for u in range(n) for v in range(n) if cap[u, v] > 0.0]
+    incidence = np.zeros((n, len(arcs)))
+    c = np.zeros(len(arcs))
+    bounds = []
+    for j, (u, v) in enumerate(arcs):
+        incidence[u, j] = 1.0
+        incidence[v, j] = -1.0
+        c[j] = cost[u, v]
+        bounds.append((0.0, cap[u, v]))
+    res = linprog(c, A_eq=incidence, b_eq=supply, bounds=bounds, method="highs")
+    assert res.success
+    return res.fun
+
+
+def test_min_cost_flow_matches_linprog_reference():
+    cap, cost, supply = _base_network()
+    result = min_cost_flow(cap, cost, supply)
+    assert isinstance(result, Flow)
+    reference = _reference_min_cost_flow(cap, cost, supply)
+    assert abs(result.value - reference) < 1.0e-6
+
+    # flow conservation at every transship/customer node
+    net = result.flow.sum(axis=1) - result.flow.sum(axis=0)
+    assert np.allclose(net, supply, atol=1.0e-6)
+    assert np.all(result.flow <= cap + 1.0e-6)
+    assert np.all(result.flow >= -1.0e-9)
+
+
+def test_inter_plant_transfer_arc_strictly_lowers_cost():
+    cap, cost, supply = _base_network()
+    base_value = min_cost_flow(cap, cost, supply).value
+
+    cap2 = cap.copy()
+    cost2 = cost.copy()
+    cap2[3, 4] = 50.0  # open a cheap inter-plant transfer arc
+    cost2[3, 4] = 0.2
+    transfer_value = min_cost_flow(cap2, cost2, supply).value
+
+    assert transfer_value < base_value - 1.0e-9
+
+    # matches the hand-solved optimum: the transfer arc entirely displaces the expensive 3->7 fallback
+    assert abs(transfer_value - 182.0) < 1.0e-6
+    assert abs(base_value - 230.0) < 1.0e-6
+
+
+def test_min_cost_flow_infeasible_raises():
+    cap = np.array([[0.0, 1.0], [0.0, 0.0]])
+    cost = np.array([[0.0, 1.0], [0.0, 0.0]])
+    supply = np.array([5.0, -5.0])  # arc capacity (1) below required supply (5)
+    try:
+        min_cost_flow(cap, cost, supply)
+        raise AssertionError("expected ValueError for an infeasible instance")
+    except ValueError:
+        pass
+
+
+def test_multicommodity_flow_respects_shared_capacity_and_cost():
+    # nodes: 0 srcA, 1 srcB, 2 trunk-in, 3 trunk-out, 4 sinkA, 5 sinkB
+    n = 6
+    cap = np.zeros((n, n))
+    cost = np.zeros((n, n))
+    cap[0, 2], cost[0, 2] = 100.0, 1.0
+    cap[1, 2], cost[1, 2] = 100.0, 1.0
+    cap[2, 3], cost[2, 3] = 15.0, 0.0  # shared bottleneck trunk arc
+    cap[3, 4], cost[3, 4] = 100.0, 1.0
+    cap[3, 5], cost[3, 5] = 100.0, 1.0
+
+    demands = np.array([[0, 4, 7.0], [1, 5, 7.0]])  # commodity A: 0->4 qty 7; commodity B: 1->5 qty 7
+    result = multicommodity_flow(cap, cost, demands)
+    assert isinstance(result, Flow)
+    assert abs(result.value - 28.0) < 1.0e-6  # each commodity pays (1 + 0 + 1) * 7 = 14
+    assert result.flow[2, 3] <= cap[2, 3] + 1.0e-6  # shared trunk capacity respected
+    assert abs(result.flow[2, 3] - 14.0) < 1.0e-6
+
+
+def test_multicommodity_flow_infeasible_raises():
+    cap = np.array([[0.0, 1.0], [0.0, 0.0]])
+    cost = np.array([[0.0, 1.0], [0.0, 0.0]])
+    demands = np.array([[0, 1, 5.0]])  # needs 5 units through a capacity-1 arc
+    try:
+        multicommodity_flow(cap, cost, demands)
+        raise AssertionError("expected ValueError for an infeasible instance")
+    except ValueError:
+        pass
+
+
+def test_network_design_opens_cheaper_two_hop_path():
+    nodes = [0, 1, 2]
+    arcs = [(0, 1), (1, 2), (0, 2)]
+    fixed_costs = np.array([5.0, 5.0, 100.0])  # direct arc is expensive to open; the two-hop route is cheap
+    demands = np.array([10.0, 0.0, -10.0])
+
+    result = network_design(nodes, arcs, fixed_costs, demands)
+    assert isinstance(result, Design)
+    assert abs(result.cost - 10.0) < 1.0e-6
+    assert bool(result.open[0]) is True  # 0 -> 1 opened
+    assert bool(result.open[1]) is True  # 1 -> 2 opened
+    assert bool(result.open[2]) is False  # the expensive direct arc stays closed
+    assert abs(result.flow[0, 1] - 10.0) < 1.0e-6
+    assert abs(result.flow[1, 2] - 10.0) < 1.0e-6
+
+
+def test_network_design_infeasible_raises():
+    nodes = [0, 1, 2]
+    arcs = [(0, 1)]  # node 2 has no arc at all, so its -10 demand can never be met
+    fixed_costs = np.array([1.0])
+    demands = np.array([10.0, 0.0, -10.0])
+    try:
+        network_design(nodes, arcs, fixed_costs, demands)
+        raise AssertionError("expected ValueError for an infeasible instance")
+    except ValueError:
+        pass

--- a/mixle/tests/test_h8_twin.py
+++ b/mixle/tests/test_h8_twin.py
@@ -1,0 +1,90 @@
+"""Digital-twin simulation of the pipeline (H8): period-stepped re-solve + scenario intervention."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from mixle.pipeline_twin import PipelineTwin, build_twin
+
+# Nodes: 0 mine0, 1 mine1, 2 plant0, 3 plant1, 4 customer0, 5 customer1.
+N = 6
+
+
+def _network():
+    """A 2-mine/2-plant/2-customer network. Plant0's line to customer0 has a generous nameplate
+    arc capacity (100) but H5 slurry-transport physics binds the real throughput to 12 -- well
+    below customer0's demand of 18 -- so it saturates every period absent an inter-plant transfer.
+    Plant1 already has an (idle, in the base case) arc to customer0 that a transfer arc can feed."""
+    cap = np.zeros((N, N))
+    cost = np.zeros((N, N))
+
+    def arc(u, v, c, w):
+        cap[u, v] = c
+        cost[u, v] = w
+
+    arc(0, 2, 100.0, 0.1)  # mine0 -> plant0
+    arc(1, 3, 100.0, 0.1)  # mine1 -> plant1
+    arc(2, 4, 100.0, 5.0)  # plant0 -> customer0 (nameplate; H5 transport caps the real throughput)
+    arc(3, 5, 100.0, 1.0)  # plant1 -> customer1
+    arc(3, 4, 100.0, 1.0)  # plant1 -> customer0 (present but idle without a transfer feeding plant1)
+
+    supply = np.zeros(N)
+    supply[0] = 18.0
+    supply[1] = 10.0
+    supply[4] = -18.0
+    supply[5] = -10.0
+
+    network = {
+        "cap": cap,
+        "cost": cost,
+        "supply": supply,
+        "supply_nodes": [0, 1],
+        "demand_nodes": [4, 5],
+    }
+    transport = {(2, 4): 12.0}  # H5-derived slurry-line throughput ceiling, plain-array input
+    return network, transport
+
+
+def test_twin_reproduces_and_relieves_a_saturated_plant_arc():
+    network, transport = _network()
+    twin = build_twin(network, transport, seed=0)
+
+    base = twin.run(6)
+    assert base["bottleneck_arc"] == (2, 4)
+    assert np.all(base["bottleneck_utilization"] > 0.999)  # arc (2,4) runs pinned at its cap every period
+    assert base["queue"][-1] > 0.0  # unmet customer0 demand accumulates as backlog
+
+    relieved = twin.scenario("inter_plant_transfer", {"add_arc": {(2, 3): (20.0, 0.3)}}).run(
+        6, scenario="inter_plant_transfer"
+    )
+
+    assert relieved["throughput"][-1] > base["throughput"][-1]
+    assert relieved["queue"][-1] < base["queue"][-1]
+
+    base_util_24 = base["utilization"][:, 2, 4]
+    relieved_util_24 = relieved["utilization"][:, 2, 4]
+    assert np.mean(relieved_util_24) < np.mean(base_util_24) - 1.0e-6
+
+
+def test_build_twin_returns_pipeline_twin_and_scenario_is_immutable():
+    network, transport = _network()
+    twin = build_twin(network, transport, seed=1)
+    assert isinstance(twin, PipelineTwin)
+
+    out = twin.run(1)
+    assert {"throughput", "queue", "utilization", "bottleneck_arc", "bottleneck_utilization"} <= set(out)
+
+    twin.scenario("plant_down", {"zero_capacity_node": [3]})
+    # the base twin (no scenario requested) is unaffected by having registered one
+    still_base = twin.run(1)
+    assert still_base["bottleneck_arc"] == out["bottleneck_arc"]
+
+
+def test_unregistered_scenario_name_raises():
+    network, transport = _network()
+    twin = build_twin(network, transport, seed=0)
+    try:
+        twin.run(1, scenario="nonexistent")
+        raise AssertionError("expected KeyError for an unregistered scenario name")
+    except KeyError:
+        pass


### PR DESCRIPTION
## Worklist item

**Item:** H8

From notes/exploration-e2e-work-plan.md (the post-0.7 capability-expansion worklist, commissioned directly by the maintainer) and notes/exec/workstream-H.md — not the original 0.8.0 stability worklist; this is new, explicitly authorized capability work.

## Summary

Adds `mixle/pipeline_twin.py` (new module):

- `build_twin(network: dict, transport: dict, *, seed: int = 0) -> PipelineTwin` — builds a period-stepped digital twin from a network spec (`cap`/`cost` arc matrices, `supply` vector, optional `supply_nodes`/`demand_nodes`/`arrival_noise`) and an H5-derived `{(u, v): capacity}` transport-throughput mapping that tightens the network's nameplate arc capacities (`min` of the two — plain numbers only, no cross-plugin import).
- `class PipelineTwin` — `.run(n_periods, *, scenario=None) -> dict` re-solves `mixle.relations.min_cost_flow` (IC-9) once per period under the current capacities/costs plus a draw of stochastic arrivals on the supply nodes, returning per-period `throughput`, cumulative `queue` (backlog), per-arc `utilization`, and the final-period `bottleneck_arc`/its utilization series. `.scenario(name, interventions) -> PipelineTwin` registers a named intervention (`add_arc`, `zero_capacity_node` for a plant outage, `grade_shift`, `demand_delta`) and returns a new twin with it available to a later `.run(n, scenario=name)` call — mirroring `mixle.inference.simulate.Simulator`'s own register-then-invoke-by-name convention.
- Internally, every period's flow problem is solved on a network augmented with one universal slack node (large capacity, heavily-penalized cost) so `min_cost_flow` is always feasible even when the real subnetwork can't fully satisfy conservation (a saturated arc, a plant outage); only the genuinely-unroutable remainder ever touches it, so real capacity is always preferred.
- The twin is wrapped as a `mixle.inference.simulate.Simulator` (its stochastic-arrivals model implements the `.sampler(seed=...)` surface) so per-period draws come from the same mechanism every other simulated model in the codebase uses, and interventions are registered through the same `Scenario` bookkeeping the module already exposes for symmetry with the do-operator pattern -- though a deterministic flow network has no `do`-operator to route through, so the actual overrides (arc/capacity/supply) are applied directly by `PipelineTwin`, not via `mixle.inference.causal.do` (that machinery is specific to `HeterogeneousBayesianNetwork` models).

Only reads frozen surfaces (`mixle.relations.min_cost_flow`, `mixle.inference.simulate.{Simulator, Scenario}`); no edits to `relations.py` or `inference/simulate.py`.

## Public API impact

- [x] It changes the public surface, and I regenerated the manifest (`python scripts/gen_api_manifest.py`) and committed `api_manifest.json`.

Ran the generator; it produced **no diff**. `mixle/pipeline_twin.py` is a new top-level module (like `mixle/relations.py`/`mixle/blending.py`), not a package `__init__.py` — the manifest generator's declared scope is `pkg_root.rglob("__init__.py")`, so top-level modules' `__all__` are outside its tracked surface by design. Noting this explicitly rather than silently checking the "no impact" box, since the module does add two new public names (`build_twin`, `PipelineTwin`).

## Claims impact

- [x] No public claim (README, docs, benchmarks) is affected.

## Evidence

DoD command (run from the isolated worktree, venv-pinned per the repo's own env-pin convention):

```
PYTHONPATH=/tmp/mixle-exec/mixle-h8/mixle /Users/grantboquet/mixle/.venv/bin/python -m pytest mixle/tests/test_h8_twin.py -q
3 passed in 163.33s
```

Broader regression check (existing `relations.py` / H1 flow / `Simulator` suites, unmodified):

```
PYTHONPATH=/tmp/mixle-exec/mixle-h8/mixle /Users/grantboquet/mixle/.venv/bin/python -m pytest mixle/tests/relations_test.py mixle/tests/test_h1_flows.py mixle/tests/simulate_test.py -q
30 passed
```

`ruff format` / `ruff check` on the two changed files: clean after one `--fix` (two `UP037` quoted-forward-ref nits; harmless given `from __future__ import annotations` is already in effect).

## Checklist

- [x] Tests added/updated and passing; `ruff check` + `ruff format --check` clean.
- [x] Consumer suites for any edited module pass. (No existing module edited; ran the `relations`/H1-flow/`simulate` suites anyway since the new module imports from all three.)
- [x] I am not merging this PR myself, and I have not enabled auto-merge.

## Notes

- **H1 dependency (real blocker, resolved by merge-in):** `release/0.8.0` does not yet have H1's IC-9 fill-in (`min_cost_flow`/`multicommodity_flow`/`network_design`/`Flow`/`Design` — PR #451, open, not merged as of this PR) even though H1 is Wave 1 and H8 is Wave 3. H8's core algorithm explicitly re-solves `min_cost_flow` every period, so this is a genuine functional dependency, not just a wave-ordering one (unlike H2/H3/H4, which only needed pre-existing `relations.py` surfaces). Judgment call: merged `origin/work/h1-min-cost-multi-commodity-network-flow` (commit `646fce0a`) into this branch so `min_cost_flow` is importable and the DoD test is real, rather than re-implementing IC-9 logic locally (which would duplicate frozen-contract work that belongs to H1) or leaving the DoD un-runnable. This PR is effectively stacked on #451 — once #451 merges to `release/0.8.0`, a rebase of this branch will shrink its diff down to just `pipeline_twin.py` + its test; until then, this PR's diff includes H1's `relations.py`/`test_h1_flows.py` changes as an artifact of the merge, not as edits authored here.
- **`network`/`transport` dict schema:** not specified by the work order beyond "as plain-array inputs) H5 transport capacities," so I defined a schema (`cap`/`cost`/`supply`/`supply_nodes`/`demand_nodes`/`arrival_noise` for `network`; `{(u, v): capacity}` for `transport`) rather than importing anything from `mixle-pde` (per the work order's own "no cross-plugin import" parallel-safety note).
- **Scenario invocation:** `.scenario(name, interventions)` registers but does not auto-apply; the caller must still pass `scenario=name` to `.run(...)`, matching `Simulator.scenario`/`Simulator.run`'s existing two-step convention in `mixle/inference/simulate.py` rather than inventing a new auto-apply-on-chain behavior.
- **Queue semantics:** `queue` is a *cumulative* backlog counter (this period's unmet demand added to the running total each period, not fed back into next period's flow-solve demand) — matches "queues ... accumulate as state" from the work order without making the per-period LP's demand itself grow, which would otherwise couple queue growth into the capacity-feasibility check in a way the DoD doesn't require.
