### PR TITLE
L5: Cross-model adjudication & fusion

### DIFF
--- a/mixle/reason/fusion.py
+++ b/mixle/reason/fusion.py
@@ -22,11 +22,22 @@ where relational interactions are part of the signal.
 mixle.reason's exact core (:class:`GaussianBelief`) does this fusion in closed form for *inference*; this is the
 torch, end-to-end-trainable version -- the encoders that emit the experts are learned, the fusion stays exact.
 Torch is imported lazily.
+
+Workstream L (cross-model adjudication): the same precision-weighted product-of-experts rule above, applied
+not to learned tokens but to scalar claims from independent *external* models (a CMIP climate projection, a
+hydrology emulator, ...). :func:`fuse_claims` fuses a list of :class:`ModelClaim` into one :class:`FusedBelief`,
+flags when two models disagree beyond a standardized-distance threshold, and -- on disagreement -- adjudicates
+via an IC-6-shaped ``verifier`` plus the ``language_bridge`` conformal claim score before ever emitting a fused
+point, so a driller-facing cross-model number is never quietly averaged out of a real disagreement.
 """
 
 from __future__ import annotations
 
+import math
+from dataclasses import dataclass
 from typing import Any
+
+import numpy as np
 
 
 def fusion_flops(n_tokens: int, latent_dim: int, *, attention: bool = False) -> int:
@@ -37,6 +48,160 @@ def fusion_flops(n_tokens: int, latent_dim: int, *, attention: bool = False) -> 
     if attention:
         return n_tokens * n_tokens * latent_dim  # the QK^T score matrix dominates
     return n_tokens * latent_dim  # one precision-weighted accumulate per token
+
+
+@dataclass(frozen=True)
+class ModelClaim:
+    """One external model's scalar claim about a shared quantity, with the provenance it must carry.
+
+    ``variance`` is that model's own uncertainty about ``value`` (physical units, not log-precision);
+    ``reliability`` is a prior trust weight (1.0 = taken at face value) folded into the fused precision
+    the same way L8's per-member ``skill`` later will. ``model_id``/``version``/``content_hash`` mirror
+    IC-7's ``ProvenancedResult`` fields so every fused belief traces back to the calls that produced it.
+    """
+
+    value: float
+    variance: float
+    model_id: str
+    version: str
+    content_hash: str
+    reliability: float = 1.0
+
+
+@dataclass(frozen=True)
+class FusedBelief:
+    """The precision-weighted fusion of several :class:`ModelClaim`, with attribution and an honesty gate.
+
+    ``weights`` is each model's share of the fused precision (sums to 1). ``disagreement`` fires when the
+    worst pairwise standardized distance between two claims exceeds ``sigma_flag`` (default 3-sigma);
+    ``abstained`` is only ever ``True`` when ``disagreement`` is ``True`` AND no single claim clears the
+    conformal accept bar under cross-model adjudication -- the mean/variance are still the precision-weighted
+    values even then, but callers MUST check ``abstained`` before surfacing ``mean`` as a driller-facing number.
+    """
+
+    mean: float
+    variance: float
+    weights: dict[str, float]
+    disagreement: bool
+    abstained: bool
+    provenance: dict[str, Any]
+
+
+def _max_pairwise_standardized_distance(claims: list[ModelClaim]) -> float:
+    """``max_{i<j} |value_i - value_j| / sqrt(variance_i + variance_j)`` -- 0.0 for a single claim."""
+    worst = 0.0
+    for i in range(len(claims)):
+        for j in range(i + 1, len(claims)):
+            a, b = claims[i], claims[j]
+            z = abs(a.value - b.value) / math.sqrt(a.variance + b.variance)
+            worst = max(worst, z)
+    return worst
+
+
+def _any_claim_clears_accept_bar(
+    claims: list[ModelClaim], *, verifier: Any = None, n_samples: int = 200, seed: int = 0, width_sigma: float = 1.0
+) -> bool:
+    """Cross-model adjudication for a disagreeing claim set: does *any* claim survive scrutiny?
+
+    Two independent checks, either of which can clear a claim (so it is not folded into an abstain):
+
+    1. IC-6 ``verifier`` (if supplied): ``verifier.verify(claim, context) -> Verdict``-shaped, duck-typed
+       so this module never imports ``mixle_mlops`` (E10 owns the real physical/calibration verifiers).
+    2. ``language_bridge.claim_score`` (frozen at ``reason/language_bridge.py:146``): build a
+       ``width_sigma``-sigma interval :class:`~mixle.reason.language_bridge.Claim` around each model's value
+       and score it -- via the *other* models' synthetic posteriors -- for coverage-per-unit-width. Under
+       real disagreement (the only path that reaches this function) every other model's mass sits many sigma
+       away from a claim's own interval, so its cross-model coverage is 0 and the score cannot clear any
+       positive bar; near-agreeing claims (the common case that never reaches here because disagreement is
+       False) would instead see substantial cross-coverage. A claim "clears the bar" iff its score against at
+       least one other model's posterior is strictly positive.
+    """
+    from mixle.reason.language_bridge import Claim, claim_score
+
+    if len(claims) < 2:
+        return True  # nothing to adjudicate against -- a lone claim cannot disagree with itself
+
+    rng = np.random.default_rng(seed)
+    posteriors = {c.model_id: rng.normal(c.value, math.sqrt(c.variance), n_samples) for c in claims}
+
+    for claim in claims:
+        if verifier is not None:
+            context = {
+                "claims": [
+                    {"model_id": o.model_id, "value": o.value, "variance": o.variance} for o in claims if o is not claim
+                ]
+            }
+            candidate = {"model_id": claim.model_id, "value": claim.value, "variance": claim.variance}
+            verdict = verifier.verify(candidate, context)
+            if getattr(verdict, "passed", False):
+                return True
+
+        sd = math.sqrt(claim.variance)
+        interval = Claim(field=claim.model_id, lo=claim.value - width_sigma * sd, hi=claim.value + width_sigma * sd)
+        for other in claims:
+            if other.model_id == claim.model_id:
+                continue
+            score = claim_score(interval, posterior=posteriors[other.model_id], n_samples=n_samples, seed=seed)
+            if score > 0.0:
+                return True
+    return False
+
+
+def fuse_claims(
+    claims: list[ModelClaim],
+    *,
+    prior_prec: float = 0.0,
+    sigma_flag: float = 3.0,
+    verifier: Any = None,
+) -> FusedBelief:
+    """Precision-weighted product-of-experts fusion of independent external-model claims (workstream L5).
+
+    Exactly the rule stated at the top of this module (``prec_fused = sum(prec_i) + prior_prec``,
+    ``mean = sum(prec_i * value_i) / prec_fused``), applied to scalar :class:`ModelClaim`\\ s instead of
+    learned tokens: ``prec_i = reliability_i / variance_i``. On disagreement (worst pairwise standardized
+    distance ``> sigma_flag``), the fused point is only trusted once at least one claim clears cross-model
+    adjudication (:func:`_any_claim_clears_accept_bar`); otherwise ``abstained=True`` and the caller must not
+    surface ``mean`` as a resolved answer. ``provenance`` records every claim's id/version/content_hash/weight
+    so a fused belief is always attributable back to the models that produced it.
+    """
+    if not claims:
+        raise ValueError("fuse_claims needs at least one ModelClaim")
+    for c in claims:
+        if c.variance <= 0:
+            raise ValueError(f"ModelClaim {c.model_id!r} has non-positive variance {c.variance!r}")
+
+    precisions = [c.reliability / c.variance for c in claims]
+    total_prec = sum(precisions)
+    prec_fused = total_prec + prior_prec
+    mean = sum(p * c.value for p, c in zip(precisions, claims)) / prec_fused
+    variance = 1.0 / prec_fused
+    weights = {c.model_id: p / total_prec for p, c in zip(precisions, claims)}
+
+    max_z = _max_pairwise_standardized_distance(claims)
+    disagreement = max_z > sigma_flag
+    abstained = disagreement and not _any_claim_clears_accept_bar(claims, verifier=verifier)
+
+    provenance = {
+        "claims": [
+            {
+                "model_id": c.model_id,
+                "version": c.version,
+                "content_hash": c.content_hash,
+                "weight": weights[c.model_id],
+            }
+            for c in claims
+        ],
+        "max_pairwise_standardized_distance": max_z,
+        "sigma_flag": sigma_flag,
+    }
+    return FusedBelief(
+        mean=mean,
+        variance=variance,
+        weights=weights,
+        disagreement=disagreement,
+        abstained=abstained,
+        provenance=provenance,
+    )
 
 
 def _build():

--- a/mixle/tests/test_cross_model_fusion.py
+++ b/mixle/tests/test_cross_model_fusion.py
@@ -1,0 +1,106 @@
+"""L5 DoD -- cross-model adjudication & fusion (notes/exec/workstream-L.md).
+
+``fuse_claims`` is the precision-weighted product-of-experts rule already stated at the top of
+``reason/fusion.py`` (``prec_fused = sum(prec_i) + prior_prec``; ``mean = sum(prec_i * value_i) /
+prec_fused``), applied to scalar claims from independent external models instead of learned tokens.
+Two model stubs (a synthetic "cmipA"/"cmipB" climate-projection pair) exercise both branches:
+
+* strongly disagreeing claims (``|2 - 4| / sqrt(0.1 + 0.1) = 4.47 > 3`` sigma) trip ``disagreement``
+  and -- since no claim survives cross-model adjudication when both models are that far apart --
+  ``abstained`` too, so a driller-facing number is never quietly averaged out of a real conflict.
+* near-agreeing claims (``2.0`` vs ``2.1``) stay well under the 3-sigma flag and fuse normally.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from mixle.reason.fusion import FusedBelief, ModelClaim, fuse_claims
+
+
+def test_disagreeing_stubs_fused():
+    disagreeing = fuse_claims(
+        [
+            ModelClaim(value=2.0, variance=0.1, model_id="cmipA", version="v1", content_hash="a" * 64),
+            ModelClaim(value=4.0, variance=0.1, model_id="cmipB", version="v1", content_hash="b" * 64),
+        ]
+    )
+    assert isinstance(disagreeing, FusedBelief)
+    assert disagreeing.mean == pytest.approx(3.0, abs=1e-9)
+    assert disagreeing.weights["cmipA"] == pytest.approx(0.5, abs=1e-9)
+    assert disagreeing.weights["cmipB"] == pytest.approx(0.5, abs=1e-9)
+    z = abs(2.0 - 4.0) / math.sqrt(0.1 + 0.1)
+    assert z == pytest.approx(4.4721, abs=1e-3)
+    assert disagreeing.disagreement is True
+    assert disagreeing.abstained is True
+
+    agreeing = fuse_claims(
+        [
+            ModelClaim(value=2.0, variance=0.1, model_id="cmipA", version="v1", content_hash="a" * 64),
+            ModelClaim(value=2.1, variance=0.1, model_id="cmipB", version="v1", content_hash="b" * 64),
+        ]
+    )
+    assert agreeing.disagreement is False
+    assert agreeing.abstained is False
+
+
+def test_weights_track_reliability_and_provenance_is_attributable():
+    fused = fuse_claims(
+        [
+            ModelClaim(
+                value=1.0, variance=0.2, model_id="modelA", version="v1", content_hash="c" * 64, reliability=3.0
+            ),
+            ModelClaim(
+                value=2.0, variance=0.2, model_id="modelB", version="v1", content_hash="d" * 64, reliability=1.0
+            ),
+        ]
+    )
+    # higher reliability -> higher precision -> higher weight, in the frozen 3:1 ratio
+    assert fused.weights["modelA"] == pytest.approx(0.75, abs=1e-9)
+    assert fused.weights["modelB"] == pytest.approx(0.25, abs=1e-9)
+    assert sum(fused.weights.values()) == pytest.approx(1.0, abs=1e-9)
+
+    by_id = {entry["model_id"]: entry for entry in fused.provenance["claims"]}
+    assert by_id["modelA"]["content_hash"] == "c" * 64
+    assert by_id["modelA"]["version"] == "v1"
+    assert by_id["modelA"]["weight"] == pytest.approx(0.75, abs=1e-9)
+    assert by_id["modelB"]["content_hash"] == "d" * 64
+
+
+def test_prior_precision_pulls_the_fused_mean_and_shrinks_variance():
+    claims = [
+        ModelClaim(value=5.0, variance=1.0, model_id="only", version="v1", content_hash="e" * 64),
+    ]
+    unregularized = fuse_claims(claims)
+    regularized = fuse_claims(claims, prior_prec=1.0)
+    assert unregularized.mean == pytest.approx(5.0, abs=1e-9)
+    assert regularized.mean == pytest.approx(2.5, abs=1e-9)  # (1*5 + 0) / (1 + 1)
+    assert regularized.variance < unregularized.variance
+
+
+def test_verifier_accepting_a_claim_prevents_abstention_on_disagreement():
+    class _AlwaysPass:
+        def verify(self, claim, context):
+            class _Verdict:
+                passed = True
+
+            return _Verdict()
+
+    fused = fuse_claims(
+        [
+            ModelClaim(value=2.0, variance=0.1, model_id="cmipA", version="v1", content_hash="a" * 64),
+            ModelClaim(value=4.0, variance=0.1, model_id="cmipB", version="v1", content_hash="b" * 64),
+        ],
+        verifier=_AlwaysPass(),
+    )
+    assert fused.disagreement is True
+    assert fused.abstained is False  # the verifier vouched for a claim despite the raw disagreement
+
+
+def test_rejects_non_positive_variance_and_empty_claim_list():
+    with pytest.raises(ValueError):
+        fuse_claims([])
+    with pytest.raises(ValueError):
+        fuse_claims([ModelClaim(value=1.0, variance=0.0, model_id="bad", version="v1", content_hash="f" * 64)])


### PR DESCRIPTION
## Worklist item

**Item:** L5

## Summary

From notes/exploration-e2e-work-plan.md (the post-0.7 capability-expansion worklist, commissioned directly by the maintainer) and notes/exec/workstream-L.md -- not the original 0.8.0 stability worklist; this is new, explicitly authorized capability work.

Adds `ModelClaim`, `FusedBelief`, and `fuse_claims` to `mixle/reason/fusion.py`: precision-weighted product-of-experts fusion (the same rule already documented at the top of that module) applied to scalar claims from independent external models instead of learned tokens. Each `ModelClaim` carries a value/variance/reliability plus IC-7-shaped provenance (model_id, version, content_hash). `fuse_claims` computes the fused mean/variance and each model's attribution weight, flags disagreement when the worst pairwise standardized distance between two claims exceeds `sigma_flag` (default 3-sigma), and on disagreement adjudicates via an optional IC-6-shaped `verifier` plus a `language_bridge.claim_score` cross-model check before trusting the fused point -- otherwise `abstained=True` so a caller never surfaces a confidently-stated number that quietly averaged away a real conflict between models. `provenance` records every contributing claim's id/version/content_hash/weight.

## Public API impact

- [x] This PR does **not** change any public `__all__`.
- [ ] It changes the public surface, and I regenerated the manifest (`python scripts/gen_api_manifest.py`) and committed `api_manifest.json`.
- [ ] It adds public surface: a written exception is recorded in the release decision log (freeze rule -- a change adding more public surface than it removes needs one).

(`fusion.py` has no `__all__`; the new symbols are not threaded through `reason/__init__.py`'s `__all__`, per the work order's parallel-safety note restricting this task to `fusion.py` alone so a concurrent edit to `reason/__init__.py` -- e.g. by L8, which builds on `fuse_claims` -- doesn't collide. `api_manifest.json` is unaffected since it only scans `__init__.py` files with a static `__all__`.)

## Claims impact

- [x] No public claim (README, docs, benchmarks) is affected.

## Evidence

```
PYTHONPATH=<worktree>/mixle python -m pytest mixle/tests/test_cross_model_fusion.py::test_disagreeing_stubs_fused -q
-> 1 passed in 104.95s

PYTHONPATH=<worktree>/mixle python -m pytest mixle/tests/reason_fusion_test.py mixle/tests/language_bridge_test.py mixle/tests/test_cross_model_fusion.py mixle/tests/public_api_manifest_test.py -q -n0 -m ""
-> 26 passed in 208.85s

ruff format + ruff check on mixle/reason/fusion.py and mixle/tests/test_cross_model_fusion.py -> clean
```

(DoD path note: the work order's literal DoD path is `mixle/mixle/tests/test_cross_model_fusion.py`, i.e. relative to `$MX=/Users/grantboquet/mixle`; run from inside this isolated worktree -- which IS the `mixle` repo root -- the equivalent path is `mixle/tests/test_cross_model_fusion.py`, confirmed to resolve inside the worktree via `mixle.__file__` before trusting the run.)

## Notes (judgment calls)

- L4/E10/M2 (this task's declared dependencies) have not merged into `release/0.8.0` yet at authoring time (L4 exists as an open branch in mixle-mlops; E10/M2 not found). Per the work order's own Files/parallel-safety scope (only `fusion.py`, no `mixle_mlops` import), `verifier` is consumed structurally/duck-typed (`verifier.verify(claim, context) -> has .passed`) rather than importing IC-6's `Verifier` protocol from `mixle_mlops` -- this module has zero dependency on `mixle_mlops` being installed or on its branch landing first.
- The DR-ALG's disagreement-adjudication step ("route to the IC-6 verifier + language_bridge accept-or-abstain: if no claim clears the conformal accept bar, set abstained=True") does not fully specify the accept bar's construction. Implemented as: build a `width_sigma`-sigma interval `Claim` around each model's own value, and score it (via `language_bridge.claim_score`) against every *other* model's synthetic posterior (`N(value_i, variance_i)` samples); a claim "clears the bar" if that cross-model coverage is strictly positive for at least one other model, or if the optional `verifier` explicitly passes it. Under real disagreement (many-sigma separation) cross-model coverage is 0 for every claim, so the DoD's disagreement case abstains as specified; a near-agreeing pair never reaches this path since `disagreement` is only computed as `True` past the sigma threshold.
- `ModelClaim`/`FusedBelief`/`fuse_claims` are importable directly from `mixle.reason.fusion` (as the DoD test and L8 do) but are not re-exported through `reason/__init__.py`; see Public API impact note above.