### PR TITLE
J3: Real options & decision-under-uncertainty  ⚗

### DIFF
--- a/api_manifest.json
+++ b/api_manifest.json
@@ -30,6 +30,7 @@
     "KDE",
     "LedoitWolfEstimator",
     "NPVDistribution",
+    "OptionValue",
     "SmithMaxStable",
     "SmithMaxStableSampler",
     "SpatialMixture",
@@ -76,13 +77,15 @@
     "population_risk",
     "priced_liabilities",
     "rarefaction_curve",
+    "real_option_value",
     "record_times",
     "return_level",
     "scott_bandwidth",
     "silverman_bandwidth",
     "spearman_footrule",
     "turing_coverage",
-    "universal_kriging"
+    "universal_kriging",
+    "voi_dollars"
   ],
   "mixle.data": [
     "Boolean",

--- a/mixle/analysis/__init__.py
+++ b/mixle/analysis/__init__.py
@@ -69,6 +69,7 @@ from mixle.analysis.rank_aggregation import (
     mallows_fit,
     spearman_footrule,
 )
+from mixle.analysis.real_options import OptionValue, real_option_value, voi_dollars
 from mixle.analysis.sdm import HabitatModel, SpeciesObservation, fit_sdm
 from mixle.analysis.spatial_mixture import SpatialMixture
 from mixle.analysis.valuation import NPVDistribution, capex_opex, cost_curve, monte_carlo_npv
@@ -150,4 +151,8 @@ __all__ = [
     # mixle.stochastic_opt.risk_adjusted_plan
     "priced_liabilities",
     "hard_constraints",
+    # real options & decision-under-uncertainty
+    "OptionValue",
+    "real_option_value",
+    "voi_dollars",
 ]

--- a/mixle/analysis/real_options.py
+++ b/mixle/analysis/real_options.py
@@ -1,0 +1,262 @@
+"""Real options & decision-under-uncertainty (work-plan Sec.7-J, J3).
+
+A risk-neutral NPV distribution (J2's :class:`~mixle.analysis.valuation.NPVDistribution`) answers "what
+is the project worth if we commit now?" It does not answer the question a real decision-maker actually
+faces: "should we commit now, or is it worth paying for the *option* to wait, expand, or walk away once
+more is known?" Two tools close that gap:
+
+  * :func:`real_option_value` -- prices the option embedded in the decision (defer / expand / abandon)
+    with a binomial lattice on the NPV process itself, American-exercised at every step. NPV -- unlike a
+    commodity price -- is a signed quantity that must be able to cross zero for "wait and see" to mean
+    anything, so the lattice is *additive* (an arithmetic random walk around ``npv_dist.mean``, scaled by
+    ``volatility`` as a fraction of the NPV's own magnitude) rather than the usual multiplicative GBM
+    lattice: a strictly-positive geometric process started above zero can never reach the ``max(V, 0)``
+    kink that gives the option its value. Volatility is what makes the option valuable: by Jensen's
+    inequality, an American option on a driftless process is worth strictly more than the naive point NPV
+    whenever there is dispersion wide enough to reach the kink, and it collapses to the naive
+    ``max(NPV, 0)`` as volatility falls to zero (no dispersion, nothing to wait for).
+  * :func:`voi_dollars` -- the dollar value of a piece of information (e.g. a delineation drillhole)
+    computed the textbook way: the expected value of the best decision *with* that information, minus
+    the expected value of the best decision *without* it. A hypothetical drillhole's effect on the
+    posterior is summarized as a fractional variance reduction (either supplied directly via
+    ``drill_info["variance_reduction"]``, or -- when available -- via C8's
+    ``mixle_pde.voi.expected_variance_reduction`` hook); the pre-posterior simulation splits the prior
+    variance, by the law of total variance, into "where the future posterior will be centered" and "how
+    much uncertainty remains once it lands there." A rational decision-maker never loses from more
+    information, so the estimate is floored at zero.
+
+Repo-boundary note (see this task's PR description): as of this PR neither J2's
+``mixle.analysis.valuation`` module (``NPVDistribution`` / ``monte_carlo_npv``) nor C8's ``mixle_pde``
+VOI hooks had landed on ``release/0.8.0`` -- J2 and C8 are this task's stated dependencies but are
+themselves still in flight. Consistent with how J4's ``valuation.py`` already handled the same kind of
+repo-boundary gap (see that module's docstring), this module treats both as soft dependencies: the
+``npv_dist`` parameter is duck-typed against anything exposing a ``.mean`` (the ``"NPVDistribution"``
+annotation is a forward reference, exactly as written in the frozen work order, never imported at
+runtime), and ``voi_dollars`` best-effort imports the C8 hook and falls back to a self-contained
+posterior-refinement simulation over the frozen IC-1 :class:`~mixle.reason.posterior_protocol.Posterior`
+when it is unavailable. Nothing here blocks on either dependency merging first.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, NamedTuple
+
+import numpy as np
+
+from mixle.reason.posterior_protocol import Posterior
+
+if TYPE_CHECKING:
+    from mixle.analysis.valuation import NPVDistribution
+
+__all__ = ["OptionValue", "real_option_value", "voi_dollars"]
+
+_KINDS = ("defer", "expand", "abandon")
+
+
+class OptionValue(NamedTuple):
+    """The priced option, alongside the exercise policy that generated it.
+
+    ``value`` is the total value of holding the option (project value + optionality). ``exercise_boundary``
+    is the per-time-step critical underlying value at which immediate exercise first becomes optimal
+    (``nan`` at any step where it is never optimal to exercise). ``premium_over_npv`` is ``value`` minus
+    the naive ``npv_dist.mean`` -- the dollar amount the flexibility to defer/expand/abandon is worth
+    over just committing to the point-estimate NPV today.
+    """
+
+    value: float
+    exercise_boundary: np.ndarray
+    premium_over_npv: float
+
+
+def _intrinsic(v: np.ndarray, kind: str, expand_fraction: float) -> np.ndarray:
+    """Exercise payoff at underlying value(s) ``v`` for the given option ``kind``."""
+    if kind == "defer":
+        # Option to wait, then invest only if the project is worth it: invest for max(V, 0), else walk.
+        return np.maximum(v, 0.0)
+    if kind == "abandon":
+        # Already committed; option to abandon for salvage (assumed 0) rather than ride a negative NPV.
+        return np.maximum(v, 0.0)
+    if kind == "expand":
+        # Option to scale up capacity by `expand_fraction` whenever doing so is profitable.
+        return v + expand_fraction * np.maximum(v, 0.0)
+    raise ValueError(f"real_option_value: kind must be one of {_KINDS}, got {kind!r}")
+
+
+def real_option_value(
+    npv_dist: NPVDistribution,
+    *,
+    volatility: float,
+    horizon: int,
+    kind: str = "defer",
+    rate: float,
+    n_steps: int | None = None,
+    expand_fraction: float = 0.3,
+) -> OptionValue:
+    """Price the defer/expand/abandon option on a project via an additive binomial lattice on NPV.
+
+    The NPV process is modeled as a driftless arithmetic random walk started at ``npv_dist.mean``: each
+    of ``n_steps`` (default: ``max(horizon, 1)``) steps up to ``horizon`` moves the value by
+    ``+-h`` with ``h = volatility * scale * sqrt(dt)``, ``scale = abs(npv_dist.mean)`` (or ``1.0`` if the
+    mean is exactly zero, so ``volatility`` is never degenerate) -- i.e. ``volatility`` is a *fractional*
+    per-sqrt-period dispersion relative to the project's own scale, matching how the parameter is usually
+    quoted (e.g. ``0.3`` ~ "30% dispersion"), while still letting the walk go negative the way a signed
+    NPV must be able to. The risk-neutral measure is taken driftless (an NPV is already the discounted
+    expectation of a self-financing project, so there is no further risk-neutral drift to add); ``rate``
+    only discounts the continuation value, which is what makes immediate exercise optimal once volatility
+    vanishes. At every node the holder may exercise (payoff via :func:`_intrinsic`, depending on ``kind``)
+    or continue holding the option; the American value is the larger of the two, by backward induction
+    from the horizon.
+
+    Args:
+        npv_dist: anything exposing ``.mean`` (a float) -- typically J2's ``NPVDistribution``. Only the
+            mean is used; ``real_option_value`` prices the *option on top of* the point estimate, not a
+            re-derivation of the distribution itself.
+        volatility: fractional (per-sqrt-period) dispersion of NPV around its mean. Must be ``>= 0``;
+            ``0`` means no dispersion and the option collapses to the naive ``max(npv_dist.mean, 0)``.
+        horizon: number of periods over which the option may be exercised. ``0`` means "decide now".
+        kind: one of ``"defer"``, ``"expand"``, ``"abandon"``.
+        rate: per-period discount rate applied to the continuation value.
+        n_steps: lattice steps (defaults to ``max(horizon, 1)``, i.e. one step per period).
+        expand_fraction: for ``kind="expand"``, the fractional capacity bonus applied to a positive
+            underlying value when the expansion is exercised.
+
+    Returns:
+        An :class:`OptionValue`.
+    """
+    if kind not in _KINDS:
+        raise ValueError(f"real_option_value: kind must be one of {_KINDS}, got {kind!r}")
+    if volatility < 0.0:
+        raise ValueError("real_option_value: volatility must be non-negative")
+    if horizon < 0:
+        raise ValueError("real_option_value: horizon must be non-negative")
+
+    npv_mean = float(npv_dist.mean)
+    n = int(n_steps) if n_steps is not None else max(int(horizon), 1)
+    dt = float(horizon) / n if horizon > 0 else 0.0
+    scale = abs(npv_mean) if npv_mean != 0.0 else 1.0
+    h = volatility * scale * float(np.sqrt(dt))
+
+    if h == 0.0:
+        # No dispersion (or no time to disperse in): waiting has no upside, and discounting only makes it
+        # worse, so the optimal policy is "exercise now if positive, else never" -- the naive NPV floor.
+        value = max(npv_mean, 0.0)
+        boundary = np.full(n + 1, np.nan)
+        return OptionValue(value=value, exercise_boundary=boundary, premium_over_npv=value - npv_mean)
+
+    disc = float(np.exp(-rate * dt))
+    boundary = np.full(n + 1, np.nan)
+
+    j = np.arange(n + 1)
+    v = npv_mean + (2 * j - n) * h  # j up-moves, (n - j) down-moves out of n steps
+    option = _intrinsic(v, kind, expand_fraction)
+    boundary[n] = 0.0  # at maturity, exercise iff the underlying is non-negative (kind-independent here)
+
+    for step in range(n - 1, -1, -1):
+        j = np.arange(step + 1)
+        v = npv_mean + (2 * j - step) * h
+        continuation = disc * 0.5 * (option[1 : step + 2] + option[0 : step + 1])
+        intrinsic = _intrinsic(v, kind, expand_fraction)
+        exercise = intrinsic > continuation
+        option = np.where(exercise, intrinsic, continuation)
+        if np.any(exercise):
+            exercised_v = v[exercise]
+            boundary[step] = float(np.min(exercised_v)) if kind != "abandon" else float(np.max(exercised_v))
+
+    value = float(option[0])
+    return OptionValue(value=value, exercise_boundary=boundary, premium_over_npv=value - npv_mean)
+
+
+def _variance_reduction(posterior: Posterior, drill_info: dict) -> float:
+    """Fraction of posterior variance a hypothetical drillhole is expected to remove, in ``[0, 1)``.
+
+    Best-effort: if C8's ``mixle_pde.voi.expected_variance_reduction`` hook is importable and
+    ``drill_info`` supplies the geometry/forward-operator it needs, use it. Otherwise fall back to a
+    directly-supplied ``drill_info["variance_reduction"]`` (default ``0.5`` -- a generic "meaningfully
+    informative" delineation hole).
+    """
+    candidate_geometry = drill_info.get("candidate_geometry")
+    forward_op = drill_info.get("forward_op")
+    if candidate_geometry is not None and forward_op is not None:
+        try:
+            from mixle_pde.voi import expected_variance_reduction  # C8 hook; mixle_pde is a soft dependency
+        except ImportError:
+            expected_variance_reduction = None
+        if expected_variance_reduction is not None:
+            reduction = float(
+                expected_variance_reduction(
+                    posterior,
+                    candidate_geometry,
+                    forward_op,
+                    region=drill_info.get("region"),
+                    cell_volumes=drill_info.get("cell_volumes"),
+                )
+            )
+            return min(max(reduction, 0.0), 1.0 - 1e-9)
+    return min(max(float(drill_info.get("variance_reduction", 0.5)), 0.0), 1.0 - 1e-9)
+
+
+def voi_dollars(
+    posterior: Posterior,
+    decision_fn: Callable[[np.ndarray], float],
+    drill_info: dict[str, Any],
+    *,
+    rng: np.random.Generator,
+    n_outer: int = 64,
+    n_inner: int = 256,
+) -> float:
+    """Value of information, in dollars: ``E[value | drill info] - E[value | no info]``.
+
+    ``decision_fn`` maps a set of posterior draws (an ``(n, d)`` array, physical units) to the dollar
+    value of the *single* best decision made using that belief state -- e.g. a risk-neutral go/no-go
+    choice is ``max(samples.mean(), 0)``, not an average of a per-draw payoff: the latter implicitly
+    assumes the realization is already known, which is exactly the perfect-information case this function
+    is pricing the *gap* to, not the belief itself. The no-info value is ``decision_fn`` applied to
+    today's posterior draws.
+
+    The with-info value is a pre-posterior Monte Carlo built on the law of total variance: today's
+    posterior variance splits into "where the post-drill posterior will be centered" (unknown until the
+    drillhole is actually put in) and "how much spread remains once it lands there." If the drillhole is
+    expected to remove a fraction ``r`` of variance (:func:`_variance_reduction`), then for ``n_outer``
+    hypothetical drill outcomes: a center is drawn with standard deviation scaled by ``sqrt(r)`` around
+    today's posterior mean (how much the belief could plausibly shift), and for each center, ``n_inner``
+    refined-posterior draws are formed with the remaining spread scaled by ``sqrt(1 - r)``. Re-deciding
+    with ``decision_fn`` on each refined belief and averaging over the (unknown, before drilling) outcome
+    gives ``E[value | drill info]``; as ``r -> 0`` this construction degenerates back to exactly today's
+    posterior (no information, no premium), and as ``r -> 1`` the center draws recover the full prior
+    spread while the refined posterior collapses to a point (perfect information).
+
+    A perfectly rational decision-maker is never made worse off by more information, so the result is
+    floored at ``0.0``.
+
+    Args:
+        posterior: the current (pre-drill) belief, satisfying IC-1's ``Posterior`` protocol.
+        decision_fn: belief state (``(n, d)`` draws) -> expected dollar value of the best decision.
+        drill_info: describes the hypothetical drillhole. Recognized keys: ``variance_reduction`` (direct
+            fractional variance reduction, default ``0.5``), or ``candidate_geometry`` + ``forward_op``
+            (+ optional ``region`` / ``cell_volumes``) to route through the C8 VOI hook when available;
+            ``n_outer_samples`` / ``n_inner_samples`` override the Monte Carlo sample counts.
+        rng: seeded random generator for reproducibility.
+
+    Returns:
+        The value of information in dollars, ``>= 0``.
+    """
+    n_outer = int(drill_info.get("n_outer_samples", n_outer))
+    n_inner = int(drill_info.get("n_inner_samples", n_inner))
+
+    value_no_info = float(decision_fn(posterior.samples(n_inner, rng)))
+
+    reduction = _variance_reduction(posterior, drill_info)
+    center_scale = float(np.sqrt(reduction))
+    inner_scale = float(np.sqrt(1.0 - reduction))
+    mean = np.asarray(posterior.mean, dtype=np.float64)
+
+    centers = mean + center_scale * (posterior.samples(n_outer, rng) - mean)
+    values_with_info = np.empty(n_outer, dtype=np.float64)
+    for i in range(n_outer):
+        base = posterior.samples(n_inner, rng)
+        refined = centers[i] + inner_scale * (base - mean)
+        values_with_info[i] = decision_fn(refined)
+    value_with_info = float(np.mean(values_with_info))
+
+    return max(value_with_info - value_no_info, 0.0)

--- a/mixle/tests/test_j3_real_options.py
+++ b/mixle/tests/test_j3_real_options.py
@@ -1,0 +1,135 @@
+"""J3 DoD -- real options & decision-under-uncertainty (notes/exec/workstream-J.md).
+
+The Definition of Done asks for exactly two things about the deferral option:
+
+1. Its value strictly exceeds the naive ``npv_dist.mean`` under high price volatility.
+2. It collapses to ``~= max(npv_dist.mean, 0)`` as volatility -> 0.
+
+Both are asserted below on the same underlying (positive-mean) project, plus a handful of supporting
+checks on the rest of this task's public API (``OptionValue``'s shape, ``expand``/``abandon`` kinds,
+and ``voi_dollars``' non-negativity) that aren't part of the DoD command itself but guard against
+regressions in code this task also ships.
+
+Repo-boundary note: J2's ``mixle.analysis.valuation.NPVDistribution`` had not landed on ``release/0.8.0``
+as of this PR (see ``mixle/analysis/real_options.py``'s module docstring), so these tests build the
+minimal duck-typed stand-in the real work order itself types as a forward reference (``"NPVDistribution"``)
+rather than importing a class that doesn't exist yet on this branch.
+"""
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+import numpy as np
+import pytest
+
+from mixle.analysis.real_options import OptionValue, real_option_value, voi_dollars
+
+
+class _FakeNPVDistribution(NamedTuple):
+    """Minimal duck-typed stand-in for J2's NPVDistribution -- only `.mean` is consumed."""
+
+    samples: np.ndarray
+    mean: float
+
+
+def _npv_dist(mean: float, spread: float = 5.0, n: int = 2000, seed: int = 0) -> _FakeNPVDistribution:
+    rng = np.random.default_rng(seed)
+    samples = rng.normal(mean, spread, size=n)
+    return _FakeNPVDistribution(samples=samples, mean=float(mean))
+
+
+def test_defer_option_exceeds_npv_under_high_volatility():
+    npv_dist = _npv_dist(mean=10.0)
+    opt = real_option_value(npv_dist, volatility=0.6, horizon=5, kind="defer", rate=0.05)
+    assert isinstance(opt, OptionValue)
+    assert opt.value > npv_dist.mean
+    assert opt.premium_over_npv == pytest.approx(opt.value - npv_dist.mean)
+
+
+def test_defer_option_collapses_to_naive_npv_as_volatility_to_zero():
+    npv_dist = _npv_dist(mean=10.0)
+    opt = real_option_value(npv_dist, volatility=1e-9, horizon=5, kind="defer", rate=0.05)
+    assert opt.value == pytest.approx(max(npv_dist.mean, 0.0), abs=1e-6)
+
+
+def test_defer_option_monotone_in_volatility():
+    npv_dist = _npv_dist(mean=10.0)
+    low = real_option_value(npv_dist, volatility=0.05, horizon=5, kind="defer", rate=0.05)
+    high = real_option_value(npv_dist, volatility=0.6, horizon=5, kind="defer", rate=0.05)
+    assert high.value > low.value
+
+
+def test_defer_option_on_negative_mean_project_still_floors_at_zero_as_volatility_vanishes():
+    npv_dist = _npv_dist(mean=-8.0)
+    opt = real_option_value(npv_dist, volatility=1e-9, horizon=5, kind="defer", rate=0.05)
+    assert opt.value == pytest.approx(0.0, abs=1e-6)
+    # but with real volatility, the option to wait for an upswing is worth strictly more than 0
+    opt_vol = real_option_value(npv_dist, volatility=0.6, horizon=5, kind="defer", rate=0.05)
+    assert opt_vol.value > 0.0
+
+
+def test_exercise_boundary_has_one_entry_per_lattice_step():
+    npv_dist = _npv_dist(mean=10.0)
+    opt = real_option_value(npv_dist, volatility=0.4, horizon=6, kind="defer", rate=0.05)
+    assert opt.exercise_boundary.shape == (7,)
+
+
+@pytest.mark.parametrize("kind", ["defer", "expand", "abandon"])
+def test_all_kinds_run_and_return_option_value(kind):
+    npv_dist = _npv_dist(mean=10.0)
+    opt = real_option_value(npv_dist, volatility=0.3, horizon=4, kind=kind, rate=0.05)
+    assert isinstance(opt, OptionValue)
+    assert np.isfinite(opt.value)
+
+
+def test_unknown_kind_raises():
+    npv_dist = _npv_dist(mean=10.0)
+    with pytest.raises(ValueError):
+        real_option_value(npv_dist, volatility=0.3, horizon=4, kind="bogus", rate=0.05)
+
+
+class _ToyPosterior:
+    """A minimal IC-1-conforming posterior: an independent Gaussian belief over one grade parameter."""
+
+    def __init__(self, mean: float, std: float):
+        self._mean = mean
+        self._std = std
+
+    def samples(self, n, rng):
+        return rng.normal(self._mean, self._std, size=(n, 1))
+
+    @property
+    def mean(self):
+        return np.array([self._mean])
+
+    @property
+    def cov(self):
+        return np.array([[self._std**2]])
+
+    def credible_interval(self, level):
+        z = self._std * 1.6448536269514722  # ~ inverse-CDF fudge, not exercised by this test
+        return self.mean - z, self.mean + z
+
+    def derived_quantity(self, fn, n, rng):
+        raise NotImplementedError
+
+
+def _decision_value(samples: np.ndarray) -> float:
+    """Toy decision rule: a single risk-neutral go/no-go choice, priced at the belief's mean."""
+    return float(max(np.mean(samples[:, 0]), 0.0))
+
+
+def test_voi_dollars_is_non_negative():
+    posterior = _ToyPosterior(mean=1.0, std=5.0)
+    rng = np.random.default_rng(0)
+    voi = voi_dollars(posterior, _decision_value, {"variance_reduction": 0.7}, rng=rng)
+    assert voi >= 0.0
+
+
+def test_voi_dollars_grows_with_variance_reduction():
+    rng = np.random.default_rng(0)
+    posterior = _ToyPosterior(mean=1.0, std=5.0)
+    voi_small = voi_dollars(posterior, _decision_value, {"variance_reduction": 0.1}, rng=np.random.default_rng(1))
+    voi_large = voi_dollars(posterior, _decision_value, {"variance_reduction": 0.9}, rng=np.random.default_rng(1))
+    assert voi_large >= voi_small


### PR DESCRIPTION
## Summary

Worklist item: J3.

From `notes/exploration-e2e-work-plan.md` (the post-0.7 capability-expansion worklist, commissioned directly by the maintainer) and `notes/exec/workstream-J.md` — not the original 0.8.0 stability worklist; this is new, explicitly authorized capability work.

Adds `mixle/analysis/real_options.py`:

- `OptionValue` (NamedTuple): `value`, `exercise_boundary`, `premium_over_npv`.
- `real_option_value(npv_dist, *, volatility, horizon, kind="defer", rate)`: prices the defer/expand/abandon option embedded in an NPV distribution via an American binomial lattice.
- `voi_dollars(posterior, decision_fn, drill_info, *, rng)`: the dollar value of a hypothetical delineation drillhole, via a pre-posterior Monte Carlo re-decision.

## Why

A Monte-Carlo NPV distribution (J2) says what a project is worth if you commit today. It says nothing about whether committing today is the right call versus waiting, expanding later, or walking away — that is the actual decision a driller/operator faces, and it is what real-options analysis prices. Likewise, before paying for a delineation drillhole, the operator wants to know what that information is worth in dollars, not just that it "reduces uncertainty."

The lattice deliberately runs on an *additive* (arithmetic) NPV process rather than the textbook multiplicative GBM lattice: NPV is signed and must be able to cross zero for "wait and see" to have any content, whereas a geometric process started above zero never reaches the `max(NPV, 0)` kink that gives the option its value. `volatility` is expressed as a fraction of the NPV's own scale so a given volatility level stays meaningful whether the project mean is large or small. `voi_dollars` follows the law of total variance: a drillhole's expected variance reduction splits today's posterior uncertainty into "where the future (post-drill) posterior will be centered" and "how much spread remains once it lands there," simulates both, and re-decides with the caller's `decision_fn` on each simulated outcome.

## Test plan

DoD command (verbatim), run against the worktree:

```
PYTHONPATH=/Users/grantboquet/mixle/mixle python -m pytest mixle/tests/test_j3_real_options.py -q
```

Result: **11 passed**. The two DoD-mandated assertions (deferral option value strictly exceeds the naive `npv_dist.mean` under high volatility; collapses to `≈max(npv_mean, 0)` as volatility → 0) both pass, plus 9 supporting tests on `OptionValue`'s shape, all three option `kind`s, and `voi_dollars`.

Broader regression (same-package tests + the public-API manifest drift test):

```
PYTHONPATH=/Users/grantboquet/mixle/mixle python -m pytest mixle/tests/test_j3_real_options.py mixle/tests/extreme_value_test.py mixle/tests/generalized_extreme_value_test.py mixle/tests/automatic_generalized_extreme_value_test.py mixle/tests/public_api_manifest_test.py -q
```

Result: **32 passed**.

`ruff format` / `ruff check` clean on all changed files.

## Notes (judgment calls)

- **J2 and C8 had not landed on `release/0.8.0` as of this PR.** J3's stated dependencies are J2 (`mixle.analysis.valuation.NPVDistribution` / `monte_carlo_npv`) and C8 (`mixle_pde`'s VOI hooks), but neither had merged into `release/0.8.0` at the time this branch was cut (confirmed via `git ls-tree`/`git log` — `mixle/analysis/valuation.py` does not exist on `release/0.8.0` yet, and `mixle_pde` is a separate repo not on this task's PYTHONPATH). Following the precedent already set by this same file's neighbor (J4's `valuation.py` docstring) for an identical repo-boundary gap: `real_option_value`'s `npv_dist` parameter is duck-typed against anything exposing a `.mean` — the `NPVDistribution` annotation is a forward reference under `from __future__ import annotations`, never imported at runtime, so this module works unmodified once J2 lands. `voi_dollars` best-effort imports C8's `mixle_pde.voi.expected_variance_reduction` hook when `drill_info` supplies the geometry/forward-operator it needs, and falls back to a self-contained posterior-refinement simulation over the frozen IC-1 `Posterior` protocol otherwise. Nothing in this PR blocks on either dependency merging first, and nothing needs to change here once they do.
- **Lattice process choice (additive, not multiplicative).** The obvious first implementation (a standard CRR multiplicative/GBM lattice, matching most textbook real-options code) is wrong for this signature: started from a positive `npv_dist.mean`, a geometric process can never go negative, so the `max(NPV, 0)` payoff never actually clips anything and the "option" collapses to the point estimate at every volatility level — silently defeating the entire point of the function. Switched to a driftless additive (arithmetic) random walk on NPV itself, with `volatility` scaled by `abs(npv_dist.mean)` so it remains a meaningful fractional dispersion parameter. This is called out at length in the module docstring since it is the one place a naive reading of "binomial lattice on the NPV process" goes wrong.
- **`kind="expand"` / `kind="abandon"` payoff shapes** are my own reasonable, simple, documented choices (the work order names the three but doesn't specify their payoffs); the DoD only exercises `kind="defer"`. `abandon` and `defer` share the same `max(V, 0)` intrinsic (mathematically equivalent for a European/American floor at zero); `expand` adds a fractional bonus (`expand_fraction`, default `0.3`) to a positive underlying value.
- Ran `python scripts/gen_api_manifest.py` and committed the regenerated `api_manifest.json` (adds `OptionValue`, `real_option_value`, `voi_dollars` to `mixle.analysis`'s manifest entry — no other diff).