### PR TITLE
M2: Numeric cross-model belief fusion

### DIFF
--- a/api_manifest.json
+++ b/api_manifest.json
@@ -1141,6 +1141,7 @@
     "fit_conditional_transport",
     "fit_cycle_transport",
     "fit_fact_calibrator",
+    "fuse_models",
     "fusion_flops",
     "information_corroborator",
     "joint_cycle_consistency_receipt",

--- a/mixle/reason/__init__.py
+++ b/mixle/reason/__init__.py
@@ -61,6 +61,7 @@ from mixle.reason.llm import (
     sentence_claims,
 )
 from mixle.reason.modality import ModalityGraph, ModalityView
+from mixle.reason.model_fusion import fuse_models
 from mixle.reason.ontology import (
     AXIOMS,
     ConstrainedDecode,
@@ -112,6 +113,7 @@ __all__ = [
     "content_overlap",
     "ModalityView",
     "ModalityGraph",
+    "fuse_models",
     "TaskReadout",
     "task_sufficient_projection",
     "read_out",

--- a/mixle/reason/model_fusion.py
+++ b/mixle/reason/model_fusion.py
@@ -1,0 +1,161 @@
+"""Numeric cross-model belief fusion -- precision-weighted assimilation across MODELS, not modalities.
+
+``mixle.reason.core.reason`` already folds a sequence of per-*modality* linear-Gaussian evidence
+into a shared latent belief (a product of experts). This module reuses exactly that Kalman path to
+fuse per-*model* claims about the same latent: several independently-run models (e.g. two physics
+solvers, or a solver and a learned emulator) each hand back a linear-Gaussian view of the same
+quantity, tagged with the model's identity and an operator-supplied reliability. ``fuse_models``
+scales each claim's noise by its reliability (inverse-variance precision weighting), assimilates
+all of them in one pass, and reports which model contributed how much (in nats, via
+``ReasonedAnswer.attribution``) plus whether the models disagree badly enough that the fused
+answer should not be trusted outright.
+
+This is deliberately *not* new fusion math: the only new logic here is precision-scaling claim
+noise and a pairwise disagreement check before/around the existing ``reason`` call. Merging
+non-scalar structured knowledge (graphs/tables/images) across models is a different lifecycle
+owned by the knowledge-conflict machinery, not this module.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+from mixle.reason.core import GaussianBelief, LinearGaussianEvidence, ReasonedAnswer, reason
+
+
+@dataclass(frozen=True)
+class ModelClaim:
+    """One model's linear-Gaussian claim about the shared latent, tagged with identity + trust.
+
+    ``evidence`` is the model's raw ``(H, y, R)`` observation of the latent (its ``name`` is
+    ignored -- :func:`fuse_models` stamps ``f"{model_id}@{version}"`` on it so attribution and
+    disagreement reporting are keyed by model identity rather than whatever the caller set).
+    ``reliability`` in ``(0, 1]`` is how much the claim's stated noise should be trusted: ``1.0``
+    takes ``R`` at face value; smaller values inflate ``R`` (divide by ``reliability``), so a
+    known-flaky model's claim is assimilated as effectively noisier and contributes less
+    information to the fused belief.
+    """
+
+    evidence: LinearGaussianEvidence
+    model_id: str
+    version: str
+    reliability: float = 1.0
+
+    def __post_init__(self) -> None:
+        if not (0.0 < self.reliability <= 1.0):
+            raise ValueError(f"reliability must be in (0, 1]; got {self.reliability!r}")
+        if not self.model_id:
+            raise ValueError("model_id must be non-empty")
+        if not self.version:
+            raise ValueError("version must be non-empty")
+
+    @property
+    def name(self) -> str:
+        """The stable ``model_id@version`` identity used as this claim's evidence/attribution key."""
+        return f"{self.model_id}@{self.version}"
+
+
+@dataclass
+class ModelFusionResult:
+    """The outcome of fusing several models' claims about one latent.
+
+    ``answer`` is the fused :class:`ReasonedAnswer` (posterior belief + UQ). ``weights`` is each
+    model's attribution -- nats of uncertainty it removed (``ReasonedAnswer.attribution()``),
+    keyed by ``model_id@version``. ``disagreement`` reports the pairwise standardized differences
+    between models' individual (solo) views of the query, in the same units as ``disagree_sigma``.
+    ``abstain`` is ``True`` when any pair disagrees by more than ``disagree_sigma`` -- the fused
+    number should not be trusted at face value; callers are expected to route that case to a
+    verifier (IC-6) / an abstaining natural-language surface rather than presenting the fused mean
+    as settled.
+    """
+
+    answer: ReasonedAnswer
+    weights: dict[str, float]
+    disagreement: dict[str, Any]
+    abstain: bool
+
+
+def _precision_scaled_evidence(claim: ModelClaim) -> LinearGaussianEvidence:
+    """Return ``claim.evidence`` with its noise ``R`` divided by reliability and named by model identity."""
+    e = claim.evidence
+    scaled_R = np.asarray(e.R, dtype=float) / claim.reliability
+    return LinearGaussianEvidence(H=e.H, y=e.y, R=scaled_R, name=claim.name)
+
+
+def _pairwise_disagreement(
+    prior: GaussianBelief,
+    scaled: list[LinearGaussianEvidence],
+    *,
+    query: Any,
+    disagree_sigma: float,
+) -> dict[str, Any]:
+    """Standardized pairwise distance between each model's solo posterior (folding only that model's
+    evidence into ``prior``), restricted to ``query`` when given -- the same readout ``fuse_models``
+    ultimately returns. A pair's sigma is the largest per-coordinate ``|mean_i - mean_j| / sqrt(var_i
+    + var_j)`` across the queried coordinates -- a conservative (worst-coordinate) conflict test.
+    """
+    solo = {e.name: reason(prior, [e], query=query) for e in scaled}
+    names = list(solo)
+    pairwise_sigma: dict[str, float] = {}
+    for i in range(len(names)):
+        for j in range(i + 1, len(names)):
+            a, b = solo[names[i]], solo[names[j]]
+            diff = np.abs(a.mean - b.mean)
+            var_sum = np.maximum(np.diag(np.atleast_2d(a.cov())) + np.diag(np.atleast_2d(b.cov())), 1e-300)
+            sigma = float(np.max(diff / np.sqrt(var_sum))) if diff.size else 0.0
+            pairwise_sigma[f"{names[i]}|{names[j]}"] = sigma
+    max_sigma = max(pairwise_sigma.values()) if pairwise_sigma else 0.0
+    flagged = [pair for pair, sigma in pairwise_sigma.items() if sigma > disagree_sigma]
+    return {
+        "pairwise_sigma": pairwise_sigma,
+        "max_sigma": max_sigma,
+        "disagree_sigma": float(disagree_sigma),
+        "flagged_pairs": flagged,
+    }
+
+
+def fuse_models(
+    prior: GaussianBelief,
+    claims: list[ModelClaim],
+    *,
+    query: Any = None,
+    disagree_sigma: float = 3.0,
+) -> ModelFusionResult:
+    """Fuse several models' claims about the same latent into one belief (precision-weighted Kalman).
+
+    Each claim's noise is scaled by ``1 / reliability`` and named ``model_id@version`` (DR-ALG L5/M2
+    precision weighting), then all claims are folded into ``prior`` in one pass via
+    :func:`mixle.reason.core.reason` -- the existing multi-source assimilation path, with one
+    evidence per *model* rather than per modality. Per-model attribution comes straight from
+    ``ReasonedAnswer.attribution()``. Before returning, each pair of models' *individual* (solo)
+    views of the query are compared; if any pair disagrees by more than ``disagree_sigma`` standard
+    deviations, ``abstain`` is set so callers don't present the fused answer as settled without
+    further verification.
+
+    Args:
+        prior: the latent's prior belief.
+        claims: one :class:`ModelClaim` per model (must have distinct ``model_id@version`` identity).
+        query: optional latent coordinate indices to restrict the fused answer (and the
+            disagreement check) to.
+        disagree_sigma: the standardized-distance threshold above which models are considered to
+            be in conflict.
+
+    Returns:
+        A :class:`ModelFusionResult` with the fused answer, per-model weights, the disagreement
+        report, and the abstain flag.
+    """
+    if not claims:
+        raise ValueError("fuse_models requires at least one ModelClaim")
+    scaled = [_precision_scaled_evidence(c) for c in claims]
+    names = [e.name for e in scaled]
+    if len(set(names)) != len(names):
+        raise ValueError(f"duplicate model claim identity (model_id@version): {names}")
+
+    fused = reason(prior, scaled, query=query)
+    weights = fused.attribution()
+    disagreement = _pairwise_disagreement(prior, scaled, query=query, disagree_sigma=disagree_sigma)
+    abstain = bool(disagreement["flagged_pairs"])
+    return ModelFusionResult(answer=fused, weights=weights, disagreement=disagreement, abstain=abstain)

--- a/mixle/tests/reason/test_model_fusion.py
+++ b/mixle/tests/reason/test_model_fusion.py
@@ -1,0 +1,103 @@
+"""M2 DoD: numeric cross-model belief fusion.
+
+Two agreeing models should fuse to a tighter belief than either alone, with both model identities
+showing up in the attribution weights; two models that disagree by more than ``disagree_sigma``
+should set ``abstain`` rather than silently presenting the fused mean as settled.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mixle.reason import Latent
+from mixle.reason.core import LinearGaussianEvidence, reason
+from mixle.reason.model_fusion import ModelClaim, ModelFusionResult, fuse_models
+
+
+def _claim(model_id: str, version: str, *, y: float, r: float, reliability: float = 1.0) -> ModelClaim:
+    return ModelClaim(
+        evidence=LinearGaussianEvidence(H=[[1.0]], y=[y], R=[[r]], name="ignored"),
+        model_id=model_id,
+        version=version,
+        reliability=reliability,
+    )
+
+
+class FuseModelsAgreementTest:
+    def test_two_agreeing_models_fuse_tighter_than_either_alone(self):
+        prior = Latent.vector(1, var=10.0)
+        claim_a = _claim("A", "1", y=5.0, r=1.0)
+        claim_b = _claim("B", "1", y=5.2, r=1.0)
+
+        res = fuse_models(prior, [claim_a, claim_b])
+
+        assert isinstance(res, ModelFusionResult)
+        assert set(res.weights) == {"A@1", "B@1"}
+
+        alone_a = reason(prior, [LinearGaussianEvidence(H=[[1.0]], y=[5.0], R=[[1.0]], name="A@1")])
+        alone_b = reason(prior, [LinearGaussianEvidence(H=[[1.0]], y=[5.2], R=[[1.0]], name="B@1")])
+        assert res.answer.cov()[0, 0] < min(alone_a.cov()[0, 0], alone_b.cov()[0, 0])
+        assert res.abstain is False
+
+    def test_weights_sum_to_total_information_gain(self):
+        prior = Latent.vector(1, var=10.0)
+        res = fuse_models(prior, [_claim("A", "1", y=5.0, r=1.0), _claim("B", "1", y=5.1, r=2.0)])
+        assert sum(res.weights.values()) == pytest.approx(res.answer.information_gain(), rel=1e-9)
+
+    def test_reliability_scales_effective_noise(self):
+        prior = Latent.vector(1, var=10.0)
+        # A flaky model (low reliability) should have its noise inflated and so contribute less
+        # than an equally-noisy but fully-trusted model.
+        trusted = _claim("A", "1", y=5.0, r=1.0, reliability=1.0)
+        flaky = _claim("B", "1", y=-5.0, r=1.0, reliability=0.01)
+        res = fuse_models(prior, [trusted, flaky])
+        assert res.weights["A@1"] > res.weights["B@1"]
+        assert abs(res.answer.mean[0] - 5.0) < 1.0
+
+    def test_single_claim_never_abstains(self):
+        prior = Latent.vector(1, var=10.0)
+        res = fuse_models(prior, [_claim("A", "1", y=5.0, r=1.0)])
+        assert set(res.weights) == {"A@1"}
+        assert res.abstain is False
+        assert res.disagreement["max_sigma"] == 0.0
+
+
+class FuseModelsDisagreementTest:
+    def test_far_apart_models_set_abstain(self):
+        prior = Latent.vector(1, var=100.0)
+        claim_a = _claim("A", "1", y=0.0, r=0.01)
+        claim_b = _claim("B", "1", y=50.0, r=0.01)
+
+        res = fuse_models(prior, [claim_a, claim_b], disagree_sigma=3.0)
+
+        assert res.abstain is True
+        assert res.disagreement["max_sigma"] > 3.0
+        assert res.disagreement["flagged_pairs"] == ["A@1|B@1"]
+
+    def test_close_models_do_not_abstain(self):
+        prior = Latent.vector(1, var=10.0)
+        claim_a = _claim("A", "1", y=5.0, r=1.0)
+        claim_b = _claim("B", "1", y=5.1, r=1.0)
+
+        res = fuse_models(prior, [claim_a, claim_b], disagree_sigma=3.0)
+
+        assert res.abstain is False
+        assert res.disagreement["flagged_pairs"] == []
+
+
+class ModelClaimValidationTest:
+    def test_reliability_must_be_in_unit_interval(self):
+        with pytest.raises(ValueError):
+            _claim("A", "1", y=1.0, r=1.0, reliability=0.0)
+        with pytest.raises(ValueError):
+            _claim("A", "1", y=1.0, r=1.0, reliability=1.5)
+
+    def test_duplicate_model_identity_rejected(self):
+        prior = Latent.vector(1, var=10.0)
+        with pytest.raises(ValueError):
+            fuse_models(prior, [_claim("A", "1", y=1.0, r=1.0), _claim("A", "1", y=2.0, r=1.0)])
+
+    def test_empty_claims_rejected(self):
+        prior = Latent.vector(1, var=10.0)
+        with pytest.raises(ValueError):
+            fuse_models(prior, [])


### PR DESCRIPTION
## Worklist item

**Item:** M2

## Summary

From notes/exploration-e2e-work-plan.md (the post-0.7 capability-expansion worklist, commissioned directly by the maintainer) and notes/exec/workstream-M.md — not the original 0.8.0 stability worklist; this is new, explicitly authorized capability work.

Adds `mixle.reason.fuse_models`: precision-weighted fusion of several models' claims about the same latent. Each model's claim is a `LinearGaussianEvidence` about the shared latent; `fuse_models` scales that claim's noise by `1/reliability`, stamps its identity as `model_id@version`, and folds all claims into the prior in one pass through the existing `mixle.reason.core.reason` Kalman assimilation path — the same exact machinery the front door already uses for cross-modal evidence, just one evidence item per model instead of per modality. No new fusion math.

Per-model attribution comes straight from `ReasonedAnswer.attribution()` (nats of uncertainty each model's claim removed). Before returning, pairwise standardized differences between each model's *individual* (solo) view of the query are checked against `disagree_sigma`; if any pair disagrees by more than that many standard deviations, the result comes back with `abstain=True` so a caller does not present a fused mean as settled when the models actually conflict.

## Public API impact

- [x] It changes the public surface, and I regenerated the manifest (`python scripts/gen_api_manifest.py`) and committed `api_manifest.json`.

Added: `mixle.reason.fuse_models` (also `mixle.reason.model_fusion.ModelClaim` / `ModelFusionResult`, reachable via the submodule per the work order's "one export line" scope for `reason/__init__.py`).

## Claims impact

- [x] No public claim (README, docs, benchmarks) is affected.

## Evidence

```
PYTHONPATH=/Users/grantboquet/mixle/mixle .venv/bin/python -m pytest mixle/tests/reason/test_model_fusion.py -q
9 passed in 195.78s

# broader reason/* suite (regression check)
PYTHONPATH=... pytest mixle/tests/reason/test_model_fusion.py mixle/tests/reason_frontdoor_test.py \
  mixle/tests/reason_fusion_test.py mixle/tests/reasoner_facade_test.py mixle/tests/reason_adapter_test.py \
  mixle/tests/reason_modality_test.py mixle/tests/reason_discrete_test.py mixle/tests/reason_design_test.py \
  mixle/tests/reason_nonlinear_test.py -q -m ""
50 passed in 274.59s

# public API manifest drift test
PYTHONPATH=... pytest mixle/tests/public_api_manifest_test.py -q -m ""
2 passed in 83.86s

ruff format mixle/reason/model_fusion.py mixle/reason/__init__.py mixle/tests/reason/test_model_fusion.py -> 3 files left unchanged
ruff check   (same files) -> All checks passed!
```

## Notes (judgment calls)

- The work order's algorithm step 4 says a disagreement "route[s] to the IC-6 verifier + `language_bridge` abstain," but the frozen `fuse_models` signature takes no `verifier` parameter and this task's Files/read-only list does not include `language_bridge.py`. `fuse_models` therefore only *computes and returns* `abstain`/`disagreement`; routing that flag to a verifier or an abstaining natural-language surface is left to the caller (M3/M1c), consistent with this task's own non-goal ("no new fusion math").
- Disagreement is defined as the worst-case (max) per-coordinate standardized difference between each model's *solo* posterior (prior + that one model's evidence alone, restricted to `query`), pairwise across models — the algorithm text names "pairwise standardized differences of model means" without pinning an exact statistic, so this is the natural, conservative reading that reuses the existing `reason`/`GaussianBelief` machinery with no new math.
- New test directory `mixle/tests/reason/` (parallel to the existing `mixle/tests/task/`, which a prior merged PR in this same workstream already established as the pattern for per-package test subdirectories).