### PR TITLE
N2: Critical-habitat & listed-species constraints into production

### DIFF
--- a/mixle/analysis/habitat_constraints.py
+++ b/mixle/analysis/habitat_constraints.py
@@ -1,0 +1,167 @@
+"""N2 -- critical-habitat & listed-species constraints into production (workstream N; IC-9, IC-12, IC-1).
+
+Turns N1's fitted habitat-suitability field (:class:`~mixle.analysis.sdm.HabitatModel`, IC-12/IC-1) and
+a set of typed, citation-backed listed-species records (``mixle_knowledge.contracts.ListedSpecies`` --
+this module never imports that package, it only duck-types the two attributes it needs, so core mixle
+carries no hard dependency on the paired ``mixle-knowledge`` contract) into the one thing a mine-planning
+network optimizer needs to respect a no-mine constraint: a boolean exclusion mask over blocks, folded
+into an IC-9-shaped network payload. This mirrors G9's ``mixle_pde/reclamation.py:apply_env_constraints``
+almost exactly -- same "excluded blocks become forbidden nodes / zero-capacity arcs" payload shape -- but
+for critical-habitat/listed-species law rather than seepage/subsidence risk.
+
+Per the work-plan non-goal, this module never imports or calls the network-flow solver itself (no
+dependency on ``mixle.relations``, and no edit to it); it only produces the payload H1's
+``min_cost_flow``/``network_design`` (or H4's stochastic optimizer) reads.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+if TYPE_CHECKING:  # pragma: no cover -- type-checking only, no runtime dependency on either package
+    from mixle_knowledge.contracts import ListedSpecies
+
+    from mixle.analysis.sdm import HabitatModel
+
+__all__ = ["critical_habitat_exclusion", "apply_habitat_constraints"]
+
+
+def _dilate_conservatively(mask: np.ndarray, buffer_cells: int) -> np.ndarray:
+    """Grow a boolean block mask outward by ``buffer_cells`` adjacent cells on either side.
+
+    Blocks are treated as a flat, ordered sequence (the same abstract cell-index convention N1's
+    ``HabitatModel``/``fit_sdm`` use -- resolving a real 2-D/3-D adjacency from a ``crs``-referenced grid
+    is covariate/CRS ingest, out of scope here). Each round of dilation only ever turns a cell on, never
+    off, so the result is always a superset of ``mask`` -- the buffer is a conservative expansion, not a
+    smoothing.
+    """
+    if buffer_cells <= 0:
+        return mask
+    grown = mask.copy()
+    for _ in range(int(buffer_cells)):
+        shifted_left = np.zeros_like(grown)
+        shifted_left[1:] = grown[:-1]
+        shifted_right = np.zeros_like(grown)
+        shifted_right[:-1] = grown[1:]
+        grown = grown | shifted_left | shifted_right
+    return grown
+
+
+def critical_habitat_exclusion(
+    habitat: HabitatModel,
+    listed: Sequence[ListedSpecies],
+    *,
+    suitability_cut: float,
+    buffer_cells: int = 0,
+) -> np.ndarray:
+    """Boolean no-mine mask over blocks (work-plan algorithm steps 1-2).
+
+    For every ``listed`` record whose ``critical_habitat`` flag is set, the fitted suitability field's
+    own ``habitat.critical_habitat_mask(suitability_cut)`` (IC-12) contributes its ``lambda_c >=
+    suitability_cut`` cells to the exclusion; a record with ``critical_habitat=False`` (a species that is
+    tracked but has no critical-habitat designation) contributes nothing. If no ``listed`` record
+    qualifies, nothing is excluded. The per-species contribution is unioned (``OR``) across every
+    qualifying species -- with a single shared ``habitat`` field this collapses to one mask, but the
+    union step is kept explicit so a future multi-field caller (one ``HabitatModel`` per species) composes
+    the same way. When the fit itself is prior-dominated (``habitat``'s own honesty flag: not enough
+    presence data has yet informed the field), there isn't enough evidence to clear *any* block, so
+    the mask is excluded conservatively in full (every block is treated as potential critical habitat)
+    rather than optimistically reporting whatever the under-determined field happens to say.
+
+    ``buffer_cells`` conservatively dilates the resulting mask outward (:func:`_dilate_conservatively`)
+    to approximate a regulatory buffer around a designation boundary.
+
+    A real ``CriticalHabitatDesignation`` polygon (a regulator's own mapped boundary, independent of the
+    fitted suitability field) is not rasterized here: that requires resolving its ``SpatialBounds`` (real
+    ``crs`` coordinates) onto this function's abstract block-index grid, which is exactly the
+    covariate/CRS-ingest machinery N1 scoped out (B-series, not yet landed) -- see the PR notes for this
+    documented gap. Once a grid-registration utility lands, folding a designation in is an additional
+    ``OR`` into ``mask`` before the buffer dilation, using the same conservative-inclusion rule.
+
+    Args:
+        habitat: N1's fitted habitat-suitability field (IC-12 ``HabitatModel``, satisfies IC-1
+            ``Posterior``).
+        listed: ``ListedSpecies`` records (``mixle_knowledge.contracts``); only ``critical_habitat``
+            and, when informativeness must be checked, the model's own honesty flag are consulted here
+            -- every other field (citation, jurisdiction, listing status) is provenance the caller and
+            downstream audit trail carry, not logic this function branches on.
+        suitability_cut: the fitted-intensity threshold passed to ``critical_habitat_mask``.
+        buffer_cells: conservative dilation radius, in blocks, applied after the union.
+
+    Returns:
+        A ``(K,)`` boolean array, ``True`` where the block is excluded (no-mine).
+    """
+    num_cells = int(np.asarray(habitat.mean).shape[0])
+    qualifies = [species for species in listed if bool(getattr(species, "critical_habitat", False))]
+    if not qualifies:
+        return np.zeros(num_cells, dtype=bool)
+
+    rng = np.random.default_rng(0)
+    honesty = habitat.derived_quantity(lambda draws: draws, 2, rng)
+    if bool(getattr(honesty, "prior_dominated", False)):
+        return np.ones(num_cells, dtype=bool)
+
+    mask = np.zeros(num_cells, dtype=bool)
+    base_mask = np.asarray(habitat.critical_habitat_mask(suitability_cut), dtype=bool)
+    for _species in qualifies:
+        mask = mask | base_mask
+
+    return _dilate_conservatively(mask, buffer_cells)
+
+
+def apply_habitat_constraints(network: dict[str, Any], exclusion_mask: np.ndarray) -> dict[str, Any]:
+    """Fold a critical-habitat exclusion mask into an IC-9-shaped network payload (work-plan algorithm
+    step 3); H1/H4 read this, this module never calls the solver.
+
+    ``network`` is a plain mapping over the reference block network, in exactly
+    :func:`mixle.relations.min_cost_flow`'s frozen ``(cap, cost, supply)`` shape: ``"cap"``/``"cost"``
+    are ``(n, n)`` arc matrices, ``"supply"`` is the optional length-``n`` node supply vector, and
+    ``"block_nodes"`` (optional, defaults to ``arange(len(exclusion_mask))``) maps each block index to
+    its node index in that network -- the same convention G9's ``apply_env_constraints`` uses.
+
+    Excluded blocks become forbidden nodes: every arc touching one has its capacity zeroed (no flow can
+    originate from, or land back on, a no-mine block), and, if that node carried supply, the supply is
+    zeroed too (there is nothing left to extract there). Any ``nodes``/``arcs``/``fixed_costs``/
+    ``demands`` the caller supplied (the shape :func:`mixle.relations.network_design` itself takes) are
+    passed through unchanged alongside ``forbidden_nodes``, so a fixed-charge caller can exclude the same
+    nodes from its own arc set.
+
+    Args:
+        network: the reference network payload (``cap``/``cost``/``supply``/``block_nodes``, plus any
+            ``network_design``-shaped pass-through fields).
+        exclusion_mask: the ``(K,)`` boolean no-mine mask from :func:`critical_habitat_exclusion`.
+
+    Returns:
+        A new dict: ``cap``/``cost`` (habitat-adjusted), ``forbidden_nodes`` (sorted node-id list), and
+        ``supply`` when the caller provided one, plus any pass-through fields.
+    """
+    exclusion_mask = np.asarray(exclusion_mask, dtype=bool)
+
+    cap = np.array(network["cap"], dtype=float, copy=True)
+    cost = np.array(network["cost"], dtype=float, copy=True)
+    if cap.shape != cost.shape or cap.ndim != 2 or cap.shape[0] != cap.shape[1]:
+        raise ValueError("network['cap'] and network['cost'] must be equal-shape square (n, n) arrays.")
+
+    block_nodes = np.asarray(network.get("block_nodes", np.arange(exclusion_mask.shape[0])), dtype=int)
+    if block_nodes.shape[0] != exclusion_mask.shape[0]:
+        raise ValueError("network['block_nodes'] must have one entry per block.")
+
+    forbidden_nodes = sorted(int(node) for node, excluded in zip(block_nodes, exclusion_mask) if excluded)
+    for node in forbidden_nodes:
+        cap[node, :] = 0.0
+        cap[:, node] = 0.0
+
+    result: dict[str, Any] = {"cap": cap, "cost": cost, "forbidden_nodes": forbidden_nodes}
+    if "supply" in network:
+        supply = np.array(network["supply"], dtype=float, copy=True)
+        if forbidden_nodes:
+            supply[forbidden_nodes] = 0.0
+        result["supply"] = supply
+    for passthrough in ("nodes", "arcs", "fixed_costs", "demands"):
+        if passthrough in network:
+            result[passthrough] = network[passthrough]
+
+    return result

--- a/mixle/tests/test_n2_habitat_constraints.py
+++ b/mixle/tests/test_n2_habitat_constraints.py
@@ -1,0 +1,132 @@
+"""N2: critical-habitat & listed-species constraints into production (IC-9, IC-12, IC-1)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from mixle_knowledge.contracts import CriticalHabitatDesignation, ListedSpecies, SourceRef, SpatialBounds
+
+from mixle.analysis.habitat_constraints import apply_habitat_constraints, critical_habitat_exclusion
+from mixle.analysis.sdm import HabitatModel
+from mixle.relations import min_cost_flow
+
+
+def _habitat_model(mean_targets: np.ndarray, *, prior_dominated: bool = False) -> HabitatModel:
+    """A trivial HabitatModel whose fitted intensity field is exactly ``mean_targets``: an identity
+    design matrix makes ``mean = exp(design @ beta) = exp(beta)``, so ``beta = log(mean_targets)``."""
+    k = mean_targets.shape[0]
+    return HabitatModel(
+        beta=np.log(mean_targets),
+        beta_cov=np.eye(k) * 1.0e-8,
+        design=np.eye(k),
+        cell_area=np.ones(k),
+        prior_dominated=prior_dominated,
+    )
+
+
+def _listed_species(*, critical_habitat: bool) -> ListedSpecies:
+    return ListedSpecies(
+        species_id="gopherus-agassizii",
+        scientific_name="Gopherus agassizii",
+        listing_status="ESA_threatened",
+        jurisdiction="US-FWS",
+        critical_habitat=critical_habitat,
+        source=SourceRef(uri="mixle://document/fed-register-2011-16862#page=1"),
+    )
+
+
+def test_critical_habitat_exclusion_flags_exactly_the_high_suitability_block():
+    habitat = _habitat_model(np.array([0.1, 5.0, 0.1, 0.1]))
+    listed = [_listed_species(critical_habitat=True)]
+
+    mask = critical_habitat_exclusion(habitat, listed, suitability_cut=1.0)
+
+    assert mask.dtype == np.bool_
+    np.testing.assert_array_equal(mask, np.array([False, True, False, False]))
+    # provenance: the excluded mask traces back to a listed-species record with a citation
+    assert listed[0].critical_habitat is True
+    assert listed[0].source.uri.startswith("mixle://document/")
+
+
+def test_critical_habitat_exclusion_ignores_species_without_critical_habitat():
+    habitat = _habitat_model(np.array([0.1, 5.0, 0.1, 0.1]))
+    listed = [_listed_species(critical_habitat=False)]
+
+    mask = critical_habitat_exclusion(habitat, listed, suitability_cut=1.0)
+
+    assert not mask.any()
+
+
+def test_critical_habitat_exclusion_buffers_conservatively():
+    habitat = _habitat_model(np.array([0.1, 5.0, 0.1, 0.1, 0.1]))
+    listed = [_listed_species(critical_habitat=True)]
+
+    mask = critical_habitat_exclusion(habitat, listed, suitability_cut=1.0, buffer_cells=1)
+
+    np.testing.assert_array_equal(mask, np.array([True, True, True, False, False]))
+
+
+def test_critical_habitat_exclusion_is_conservative_when_prior_dominated():
+    habitat = _habitat_model(np.array([0.1, 5.0, 0.1, 0.1]), prior_dominated=True)
+    listed = [_listed_species(critical_habitat=True)]
+
+    mask = critical_habitat_exclusion(habitat, listed, suitability_cut=1.0)
+
+    assert mask.all()  # not enough data to clear any block -- exclude everything, not nothing
+
+
+def test_apply_habitat_constraints_removes_exactly_enclosed_blocks_and_raises_cost():
+    # A 4-node reference network: 0 = source, 3 = sink; two parallel paths from 0 to 3, a cheap one
+    # through node 1 (the critical-habitat block) and an expensive detour through node 2.
+    quantity = 10.0
+    cap = np.array(
+        [
+            [0.0, quantity, quantity, 0.0],
+            [0.0, 0.0, 0.0, quantity],
+            [0.0, 0.0, 0.0, quantity],
+            [0.0, 0.0, 0.0, 0.0],
+        ]
+    )
+    cost = np.array(
+        [
+            [0.0, 1.0, 5.0, 0.0],
+            [0.0, 0.0, 0.0, 1.0],
+            [0.0, 0.0, 0.0, 5.0],
+            [0.0, 0.0, 0.0, 0.0],
+        ]
+    )
+    supply = np.array([quantity, 0.0, 0.0, -quantity])
+    network = {"cap": cap, "cost": cost, "supply": supply}
+
+    baseline = min_cost_flow(cap, cost, supply)
+    assert baseline.value == pytest.approx(2.0 * quantity)  # entirely routed through the cheap node-1 path
+
+    habitat = _habitat_model(np.array([0.1, 5.0, 0.1, 0.1]))  # node 1 is the high-suitability block
+    listed = [_listed_species(critical_habitat=True)]
+    mask = critical_habitat_exclusion(habitat, listed, suitability_cut=1.0)
+
+    payload = apply_habitat_constraints(network, mask)
+
+    assert payload["forbidden_nodes"] == [1]  # exactly the one enclosed block, no more, no less
+    assert np.all(payload["cap"][1, :] == 0.0)
+    assert np.all(payload["cap"][:, 1] == 0.0)
+    assert payload["supply"][1] == 0.0
+
+    constrained = min_cost_flow(payload["cap"], payload["cost"], payload["supply"])
+
+    assert constrained.value > baseline.value  # strictly higher cost ...
+    assert constrained.value == pytest.approx(10.0 * quantity)  # ... forced onto the detour via node 2
+    assert constrained.flow[2, 3] == pytest.approx(quantity)  # ... still feasible: full demand routed
+
+
+def test_critical_habitat_designation_and_species_carry_source_provenance():
+    designation = CriticalHabitatDesignation(
+        species_id="gopherus-agassizii",
+        bounds=SpatialBounds(crs="EPSG:32611", min_x=0.0, min_y=0.0, max_x=10.0, max_y=10.0),
+        buffer_m=100.0,
+        source=SourceRef(uri="mixle://document/fed-register-2011-16862#page=9"),
+    )
+    listed = _listed_species(critical_habitat=True)
+
+    assert designation.species_id == listed.species_id
+    assert designation.source.uri and listed.source.uri


### PR DESCRIPTION
## Worklist item

**Item:** N2

From notes/exploration-e2e-work-plan.md (the post-0.7 capability-expansion worklist, commissioned directly by the maintainer) and notes/exec/workstream-N.md — not the original 0.8.0 stability worklist; this is new, explicitly authorized capability work.

## Summary

Adds `mixle/analysis/habitat_constraints.py`:

- `critical_habitat_exclusion(habitat, listed, *, suitability_cut, buffer_cells=0)` — turns N1's `HabitatModel.critical_habitat_mask` (IC-12) into a boolean no-mine mask over blocks, gated per-species on a `ListedSpecies.critical_habitat` flag (a species that is merely tracked, with no critical-habitat designation, contributes nothing). When the underlying fit is itself prior-dominated (not enough presence data yet to trust the field), the whole mask is excluded conservatively rather than optimistically. `buffer_cells` conservatively dilates the result.
- `apply_habitat_constraints(network, exclusion_mask)` — folds that mask into the same forbidden-nodes / zero-capacity-arc IC-9 payload shape G9's `mixle_pde/reclamation.py:apply_env_constraints` already produces for `min_cost_flow`/`network_design`, so H1/H4 read one consistent constraint shape regardless of which environmental concern produced it. This module never imports or calls the network-flow solver itself (no dependency on `mixle.relations`).

The typed `ListedSpecies`/`CriticalHabitatDesignation` records those masks are provenanced against are added in a **paired PR against `mixle-knowledge`**: https://github.com/gmboquet/mixle-knowledge/pull/new/work/n2-listed-species-critical-habitat-contra (branch `work/n2-listed-species-critical-habitat-contra`), following the same owner-repo + paired-knowledge-contract split G8 used for permit obligations.

## Public API impact

- [x] This PR does **not** change any public `__all__`. (`habitat_constraints.py` is a new module with its own module-level `__all__`, but it is not re-exported through `mixle/analysis/__init__.py` — same precedent as G9's `mixle_pde/reclamation.py`, which also isn't re-exported through its package `__init__`. `python scripts/gen_api_manifest.py` produces no diff to `api_manifest.json`.)

## Claims impact

- [x] No public claim (README, docs, benchmarks) is affected.

## Evidence

```
PYTHONPATH=/Users/grantboquet/mixle/mixle:/Users/grantboquet/mixle/mixle-knowledge /Users/grantboquet/mixle/.venv/bin/python -m pytest /Users/grantboquet/mixle/mixle/mixle/tests/test_n2_habitat_constraints.py -q
-> 6 passed

# broader regression (N1 sdm + this PR's tests + the full IC-9/H1 network-flow suite):
PYTHONPATH=.../mixle:.../mixle-knowledge python -m pytest mixle/tests/test_n1_sdm.py mixle/tests/test_n2_habitat_constraints.py mixle/tests/relations_test.py -q
-> 26 passed

ruff format + ruff check on both changed files -> clean
```

(PYTHONPATH points at isolated build worktrees during development; the shapes are identical to the real repo paths above.)

## Checklist

- [x] Tests added/updated and passing; `ruff check` + `ruff format --check` clean.
- [x] Consumer suites for any edited module pass (N1's `test_n1_sdm.py`, and the full IC-9 `relations_test.py` suite, both pass unchanged).
- [x] I am not merging this PR myself, and I have not enabled auto-merge.

## Notes (judgment calls / deviations)

- **N1 dependency not yet merged.** N1 (`HabitatModel`/`fit_sdm`, IC-12) is still open as PR #460 at the time of this PR, so this branch was built by cherry-picking N1's commit (`49af6985`) onto `release/0.8.0` as a prerequisite (one trivial additive-list merge conflict in `mixle/analysis/__init__.py`, resolved by keeping both entries). This PR's own diff is limited to the two new files listed above; the N1 commit should be treated as already-reviewed-elsewhere and this branch rebased once #460 merges.
- **`CriticalHabitatDesignation` polygon rasterization is not wired into `critical_habitat_exclusion`.** The work order's Public API section gives `critical_habitat_exclusion(habitat, listed, *, suitability_cut, buffer_cells=0)` — no designation/bounds argument — while its algorithm text describes OR-ing in a rasterized `CriticalHabitatDesignation.bounds` polygon. Rasterizing a real `SpatialBounds` (geographic `crs` coordinates) onto `HabitatModel`'s abstract block-index grid requires the covariate/CRS-ingest grid-registration machinery that N1 explicitly scopes out (B-series, not yet landed) — there is no grid geometry to intersect against yet. I kept the frozen signature exactly as specified (no added parameter) and documented the gap in the function's docstring rather than inventing a grid convention; once a CRS→grid registration utility exists, folding a designation in is a straightforward additional `OR` before the buffer-dilation step.
- **Paired `mixle-knowledge` PR.** The task's Files section calls for `ListedSpecies`/`CriticalHabitatDesignation` in `mixle-knowledge/mixle_knowledge/contracts.py`, but this execution's Steps only provision a single worktree/PR against `gmboquet/mixle`. Since the DoD test imports both packages, I set up a second isolated worktree/branch/PR against `gmboquet/mixle-knowledge` (branch `work/n2-listed-species-critical-habitat-contra`) mirroring the real G8 precedent (a separate merged PR, `work/g8-permit-obligation-contract`, against that same repo) rather than inventing a different mechanism.