### PR TITLE
L8: Multi-climate-model ensemble fusion (skill-weighted BMA)

### DIFF
--- a/mixle/reason/fusion.py
+++ b/mixle/reason/fusion.py
@@ -29,6 +29,13 @@ hydrology emulator, ...). :func:`fuse_claims` fuses a list of :class:`ModelClaim
 flags when two models disagree beyond a standardized-distance threshold, and -- on disagreement -- adjudicates
 via an IC-6-shaped ``verifier`` plus the ``language_bridge`` conformal claim score before ever emitting a fused
 point, so a driller-facing cross-model number is never quietly averaged out of a real disagreement.
+
+L8 (multi-climate-model ensemble fusion) does not add new fusion math: a real climate question is never
+answered by one model, it is answered by an ensemble (CMIP members, AI emulators, ...) with uneven skill
+against held-out observations. :func:`skill_weighted_fuse` maps each :class:`ClimateMember`'s ``skill`` onto
+:func:`fuse_claims`'s ``reliability`` slot, so the ensemble posterior is the same precision-weighted
+product-of-experts rule with higher-skill members earning proportionally more weight -- disagreement/abstention
+are inherited unchanged from L5.
 """
 
 from __future__ import annotations
@@ -202,6 +209,66 @@ def fuse_claims(
         abstained=abstained,
         provenance=provenance,
     )
+
+
+@dataclass(frozen=True)
+class ClimateMember:
+    """One external climate model's projection in a multi-model ensemble (workstream L8).
+
+    A ``ClimateMember`` is a CMIP ensemble member or an AI emulator's projection of a shared climate quantity.
+    ``skill`` is a per-member inverse validation error against held-out observations (1.0 = neutral trust) --
+    it plays exactly the role :class:`ModelClaim`'s ``reliability`` plays in L5, because L8 folds skill into
+    L5's frozen precision-weighted rule rather than inventing new fusion math. ``model_id``/``version``/
+    ``content_hash`` mirror IC-7's ``ProvenancedResult`` fields so every ensemble member traces back to the
+    domain-model call that produced it.
+    """
+
+    value: float
+    variance: float
+    model_id: str
+    version: str
+    content_hash: str
+    skill: float = 1.0
+
+
+def skill_weighted_fuse(
+    members: list[ClimateMember],
+    *,
+    sigma_flag: float = 3.0,
+    verifier: Any = None,
+) -> FusedBelief:
+    """Skill-weighted Bayesian model averaging of a multi-climate-model ensemble (workstream L8/DR-ALG L8).
+
+    Each :class:`ClimateMember` maps onto an L5 :class:`ModelClaim` with ``reliability = skill``, then
+    :func:`fuse_claims` (the frozen precision-weighted product-of-experts rule) does the actual fusion:
+    ``prec_i = skill_i / variance_i`` and the BMA posterior weight is ``skill_i * prec_i / sum_j skill_j *
+    prec_j``, so a higher-skill ensemble member earns proportionally more weight in the fused projection.
+    Disagreement/abstention are inherited unchanged from L5: the max pairwise standardized distance flags at
+    ``sigma_flag`` (default 3-sigma) and, on disagreement, routes through the same IC-6 ``verifier`` +
+    ``language_bridge`` adjudication before a fused ensemble point is ever trusted. ``provenance`` records
+    every member's ``{model_id, version, content_hash, weight, skill}`` so the fused projection driving
+    L2/L3/L7 is always attributable back to the ensemble members that produced it.
+    """
+    if not members:
+        raise ValueError("skill_weighted_fuse needs at least one ClimateMember")
+
+    claims = [
+        ModelClaim(
+            value=m.value,
+            variance=m.variance,
+            model_id=m.model_id,
+            version=m.version,
+            content_hash=m.content_hash,
+            reliability=m.skill,
+        )
+        for m in members
+    ]
+    fused = fuse_claims(claims, sigma_flag=sigma_flag, verifier=verifier)
+
+    skill_by_id = {m.model_id: m.skill for m in members}
+    for entry in fused.provenance["claims"]:
+        entry["skill"] = skill_by_id[entry["model_id"]]
+    return fused
 
 
 def _build():

--- a/mixle/tests/test_climate_ensemble.py
+++ b/mixle/tests/test_climate_ensemble.py
@@ -1,0 +1,58 @@
+"""L8 DoD -- multi-climate-model ensemble fusion, skill-weighted BMA (notes/exec/workstream-L.md).
+
+``skill_weighted_fuse`` adds no new fusion math: each :class:`ClimateMember` (one CMIP member or AI emulator,
+with a per-member ``skill`` = inverse validation-error against held-out observations) maps straight onto an
+L5 :class:`ModelClaim` with ``reliability = skill``, then goes through the frozen precision-weighted
+:func:`fuse_claims` rule. Two scenarios exercise the ensemble:
+
+* two climate stubs with a 3:1 skill ratio and equal variance fuse with a 3:1 weight ratio, and stay well
+  under the 3-sigma disagreement flag.
+* a strongly disagreeing pair (``|2 - 4| / sqrt(0.1 + 0.1) = 4.47 > 3`` sigma) trips ``disagreement`` and,
+  since neither claim survives cross-model adjudication that far apart, ``abstained`` too.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from mixle.reason.fusion import ClimateMember, FusedBelief, skill_weighted_fuse
+
+
+def test_skill_weights_track_skill():
+    fused = skill_weighted_fuse(
+        [
+            ClimateMember(
+                value=2.0, variance=0.1, model_id="emulator_hi", version="v1", content_hash="a" * 64, skill=3.0
+            ),
+            ClimateMember(
+                value=2.2, variance=0.1, model_id="emulator_lo", version="v1", content_hash="b" * 64, skill=1.0
+            ),
+        ]
+    )
+    assert isinstance(fused, FusedBelief)
+    assert fused.weights["emulator_hi"] > fused.weights["emulator_lo"]
+    ratio = fused.weights["emulator_hi"] / fused.weights["emulator_lo"]
+    assert ratio == pytest.approx(3.0, rel=0.05)
+    assert fused.disagreement is False
+    assert fused.abstained is False
+
+    by_id = {entry["model_id"]: entry for entry in fused.provenance["claims"]}
+    assert by_id["emulator_hi"]["skill"] == pytest.approx(3.0)
+    assert by_id["emulator_lo"]["skill"] == pytest.approx(1.0)
+    assert by_id["emulator_hi"]["content_hash"] == "a" * 64
+
+
+def test_strongly_disagreeing_ensemble_abstains():
+    z = abs(2.0 - 4.0) / math.sqrt(0.1 + 0.1)
+    assert z == pytest.approx(4.4721, abs=1e-3)
+
+    fused = skill_weighted_fuse(
+        [
+            ClimateMember(value=2.0, variance=0.1, model_id="cmipA", version="v1", content_hash="c" * 64),
+            ClimateMember(value=4.0, variance=0.1, model_id="cmipB", version="v1", content_hash="d" * 64),
+        ]
+    )
+    assert fused.disagreement is True
+    assert fused.abstained is True


### PR DESCRIPTION
## Worklist item

**Item:** L8

From notes/exploration-e2e-work-plan.md (the post-0.7 capability-expansion worklist, commissioned directly by the maintainer) and notes/exec/workstream-L.md -- not the original 0.8.0 stability worklist; this is new, explicitly authorized capability work.

## Summary

Adds skill-weighted Bayesian model averaging for multi-climate-model ensembles on top of L5's `fuse_claims`. A real climate projection is never one model's output -- it's an ensemble of CMIP members and/or AI emulators with uneven skill against held-out observations. `ClimateMember{value, variance, model_id, version, content_hash, skill=1.0}` and `skill_weighted_fuse(members, *, sigma_flag=3.0, verifier=None) -> FusedBelief` are added to `mixle/reason/fusion.py`. `skill_weighted_fuse` maps each member's `skill` onto L5's `ModelClaim.reliability` and delegates fusion entirely to `fuse_claims` -- no new fusion math, per the L8 work order's non-goals. The BMA posterior weight is `skill_i * prec_i / sum_j skill_j * prec_j`; disagreement/abstention (3-sigma flag, IC-6 verifier + language_bridge adjudication) are inherited unchanged from L5. `provenance` records each member's `{model_id, version, content_hash, weight, skill}`.

## Public API impact

- [x] It adds public surface (`ClimateMember`, `skill_weighted_fuse` in `mixle.reason.fusion`), but mirrors L5's `ModelClaim`/`FusedBelief`/`fuse_claims` precedent: none of those are re-exported through `mixle/reason/__init__.py`'s `__all__` or `api_manifest.json` either (they're consumed as `mixle.reason.fusion.X`), so this PR makes no change to `__all__` and `api_manifest.json` is unchanged -- consistent with how L5 landed the equivalent symbols.

## Claims impact

- [x] No public claim (README, docs, benchmarks) is affected.

## Evidence

```
PYTHONPATH=<worktree>/mixle python -m pytest mixle/tests/test_climate_ensemble.py::test_skill_weights_track_skill -q
-> 1 passed

PYTHONPATH=<worktree>/mixle python -m pytest mixle/tests/test_climate_ensemble.py mixle/tests/test_cross_model_fusion.py -q
-> 7 passed
```

`ruff format` / `ruff check` clean on both changed files.

## Notes

- L8 depends on L4/L5/L7 per the work order. L5 (`fuse_claims`/`ModelClaim`/`FusedBelief`) is already merged into `release/0.8.0` and is what this PR builds on directly. L4 (mixle-mlops `DomainModelAdapter`) and L7 (mixle-pde `climate_downscale`) are separate-repo connectors that L8's own DoD test does not exercise (it fuses `ClimateMember` stubs directly, matching the work order's literal DoD command), so this PR does not depend on either landing first in this repo.
- Followed L5's precedent of not adding the new fusion symbols to `reason/__init__.py.__all__` or regenerating `api_manifest.json`, since L5 established that `fusion.py`'s cross-model symbols are consumed via the submodule path, not re-exported.

## Checklist

- [x] Tests added/updated and passing; `ruff check` + `ruff format --check` clean.
- [x] Consumer suites for any edited module pass (`test_cross_model_fusion.py`, `reason_fusion_test.py`).
- [x] I am not merging this PR myself, and I have not enabled auto-merge.