### PR TITLE
K3: Dose-response / health-risk models

### DIFF
--- a/api_manifest.json
+++ b/api_manifest.json
@@ -21,6 +21,8 @@
     "what_supports"
   ],
   "mixle.analysis": [
+    "DOSE_RESPONSE_MODELS",
+    "DoseResponse",
     "EmissionFactors",
     "Footprint",
     "GPDFit",
@@ -39,6 +41,7 @@
     "chao2",
     "copeland",
     "cost_curve",
+    "cumulative_exposure",
     "emissions_footprint",
     "empirical_variogram",
     "endpoint_estimator",
@@ -60,6 +63,7 @@
     "n_records",
     "ordinary_kriging",
     "peaks_over_threshold",
+    "population_risk",
     "rarefaction_curve",
     "record_times",
     "return_level",

--- a/mixle/analysis/__init__.py
+++ b/mixle/analysis/__init__.py
@@ -33,6 +33,12 @@ from mixle.analysis.extreme import (
     record_times,
     return_level,
 )
+from mixle.analysis.health_risk import (
+    DOSE_RESPONSE_MODELS,
+    DoseResponse,
+    cumulative_exposure,
+    population_risk,
+)
 from mixle.analysis.kde import (
     KDE,
     intensity,
@@ -74,6 +80,11 @@ __all__ = [
     "endpoint_estimator",
     "n_records",
     "record_times",
+    # dose-response / health-risk models (K3)
+    "DOSE_RESPONSE_MODELS",
+    "DoseResponse",
+    "cumulative_exposure",
+    "population_risk",
     # kernel density estimation
     "KDE",
     "kde",

--- a/mixle/analysis/health_risk.py
+++ b/mixle/analysis/health_risk.py
@@ -1,0 +1,199 @@
+"""Dose-response and population health-risk models (K3, work-plan Workstream K).
+
+Given an exposure/dose -- a bare number, an array of dose realisations, or an IC-1 `Posterior` over
+a receptor field (K1/K2 transport output) -- these push it through a named dose-response curve into
+an outcome-probability distribution, so downstream liability/constraint code (K6) always has a
+distribution, never a bare point estimate:
+
+  * :class:`DoseResponse` -- a named model (``loglinear`` / ``logit`` / ``hill`` /
+    ``threshold_linear``) with caller-supplied ``params``; :meth:`DoseResponse.probability` maps a
+    dose into an IC-1-shaped `DerivedQuantity` (samples + credible interval + the `prior_dominated`
+    honesty flag). When ``dose`` is a `Posterior`, the pushforward runs through the posterior's own
+    ``derived_quantity`` so the flag propagates correctly from the exposure uncertainty.
+  * :func:`cumulative_exposure` -- trapezoidal time-integration of an exposure series, with an
+    optional first-order biological-decay discount (older exposure counts less toward the current
+    body burden) -- the intake feeding a chronic dose-response evaluation.
+  * :func:`population_risk` -- aggregates per-receptor dose-response probabilities (one draw per
+    posterior sample, or a single point evaluation for a bare array) into an expected-case-count
+    `DerivedQuantity`.
+
+This module supplies the dose-response *machinery*; it ships no regulatory/clinical dose-response
+table -- ``params`` are always supplied by the caller or a knowledge lookup (see Non-goals).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from mixle.reason.posterior_protocol import DerivedQuantity, Posterior
+
+# `Posterior`/`DerivedQuantity` are imported lazily inside the functions that need them at runtime
+# (rather than at module level) so that merely importing `mixle.analysis` does not force-load
+# `mixle.reason`'s package `__init__` -- `mixle.analysis.extreme` sits on `mixle.inference.risk`'s
+# import path, which `mixle.stats.bayes.dirichlet` pulls in while it is itself mid-initialization;
+# a module-level import here would close that into a real circular-import failure of `mixle.stats`.
+
+DOSE_RESPONSE_MODELS = ("loglinear", "logit", "hill", "threshold_linear")
+
+
+@dataclass
+class _SampleDerivedQuantity:
+    """A concrete IC-1 `DerivedQuantity`: a draw matrix + the honesty flag, CI by empirical quantile.
+
+    The same "samples + quantile-based `credible_interval` + `prior_dominated`" shape used by the
+    frozen IC-1 conformance stub and the H4 stochastic-plan tests -- the repo's established idiom for
+    a concrete derived quantity, rather than a bespoke one per caller.
+    """
+
+    samples: np.ndarray
+    prior_dominated: bool = False
+
+    def credible_interval(self, level: float) -> tuple[np.ndarray, np.ndarray]:
+        a = (1.0 - level) / 2.0
+        return np.quantile(self.samples, a, axis=0), np.quantile(self.samples, 1.0 - a, axis=0)
+
+
+def _dose_response_fn(model: str, params: dict[str, Any]) -> Callable[[np.ndarray], np.ndarray]:
+    """Return the elementwise dose -> outcome-probability map for the named ``model``."""
+    if model == "loglinear":
+        beta = float(params["beta"])
+        return lambda d: 1.0 - np.exp(-beta * np.clip(np.asarray(d, dtype=float), 0.0, None))
+    if model == "logit":
+        a = float(params.get("a", 1.0))
+        b = float(params.get("b", 0.0))
+        return lambda d: 1.0 / (1.0 + np.exp(-(a * np.asarray(d, dtype=float) + b)))
+    if model == "hill":
+        emax = float(params.get("emax", 1.0))
+        ec50 = float(params["ec50"])
+        hill_n = float(params.get("n", 1.0))
+
+        def _hill(d: np.ndarray) -> np.ndarray:
+            x = np.clip(np.asarray(d, dtype=float), 0.0, None)
+            xn = x**hill_n
+            return emax * xn / (ec50**hill_n + xn)
+
+        return _hill
+    if model == "threshold_linear":
+        slope = float(params["slope"])
+        threshold = float(params.get("threshold", 0.0))
+        return lambda d: np.clip(slope * (np.asarray(d, dtype=float) - threshold), 0.0, 1.0)
+    raise ValueError(f"unknown dose-response model {model!r}; expected one of {DOSE_RESPONSE_MODELS}")
+
+
+def _as_dose_samples(dose: Any, n: int, rng: np.random.Generator) -> np.ndarray:
+    """Coerce a bare-array/scalar ``dose`` into ``n`` dose draws (Posterior doses take a separate path).
+
+    A scalar (or length-1 array) is a degenerate point mass, replicated ``n`` times. A length-``n``
+    array is treated as an already-drawn ensemble. Any other length is an "array-with-UQ" sample set
+    of a different size, resampled with replacement to ``n`` draws.
+    """
+    arr = np.atleast_1d(np.asarray(dose, dtype=float))
+    if arr.size == 1:
+        return np.full(n, float(arr[0]))
+    if arr.shape[0] == n:
+        return arr
+    idx = rng.integers(0, arr.shape[0], size=n)
+    return arr[idx]
+
+
+@dataclass
+class DoseResponse:
+    """A named dose-response model: ``model`` selects the functional form, ``params`` its coefficients.
+
+    ``model in {"loglinear", "logit", "hill", "threshold_linear"}``:
+
+      * ``loglinear``: ``P = 1 - exp(-beta * dose)`` (``params: {"beta"}``) -- the EPA-style linear
+        low-dose cancer/chronic form.
+      * ``logit``: ``P = sigmoid(a * dose + b)`` (``params: {"a", "b"}``, both optional).
+      * ``hill``: ``P = emax * dose^n / (ec50^n + dose^n)`` (``params: {"ec50"}``, ``"emax"``/``"n"``
+        optional) -- saturating receptor-occupancy form.
+      * ``threshold_linear``: ``P = clip(slope * (dose - threshold), 0, 1)`` (``params: {"slope"}``,
+        ``"threshold"`` optional) -- no response below ``threshold``.
+
+    No regulatory dose-response table ships here -- ``params`` are supplied by the caller (see the
+    module Non-goals).
+    """
+
+    model: str
+    params: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.model not in DOSE_RESPONSE_MODELS:
+            raise ValueError(f"unknown dose-response model {self.model!r}; expected one of {DOSE_RESPONSE_MODELS}")
+
+    def response_fn(self) -> Callable[[np.ndarray], np.ndarray]:
+        """The elementwise dose -> outcome-probability function for this model + params."""
+        return _dose_response_fn(self.model, self.params)
+
+    def probability(self, dose: Any, *, n: int = 2000, rng: np.random.Generator) -> DerivedQuantity:
+        """Push ``dose`` through the dose-response model into an outcome-probability `DerivedQuantity`.
+
+        ``dose`` may be an IC-1 `Posterior` over exposure (the pushforward runs through the
+        posterior's own ``derived_quantity``, so `prior_dominated` propagates from the exposure
+        uncertainty), an array of dose draws/ensemble members ("array-with-UQ", resampled to ``n``
+        if its length differs), or a bare scalar (a degenerate point mass -- the returned quantity
+        still carries a (trivial) credible interval).
+        """
+        from mixle.reason.posterior_protocol import Posterior
+
+        fn = self.response_fn()
+        if isinstance(dose, Posterior):
+            return dose.derived_quantity(fn, n, rng)
+        draws = _as_dose_samples(dose, n, rng)
+        return _SampleDerivedQuantity(samples=fn(draws), prior_dominated=False)
+
+
+def cumulative_exposure(series: np.ndarray, dt: float, *, decay: float = 0.0) -> float:
+    """Time-integrated exposure (trapezoidal rule), with optional first-order biological decay.
+
+    ``decay=0`` is the plain trapezoidal integral of ``series`` over its ``dt``-spaced timesteps
+    (area under the exposure-rate curve). ``decay > 0`` discounts each sample toward the *final*
+    timestep by ``exp(-decay * (t_end - t))`` before integrating -- the way a biological half-life
+    would -- so a spike long ago contributes less to the current cumulative body burden than an
+    equally large spike near the end of the series. Feeds a chronic dose-response evaluation (e.g.
+    via :meth:`DoseResponse.probability`).
+    """
+    x = np.asarray(series, dtype=float).ravel()
+    if x.size == 0:
+        return 0.0
+    if x.size == 1:
+        return float(x[0] * dt)
+    if decay <= 0.0:
+        return float(np.trapz(x, dx=dt))
+    times = np.arange(x.size) * dt
+    decayed = x * np.exp(-decay * (times[-1] - times))
+    return float(np.trapz(decayed, dx=dt))
+
+
+def population_risk(
+    exposure: Posterior | np.ndarray, dr: DoseResponse, *, n: int, rng: np.random.Generator
+) -> DerivedQuantity:
+    """Aggregate per-receptor dose-response probabilities into an expected-case-count `DerivedQuantity`.
+
+    ``exposure`` is a per-receptor dose: an IC-1 `Posterior` whose draws are ``(n, n_receptors)`` dose
+    vectors (K1/K2 transport output propagated through UQ), or a plain ``(n_receptors,)`` array of
+    point doses. Each posterior draw is pushed through ``dr``'s response function and summed over
+    receptors, so the returned quantity carries the expected-case-count distribution (not just its
+    mean); a bare array has no exposure uncertainty and yields a degenerate (constant) distribution.
+    """
+    from mixle.reason.posterior_protocol import Posterior
+
+    fn = dr.response_fn()
+    if isinstance(exposure, Posterior):
+        return exposure.derived_quantity(lambda draws: fn(draws).sum(axis=-1), n, rng)
+    arr = np.atleast_1d(np.asarray(exposure, dtype=float))
+    expected_cases = float(np.sum(fn(arr)))
+    return _SampleDerivedQuantity(samples=np.full(int(n), expected_cases), prior_dominated=False)
+
+
+__all__ = [
+    "DOSE_RESPONSE_MODELS",
+    "DoseResponse",
+    "cumulative_exposure",
+    "population_risk",
+]

--- a/mixle/tests/test_health_risk.py
+++ b/mixle/tests/test_health_risk.py
@@ -1,0 +1,84 @@
+"""K3 DoD -- dose-response / health-risk models (notes/exec/workstream-K.md).
+
+`DoseResponse.probability` must turn an exposure `Posterior` (IC-1) into an outcome-probability
+`DerivedQuantity` whose credible interval is *calibrated*: a nominal 90% interval built from one draw
+of the pushforward should cover the true dose-response probability -- computed from independent
+fresh draws of the same exposure distribution -- close to 90% of the time, and that interval should
+widen as the exposure posterior's own variance grows.
+
+Named with the ``test_*.py`` prefix (rather than this repo's own ``*_test.py`` `python_files`
+convention -- see ``pyproject.toml``) because this exact path + node id is the frozen DoD command in
+``notes/exec/workstream-K.md``; explicit pytest node ids are collected regardless of the
+``python_files`` glob, so this does not conflict with the repo's discovery config.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from mixle.analysis.health_risk import DoseResponse
+from mixle.reason.posterior_protocol import Posterior
+
+
+def _lognormal_exposure_posterior(mu: float, sigma: float) -> Posterior:
+    """A minimal IC-1 `Posterior` over a single-receptor exposure: dose ~ LogNormal(mu, sigma)."""
+
+    class _ExposurePosterior:
+        def samples(self, n: int, rng: np.random.Generator) -> np.ndarray:
+            return np.exp(mu + sigma * rng.standard_normal(n))
+
+        @property
+        def mean(self) -> np.ndarray:
+            return np.array([np.exp(mu + sigma**2 / 2.0)])
+
+        @property
+        def cov(self) -> np.ndarray:
+            var = (np.exp(sigma**2) - 1.0) * np.exp(2.0 * mu + sigma**2)
+            return np.array([[var]])
+
+        def credible_interval(self, level: float) -> tuple[np.ndarray, np.ndarray]:
+            s = self.samples(200_000, np.random.default_rng(999))
+            a = (1.0 - level) / 2.0
+            return np.array([np.quantile(s, a)]), np.array([np.quantile(s, 1.0 - a)])
+
+        def derived_quantity(self, fn, n: int, rng: np.random.Generator):
+            draws = self.samples(n, rng)
+            pushed = fn(draws)
+
+            class _DQ:
+                samples = pushed
+                prior_dominated = False
+
+                def credible_interval(self, level: float) -> tuple[np.ndarray, np.ndarray]:
+                    a = (1.0 - level) / 2.0
+                    return np.quantile(self.samples, a), np.quantile(self.samples, 1.0 - a)
+
+            return _DQ()
+
+    return _ExposurePosterior()
+
+
+def test_dose_response_calibrated():
+    mu, sigma = np.log(15.0), 0.4
+    posterior = _lognormal_exposure_posterior(mu, sigma)
+    assert isinstance(posterior, Posterior)
+
+    dr = DoseResponse(model="loglinear", params={"beta": 0.05})
+    dq = dr.probability(posterior, n=5000, rng=np.random.default_rng(1))
+    assert dq.prior_dominated is False
+    lo, hi = dq.credible_interval(0.9)
+
+    # Empirical coverage: fresh, independent draws from the *same* generative exposure distribution,
+    # pushed through the same response curve, should fall inside the nominal 90% interval close to
+    # 90% of the time (loglinear is monotone in dose, so quantiles commute with the pushforward).
+    check_rng = np.random.default_rng(42)
+    true_doses = np.exp(mu + sigma * check_rng.standard_normal(5000))
+    true_probs = dr.response_fn()(true_doses)
+    coverage = float(np.mean((true_probs >= lo) & (true_probs <= hi)))
+    assert coverage >= 0.88
+
+    # The interval must widen as the exposure posterior's variance grows.
+    wide_posterior = _lognormal_exposure_posterior(mu, sigma * 2.0)
+    dq_wide = dr.probability(wide_posterior, n=5000, rng=np.random.default_rng(2))
+    lo_wide, hi_wide = dq_wide.credible_interval(0.9)
+    assert (hi_wide - lo_wide) > (hi - lo)


### PR DESCRIPTION
## Worklist item

**Item:** K3

## Summary

From notes/exploration-e2e-work-plan.md (the post-0.7 capability-expansion worklist, commissioned directly by the maintainer) and notes/exec/workstream-K.md — not the original 0.8.0 stability worklist; this is new, explicitly authorized capability work.

Adds `mixle/mixle/analysis/health_risk.py` (sibling of `analysis/coverage.py`, `analysis/extreme.py`), exported from `analysis/__init__.py`:

- `DoseResponse` (`@dataclass`, `model ∈ {loglinear, logit, hill, threshold_linear}` + `params`) with `.probability(dose, *, n=2000, rng) -> DerivedQuantity`. When `dose` is an IC-1 `Posterior`, the pushforward runs through the posterior's own `derived_quantity(fn, n, rng)` so the `prior_dominated` honesty flag propagates correctly from the exposure uncertainty rather than being asserted after the fact. A bare array is treated as an already-drawn exposure ensemble (bootstrap-resampled to `n` if its length differs); a scalar is a degenerate point mass.
- `cumulative_exposure(series, dt, *, decay=0.0) -> float`: trapezoidal time-integration with an optional first-order biological-decay discount (older exposure counts less toward the current body burden), feeding a chronic dose-response evaluation.
- `population_risk(exposure, dr, *, n, rng) -> DerivedQuantity`: aggregates per-receptor dose-response probabilities (via the same Posterior-pushforward or bare-array path) into an expected-case-count distribution.

No regulatory/clinical dose-response table ships here — `params` are supplied by the caller/knowledge, per the work order's non-goals.

## Public API impact

- [x] It changes the public surface, and I regenerated the manifest (`python scripts/gen_api_manifest.py`) and committed `api_manifest.json`.

`DOSE_RESPONSE_MODELS`, `DoseResponse`, `cumulative_exposure`, `population_risk` added to `mixle.analysis.__all__`. This is net-new public surface under an explicitly authorized capability workstream (see Summary) rather than the 0.8.0 freeze worklist, so I did not add a freeze-exception log entry — flagging this explicitly in case that process still applies here.

## Claims impact

- [x] No public claim (README, docs, benchmarks) is affected.

## Evidence

DoD (verbatim from notes/exec/workstream-K.md, run against a worktree at the equivalent path):

```
PYTHONPATH=<repo>/mixle python -m pytest mixle/tests/test_health_risk.py::test_dose_response_calibrated -q
1 passed
```

Broader consumer/regression suite (analysis package siblings + IC-1 conformance + H4, which also builds on `Posterior`/`DerivedQuantity`, + the public-API-manifest drift test):

```
pytest mixle/tests/covariance_shrinkage_test.py mixle/tests/coverage_estimation_test.py \
  mixle/tests/extreme_value_test.py mixle/tests/generalized_extreme_value_test.py \
  mixle/tests/automatic_generalized_extreme_value_test.py mixle/tests/kde_test.py \
  mixle/tests/kriging_test.py mixle/tests/max_stable_test.py mixle/tests/posterior_protocol_test.py \
  mixle/tests/rank_aggregation_test.py mixle/tests/spatial_mixture_test.py \
  mixle/tests/public_api_manifest_test.py mixle/tests/test_health_risk.py -q
85 passed
```

`ruff format --check` / `ruff check` clean on all touched files.

## Checklist

- [x] Tests added/updated and passing; `ruff check` + `ruff format --check` clean.
- [x] Consumer suites for any edited module pass.
- [ ] I am not merging this PR myself, and I have not enabled auto-merge.

## Notes (judgment calls)

- **DoD test file naming.** The work order's frozen DoD command names the test file `mixle/mixle/tests/test_health_risk.py` (a `test_*.py` prefix), but this repo's own `pyproject.toml` `python_files = ["*_test.py"]` convention (and precedent — see `posterior_protocol_test.py`) uses the suffix form. Since the DoD command is verbatim/non-negotiable and pytest collects an explicitly named file regardless of the `python_files` glob, I created the test at the literal path the work order specifies rather than renaming it to `health_risk_test.py`.
- **Real circular-import regression found and fixed.** A naive module-level `from mixle.reason.posterior_protocol import Posterior, DerivedQuantity` in the new `health_risk.py` closes a latent cycle: `mixle.stats.bayes.dirichlet` (mid-init) → `mixle.inference` → `mixle.inference.risk` → `mixle.analysis.extreme` (which forces `mixle.analysis.__init__` to run) → `health_risk` → `mixle.reason` (package init) → ... → `mixle.stats.latent.mixture` → `mixle.stats.bayes.dirichlet` again, breaking `import mixle.stats` outright. Verified this is a regression introduced by this change (confirmed `import mixle.stats` succeeds on `release/0.8.0` tip without it) and fixed it by importing `Posterior` lazily inside the two functions that need it at runtime (`DerivedQuantity`/`Posterior` are otherwise only used as type hints, which `from __future__ import annotations` never evaluates). Left a comment explaining why the import is deferred so a future edit doesn't "clean it up" back to a module-level import.
- **`_SampleDerivedQuantity`** is a private, non-exported concrete `DerivedQuantity` (samples + quantile `credible_interval` + `prior_dominated`) used for the non-`Posterior` (bare array/scalar) input path — there is no shared concrete implementation elsewhere in core `mixle` yet, so this follows the same ad hoc "samples + quantile CI" shape used by the IC-1 conformance test and the H4 stochastic-plan test stubs.