### PR TITLE
L3: Transition risk

### DIFF
--- a/api_manifest.json
+++ b/api_manifest.json
@@ -93,6 +93,7 @@
     "scott_bandwidth",
     "silverman_bandwidth",
     "spearman_footrule",
+    "transition_risk",
     "turing_coverage",
     "universal_kriging",
     "voi_dollars"

--- a/mixle/analysis/__init__.py
+++ b/mixle/analysis/__init__.py
@@ -27,7 +27,7 @@ from mixle.analysis.coverage import (
     rarefaction_curve,
     turing_coverage,
 )
-from mixle.analysis.emissions import EmissionFactors, Footprint, emissions_footprint
+from mixle.analysis.emissions import EmissionFactors, Footprint, emissions_footprint, transition_risk
 from mixle.analysis.epidemiology import CohortAttribution, cohort_attribution
 from mixle.analysis.extreme import (
     GPDFit,
@@ -150,10 +150,11 @@ __all__ = [
     "capex_opex",
     "NPVDistribution",
     "monte_carlo_npv",
-    # emissions / carbon accounting (Scope 1/2/3 GHG footprint)
+    # emissions / carbon accounting (Scope 1/2/3 GHG footprint) + carbon transition risk
     "EmissionFactors",
     "Footprint",
     "emissions_footprint",
+    "transition_risk",
     # reclamation ecology / biodiversity offsets (priced habitat-offset liability + no-net-loss constraint)
     "habitat_offset_liability",
     "no_net_loss_constraint",

--- a/mixle/analysis/emissions.py
+++ b/mixle/analysis/emissions.py
@@ -10,11 +10,16 @@ GHG-Protocol-style :class:`EmissionFactors`.
     are supplied, and a content-addressed ``activity_content_hash`` in the returned
     :class:`Footprint`'s provenance so every number traces back to the exact activity schedule that
     produced it.
+  * :func:`transition_risk` -- prices a :class:`Footprint` against a set of carbon-price/policy
+    scenario paths and subtracts the resulting per-scenario carbon cost from a J2 ``npv_samples``
+    distribution, returning an IC-1 `DerivedQuantity` that carries the carbon-adjusted NPV samples
+    (uncertainty-aware, not just a point estimate) plus a mean-value scenario ranking.
 
 Emission factors are always supplied by the caller (or an upstream knowledge store) -- this module
-vendors no lifecycle-inventory database; see the work-plan Non-goals for L1. Carbon *pricing* (turning
-a footprint into a cost/NPV term) is out of scope here too -- see :mod:`mixle.analysis.emissions`'s
-``transition_risk`` (L3) and ``climate_terms`` (L6), which build on :class:`Footprint`.
+vendors no lifecycle-inventory database; see the work-plan Non-goals for L1. A full risk-adjusted
+mining objective that also folds in water constraints is out of scope here too -- see
+:mod:`mixle.analysis.emissions`'s ``climate_terms`` (L6), which builds on :class:`Footprint` and
+:func:`transition_risk` alongside L2's water balance.
 """
 
 from __future__ import annotations
@@ -25,6 +30,7 @@ from dataclasses import dataclass
 import numpy as np
 
 from mixle.data.hashing import _canonical
+from mixle.reason.posterior_protocol import DerivedQuantity
 
 _VALID_SCOPES = (1, 2, 3)
 
@@ -148,5 +154,119 @@ def emissions_footprint(
         scope3=scope_values[3],
         total=total,
         ci=ci,
+        provenance=provenance,
+    )
+
+
+@dataclass
+class TransitionRiskResult:
+    """The carbon-adjusted NPV distribution across carbon-price/policy scenarios (L3).
+
+    Satisfies the frozen ``mixle.reason.posterior_protocol.DerivedQuantity`` structural protocol --
+    ``samples``, ``prior_dominated``, ``credible_interval`` -- so a carbon-adjusted value can flow
+    anywhere a `DerivedQuantity` is expected (J5 tail risk, J2 re-valuation). ``samples`` is shaped
+    ``(n, k)``: the ``n`` baseline ``npv_samples`` draws, each re-priced under every one of the ``k``
+    carbon-price scenarios (one column per scenario) -- the re-ranking below stays uncertainty-aware
+    rather than collapsing straight to a point estimate. ``prior_dominated`` is always ``False``: there
+    is no prior/regulariser here, the distribution's width is set entirely by ``npv_samples``.
+
+    Beyond the protocol, ``scenario_mean`` (per-scenario mean carbon-adjusted NPV), ``ranking``
+    (scenario indices sorted best -> worst by ``scenario_mean``), and ``carbon_cost`` (the
+    priced-and-discounted carbon cost subtracted from each scenario) carry the scenario-level
+    comparison :func:`transition_risk` exists to produce.
+    """
+
+    samples: np.ndarray
+    prior_dominated: bool
+    scenario_mean: np.ndarray
+    ranking: list[int]
+    carbon_cost: np.ndarray
+    provenance: dict
+
+    def credible_interval(self, level: float) -> tuple[np.ndarray, np.ndarray]:
+        """Per-scenario central ``level`` interval of the carbon-adjusted NPV, each shape ``(k,)``."""
+        alpha = (1.0 - level) / 2.0
+        lo = np.quantile(self.samples, alpha, axis=0)
+        hi = np.quantile(self.samples, 1.0 - alpha, axis=0)
+        return lo, hi
+
+
+def _coerce_price_paths(carbon_price_paths: np.ndarray) -> np.ndarray:
+    """Coerce ``carbon_price_paths`` to a ``(k, t)`` scenario matrix (one row per scenario).
+
+    A 1-D ``(k,)`` array is a flat carbon price per scenario with no explicit period axis (each
+    scenario has a single "period"); a 2-D ``(k, t)`` array is one price path per scenario, ``t``
+    periods each -- the same "one row per scenario" convention `monte_carlo_npv` (J2) uses for
+    ``price_paths``.
+    """
+    prices = np.asarray(carbon_price_paths, dtype=np.float64)
+    if prices.ndim == 1:
+        return prices[:, None]
+    if prices.ndim == 2:
+        return prices
+    raise ValueError(f"transition_risk: carbon_price_paths must be 1-D (k,) or 2-D (k, t); got shape {prices.shape}")
+
+
+def transition_risk(
+    footprint: Footprint,
+    carbon_price_paths: np.ndarray,
+    *,
+    npv_samples: np.ndarray,
+    discount: np.ndarray | None = None,
+) -> DerivedQuantity:
+    """Carbon-adjusted NPV distribution + scenario ranking under a set of carbon-price paths (L3).
+
+    For each of the ``k`` scenarios in ``carbon_price_paths`` (a ``(k,)`` flat price or a ``(k, t)``
+    per-period path -- see :func:`_coerce_price_paths`), the priced carbon cost is
+    ``footprint.total * sum_t(price[t] * discount[t])`` (``discount`` defaults to all-ones, i.e. no
+    discounting, when omitted -- pass period discount factors, e.g. ``1 / (1 + r) ** t``, to match a
+    J2 ``monte_carlo_npv`` DCF). That per-scenario carbon cost is subtracted from every draw of the
+    baseline ``npv_samples`` (a J2 `NPVDistribution.samples`-shaped ``(n,)`` array), yielding an
+    ``(n, k)`` carbon-adjusted value distribution: one re-priced NPV distribution per scenario, still
+    carrying the original valuation uncertainty.
+
+    Scenarios are ranked by mean carbon-adjusted NPV (``scenario_mean``, descending: best scenario
+    first) so a high-carbon-price/policy scenario reliably re-ranks below a low-price one, with the
+    gap between any two scenarios scaling linearly in ``footprint.total`` -- a bigger footprint pays
+    proportionally more carbon cost under the same price paths. The returned
+    :class:`TransitionRiskResult` satisfies IC-1's `DerivedQuantity` protocol so the re-ranking is
+    always inspectable with a credible interval, not just a point estimate; it feeds J5 tail risk and
+    J2 re-valuation directly.
+    """
+    prices = _coerce_price_paths(carbon_price_paths)
+    n_scenarios, n_periods = prices.shape
+
+    if discount is None:
+        weights = np.ones(n_periods, dtype=np.float64)
+    else:
+        weights = np.asarray(discount, dtype=np.float64)
+        if weights.shape != (n_periods,):
+            raise ValueError(
+                f"transition_risk: discount must have shape ({n_periods},) to match carbon_price_paths' "
+                f"period axis; got {weights.shape}"
+            )
+
+    carbon_cost = footprint.total * (prices * weights[None, :]).sum(axis=1)  # (k,)
+
+    npv = np.asarray(npv_samples, dtype=np.float64).reshape(-1)  # (n,)
+    adjusted = npv[:, None] - carbon_cost[None, :]  # (n, k)
+
+    scenario_mean = adjusted.mean(axis=0)
+    ranking = [int(i) for i in np.argsort(-scenario_mean)]
+
+    provenance = {
+        "footprint_activity_hash": footprint.provenance.get("activity_content_hash"),
+        "n_scenarios": n_scenarios,
+        "n_periods": n_periods,
+        "discounted": discount is not None,
+        "carbon_cost": [float(c) for c in carbon_cost],
+    }
+
+    return TransitionRiskResult(
+        samples=adjusted,
+        prior_dominated=False,
+        scenario_mean=scenario_mean,
+        ranking=ranking,
+        carbon_cost=carbon_cost,
         provenance=provenance,
     )

--- a/mixle/tests/test_transition_risk.py
+++ b/mixle/tests/test_transition_risk.py
@@ -1,0 +1,92 @@
+"""L3 DoD -- transition risk (notes/exec/workstream-L.md).
+
+A high carbon-price scenario should re-rank strictly below a low carbon-price scenario on
+carbon-adjusted mean NPV once :func:`transition_risk` prices L1's :class:`Footprint` against a set of
+carbon-price/policy scenario paths and subtracts the result from J2-shaped ``npv_samples``; the gap
+between the two scenarios' carbon-adjusted mean NPV should scale linearly with ``footprint.total``
+(a bigger footprint pays more carbon cost under the same price paths). The returned object also has to
+satisfy the IC-1 ``DerivedQuantity`` shape (``samples``, ``prior_dominated``, ``credible_interval``) so
+the re-ranking stays uncertainty-aware rather than collapsing straight to a point estimate.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from mixle.analysis.emissions import Footprint, transition_risk
+
+
+def _footprint(total: float) -> Footprint:
+    return Footprint(
+        scope1=total,
+        scope2=0.0,
+        scope3=0.0,
+        total=total,
+        ci=None,
+        provenance={"factor_source": "test", "activity_content_hash": "0" * 64, "scopes": (1, 2, 3)},
+    )
+
+
+LOW_IDX, HIGH_IDX = 0, 1
+
+
+def _price_paths() -> np.ndarray:
+    # Two flat 10-period carbon-price scenarios ($/tCO2e): a low-price and a high-price policy path.
+    low = np.full(10, 20.0)
+    high = np.full(10, 120.0)
+    return np.stack([low, high])
+
+
+def test_carbon_price_reranks_value():
+    rng = np.random.default_rng(0)
+    npv_samples = rng.normal(loc=1_000_000.0, scale=50_000.0, size=5_000)
+    carbon_price_paths = _price_paths()
+    discount = 1.0 / 1.08 ** np.arange(10)
+
+    footprint = _footprint(1_000.0)  # tCO2e
+    result = transition_risk(footprint, carbon_price_paths, npv_samples=npv_samples, discount=discount)
+
+    # IC-1 DerivedQuantity shape.
+    assert isinstance(result.samples, np.ndarray)
+    assert result.samples.shape == (5_000, 2)
+    assert result.prior_dominated is False
+    lo, hi = result.credible_interval(0.9)
+    assert lo.shape == (2,) and hi.shape == (2,)
+    assert np.all(lo <= hi)
+
+    # High carbon price ranks strictly below low carbon price on mean carbon-adjusted NPV.
+    assert result.scenario_mean[HIGH_IDX] < result.scenario_mean[LOW_IDX]
+    assert result.ranking.index(LOW_IDX) < result.ranking.index(HIGH_IDX)
+
+    gap_small = result.scenario_mean[LOW_IDX] - result.scenario_mean[HIGH_IDX]
+    assert gap_small > 0.0
+
+    # The gap scales with footprint.total: a 5x bigger footprint pays 5x more carbon cost under the
+    # same price paths, so the low-vs-high scenario gap grows by the same factor.
+    bigger_footprint = _footprint(5_000.0)
+    result2 = transition_risk(bigger_footprint, carbon_price_paths, npv_samples=npv_samples, discount=discount)
+    gap_big = result2.scenario_mean[LOW_IDX] - result2.scenario_mean[HIGH_IDX]
+    assert gap_big == pytest.approx(5.0 * gap_small)
+
+
+def test_zero_footprint_is_carbon_price_invariant():
+    rng = np.random.default_rng(1)
+    npv_samples = rng.normal(loc=500_000.0, scale=10_000.0, size=2_000)
+    carbon_price_paths = _price_paths()
+
+    result = transition_risk(_footprint(0.0), carbon_price_paths, npv_samples=npv_samples)
+    assert result.scenario_mean[LOW_IDX] == pytest.approx(result.scenario_mean[HIGH_IDX])
+    assert result.scenario_mean[LOW_IDX] == pytest.approx(float(np.mean(npv_samples)))
+
+
+def test_undiscounted_matches_explicit_flat_discount():
+    rng = np.random.default_rng(2)
+    npv_samples = rng.normal(loc=200_000.0, scale=5_000.0, size=1_000)
+    carbon_price_paths = _price_paths()
+
+    no_discount = transition_risk(_footprint(500.0), carbon_price_paths, npv_samples=npv_samples)
+    flat_discount = transition_risk(
+        _footprint(500.0), carbon_price_paths, npv_samples=npv_samples, discount=np.ones(10)
+    )
+    assert no_discount.scenario_mean == pytest.approx(flat_discount.scenario_mean)


### PR DESCRIPTION
## Worklist item

**Item:** L3

From notes/exploration-e2e-work-plan.md (the post-0.7 capability-expansion worklist, commissioned directly by the maintainer) and notes/exec/workstream-L.md -- not the original 0.8.0 stability worklist; this is new, explicitly authorized capability work.

## Summary

Adds `transition_risk()` to `mixle/analysis/emissions.py`, turning a Scope 1/2/3 carbon `Footprint` (L1) into a carbon-price/policy stress test on project value. For each carbon-price/policy scenario path, the priced (optionally discounted) carbon cost is subtracted from a baseline Monte-Carlo `npv_samples` distribution, producing a carbon-adjusted value distribution per scenario; scenarios are then ranked by mean carbon-adjusted NPV. The result is a `TransitionRiskResult` satisfying IC-1's `DerivedQuantity` structural protocol (`samples`/`prior_dominated`/`credible_interval`), so the scenario re-ranking is always uncertainty-aware rather than a bare point estimate, and it composes with the rest of the decision-quantity stack (feeds J5 tail risk, J2 re-valuation).

`carbon_price_paths` accepts either a flat per-scenario price (`(k,)`) or a full per-period path (`(k, t)`); `discount` is an optional period-weight vector matching the DCF convention already used by `monte_carlo_npv` (J2). Only a plain `npv_samples` array is consumed from J2, not any J2 type, so this lands independently of J2's own dataclass shape.

**Dependency note:** L1 (`mixle/analysis/emissions.py`'s `Footprint`/`EmissionFactors`/`emissions_footprint`) has not yet merged into `release/0.8.0` (it is open as PR #454); this branch merges `origin/work/l1-emissions-carbon-accounting` in as a prerequisite so `transition_risk` has a real `Footprint` to build on, per the work order's own framing ("appends one function to `emissions.py` after L1"). That merge is why this diff also carries L1's files (`emissions.py`'s `EmissionFactors`/`Footprint`/`emissions_footprint`, `test_emissions.py`); it will collapse to just the L3 delta once #454 merges first, per the wave ordering (L1 wave 1, L3 wave 3).

## Public API impact

- [ ] This PR does **not** change any public `__all__`.
- [x] It changes the public surface, and I regenerated the manifest (`python scripts/gen_api_manifest.py`) and committed `api_manifest.json`.
- [ ] It adds public surface: a written exception is recorded in the release decision log (freeze rule -- a change adding more public surface than it removes needs one).

(This PR is explicitly-authorized post-0.7 capability work per the worklist item above, not 0.8.0-freeze-governed net-new surface, so no release-decision-log exception was filed -- flagging here for visibility.)

## Claims impact

- [x] No public claim (README, docs, benchmarks) is affected.

## Evidence

DoD (exact command from the work order, run with `PYTHONPATH` pinned to this worktree):

```
PYTHONPATH=<worktree> python -m pytest mixle/tests/test_transition_risk.py::test_carbon_price_reranks_value -q
-> 1 passed in 75.94s
```

Broader consumer suite (L1's `test_emissions.py`, the full `test_transition_risk.py`, IC-1 protocol conformance, and the public-API-manifest drift test):

```
PYTHONPATH=<worktree> python -m pytest mixle/tests/test_emissions.py mixle/tests/test_transition_risk.py mixle/tests/posterior_protocol_test.py mixle/tests/public_api_manifest_test.py -q
-> 13 passed
```

Wider analysis-package regression sweep (every existing test that imports `mixle.analysis`):

```
-> 90 passed
```

`ruff format` / `ruff check` clean on all changed files.

## Notes (judgment calls)

- L1 and J2 are this task's declared dependencies but neither has merged into `release/0.8.0` yet. L1 was required at import time (the `Footprint` this function operates on), so its branch was merged in here rather than reimplementing `Footprint` a second time -- see the Dependency note above. J2 was not required: the frozen signature only takes a plain `npv_samples: np.ndarray`, so no J2 code needed importing.
- `carbon_price_paths` shape handling (flat `(k,)` vs. per-period `(k, t)`, "one row per scenario") mirrors the existing convention `monte_carlo_npv`'s `_align_price_paths` (J2, `valuation.py`) already uses for its own `price_paths`, for consistency across the codebase's carbon/price-scenario handling.
- `transition_risk` is exported through `mixle/analysis/__init__.py`'s `__all__` (matching how L1 exported `Footprint`/`EmissionFactors`/`emissions_footprint`); the new `TransitionRiskResult` dataclass is not re-exported since the work order's Public API line only names `transition_risk` itself (the return type is documented as the existing IC-1 `DerivedQuantity`).

## Checklist

- [x] Tests added/updated and passing; `ruff check` + `ruff format --check` clean.
- [x] Consumer suites for any edited module pass.
- [x] I am not merging this PR myself, and I have not enabled auto-merge.