### PR TITLE
K9: Epidemiological cohort attribution (Cox PH + Aalen-Johansen)

### DIFF
--- a/api_manifest.json
+++ b/api_manifest.json
@@ -21,6 +21,7 @@
     "what_supports"
   ],
   "mixle.analysis": [
+    "CohortAttribution",
     "DOSE_RESPONSE_MODELS",
     "DoseResponse",
     "EmissionFactors",
@@ -46,6 +47,7 @@
     "cayley_distance",
     "chao1",
     "chao2",
+    "cohort_attribution",
     "copeland",
     "cost_curve",
     "cumulative_exposure",

--- a/mixle/analysis/__init__.py
+++ b/mixle/analysis/__init__.py
@@ -28,6 +28,7 @@ from mixle.analysis.coverage import (
     turing_coverage,
 )
 from mixle.analysis.emissions import EmissionFactors, Footprint, emissions_footprint
+from mixle.analysis.epidemiology import CohortAttribution, cohort_attribution
 from mixle.analysis.extreme import (
     GPDFit,
     endpoint_estimator,
@@ -120,6 +121,9 @@ __all__ = [
     "ice",
     "hill_numbers",
     "rarefaction_curve",
+    # epidemiological cohort attribution: Cox PH hazard ratio + Aalen-Johansen competing-risks CIF
+    "CohortAttribution",
+    "cohort_attribution",
     # geostatistics: variograms and kriging
     "Variogram",
     "empirical_variogram",

--- a/mixle/analysis/epidemiology.py
+++ b/mixle/analysis/epidemiology.py
@@ -1,0 +1,220 @@
+"""Epidemiological cohort attribution: Cox PH + Aalen-Johansen (work-plan Sec.7-K, K9).
+
+Given a cohort's covariates (one column marking the exposure of interest), event times, and censoring,
+:func:`cohort_attribution` answers the two questions a health-risk sign-off actually needs: *how much*
+does the exposure multiply the hazard (the hazard ratio, ``HR``), and *what fraction* of the hazard among
+the exposed is attributable to it (``AF = (HR - 1) / HR``). Both come with an honest interval, not a bare
+point estimate:
+
+  * the hazard ratio and its Wald confidence interval fall straight out of the already-frozen
+    :func:`mixle.inference.survival.cox_ph` partial-likelihood fit (``CoxResult.se``) -- no new survival
+    math here, this module is a thin, health-domain-shaped wrapper around it (K9's non-goal list).
+  * the attributable-fraction interval is a nonparametric bootstrap over cohort resamples, refitting
+    ``cox_ph`` each draw; the bootstrap AF distribution is also handed back in ``provenance`` as an
+    object satisfying the IC-1 ``DerivedQuantity`` shape (``samples`` + ``credible_interval`` +
+    ``prior_dominated``), so it slots into the same decision-quantity plumbing (IC-8) the rest of the
+    codebase uses for "never emit a number without its honesty flag."
+  * ``competing=True`` additionally runs :func:`mixle.inference.survival.aalen_johansen` on the raw
+    (multi-cause) event labels for cause-specific cumulative incidence -- the right absolute-risk curve
+    when a competing cause (e.g. all-other-cause mortality) can remove a subject from the risk set before
+    the outcome of interest can occur, which plain ``1 - KM`` overstates.
+  * ``latency > 0`` encodes an exposure-to-effect lag as left-truncation: subjects contribute to the risk
+    set (and to the bootstrap) only once they have survived past the latency period, via ``cox_ph``'s
+    counting-process ``start`` argument. This is the standard occupational/environmental-epi device for
+    "the exposure cannot have caused an event that happened before the biological lag had elapsed."
+
+Every number in the returned :class:`CohortAttribution` traces back to one ``cox_ph`` fit (plus, when
+``competing``, one ``aalen_johansen`` run) and one seeded RNG -- both recorded in ``provenance``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+from scipy import stats
+
+from mixle.inference.survival import aalen_johansen, cox_ph
+
+__all__ = ["CohortAttribution", "cohort_attribution"]
+
+
+class _AFDistribution:
+    """The bootstrap attributable-fraction distribution, shaped to satisfy IC-1's ``DerivedQuantity``.
+
+    Frequentist bootstrap over cohort resamples -- there is no prior/regulariser in a Cox partial-
+    likelihood fit, so ``prior_dominated`` is always ``False``; the honesty flag is carried for
+    interface uniformity with the rest of the decision-quantity surface (IC-8), not because it can ever
+    trip here.
+    """
+
+    def __init__(self, samples: np.ndarray):
+        self.samples = samples
+        self.prior_dominated = False
+
+    def credible_interval(self, level: float) -> tuple[np.ndarray, np.ndarray]:
+        a = (1.0 - level) / 2.0
+        lo = np.nanquantile(self.samples, a)
+        hi = np.nanquantile(self.samples, 1.0 - a)
+        return lo, hi
+
+
+@dataclass
+class CohortAttribution:
+    """Cox-PH hazard ratio + attributable fraction for one exposure, with intervals and provenance.
+
+    Attributes:
+        hazard_ratio: ``exp(coef[exposure_col])`` from the fitted Cox model.
+        hr_ci: Wald ``(lo, hi)`` confidence interval on ``hazard_ratio`` (log scale, from ``CoxResult.se``).
+        attributable_fraction: fraction of hazard among the *exposed* attributable to exposure,
+            ``(hazard_ratio - 1) / hazard_ratio``.
+        af_ci: bootstrap ``(lo, hi)`` confidence interval on ``attributable_fraction``.
+        cif: cause-specific Aalen-Johansen cumulative incidence, ``{cause: array}`` (empty unless
+            ``competing=True``).
+        provenance: fit diagnostics, the RNG seed, and a bootstrap ``DerivedQuantity``-shaped AF summary.
+    """
+
+    hazard_ratio: float
+    hr_ci: tuple[float, float]
+    attributable_fraction: float
+    af_ci: tuple[float, float]
+    cif: dict[int, np.ndarray]
+    provenance: dict
+
+
+def _fit_lagged(x: np.ndarray, time: np.ndarray, event: np.ndarray, latency: float):
+    """Fit ``cox_ph`` with an optional latency (left-truncation): subjects enter risk at ``latency``.
+
+    Rows whose observed time does not exceed ``latency`` never survive into the truncated risk set (the
+    exposure cannot yet have had an effect), so they are dropped rather than passed with a degenerate
+    ``(start, stop]`` interval. Returns the fit plus the number of rows actually used.
+    """
+    if latency > 0:
+        keep = time > latency
+        x, time, event = x[keep], time[keep], event[keep]
+        start = np.full(time.shape[0], latency)
+    else:
+        start = None
+    return cox_ph(x, time, event, start=start, ties="efron"), time.shape[0]
+
+
+def cohort_attribution(
+    covariates: np.ndarray,
+    time: np.ndarray,
+    event: np.ndarray,
+    *,
+    exposure_col: int = 0,
+    competing: bool = False,
+    latency: float = 0.0,
+    n_boot: int = 1000,
+    rng=None,
+) -> CohortAttribution:
+    """Attribute a cohort's hazard to one exposure via Cox PH, with an Aalen-Johansen competing-risks CIF.
+
+    Args:
+        covariates: ``(n, p)`` covariates; column ``exposure_col`` is the exposure of interest.
+        time: ``(n,)`` event/censoring times.
+        event: ``(n,)`` event indicator. Binary (``0``/``1``) when ``competing=False``; an integer cause
+            label (``0`` = censored, ``1`` = the outcome of interest, ``2..K`` = competing causes) when
+            ``competing=True``. Either way, the Cox fit is cause-specific for cause ``1``: competing-cause
+            events are censored at their time for the hazard-ratio fit (only the CIF, when requested,
+            reports the competing causes' own cumulative incidence).
+        exposure_col: column of ``covariates`` treated as the exposure.
+        competing: if True, also run `aalen_johansen` for cause-specific cumulative incidence.
+        latency: exposure-to-effect lag (left-truncation, via `cox_ph`'s `start`); ``0`` disables it.
+        n_boot: cohort-resample bootstrap draws for the attributable-fraction interval.
+        rng: seed, `numpy.random.Generator`, or None.
+
+    Returns:
+        A :class:`CohortAttribution`.
+    """
+    cov_arr = np.asarray(covariates, dtype=float)
+    x = cov_arr.reshape(-1, 1) if cov_arr.ndim == 1 else cov_arr
+    t = np.asarray(time, dtype=float)
+    e_raw = np.asarray(event, dtype=int)
+    n = x.shape[0]
+    rng = np.random.default_rng(rng)
+
+    # Cause-specific event indicator for the hazard-ratio fit: only cause 1 counts as an event; true
+    # censoring (0) AND competing causes (>=2) are both censored here, per the cause-specific-hazard
+    # convention -- the CIF below is what reports the competing causes' own incidence.
+    cox_event = (e_raw == 1).astype(float)
+
+    fit, n_fit_rows = _fit_lagged(x, t, cox_event, latency)
+    beta = float(fit.coef[exposure_col])
+    se = float(fit.se[exposure_col])
+    hazard_ratio = float(np.exp(beta))
+    z = stats.norm.ppf(0.975)
+    hr_ci = (float(np.exp(beta - z * se)), float(np.exp(beta + z * se)))
+
+    attributable_fraction = (hazard_ratio - 1.0) / hazard_ratio
+
+    exposed = x[:, exposure_col] > 0
+    exposure_prevalence = float(exposed.mean())
+    denom = 1.0 + exposure_prevalence * (hazard_ratio - 1.0)
+    population_attributable_fraction = (
+        float(exposure_prevalence * (hazard_ratio - 1.0) / denom) if denom != 0 else float("nan")
+    )
+
+    boot_af = np.full(n_boot, np.nan)
+    for b in range(n_boot):
+        idx = rng.integers(0, n, size=n)
+        try:
+            fit_b, _ = _fit_lagged(x[idx], t[idx], cox_event[idx], latency)
+            hr_b = float(np.exp(fit_b.coef[exposure_col]))
+            if hr_b > 0:
+                boot_af[b] = (hr_b - 1.0) / hr_b
+        except (np.linalg.LinAlgError, ValueError, FloatingPointError):
+            continue  # a degenerate resample (e.g. no variation in the exposure column); skip it
+
+    n_boot_valid = int(np.sum(np.isfinite(boot_af)))
+    if n_boot_valid > 0:
+        af_ci = (
+            float(np.nanquantile(boot_af, 0.025)),
+            float(np.nanquantile(boot_af, 0.975)),
+        )
+    else:
+        af_ci = (float("nan"), float("nan"))
+
+    cif: dict[int, np.ndarray] = {}
+    aj: dict[str, Any] | None = None
+    if competing:
+        aj = aalen_johansen(t, e_raw)
+        cif = aj["cif"]
+
+    af_distribution = _AFDistribution(boot_af)
+    seed_entropy = getattr(getattr(rng.bit_generator, "seed_seq", None), "entropy", None)
+    provenance: dict[str, Any] = {
+        "algorithm": "cox_ph+aalen_johansen" if competing else "cox_ph",
+        "ties": "efron",
+        "n": n,
+        "n_fit_rows": n_fit_rows,
+        "n_events": int(cox_event.sum()),
+        "exposure_col": exposure_col,
+        "exposure_prevalence": exposure_prevalence,
+        "population_attributable_fraction": population_attributable_fraction,
+        "latency": latency,
+        "n_boot": n_boot,
+        "n_boot_valid": n_boot_valid,
+        "seed": seed_entropy,
+        "coef": fit.coef.tolist(),
+        "se": fit.se.tolist(),
+        "concordance": fit.concordance,
+        "loglik": fit.loglik,
+        "n_iter": fit.n_iter,
+        "competing": competing,
+        "af_distribution": af_distribution,
+    }
+    if aj is not None:
+        provenance["cif_time"] = aj["time"]
+        provenance["overall_survival"] = aj["overall_survival"]
+
+    return CohortAttribution(
+        hazard_ratio=hazard_ratio,
+        hr_ci=hr_ci,
+        attributable_fraction=attributable_fraction,
+        af_ci=af_ci,
+        cif=cif,
+        provenance=provenance,
+    )

--- a/mixle/tests/test_epidemiology.py
+++ b/mixle/tests/test_epidemiology.py
@@ -1,0 +1,136 @@
+"""K9 DoD -- epidemiological cohort attribution (notes/exec/workstream-K.md).
+
+The Definition of Done asks for one concrete scenario: on a simulated cohort with a known exposure ->
+outcome hazard ratio (``HR_true``) and right-censoring, ``cohort_attribution`` recovers ``hazard_ratio``
+within 15% of truth, ``hr_ci`` covers ``HR_true``, and ``af_ci`` covers the implied true attributable
+fraction ``(HR_true - 1) / HR_true``. The remaining tests exercise the other DoD clauses: CI coverage
+tracking the nominal rate across repeated seeds, competing-risks CIF validity, and the IC-1
+``DerivedQuantity``-shaped bootstrap summary in ``provenance``.
+
+Cohort sizes and ``n_boot`` are kept as small as the assertions tolerate -- each bootstrap draw is a
+full `cox_ph` refit, so this file's total cost is ``n_boot`` Cox fits, not one; seeds below were checked
+to give a comfortable margin against their tolerance (not cherry-picked to the edge) so the file stays
+in the fast gate instead of ballooning it (see conftest.py's fast/slow triage policy).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from mixle.analysis.epidemiology import CohortAttribution, cohort_attribution
+from mixle.reason.posterior_protocol import DerivedQuantity
+
+HR_TRUE = 2.0
+
+
+def _simulate_cohort(seed: int, *, n: int = 300, hr_true: float = HR_TRUE, p_exposed: float = 0.5):
+    """A one-covariate (binary exposure) proportional-hazards cohort with exponential censoring.
+
+    Same construction as `mixle/tests/survival_regression_test.py`'s `CoxTest._sim`: event time
+    ``T = -log(U) / exp(x @ beta)`` gives exactly the proportional-hazards model `cox_ph` assumes, so
+    `beta = log(hr_true)` on the exposure column is the ground truth `cohort_attribution` should recover.
+    """
+    rng = np.random.default_rng(seed)
+    exposed = (rng.random(n) < p_exposed).astype(float)
+    covariates = exposed.reshape(-1, 1)
+    beta = np.log(hr_true)
+    event_time = -np.log(rng.random(n)) / np.exp(covariates[:, 0] * beta)
+    censor_time = rng.exponential(3.0, n)
+    time = np.minimum(event_time, censor_time)
+    event = (event_time <= censor_time).astype(float)
+    return covariates, time, event
+
+
+def test_known_hazard_recovered():
+    covariates, time, event = _simulate_cohort(seed=0)
+
+    result = cohort_attribution(covariates, time, event, exposure_col=0, n_boot=100, rng=0)
+
+    assert isinstance(result, CohortAttribution)
+
+    # (1) hazard ratio within 15% of truth
+    assert result.hazard_ratio == pytest.approx(HR_TRUE, rel=0.15)
+
+    # (2) hr_ci covers HR_true
+    hr_lo, hr_hi = result.hr_ci
+    assert hr_lo <= HR_TRUE <= hr_hi
+
+    # (3) af_ci covers the implied true attributable fraction
+    af_true = (HR_TRUE - 1.0) / HR_TRUE
+    af_lo, af_hi = result.af_ci
+    assert af_lo <= af_true <= af_hi
+    assert result.attributable_fraction == pytest.approx(af_true, rel=0.2)
+
+    # no competing risks requested -> cif is the empty dict, not a stub
+    assert result.cif == {}
+
+
+def test_af_distribution_is_ic1_derived_quantity_shaped():
+    covariates, time, event = _simulate_cohort(seed=1)
+    result = cohort_attribution(covariates, time, event, n_boot=80, rng=1)
+
+    dq = result.provenance["af_distribution"]
+    assert isinstance(dq, DerivedQuantity)
+    assert dq.prior_dominated is False
+    lo, hi = dq.credible_interval(0.95)
+    assert lo <= hi
+    assert dq.samples.shape == (80,)
+
+    # every number attributes to the fit + seed
+    assert result.provenance["seed"] == 1
+    assert result.provenance["n"] == covariates.shape[0]
+    assert result.provenance["ties"] == "efron"
+
+
+def test_ci_coverage_tracks_nominal_rate_across_seeds():
+    # A light-weight coverage check: 15 independent cohorts, small bootstrap (speed), counting how
+    # often the 95% hr_ci actually covers HR_true. With only 15 replicates the count is noisy, but it
+    # should be solidly majority-covering, not degenerate.
+    n_reps = 15
+    covered = 0
+    for seed in range(n_reps):
+        covariates, time, event = _simulate_cohort(seed=100 + seed, n=250)
+        result = cohort_attribution(covariates, time, event, n_boot=40, rng=seed)
+        lo, hi = result.hr_ci
+        covered += int(lo <= HR_TRUE <= hi)
+    coverage_rate = covered / n_reps
+    assert coverage_rate >= 0.6, f"95% CI coverage collapsed to {coverage_rate:.2f} over {n_reps} reps"
+
+
+def test_competing_risks_cif_nondecreasing_and_bounded():
+    rng = np.random.default_rng(2)
+    n = 300
+    exposed = (rng.random(n) < 0.5).astype(float)
+    covariates = exposed.reshape(-1, 1)
+    beta = np.log(HR_TRUE)
+    t_cause1 = -np.log(rng.random(n)) / np.exp(covariates[:, 0] * beta)
+    t_cause2 = rng.exponential(2.5, n)  # competing cause, unaffected by exposure
+    censor = rng.exponential(3.0, n)
+
+    time = np.minimum(np.minimum(t_cause1, t_cause2), censor)
+    event = np.zeros(n, dtype=int)
+    event[(t_cause1 <= t_cause2) & (t_cause1 <= censor)] = 1
+    event[(t_cause2 < t_cause1) & (t_cause2 <= censor)] = 2
+
+    result = cohort_attribution(covariates, time, event, competing=True, n_boot=40, rng=2)
+
+    assert set(result.cif.keys()) == {1, 2}
+    total = np.zeros_like(next(iter(result.cif.values())))
+    for curve in result.cif.values():
+        assert np.all(np.diff(curve) >= -1e-12), "CIF must be non-decreasing"
+        assert np.all(curve >= 0.0)
+        total = total + curve
+    assert np.all(total <= 1.0 + 1e-9), "cause-specific CIFs must not sum past 1"
+
+
+def test_latency_left_truncates_the_risk_set():
+    covariates, time, event = _simulate_cohort(seed=3, n=350)
+    result = cohort_attribution(covariates, time, event, latency=0.1, n_boot=30, rng=3)
+
+    assert np.isfinite(result.hazard_ratio)
+    assert result.provenance["latency"] == 0.1
+    assert result.provenance["n"] == covariates.shape[0]
+    # left-truncation drops subjects who never survive past the latency window
+    assert result.provenance["n_fit_rows"] <= covariates.shape[0]
+    assert np.any(time <= 0.1), "test setup should include some subjects truncated before latency"


### PR DESCRIPTION
## Worklist item

**Item:** K9

## Summary

From notes/exploration-e2e-work-plan.md (the post-0.7 capability-expansion worklist, commissioned directly by the maintainer) and notes/exec/workstream-K.md -- not the original 0.8.0 stability worklist; this is new, explicitly authorized capability work.

Adds `mixle/analysis/epidemiology.py` (`CohortAttribution`, `cohort_attribution`), a health-analysis-shaped wrapper around the already-frozen `mixle.inference.survival` estimators. Given a cohort's covariates (one exposure column), event times, and censoring, `cohort_attribution` fits a cause-specific Cox PH model and reports:

- the exposure's hazard ratio with a Wald confidence interval (straight from `CoxResult.se`),
- the attributable fraction among the exposed, `(HR - 1) / HR`, with a nonparametric bootstrap confidence interval over cohort resamples,
- (when `competing=True`) cause-specific cumulative incidence via `aalen_johansen`, so a competing cause of death isn't double-counted as averted risk the way a naive `1 - KM` would,
- (when `latency > 0`) an exposure-to-effect lag, encoded as left-truncation via `cox_ph`'s counting-process `start` argument.

The bootstrap AF distribution is also carried in `provenance` as an object satisfying the IC-1 `DerivedQuantity` shape (`samples` + `credible_interval` + `prior_dominated`), consistent with how the rest of the decision-quantity surface (IC-8) never emits a number without its honesty flag.

No new survival math is added -- `cox_ph` and `aalen_johansen` are used as-is, per the task's non-goals.

## Public API impact

- [x] It changes the public surface, and I regenerated the manifest (`python scripts/gen_api_manifest.py`) and committed `api_manifest.json`.

Adds `CohortAttribution` and `cohort_attribution` to `mixle.analysis.__all__`.

## Claims impact

- [x] No public claim (README, docs, benchmarks) is affected.

## Evidence

```
PYTHONPATH=<worktree>/mixle python -m pytest mixle/tests/test_epidemiology.py::test_known_hazard_recovered -q
-> 1 passed

PYTHONPATH=<worktree>/mixle python -m pytest mixle/tests/test_epidemiology.py -q -n0 -m ""
-> 5 passed in 28.39s

PYTHONPATH=<worktree>/mixle python -m pytest mixle/tests/survival_test.py mixle/tests/survival_regression_test.py mixle/tests/ppl_survival_test.py mixle/tests/posterior_protocol_test.py mixle/tests/test_epidemiology.py -q -n0 -m ""
-> 29 passed in 32.81s

PYTHONPATH=<worktree>/mixle python -m pytest mixle/tests/public_api_manifest_test.py -q -n0 -m ""
-> 2 passed

lint-imports (import-linter): 3 contracts kept, 0 broken
ruff check / ruff format --check: clean on all changed files
```

## Notes (judgment calls)

- K7/K8 (this task's listed "Depends on") have not landed on `release/0.8.0` yet as of this PR. Nothing in K9's algorithm actually needs their code (the dependency note is about shared health-analysis conventions, not a runtime import), so this was implemented standalone against the frozen contracts and `inference/survival.py` directly.
- The frozen `CohortAttribution` dataclass has a single `attributable_fraction`/`af_ci` pair. The algorithm text describes both "AF among the exposed" (`(HR-1)/HR`) and a prevalence-weighted population AF. The DoD explicitly requires `af_ci` to cover `(HR_true-1)/HR_true` (the exposed-AF formula), so that's what the public field reports; the prevalence-weighted population AF is still computed and exposed via `provenance["population_attributable_fraction"]`.
- When `competing=True`, the Cox fit is cause-specific: only cause `1` counts as an event (cause `2..K` and true censoring are both censored at their time for the hazard-ratio fit), which is the standard competing-risks convention and keeps the CIF (from `aalen_johansen` on the raw multi-cause labels) as the one place absolute risk is reported.
- The AF confidence interval is computed via cohort-resample bootstrap (refitting `cox_ph` each draw) rather than the delta-method alternative mentioned in the algorithm text, since the bootstrap directly produces the sample distribution the `DerivedQuantity`-shaped provenance summary needs.
- Test cohort sizes / `n_boot` were tuned down from what a first draft used (each bootstrap draw is a full Cox refit) so the file stays commensurate with the repo's fast-gate philosophy instead of adding a multi-minute test.