### PR TITLE
Fix circular-import ordering and KeyError in gen_api_manifest.py

### DIFF
--- a/mixle/tests/public_api_manifest_test.py
+++ b/mixle/tests/public_api_manifest_test.py
@@ -64,6 +64,26 @@ class PublicApiManifestTest(unittest.TestCase):
             "and commit if intended):\n" + "\n".join(drift),
         )
 
+    def test_dynamic_packages_resolve_cleanly(self):
+        """``mixle``, ``mixle.stats``, and ``mixle.utils`` assemble ``__all__`` at runtime and must
+        actually resolve here -- every dependency they need is installed in this environment, none is
+        optional. A prior regression imported ``mixle.stats`` before ``mixle.reason`` had a chance to
+        finish initializing, tripping a real circular-import chain (``mixle.stats.bayes.dirichlet`` ->
+        ``mixle.inference`` -> ``mixle.analysis`` -> ``mixle.reason`` -> ``mixle.stats.latent.mixture``
+        -> back to ``mixle.stats.bayes.dirichlet``) and silently recording ``mixle.stats`` as
+        ``{"unresolved": "ImportError"}`` -- which ``_resolvable`` above then treats exactly like a
+        legitimately-missing optional dependency and skips, defeating drift coverage for the whole
+        package. Assert that does not happen."""
+        current = _load_generator().build_manifest(_REPO_ROOT)
+        for key in ("mixle", "mixle.stats", "mixle.utils"):
+            value = current.get(key)
+            self.assertIsInstance(
+                value,
+                list,
+                f"{key} failed to resolve ({value!r}) even though its dependencies are all installed "
+                "here -- likely an import-ordering regression, not a genuinely missing optional dep",
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/gen_api_manifest.py
+++ b/scripts/gen_api_manifest.py
@@ -83,7 +83,21 @@ def build_manifest(repo_root: Path = REPO_ROOT) -> dict[str, object]:
     that assembles ``__all__`` at runtime (``mixle``, ``mixle.stats``, ``mixle.utils``) is resolved by
     importing it; if that import fails (a missing optional dependency in the current env) it is
     recorded as ``{"unresolved": <ExceptionType>}`` so the drift test can skip it rather than falsely
-    diff against a manifest generated in a fuller env."""
+    diff against a manifest generated in a fuller env.
+
+    ``mixle.stats.bayes.dirichlet`` and ``mixle.reason`` have a real circular import between them
+    (``mixle.stats.bayes.dirichlet`` -> ``mixle.inference`` -> ``mixle.analysis`` ->
+    ``mixle.reason.posterior_protocol`` -> ... -> ``mixle.stats.latent.mixture`` -> back to
+    ``mixle.stats.bayes.dirichlet``). Importing ``mixle.stats`` first re-enters
+    ``mixle.stats.bayes.dirichlet`` while it is still mid-init and raises a spurious ImportError;
+    importing ``mixle.reason`` first lets that module finish completely before anything re-enters it,
+    so warm it here before resolving the runtime packages below.
+    """
+    try:
+        importlib.import_module("mixle.reason")
+    except Exception:  # noqa: BLE001 -- a genuinely missing dependency still surfaces per-package below
+        pass
+
     pkg_root = repo_root / "mixle"
     manifest: dict[str, object] = {}
     for init in sorted(pkg_root.rglob("__init__.py")):
@@ -105,7 +119,7 @@ def build_manifest(repo_root: Path = REPO_ROOT) -> dict[str, object]:
 def main() -> int:
     manifest = build_manifest()
     MANIFEST_PATH.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-    total = sum(len(v if isinstance(v, list) else v["names"]) for v in manifest.values())
+    total = sum(len(v) for v in manifest.values() if isinstance(v, list))
     print(f"wrote {MANIFEST_PATH.relative_to(REPO_ROOT)}: {len(manifest)} packages, {total} public names")
     return 0
 


### PR DESCRIPTION
## Summary
`scripts/gen_api_manifest.py` (run bare, in a fresh process) hits a real circular import between `mixle.stats.bayes.dirichlet` and `mixle.reason` when resolving `mixle.stats`'s runtime-assembled `__all__`, silently records `mixle.stats` as `{"unresolved": "ImportError"}` (wiping its ~484 legitimate entries), then crashes its own summary line with `KeyError: 'names'`.

## Root cause
Reproduced directly: `import mixle.stats` in a fresh interpreter fails with
```
ImportError: cannot import name 'DirichletDistribution' from partially initialized module 'mixle.stats.bayes.dirichlet' (most likely due to a circular import)
```
Traced the exact chain: `mixle.stats.bayes.dirichlet` → `mixle.inference` → `mixle.inference.risk` → `mixle.analysis` → `mixle.analysis.valuation` → `mixle.reason.posterior_protocol` → `mixle.reason` → `mixle.reason.cross_modal` → `mixle.stats.latent.mixture` → back to `mixle.stats.bayes.dirichlet`, which is still executing its own top-of-file imports (hasn't reached its class definitions yet) — so the re-entrant import fails.

Confirmed the fix: importing `mixle.reason` *before* `mixle.stats` breaks the cycle, because by the time the chain needs `mixle.stats.bayes.dirichlet`, that module hasn't been touched at all yet, so it completes fully before anything re-enters it — the later `mixle.stats` import then just hits an already-cached, fully-initialized module.

## Fix
1. `build_manifest()` now warms `mixle.reason` (guarded — a genuinely missing optional dependency still falls through to the existing per-package handling) before resolving the three runtime-assembled packages.
2. `main()`'s summary line assumed every unresolved value carried a `"names"` key to fall back on; the actual shape is `{"unresolved": <ExceptionType>}` with no such key, so any unresolved package (real dep or this bug) crashed the reporting line with `KeyError: 'names'` right after the manifest was already written to disk. Simplified to only count list-shaped (resolved) entries.

Regenerating with the fix produces a manifest **byte-identical** to the already-committed `api_manifest.json` — this is a pure robustness fix, not a public-API change.

## Why this matters beyond the standalone script
`mixle/tests/public_api_manifest_test.py`'s own drift check treats an `{"unresolved": ...}` package identically whether it's a real missing optional dependency or this import-ordering bug — so the bug was silently defeating drift coverage for the entire `mixle.stats` package (~484 public names) in any fresh-process test run that touched `mixle.stats` before `mixle.reason`.

## Test plan
```
PYTHONPATH=<repo> pytest -n0 mixle/tests/public_api_manifest_test.py
```
3 passed (added `test_dynamic_packages_resolve_cleanly`, which asserts `mixle`/`mixle.stats`/`mixle.utils` all resolve to real lists rather than `{"unresolved": ...}` in this environment, where every one of their dependencies is actually installed).

`ruff format`/`ruff check` clean on both touched files.

## Notes
- Regenerated `api_manifest.json` is unchanged (verified via `git diff`), so it isn't part of this PR's diff.