### PR TITLE
N4: Biodiversity impact & habitat connectivity

### DIFF
--- a/mixle/analysis/__init__.py
+++ b/mixle/analysis/__init__.py
@@ -9,7 +9,14 @@ collected here so the distributions package stays focused on distribution famili
 
 from __future__ import annotations
 
-from mixle.analysis.biodiversity import habitat_offset_liability, no_net_loss_constraint
+from mixle.analysis.biodiversity import (
+    fragmentation_impact,
+    habitat_connectivity,
+    habitat_offset_liability,
+    least_cost_corridor,
+    no_net_loss_constraint,
+    resistance_raster,
+)
 from mixle.analysis.carcinogenic_risk import (
     RiskQuantity,
     SlopeFactor,
@@ -163,6 +170,11 @@ __all__ = [
     "transition_risk",
     # climate objective + risk: emissions footprint and carbon/water terms into J6/H4 (L6)
     "climate_terms",
+    # habitat connectivity (graph resistance on a habitat-cost raster; N4)
+    "resistance_raster",
+    "least_cost_corridor",
+    "habitat_connectivity",
+    "fragmentation_impact",
     # reclamation ecology / biodiversity offsets (priced habitat-offset liability + no-net-loss constraint)
     "habitat_offset_liability",
     "no_net_loss_constraint",

--- a/mixle/analysis/biodiversity.py
+++ b/mixle/analysis/biodiversity.py
@@ -1,31 +1,41 @@
-"""Reclamation ecology & biodiversity offsets (workstream N, N6).
+"""Biodiversity impact, habitat connectivity, and reclamation offsets (workstream N; N4 + N6).
 
-Prices the habitat impact of a mine footprint as a liability the same shape as J6's other priced terms
-(reclamation/remediation, health, carbon) and emits the companion no-net-loss hard constraint, so
-biodiversity offsets trade off against grade/cost/carbon inside ONE risk-adjusted objective instead of
-being a separate side calculation.
+Two related pieces share this module because they share the same underlying object -- an N1
+:class:`~mixle.analysis.sdm.HabitatModel`'s fitted suitability field:
 
-``habitat_offset_liability``/``no_net_loss_constraint`` both work off the same "lost habitat-hectare-
-equivalents" quantity: the fitted suitability field (an N1 :class:`~mixle.analysis.sdm.HabitatModel`'s
-``mean``, i.e. ``lambda_c``) times per-cell area, summed over whatever footprint of cells a candidate mine
-plan disturbs. Multiplying by ``offset_ratio`` (how many equivalent hectares must be created/purchased per
-hectare lost) and ``unit_offset_cost`` (dollars per offset hectare-equivalent) turns that into a priced
-dollar liability; requiring the created/purchased offset to meet-or-exceed ``offset_ratio * lost`` is the
-companion hard (no-net-loss) constraint.
+* **N4 -- connectivity** (:func:`resistance_raster`, :func:`least_cost_corridor`,
+  :func:`habitat_connectivity`, :func:`fragmentation_impact`): graph resistance on a habitat-cost raster.
+  Suitability is inverted into a per-cell movement *cost*; :class:`mixle.relations.ShortestPath` gives the
+  cheapest corridor between two patches and :func:`mixle.relations.max_flow` over the equivalent
+  conductance graph gives a circuit-theory "effective current" connectivity between patch sets.
+  :func:`fragmentation_impact` scores a candidate mine footprint (H3) by how much it raises corridor
+  resistance / drops connectivity relative to the unmined baseline -- the population-viability proxy N6
+  and J's objective consume.
+* **N6 -- reclamation ecology & biodiversity offsets** (:func:`habitat_offset_liability`,
+  :func:`no_net_loss_constraint`): prices the habitat impact of a mine footprint as a liability the same
+  shape as J6's other priced terms (reclamation/remediation, health, carbon) and emits the companion
+  no-net-loss hard constraint, so biodiversity offsets trade off against grade/cost/carbon inside ONE
+  risk-adjusted objective instead of being a separate side calculation. ``habitat_offset_liability``/
+  ``no_net_loss_constraint`` work off the same "lost habitat-hectare-equivalents" quantity: the fitted
+  suitability field (``HabitatModel.mean``, i.e. ``lambda_c``) times per-cell area, summed over whatever
+  footprint of cells a candidate mine plan disturbs.
 
-Only ``habitat.mean`` (and, if present, ``habitat.cell_area``) is read, so any object satisfying the IC-1
-``Posterior`` surface over a suitability field -- in particular N1's ``HabitatModel`` -- works here; the
-type hint is a forward reference (evaluated only under ``TYPE_CHECKING``) so this module has no hard
-runtime dependency on ``mixle.analysis.sdm``.
-
-This module is the seed of N4's ``analysis/biodiversity.py`` (connectivity metrics: ``resistance_raster``,
-``least_cost_corridor``, ``habitat_connectivity``, ``fragmentation_impact`` -- workstream-N.md N4, not
-implemented here; see the module Notes in the N6 PR body). N6 only appends the two offset/liability
-functions below, per its own Non-goals ("no connectivity metric (N4)").
+Every function here reads only duck-typed attributes off ``habitat`` (``.mean``, optionally
+``.cell_area``) or takes plain arrays, so anything satisfying the IC-1 ``Posterior`` surface over a
+suitability field -- in particular N1's ``HabitatModel`` -- works; the ``HabitatModel`` type hint is a
+forward reference (evaluated only under ``TYPE_CHECKING``), so this module has no hard runtime dependency
+on ``mixle.analysis.sdm``. The N4 connectivity functions likewise never edit ``mixle.relations`` symbols,
+only call the frozen ``ShortestPath``/``max_flow``/``min_cut`` surface -- imported lazily inside each
+function (rather than at module scope) because ``mixle.relations`` transitively imports ``mixle.stats``,
+and this module is loaded from ``mixle.analysis.__init__`` while ``mixle.stats``/``mixle.inference``/
+``mixle.analysis``/``mixle.reason`` are, in some import orders, still themselves mid-initialization
+(a pre-existing, order-sensitive circular-import chain across those four packages); deferring the import
+to call time avoids perturbing that chain's timing instead of trying to fix it here.
 """
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
@@ -33,7 +43,219 @@ import numpy as np
 if TYPE_CHECKING:
     from mixle.analysis.sdm import HabitatModel
 
-__all__ = ["habitat_offset_liability", "no_net_loss_constraint"]
+__all__ = [
+    "resistance_raster",
+    "least_cost_corridor",
+    "habitat_connectivity",
+    "fragmentation_impact",
+    "habitat_offset_liability",
+    "no_net_loss_constraint",
+]
+
+# A numerically-safe stand-in for "infinite" super-source/-sink attachment capacity in the connectivity
+# max-flow graph: far above any real cell-to-cell conductance (bounded by ``1 / floor`` on the resistance
+# side) so the super-arcs never themselves bottleneck the flow, without risking inf-arithmetic (inf - inf)
+# in `mixle.relations.max_flow`'s residual-graph bookkeeping.
+_BIG_CAPACITY = 1.0e6
+
+
+def _rook_offsets(ndim: int) -> list[tuple[int, ...]]:
+    """Unit steps along each axis (+/-1): axis-aligned ("rook"; 4-connected in 2-D) grid neighbours."""
+    offsets = []
+    for axis in range(ndim):
+        for step in (-1, 1):
+            offset = [0] * ndim
+            offset[axis] = step
+            offsets.append(tuple(offset))
+    return offsets
+
+
+def _neighbor_flat_indices(flat_idx: int, shape: tuple[int, ...], offsets: list[tuple[int, ...]]) -> list[int]:
+    """In-bounds rook-neighbour flat (row-major/``np.ravel``) indices of ``flat_idx`` on a ``shape`` grid."""
+    coord = np.unravel_index(int(flat_idx), shape)
+    out = []
+    for offset in offsets:
+        nb = tuple(c + o for c, o in zip(coord, offset, strict=True))
+        if all(0 <= x < s for x, s in zip(nb, shape, strict=True)):
+            out.append(int(np.ravel_multi_index(nb, shape)))
+    return out
+
+
+def _edge_cost(flat_resistance: np.ndarray, i: int, j: int) -> float:
+    """Movement cost of the edge between adjacent cells ``i``/``j``: the mean of their per-cell resistance."""
+    return float(0.5 * (flat_resistance[i] + flat_resistance[j]))
+
+
+def resistance_raster(habitat: HabitatModel, *, floor: float = 1e-3) -> np.ndarray:
+    """Per-cell movement cost from a fitted suitability field: ``cost_c = 1 / max(suitability_c, floor)``.
+
+    Reads only ``habitat.mean`` (N1's fitted intensity field ``lambda_c``); ``floor`` keeps near-zero
+    suitability cells at a large-but-finite cost (near-impermeable) rather than blowing up to ``inf``, so
+    the resulting raster is always safe to feed straight into :func:`least_cost_corridor` /
+    :func:`habitat_connectivity` without any further cleanup.
+    """
+    suitability = np.asarray(habitat.mean, dtype=np.float64)
+    return 1.0 / np.maximum(suitability, float(floor))
+
+
+def least_cost_corridor(resistance: np.ndarray, patch_a: int, patch_b: int) -> tuple[float, list[int]]:
+    """Cheapest movement path between two cells of a resistance raster (the least-cost corridor).
+
+    ``resistance`` is an ``n``-dimensional cost raster (e.g. from :func:`resistance_raster`); ``patch_a``/
+    ``patch_b`` are flat (row-major/``np.ravel``) cell indices into it. Delegates to
+    :class:`mixle.relations.ShortestPath` over the rook-adjacency grid graph with each edge weighted by
+    :func:`_edge_cost` (mean resistance of its two endpoint cells); a cell resistance of ``inf`` (a mined
+    footprint, :func:`fragmentation_impact`) makes every edge touching it non-finite and so unusable,
+    effectively removing that cell from the graph. Lower resistance = better connected.
+
+    ``ShortestPath``'s underlying engine (``mixle.relations.best_first_paths``) is a pure best-first search
+    with no closed/visited set -- intentional there, since it is also used to enumerate *k* best (not just
+    the single best) paths, where revisiting a state via a costlier path is legitimate output. On a cyclic
+    grid graph asked for only its single best path (``k=1``), that same lack of a closed set is
+    combinatorially explosive (every back-and-forth detour is a distinct, never-pruned path). Since
+    ``successors(state)`` is called exactly once per pop and pops come out in non-decreasing cost order,
+    the first call for a given state is provably its cheapest arrival (Dijkstra's invariant, valid here
+    because every edge cost is non-negative) -- so a small closed set local to this call, never touching
+    ``relations.py``, turns the search back into ordinary Dijkstra: each state's successors are computed
+    once and ``[]`` (already settled) on every later call.
+
+    Returns:
+        ``(corridor_resistance, path)``: the total path resistance and the visited flat cell indices from
+        ``patch_a`` to ``patch_b`` inclusive; ``(inf, [])`` if no finite-cost path exists.
+    """
+    from mixle.relations import ShortestPath
+
+    r = np.asarray(resistance, dtype=np.float64)
+    shape = r.shape
+    flat = r.reshape(-1)
+    offsets = _rook_offsets(r.ndim)
+    settled: set[int] = set()
+
+    def successors(node: int) -> list[tuple[int, float]]:
+        if node in settled:  # already expanded via an earlier (cheaper-or-equal) pop; nothing new to offer
+            return []
+        settled.add(node)
+        out = []
+        for nb in _neighbor_flat_indices(node, shape, offsets):
+            cost = _edge_cost(flat, node, nb)
+            if np.isfinite(cost):
+                out.append((nb, cost))
+        return out
+
+    target = int(patch_b)
+    relation = ShortestPath(int(patch_a), successors, is_goal=lambda c: c == target, sense="min")
+    solution = relation.solve()
+    if solution is None:
+        return float("inf"), []
+    return float(solution.objective), list(solution.value)
+
+
+def _conductance_network(
+    resistance: np.ndarray, sources: Sequence[int], sinks: Sequence[int]
+) -> tuple[np.ndarray, int, int]:
+    """Build the ``(n + 2, n + 2)`` super-source/-sink conductance capacity matrix for max-flow/min-cut.
+
+    Node ``i < n`` is grid cell ``i`` (row-major flat index); node ``n`` is a super-source wired to every
+    cell in ``sources`` and node ``n + 1`` a super-sink wired from every cell in ``sinks``, each at
+    :data:`_BIG_CAPACITY`. Rook-adjacent cells get a *symmetric* capacity (current can flow either way)
+    equal to the conductance ``1 / edge_cost`` of the movement cost between them (the circuit-theory
+    analogue of :func:`least_cost_corridor`'s edge cost); a non-finite edge cost (a mined-out cell) yields
+    zero conductance, i.e. no arc.
+    """
+    r = np.asarray(resistance, dtype=np.float64)
+    shape = r.shape
+    n = r.size
+    flat = r.reshape(-1)
+    offsets = _rook_offsets(r.ndim)
+    cap = np.zeros((n + 2, n + 2), dtype=np.float64)
+    source_node, sink_node = n, n + 1
+    for node in range(n):
+        for nb in _neighbor_flat_indices(node, shape, offsets):
+            if nb <= node:
+                continue  # each undirected pair visited once, from its lower-indexed endpoint
+            cost = _edge_cost(flat, node, nb)
+            conductance = 1.0 / cost if np.isfinite(cost) and cost > 0.0 else 0.0
+            cap[node, nb] = conductance
+            cap[nb, node] = conductance
+    for s in sources:
+        cap[source_node, int(s)] = _BIG_CAPACITY
+    for t in sinks:
+        cap[int(t), sink_node] = _BIG_CAPACITY
+    return cap, source_node, sink_node
+
+
+def habitat_connectivity(resistance: np.ndarray, sources: Sequence[int], sinks: Sequence[int]) -> float:
+    """Effective connectivity ("current") between ``sources`` and ``sinks`` over a resistance raster.
+
+    Builds a conductance graph (arc capacity ``1 / edge_cost`` between rook-adjacent cells) with a
+    super-source over ``sources`` and a super-sink over ``sinks``, then returns
+    :func:`mixle.relations.max_flow`'s value between them -- the maximum current the habitat network can
+    carry from the source patch(es) to the sink patch(es), the standard circuit-theory proxy for landscape
+    connectivity (McRae et al. 2008). Higher = better connected.
+    """
+    from mixle.relations import max_flow
+
+    cap, source_node, sink_node = _conductance_network(resistance, sources, sinks)
+    value, _flow = max_flow(cap, source_node, sink_node)
+    return float(value)
+
+
+def fragmentation_impact(
+    resistance: np.ndarray,
+    footprint_mask: np.ndarray,
+    sources: Sequence[int],
+    sinks: Sequence[int],
+) -> dict:
+    """Habitat-connectivity impact of a mine footprint: baseline vs. mined-out corridor/connectivity.
+
+    Sets every ``footprint_mask`` cell's resistance to ``inf`` (impassable / zero conductance -- the H3
+    mine plan) and recomputes both :func:`least_cost_corridor` (between the first ``sources``/``sinks``
+    cell, taken as the representative patch-to-patch corridor endpoints -- a judgment call: the public API
+    only takes cell *sets* here, not a single designated pair) and :func:`habitat_connectivity` (over the
+    full ``sources``/``sinks`` sets) before and after. This is the population-viability proxy N6/J feed
+    into the biodiversity-offset objective: a footprint that severs the only corridor raises
+    ``corridor_resistance`` and drops ``connectivity`` sharply; one that misses every real corridor leaves
+    both essentially unchanged.
+
+    Returns:
+        A dict with ``corridor_resistance_baseline``/``corridor_resistance_mined``,
+        ``connectivity_baseline``/``connectivity_mined``, ``delta`` (``connectivity_baseline -
+        connectivity_mined``, i.e. connectivity *lost*), and ``mincut_edges`` -- the *baseline* network's
+        minimum-cut arcs (:func:`mixle.relations.min_cut`), i.e. the single weakest link a footprint would
+        need to sever to maximally damage connectivity.
+    """
+    from mixle.relations import min_cut
+
+    resistance = np.asarray(resistance, dtype=np.float64)
+    mask = np.asarray(footprint_mask, dtype=bool)
+    if mask.shape != resistance.shape:
+        raise ValueError(f"footprint_mask shape {mask.shape} does not match resistance shape {resistance.shape}")
+    mined = resistance.copy()
+    mined[mask] = np.inf
+
+    sources = list(sources)
+    sinks = list(sinks)
+    patch_a, patch_b = int(sources[0]), int(sinks[0])
+
+    corridor_baseline, _ = least_cost_corridor(resistance, patch_a, patch_b)
+    corridor_mined, _ = least_cost_corridor(mined, patch_a, patch_b)
+
+    connectivity_baseline = habitat_connectivity(resistance, sources, sinks)
+    connectivity_mined = habitat_connectivity(mined, sources, sinks)
+
+    cap, source_node, sink_node = _conductance_network(resistance, sources, sinks)
+    n = resistance.size
+    _cut_value, _side, cut_edges = min_cut(cap, source_node, sink_node)
+    mincut_edges = [(u, v) for u, v in cut_edges if u < n and v < n]
+
+    return {
+        "corridor_resistance_baseline": corridor_baseline,
+        "corridor_resistance_mined": corridor_mined,
+        "connectivity_baseline": connectivity_baseline,
+        "connectivity_mined": connectivity_mined,
+        "delta": connectivity_baseline - connectivity_mined,
+        "mincut_edges": mincut_edges,
+    }
 
 
 def _lost_equivalents(plan_footprint: Any, habitat: HabitatModel) -> tuple[np.ndarray, float]:

--- a/mixle/tests/test_n4_connectivity.py
+++ b/mixle/tests/test_n4_connectivity.py
@@ -1,0 +1,120 @@
+"""N4: biodiversity impact & habitat connectivity (graph resistance on a habitat-cost raster)."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from mixle.analysis.biodiversity import (
+    fragmentation_impact,
+    habitat_connectivity,
+    least_cost_corridor,
+    resistance_raster,
+)
+
+_ROWS, _COLS = 5, 9
+
+
+class _FakeHabitat:
+    """Minimal duck-typed stand-in exposing only ``.mean`` (mirrors N6's ``habitat.mean``-only usage)."""
+
+    def __init__(self, mean: np.ndarray) -> None:
+        self.mean = mean
+
+
+def _flat(row: int, col: int, cols: int = _COLS) -> int:
+    return row * cols + col
+
+
+def _two_patch_grid(rows: int = _ROWS, cols: int = _COLS) -> np.ndarray:
+    """A suitability grid: two full-column patches (left/right) joined by a single-row corridor.
+
+    Everything else is low-suitability "matrix"; row ``2`` (the middle row), across the interior
+    columns, is the only high-suitability route connecting the two patch columns.
+    """
+    suitability = np.full((rows, cols), 1e-6)
+    suitability[:, 0] = 1.0
+    suitability[:, cols - 1] = 1.0
+    suitability[2, 1 : cols - 1] = 1.0
+    return suitability
+
+
+def test_resistance_raster_inverts_suitability_with_a_floor():
+    habitat = _FakeHabitat(np.array([1.0, 0.1, 0.0]))
+    resistance = resistance_raster(habitat, floor=1e-3)
+    assert resistance.shape == (3,)
+    assert np.isclose(resistance[0], 1.0)
+    assert np.isclose(resistance[1], 10.0)
+    assert np.isclose(resistance[2], 1.0 / 1e-3)  # floor keeps this finite rather than inf
+
+
+def test_least_cost_corridor_follows_the_high_suitability_row():
+    resistance = resistance_raster(_FakeHabitat(_two_patch_grid()), floor=1e-3)
+    cost, path = least_cost_corridor(resistance, _flat(2, 0), _flat(2, _COLS - 1))
+    assert path[0] == _flat(2, 0)
+    assert path[-1] == _flat(2, _COLS - 1)
+    assert np.isclose(cost, float(_COLS - 1))  # COLS-1 unit-resistance edges straight along row 2
+
+
+def test_least_cost_corridor_returns_inf_when_no_path_exists():
+    resistance = np.array([[1.0, np.inf], [np.inf, 1.0]])
+    cost, path = least_cost_corridor(resistance, 0, 3)
+    assert cost == float("inf")
+    assert path == []
+
+
+def test_fragmentation_impact_on_corridor_footprint_severs_connectivity_off_corridor_does_not():
+    suitability = _two_patch_grid()
+    resistance = resistance_raster(_FakeHabitat(suitability), floor=1e-3)
+
+    sources = [_flat(r, 0) for r in range(_ROWS)]
+    sinks = [_flat(r, _COLS - 1) for r in range(_ROWS)]
+
+    on_corridor_mask = np.zeros((_ROWS, _COLS), dtype=bool)
+    on_corridor_mask[2, 3:6] = True  # 3 cells, dead center of the one and only corridor
+
+    off_corridor_mask = np.zeros((_ROWS, _COLS), dtype=bool)
+    off_corridor_mask[0, 3:6] = True  # equal area (3 cells), off the corridor row entirely
+
+    on_corridor = fragmentation_impact(resistance, on_corridor_mask, sources, sinks)
+    off_corridor = fragmentation_impact(resistance, off_corridor_mask, sources, sinks)
+
+    # baseline numbers must agree regardless of which footprint is being scored against it
+    assert np.isclose(on_corridor["corridor_resistance_baseline"], off_corridor["corridor_resistance_baseline"])
+    assert np.isclose(on_corridor["connectivity_baseline"], off_corridor["connectivity_baseline"])
+
+    # severing the only corridor strictly raises movement cost and strictly lowers connectivity
+    assert on_corridor["corridor_resistance_mined"] > on_corridor["corridor_resistance_baseline"]
+    assert on_corridor["connectivity_mined"] < on_corridor["connectivity_baseline"]
+
+    # an equal-area footprint that misses the corridor leaves both metrics within tolerance
+    assert np.isclose(
+        off_corridor["corridor_resistance_mined"], off_corridor["corridor_resistance_baseline"], rtol=1e-9
+    )
+    assert np.isclose(off_corridor["connectivity_mined"], off_corridor["connectivity_baseline"], rtol=0.05)
+
+    assert set(on_corridor) == {
+        "corridor_resistance_baseline",
+        "corridor_resistance_mined",
+        "connectivity_baseline",
+        "connectivity_mined",
+        "delta",
+        "mincut_edges",
+    }
+    assert on_corridor["delta"] > 0.0
+    assert len(on_corridor["mincut_edges"]) >= 1
+
+
+def test_habitat_connectivity_drops_to_near_zero_when_corridor_is_severed():
+    suitability = _two_patch_grid()
+    resistance = resistance_raster(_FakeHabitat(suitability), floor=1e-3)
+    sources = [_flat(r, 0) for r in range(_ROWS)]
+    sinks = [_flat(r, _COLS - 1) for r in range(_ROWS)]
+
+    baseline = habitat_connectivity(resistance, sources, sinks)
+    mined = resistance.copy()
+    mined[2, 3:6] = np.inf
+    severed = habitat_connectivity(mined, sources, sinks)
+
+    assert baseline > 0.0
+    assert severed < baseline
+    assert severed < 0.1 * baseline  # only the low-conductance background "matrix" routes remain


### PR DESCRIPTION
## Worklist item

**Item:** N4

From notes/exploration-e2e-work-plan.md (the post-0.7 capability-expansion worklist, commissioned directly by the maintainer) and notes/exec/workstream-N.md — not the original 0.8.0 stability worklist; this is new, explicitly authorized capability work.

## Summary

Fills in the connectivity half of `mixle/analysis/biodiversity.py` (N6, landed earlier out of dependency order, already added the offset/liability functions and left this half as a documented stub):

- `resistance_raster(habitat, *, floor=1e-3)` — inverts an N1 `HabitatModel`'s fitted suitability field into a per-cell movement cost (`1 / max(suitability, floor)`).
- `least_cost_corridor(resistance, patch_a, patch_b)` — cheapest path between two cells via `relations.ShortestPath`, edge cost = mean adjacent resistance.
- `habitat_connectivity(resistance, sources, sinks)` — builds a rook-adjacency conductance graph (arc capacity `1/edge_cost`) with a super-source/-sink and reports `relations.max_flow`'s value as the circuit-theory "effective current" connectivity between patch sets.
- `fragmentation_impact(resistance, footprint_mask, sources, sinks)` — recomputes both of the above with footprint cells set to infinite resistance / zero conductance and returns baseline vs. mined corridor resistance, connectivity, their delta, and the baseline network's `min_cut` edges (the weakest link a footprint would need to sever).

All four are read-only consumers of the frozen `relations.py` surface (`ShortestPath`, `max_flow`, `min_cut`) and duck-type the `habitat` argument exactly the way N6's existing functions in this file already do, so there's no new hard dependency on `sdm.py`. Exported from `mixle/analysis/__init__.py`.

## Public API impact

- [x] It adds public surface: `resistance_raster`, `least_cost_corridor`, `habitat_connectivity`, `fragmentation_impact` (see Notes below on why `api_manifest.json` itself is not regenerated in this PR).

## Claims impact

- [x] No public claim (README, docs, benchmarks) is affected.

## Evidence

```
PYTHONPATH=/Users/grantboquet/mixle/mixle /Users/grantboquet/mixle/.venv/bin/python -m pytest /Users/grantboquet/mixle/mixle/mixle/tests/test_n4_connectivity.py -q -p no:xdist
-> 5 passed

PYTHONPATH=/Users/grantboquet/mixle/mixle /Users/grantboquet/mixle/.venv/bin/python -m pytest mixle/tests/test_n1_sdm.py mixle/tests/test_n6_offsets.py mixle/tests/test_n4_connectivity.py -q -n0
-> 16 passed

ruff format --check / ruff check on the three changed files: clean
```

## Checklist

- [x] Tests added/updated and passing; `ruff check` + `ruff format --check` clean.
- [x] Consumer suites for any edited module pass (N1's `test_n1_sdm.py`, N6's `test_n6_offsets.py`, both of which share this module/`HabitatModel`).
- [x] I am not merging this PR myself, and I have not enabled auto-merge.

## Notes (judgment calls / deviations)

- **`api_manifest.json` intentionally not regenerated.** `scripts/gen_api_manifest.py` calls `importlib.import_module("mixle.stats")` for any package whose `__all__` isn't a static literal, and that import currently fails with `ImportError: cannot import name 'DirichletDistribution' from partially initialized module 'mixle.stats.bayes.dirichlet' (circular import)`. I confirmed this is **pre-existing and unrelated to this PR** — it reproduces identically on a clean `origin/release/0.8.0` checkout with none of this PR's changes applied, and there's already another branch in flight (`work/fix-gen-api-manifest-circular-import`) addressing the root cause across `mixle.stats`/`mixle.inference`/`mixle.analysis`/`mixle.reason`. Running the generator as-is would crash (`main()` has its own separate bug assuming an `{"unresolved": ...}` entry has a `"names"` key) and, if that crash is patched over locally, would silently replace `mixle.stats`'s ~480 real entries with an `unresolved` marker — i.e. committing it would be a regression, not a fix. The four new names are already correctly declared in `analysis/__init__.py`'s **static** `__all__` (verified by re-running the generator's own AST extraction logic directly, without importing anything), so the manifest will pick them up correctly once the manifest-generator fix lands and it's rerun.
- **`least_cost_corridor` imports `mixle.relations` lazily (inside the function), not at module scope.** `mixle.relations` transitively imports `mixle.stats`, and adding it as an eager import at the top of `biodiversity.py` (loaded early in `mixle.analysis.__init__`'s import sequence) was enough to perturb the timing of the circular-import chain above and turn it from "doesn't trigger in this particular entry path" into "triggers." Deferring the import to call time sidesteps that without touching any of the four packages involved in the cycle.
- **Found and worked around, scoped to this module only:** `relations.best_first_paths` (which `ShortestPath` wraps) has no closed-set/visited-state pruning — a deliberate design choice there, since it also serves *k*-best path enumeration where revisiting a state via a costlier path is legitimate output. Used for a single best path (`k=1`) over a cyclic grid graph, that same lack of pruning is combinatorially explosive as soon as a footprint forces a real detour (confirmed by hand: a single masked cell in a 15-cell test grid ran for minutes and multiple GB before I diagnosed it). `least_cost_corridor` fixes this locally with a `settled: set[int]` closure variable: since `successors(state)` is called by `best_first_paths` exactly once per pop, in non-decreasing cost order, the *first* call for any given state is provably its cheapest arrival (Dijkstra's invariant, valid here since every edge cost is non-negative) — so returning `[]` on every later call for an already-seen state turns the search back into ordinary Dijkstra, with **no change to `relations.py`**.
- **`fragmentation_impact` takes `sources`/`sinks` as cell *sets*** (per the frozen signature) but `least_cost_corridor` needs a single designated pair; I use `sources[0]`/`sinks[0]` as the representative corridor endpoints. Documented inline as a judgment call, since the spec's public API only gives sets here.
- Rook (4-connected) adjacency only, not 8-connected diagonals — the work order's Algorithm section allows either ("grid 4/8-neighbours"); 4-connected is the simpler, sufficient choice for the DoD's corridor-severing scenario.
