### PR TITLE
Fix circular import between mixle.stats.bayes.dirichlet and mixle.stats.latent.mixture

### DIFF
--- a/mixle/inference/__init__.py
+++ b/mixle/inference/__init__.py
@@ -255,8 +255,12 @@ from mixle.inference.resampling import (
     wild_bootstrap,
 )
 
-# risk / tail metrics over a Monte-Carlo outcome distribution (VaR, CVaR, stress-scenario ranking)
-from mixle.inference.risk import conditional_value_at_risk, stress_rank, value_at_risk
+# risk / tail metrics over a Monte-Carlo outcome distribution (VaR, CVaR, stress-scenario ranking).
+# Same circular-import hazard as the condition/scenario lazy exports above: mixle.inference.risk ->
+# mixle.analysis -> mixle.reason -> ... -> mixle.stats.latent.mixture -> mixle.stats.bayes.dirichlet,
+# which is exactly the module whose own top-level `from mixle.inference.fisher import FixedFisherView`
+# reaches this package mid-init. Exported lazily instead (see __getattr__ at the bottom of this module).
+_RISK_LAZY_NAMES = frozenset({"conditional_value_at_risk", "stress_rank", "value_at_risk"})
 
 # robust / sandwich covariance for M-estimators and regression (misspecification-robust SEs)
 from mixle.inference.robust import (
@@ -740,6 +744,13 @@ def __getattr__(name: str):
 
         _scenario_module = importlib.import_module("mixle.inference.scenario")
         value = getattr(_scenario_module, _SCENARIO_LAZY_NAMES[name])
+        globals()[name] = value
+        return value
+    if name in _RISK_LAZY_NAMES:
+        import importlib
+
+        _risk_module = importlib.import_module("mixle.inference.risk")
+        value = getattr(_risk_module, name)
         globals()[name] = value
         return value
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/mixle/stats/latent/mixture.py
+++ b/mixle/stats/latent/mixture.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import math
 from collections.abc import Mapping, Sequence
-from typing import Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 
 import numpy as np
 from numpy.random import RandomState
@@ -33,8 +33,6 @@ from mixle.enumeration.algorithms import (
     freeze,
 )
 from mixle.inference.fisher import Path
-from mixle.stats.bayes.dirichlet import DirichletDistribution
-from mixle.stats.bayes.symmetric_dirichlet import SymmetricDirichletDistribution
 from mixle.stats.compute.pdist import (
     ContractError,
     DataSequenceEncoder,
@@ -51,6 +49,26 @@ from mixle.stats.compute.pdist import (
 from mixle.stats.compute.posterior import CategoricalLatentPosterior
 from mixle.utils.aliasing import MISSING, coalesce_alias
 from mixle.utils.special import digamma
+
+if TYPE_CHECKING:
+    from mixle.stats.bayes.dirichlet import DirichletDistribution
+    from mixle.stats.bayes.symmetric_dirichlet import SymmetricDirichletDistribution
+
+
+def _dirichlet_types() -> tuple[type, type]:
+    """Import `(DirichletDistribution, SymmetricDirichletDistribution)` lazily.
+
+    `mixle.stats.bayes.dirichlet` itself transitively imports this module (via
+    `mixle.inference` -> `mixle.analysis` -> `mixle.reason` -> `mixle.reason.cross_modal`), so a
+    module-level import here would be circular whenever `dirichlet.py` is the entry point of that
+    chain (e.g. `import mixle.ppl` / `import mixle_pde` before anything else has warmed
+    `mixle.stats.bayes.dirichlet`). Deferring the import to call time breaks the cycle.
+    """
+    from mixle.stats.bayes.dirichlet import DirichletDistribution
+    from mixle.stats.bayes.symmetric_dirichlet import SymmetricDirichletDistribution
+
+    return DirichletDistribution, SymmetricDirichletDistribution
+
 
 T = TypeVar("T")  ### Type of Mixture component data.
 T1 = TypeVar("T1")  ### Type of encoded data.
@@ -80,8 +98,9 @@ def mixture_prior(
     return weight_prior, tuple(component_priors)
 
 
-def _default_weight_prior(num_components: int) -> DirichletDistribution:
+def _default_weight_prior(num_components: int) -> "DirichletDistribution":
     """Flat (concentration-one) Dirichlet weight prior of the given dimension."""
+    DirichletDistribution, _ = _dirichlet_types()
     return DirichletDistribution(np.ones(num_components))
 
 
@@ -154,6 +173,7 @@ def _dirichlet_expectations(prior: Any, num_components: int) -> tuple[np.ndarray
     ``E[log w_k] = digamma(alpha_k) - digamma(sum_j alpha_j)`` are the variational weight
     expectations used by ``expected_log_density``.
     """
+    DirichletDistribution, SymmetricDirichletDistribution = _dirichlet_types()
     if isinstance(prior, DirichletDistribution):
         alpha = np.asarray(prior.get_parameters(), dtype=float)
         if alpha.shape[0] != num_components:
@@ -1478,6 +1498,7 @@ class MixtureEstimator(ParameterEstimator):
         if component_priors is not None:
             for d, p in zip(self.estimators, component_priors):
                 _set_estimator_prior(d, p)
+        DirichletDistribution, SymmetricDirichletDistribution = _dirichlet_types()
         self.has_conj_prior = isinstance(self.prior, (DirichletDistribution, SymmetricDirichletDistribution))
 
     def model_log_density(self, model: MixtureDistribution) -> float:
@@ -1549,6 +1570,7 @@ class MixtureEstimator(ParameterEstimator):
             # Conjugate Dirichlet weight update: MAP weights w_k proportional to
             # (count_k + alpha_k - 1), clamped at the simplex boundary; the posterior
             # Dirichlet(alpha + counts) is carried forward as the new weight prior.
+            DirichletDistribution, SymmetricDirichletDistribution = _dirichlet_types()
             if isinstance(self.prior, SymmetricDirichletDistribution):
                 alpha = np.ones(num_components) * float(self.prior.get_parameters())
             else:

--- a/mixle/tests/circular_import_order_test.py
+++ b/mixle/tests/circular_import_order_test.py
@@ -1,0 +1,36 @@
+"""Regression test: importing `mixle.stats.bayes.dirichlet` (or anything that reaches it before
+`mixle`'s own top-level `__init__` has warmed `mixle.stats.bayes.dirichlet`) must not raise a
+circular-import `ImportError`.
+
+This is exactly the path any out-of-tree consumer package (e.g. `mixle_pde`, which does
+`from mixle.ppl.core import RandomVariable` as its own first import) hits in a fresh process: that
+chain reaches `mixle.stats.bayes.dirichlet` -> `mixle.inference.fisher` -> `mixle.inference`
+package-init -> `mixle.inference.risk` -> `mixle.analysis` -> `mixle.reason` -> ... ->
+`mixle.stats.latent.mixture` -> back to `mixle.stats.bayes.dirichlet`, which is still mid-init.
+Regression-tests the fix: `mixle.stats.latent.mixture`'s `DirichletDistribution` import deferred to
+call time, and `mixle.inference`'s `risk` re-exports made lazy (mirroring the existing
+`condition`/`scenario` lazy-export pattern in `mixle/inference/__init__.py`).
+"""
+
+import subprocess
+import sys
+
+
+def test_dirichlet_module_imports_standalone_in_a_fresh_process():
+    """A fresh process importing `mixle.stats.bayes.dirichlet` directly (not via `import mixle`
+    first) must not raise ImportError."""
+    result = subprocess.run(
+        [sys.executable, "-c", "import mixle.stats.bayes.dirichlet"],
+        capture_output=True, text=True, timeout=60,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_inference_risk_names_are_reachable_after_plain_import_mixle():
+    """`mixle.inference.value_at_risk` (a name whose eager import used to sit on the exact cycle)
+    must still be reachable -- lazily-exported, not silently dropped."""
+    result = subprocess.run(
+        [sys.executable, "-c", "import mixle.inference as m; assert callable(m.value_at_risk)"],
+        capture_output=True, text=True, timeout=60,
+    )
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
Any fresh process importing `mixle.ppl` (and therefore `mixle_pde`, which does that as its own first import) before something else has warmed `mixle.stats.bayes.dirichlet` hits a real ImportError: `dirichlet.py`'s top-level `from mixle.inference.fisher import FixedFisherView` triggers `mixle.inference`'s package-init, which eagerly imports `risk.py`, which cascades through `analysis -> reason -> ... -> mixle.stats.latent.mixture`, which imports `DirichletDistribution` back from the still-executing `dirichlet.py`.

Fix mirrors the existing lazy-export pattern already used for `mixle.inference.condition`/`scenario` (see the comments already in `mixle/inference/__init__.py` describing that exact hazard): `mixture.py`'s `DirichletDistribution`/`SymmetricDirichletDistribution` imports are deferred to call time via a small `_dirichlet_types()` helper, and `mixle.inference`'s `risk` re-exports (`conditional_value_at_risk`/`stress_rank`/`value_at_risk`) are now lazy the same way.

Found while wiring an external LLM backend through `mixle-mlops`'s `OpenAICompatAdapter` for an end-to-end test that also exercises `mixle_pde.simulate()` — that's the first thing that imports `mixle.ppl` fresh in a new process.