### PR TITLE
Fix int64/float64 dtype mismatch in Markov-chain scoring for all-length-1 corpora

### DIFF
--- a/mixle/stats/sequences/markov_chain.py
+++ b/mixle/stats/sequences/markov_chain.py
@@ -462,8 +462,15 @@ class MarkovChainDistribution(SequenceEncodableProbabilityDistribution):
 
         loc_key_map = np.asarray([self.key_map.get(u, 0) for u in inv_key_map])
 
-        temp = self.trans_log_pvec[loc_key_map[prev_x], loc_key_map[next_x]].toarray().flatten() - self.log1p_dv
-        rv = np.bincount(idx1, weights=temp, minlength=sz)
+        # np.bincount(weights=...) silently returns an int64 (not float64) array when both `idx1` and
+        # `weights` are empty -- the case for length-1 sequences (no transitions, only an initial
+        # state) -- which then breaks the float `+=` below with a same-kind casting error. Mirrors the
+        # `rv = np.zeros(sz, dtype=float)` + `if len(idx1) > 0` guard already used above in
+        # `model_log_density` for the identical reason.
+        rv = np.zeros(sz, dtype=float)
+        if len(idx1) > 0:
+            temp = self.trans_log_pvec[loc_key_map[prev_x], loc_key_map[next_x]].toarray().flatten() - self.log1p_dv
+            rv = np.bincount(idx1, weights=temp, minlength=sz)
         rv[idx0] += self.init_log_pvec[loc_key_map[init_x]] - self.log1p_dv
 
         if len_enc is not None:

--- a/mixle/tests/markov_chain_encode_test.py
+++ b/mixle/tests/markov_chain_encode_test.py
@@ -105,6 +105,20 @@ class ChainEncodeParityTest(unittest.TestCase):
         per_row = [d.log_density(seq) for seq in data]
         np.testing.assert_allclose(d.seq_log_density(enc), per_row, rtol=1e-12)
 
+    def test_scoring_an_all_length_one_corpus_does_not_crash_or_misscore(self):
+        """A corpus where EVERY sequence has length 1 (idx1/prev/next all empty -- e.g. a
+        single-domain task decomposition fit) used to crash `seq_log_density` with a numpy
+        same-kind casting error: `np.bincount([], weights=[], minlength=n)` silently returns
+        int64 zeros (not float64) when both its inputs are empty, and the subsequent
+        `rv[idx0] += <float log-density>` then fails to cast. `test_scoring_parity_end_to_end`
+        above doesn't catch this because it mixes lengths 1-6, so `idx1` is never globally empty."""
+        states = ["a", "b", "c"]
+        d = _chain(states)
+        data = [["a"], ["b"], ["a"], ["c"]]
+        enc = d.dist_to_encoder().seq_encode(data)
+        per_row = [d.log_density(seq) for seq in data]
+        np.testing.assert_allclose(d.seq_log_density(enc), per_row, rtol=1e-12)
+
 
 class CompositeValidationFastPathTest(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
`MarkovChainDistribution.seq_log_density` crashed with a numpy same-kind casting error whenever EVERY sequence in the scored corpus has length 1 (no transitions at all — e.g. fitting `mixle.task.task_decomposition.init_decomposition_proposer` on a single-domain decomposition). Root cause: `np.bincount(idx1, weights=temp, minlength=sz)` silently returns `int64` zeros instead of `float64` when both `idx1` and `weights` are empty; the following `rv[idx0] += <float log-density>` then fails to cast.

Fix mirrors the identical guard already used 140 lines above in the same file's `model_log_density` (`rv = np.zeros(sz, dtype=float)` + only bincount when `len(idx1) > 0`) — same bug, same fix, previously only patched in one of the two call sites.

Found while wiring the M3 `route_task`/`knowledge_routing` orchestration end-to-end against a real multi-stage tool pipeline — a single-domain stage's decomposition proposer hit this immediately.