### PR TITLE
Close the pickle-execution trust boundary in model deserialization

### DIFF
--- a/mixle/data/encoded_io.py
+++ b/mixle/data/encoded_io.py
@@ -2,15 +2,23 @@
 
 ``seq_encode`` turns raw records into an encoder-specific payload (nested tuples of NumPy arrays). Fitting
 re-encodes every call; for large datasets that is the dominant cost. ``save_encoded``/``load_encoded``
-persist the encoded payload (with an integrity digest and the encoder's identity) so subsequent fits load
-it directly. Format is pickle (the payloads are internal numeric structures); a content digest is stored
-and verified on load, and the encoder's class name is recorded so a payload is not silently loaded against
-a mismatched encoder.
+persist the encoded payload (with a content digest and the encoder's identity) so subsequent fits load it
+directly. The body is pickle (the payloads are internal numeric structures with no safe-JSON registry
+representation); the header carrying the digest and encoder name is plain JSON, deliberately never pickle,
+so reading it cannot itself execute code -- only the digest-verified body is ever unpickled, and only
+after its digest is checked.
+
+This digest is corruption-detection, not authentication: it is computed from and stored inside the same
+file, so it catches truncation/bit-rot but cannot prove the file was not tampered with by whoever could
+already write to ``path`` -- callers should still treat ``load_encoded`` like any other local pickle load
+and only point it at a path they trust, exactly as :func:`mixle.lifecycle.Model.load` documents for its
+own pickle-format artifacts.
 """
 
 from __future__ import annotations
 
 import hashlib
+import json
 import pickle
 from typing import Any
 
@@ -26,7 +34,7 @@ def save_encoded(encoded: Any, path: str, *, encoder: Any = None) -> str:
     meta = {"digest": digest, "encoder": type(encoder).__name__ if encoder is not None else None}
     with open(path, "wb") as f:
         f.write(_MAGIC)
-        f.write(pickle.dumps(meta, protocol=pickle.HIGHEST_PROTOCOL))
+        f.write(json.dumps(meta).encode("utf-8"))
         f.write(b"\n")
         f.write(body)
     return digest
@@ -35,7 +43,9 @@ def save_encoded(encoded: Any, path: str, *, encoder: Any = None) -> str:
 def load_encoded(path: str, *, encoder: Any = None) -> Any:
     """Load encoded data written by :func:`save_encoded`, verifying its integrity digest.
 
-    If ``encoder`` is given, its class must match the one recorded at save time (else ``ValueError``)."""
+    The header is parsed as JSON (never pickle) and the body's digest is checked BEFORE it is
+    unpickled, so a truncated or corrupted file is rejected before any deserialization runs. If
+    ``encoder`` is given, its class must match the one recorded at save time (else ``ValueError``)."""
     with open(path, "rb") as f:
         if f.read(len(_MAGIC)) != _MAGIC:
             raise ValueError(f"{path!r} is not a mixle encoded-data file")
@@ -45,10 +55,13 @@ def load_encoded(path: str, *, encoder: Any = None) -> Any:
             if c in (b"\n", b""):
                 break
             meta_line += c
-        meta = pickle.loads(meta_line)
+        try:
+            meta = json.loads(meta_line.decode("utf-8"))
+        except (UnicodeDecodeError, ValueError) as exc:
+            raise ValueError(f"{path!r} has a corrupt header") from exc
         body = f.read()
-    if hashlib.sha256(body).hexdigest() != meta["digest"]:
+    if hashlib.sha256(body).hexdigest() != meta.get("digest"):
         raise ValueError(f"{path!r} failed its integrity check (corrupt or truncated)")
-    if encoder is not None and meta["encoder"] is not None and type(encoder).__name__ != meta["encoder"]:
+    if encoder is not None and meta.get("encoder") is not None and type(encoder).__name__ != meta["encoder"]:
         raise ValueError(f"encoder mismatch: file was encoded with {meta['encoder']}, got {type(encoder).__name__}")
-    return pickle.loads(body)
+    return pickle.loads(body)  # noqa: S301 - digest-verified above; still a local-trust artifact, see module docstring

--- a/mixle/inference/production/registry.py
+++ b/mixle/inference/production/registry.py
@@ -163,11 +163,22 @@ class Registry:
             raise KeyError(f"{name!r} has no version {version!r}")
         return version
 
-    def get(self, name: str, version: str = "latest") -> tuple[Any, dict | None]:
-        """Load ``(model, header)`` for a version (``"latest"`` = highest-numbered)."""
+    def get(self, name: str, version: str = "latest", *, trust_code: bool = False) -> tuple[Any, dict | None]:
+        """Load ``(model, header)`` for a version (``"latest"`` = highest-numbered).
+
+        A registered model containing a NeuralLeaf-family component embeds its weights as a pickle
+        blob (see :mod:`mixle.models._neural_serial`); deserializing that executes code, so ``get``
+        requires ``trust_code=True`` for such an entry -- trust the registry root, not just the JSON
+        extension. A pure-statistical entry loads either way.
+        """
         version = self._resolve_version(name, version)
         with open(os.path.join(self._model_dir(name, create=False), version + ".json")) as f:
             payload = json.load(f)
+        if trust_code:
+            from mixle.utils.serialization import trusted_deserialization
+
+            with trusted_deserialization():
+                return from_serializable(payload["model"]), payload.get("header")
         return from_serializable(payload["model"]), payload.get("header")
 
     def header(self, name: str, version: str = "latest") -> dict | None:
@@ -189,13 +200,16 @@ class Registry:
         with open(os.path.join(self._dir(name), _safe_segment(alias, "alias") + ".alias"), "w") as f:
             f.write(version)
 
-    def current(self, name: str, alias: str = "production") -> tuple[Any, dict | None]:
-        """Load the model an ``alias`` points at (falls back to ``latest`` if the alias is unset)."""
+    def current(self, name: str, alias: str = "production", *, trust_code: bool = False) -> tuple[Any, dict | None]:
+        """Load the model an ``alias`` points at (falls back to ``latest`` if the alias is unset).
+
+        See :meth:`get` -- ``trust_code`` is required in the same way and for the same reason.
+        """
         p = os.path.join(self._model_dir(name, create=False), _safe_segment(alias, "alias") + ".alias")
         # the version READ FROM the alias file is still resolved against the known version list by get(),
         # so a tampered alias file cannot traverse either.
         version = open(p).read().strip() if os.path.exists(p) else "latest"
-        return self.get(name, version)
+        return self.get(name, version, trust_code=trust_code)
 
     def verify_chain(self, name: str) -> bool:
         """Verify the persisted checkpoint lineage for ``name`` (see :meth:`checkpointer`).

--- a/mixle/lifecycle.py
+++ b/mixle/lifecycle.py
@@ -24,6 +24,7 @@ and :func:`mixle.describe`. It adds no new inference -- only one place to stand.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import pickle
 import time
@@ -279,30 +280,46 @@ class Model:
         return "json"
 
     @classmethod
-    def load(cls, path: str) -> Model:
+    def load(cls, path: str, *, trust_code: bool = False) -> Model:
         """Restore a :class:`Model` from an artifact directory created by :meth:`deploy`.
 
         .. warning::
 
-           A ``pickle``-format artifact (a torch-backed model, or one written by an older mixle) is loaded
-           with :func:`pickle.load`, which **executes arbitrary code** from the file -- only load such an
-           artifact from a source you trust. JSON-format artifacts (the default for pure mixle models) are
-           deserialized through the type-tagged registry and do not execute arbitrary code.
+           A ``pickle``-format artifact (a torch-backed model, or one written by an older mixle)
+           executes arbitrary code from the file when loaded, exactly like ``pickle.load`` on any
+           untrusted input. JSON-format artifacts are deserialized through a type-tagged registry that
+           never imports or executes code from the payload -- **unless** the model contains a
+           NeuralLeaf-family component, whose weights are embedded as a pickle blob inside the
+           otherwise-safe JSON (see :mod:`mixle.models._neural_serial`); loading one of those also
+           executes code. There is no way to tell which case applies without attempting the load.
+
+           Because of this, ``load`` refuses to run any code-executing path unless the caller passes
+           ``trust_code=True`` -- an explicit statement that the artifact's source is trusted. Without
+           it, a pickle-format artifact raises immediately, and a JSON artifact raises only if it
+           actually contains an embedded module (a pure-statistical model still loads normally).
         """
+        from mixle.utils.serialization import SerializationError, trusted_deserialization
+
         p = Path(path)
         try:
             manifest = json.loads((p / "manifest.json").read_text())
         except (OSError, ValueError):
             manifest = {}
         fmt = manifest.get("format", "pickle")  # artifacts predating the format field are pickle-only
-        if fmt == "json":
-            from mixle.utils.serialization import ensure_pysp_serialization_registry, from_serializable
+        with trusted_deserialization() if trust_code else contextlib.nullcontext():
+            if fmt == "json":
+                from mixle.utils.serialization import ensure_pysp_serialization_registry, from_serializable
 
-            ensure_pysp_serialization_registry()
-            fitted = from_serializable(json.loads((p / "model.json").read_text()))
-        else:
-            with open(p / "model.pkl", "rb") as f:
-                fitted = pickle.load(f)  # noqa: S301 - trusted-source only; see the warning above
+                ensure_pysp_serialization_registry()
+                fitted = from_serializable(json.loads((p / "model.json").read_text()))
+            else:
+                if not trust_code:
+                    raise SerializationError(
+                        f"{path!r} is a pickle-format artifact: loading it executes arbitrary code from "
+                        "the file. Pass trust_code=True to Model.load() only if you trust its source."
+                    )
+                with open(p / "model.pkl", "rb") as f:
+                    fitted = pickle.load(f)  # noqa: S301 - trust_code=True required by the caller above
         m = cls(fitted)
         m.fitted = fitted
         m.notes = list(manifest.get("notes", []))

--- a/mixle/models/_neural_serial.py
+++ b/mixle/models/_neural_serial.py
@@ -8,6 +8,11 @@ hooks (so a leaf inside a ``MixtureDistribution`` serializes too) by persisting 
 The module round-trips through ``torch.save``/``torch.load`` of a ``pickle`` byte buffer -- which requires the
 wrapped nn.Module class to be reachable at module level (that is why the ``build_*`` helpers were hoisted). The
 bytes are base64-encoded so the whole payload is plain JSON.
+
+That byte buffer is still a full-object pickle, so decoding it executes arbitrary code for a malicious
+input -- exactly like unpickling an untrusted file -- even though the surrounding artifact is nominally
+"JSON format". :func:`module_from_bytes` refuses to run unless the caller has opened
+``mixle.utils.serialization.trusted_deserialization()``; see that function for why.
 """
 
 from __future__ import annotations
@@ -30,12 +35,27 @@ def module_to_bytes(module: Any) -> bytes:
 
 
 def module_from_bytes(data: bytes) -> Any:
-    """Reconstruct a torch nn.Module previously encoded by :func:`module_to_bytes`."""
+    """Reconstruct a torch nn.Module previously encoded by :func:`module_to_bytes`.
+
+    This unpickles a full object graph (architecture + weights), which executes arbitrary code for a
+    malicious byte string -- exactly like ``pickle.load`` on an untrusted file, regardless of whether
+    the caller arrived here through a nominally "JSON" artifact (a NeuralLeaf's state embeds this blob
+    base64-encoded inside otherwise-safe JSON). Refuses by default; the caller must open
+    ``mixle.utils.serialization.trusted_deserialization()`` around a load it knows the source of.
+    """
+    from mixle.utils.serialization import SerializationError, deserialization_is_trusted
+
+    if not deserialization_is_trusted():
+        raise SerializationError(
+            "refusing to deserialize an embedded torch module: this executes arbitrary code from the "
+            "artifact, the same as pickle.load on an untrusted file. Only load a model from a source "
+            "you trust, and do so inside 'with mixle.utils.serialization.trusted_deserialization():'."
+        )
     import torch
 
     buf = io.BytesIO(bytes(data))
     try:
-        return torch.load(buf, weights_only=False)  # full module (arch + weights); trusted local artifact
+        return torch.load(buf, weights_only=False)  # full module (arch + weights); trust gate above
     except TypeError:  # torch < 2.0 has no weights_only kwarg
         buf.seek(0)
         return torch.load(buf)

--- a/mixle/models/language_model.py
+++ b/mixle/models/language_model.py
@@ -128,8 +128,17 @@ class LM:
 
         Returns a model ready for scoring/generation; this is not a training-resume checkpoint (see
         :meth:`save`), so optimizer/step/RNG/data-loader state is not restored.
+
+        Loaded with ``weights_only=True``: :meth:`to_dict`'s payload is plain config scalars plus a
+        tensor ``state_dict``, never an arbitrary object graph, so this does not execute code from the
+        file (unlike a full-module pickle -- see ``mixle.models._neural_serial`` for that case).
         """
-        return cls.from_dict(_torch().load(path, weights_only=False))
+        torch = _torch()
+        try:
+            payload = torch.load(path, weights_only=True)
+        except TypeError:  # torch < 1.13 has no weights_only kwarg
+            payload = torch.load(path)
+        return cls.from_dict(payload)
 
     def fit(
         self,

--- a/mixle/tests/language_model_persistence_test.py
+++ b/mixle/tests/language_model_persistence_test.py
@@ -9,6 +9,7 @@ RNG, data-loader position, or scaler state (that contract lives in
 gaining the checkpoint fields -- which would fail here.
 """
 
+import pickle
 import tempfile
 import unittest
 
@@ -44,6 +45,10 @@ def _tiny_lm():
     return LM(vocab=16, d_model=8, n_layer=1, n_head=2, block=4, device="cpu")
 
 
+class _NotAWeight:
+    """A plain object outside torch's weights_only allowlist -- stands in for an exploit payload."""
+
+
 class LMPersistenceContractTest(unittest.TestCase):
     def test_to_dict_is_inference_artifact_only(self):
         payload = _tiny_lm().to_dict()
@@ -67,6 +72,18 @@ class LMPersistenceContractTest(unittest.TestCase):
             after = loaded.module(torch.zeros(1, 4, dtype=torch.long))
         # a loaded artifact reproduces the model's outputs (scoring-ready), no training state needed
         self.assertTrue(torch.allclose(before, after, atol=1e-6))
+
+    def test_load_rejects_a_non_weights_payload(self):
+        # LM.load must use torch.load(weights_only=True): the payload is plain config scalars plus a
+        # tensor state_dict, never an arbitrary object, so a file smuggling a non-tensor/container
+        # object (the shape an exploit would need) must be refused rather than unpickled.
+        import torch
+
+        with tempfile.TemporaryDirectory() as d:
+            path = f"{d}/lm.pt"
+            torch.save({"payload": _NotAWeight()}, path)
+            with self.assertRaises(pickle.UnpicklingError):
+                LM.load(path)
 
 
 if __name__ == "__main__":

--- a/mixle/tests/lifecycle_test.py
+++ b/mixle/tests/lifecycle_test.py
@@ -113,14 +113,40 @@ class LifecycleTest(unittest.TestCase):
             back = mixle.Model.load(path)
             self.assertAlmostEqual(back.fitted.log_density("a"), m.fitted.log_density("a"), places=10)
 
+    @unittest.skipUnless(_HAS_TORCH, "torch not installed")
+    def test_neural_json_artifact_requires_trust_code(self):
+        # A "json"-format artifact whose model embeds a NeuralLeaf carries a pickle-backed torch module
+        # inside otherwise-safe JSON; loading it must require the same explicit trust as a pickle
+        # artifact, or the "JSON does not execute code" claim above would be false for this case.
+        import os
+
+        import mixle
+        from mixle.models.neural import make_mlp
+        from mixle.models.neural_leaf import NeuralGaussian
+        from mixle.utils.serialization import SerializationError
+
+        module = make_mlp(input_dim=1, hidden_dims=[8], output_dim=2)
+        dist = NeuralGaussian(module)
+        m = mixle.Model(dist)
+        m.fitted = dist
+        with tempfile.TemporaryDirectory() as d:
+            path = m.deploy(d + "/neural")
+            self.assertIn("model.json", os.listdir(path))  # registry-serializable, so still "json" format
+            with self.assertRaises(SerializationError):
+                mixle.Model.load(path)
+            back = mixle.Model.load(path, trust_code=True)
+            self.assertIsInstance(back.fitted, NeuralGaussian)
+
     def test_legacy_pickle_artifact_still_loads(self):
-        # Artifacts written before the JSON format (manifest without a "format" field) still load via pickle.
+        # Artifacts written before the JSON format (manifest without a "format" field) still load via
+        # pickle -- but only when the caller explicitly trusts the source (pickle execs arbitrary code).
         import json
         import os
         import pickle
 
         import mixle
         from mixle.stats import CategoricalEstimator
+        from mixle.utils.serialization import SerializationError
 
         fitted = mixle.Model(CategoricalEstimator()).fit(["a", "b", "a"]).fitted
         with tempfile.TemporaryDirectory() as d:
@@ -128,7 +154,9 @@ class LifecycleTest(unittest.TestCase):
                 pickle.dump(fitted, f)
             with open(os.path.join(d, "manifest.json"), "w") as f:
                 f.write(json.dumps({"notes": ["legacy"]}))  # no "format" -> defaults to pickle
-            back = mixle.Model.load(d)
+            with self.assertRaises(SerializationError):
+                mixle.Model.load(d)  # refuses without an explicit trust_code=True
+            back = mixle.Model.load(d, trust_code=True)
             self.assertEqual(back.notes, ["legacy"])
             self.assertAlmostEqual(back.fitted.log_density("a"), fitted.log_density("a"), places=10)
 

--- a/mixle/tests/lm_serialization_test.py
+++ b/mixle/tests/lm_serialization_test.py
@@ -98,17 +98,18 @@ class LeafSerializationTest(unittest.TestCase):
     def test_streaming_transformer_to_dict_and_json_preserve_seq_log_density(self):
         from mixle.models.streaming_transformer_leaf import StreamingTransformer
         from mixle.models.transformer import build_causal_lm
-        from mixle.utils.serialization import from_json, to_json
+        from mixle.utils.serialization import from_json, to_json, trusted_deserialization
 
         torch.manual_seed(0)
         st = StreamingTransformer(build_causal_lm(10, d_model=32, n_layer=2, n_head=4, block=8))
         enc = (np.zeros((4, 8), dtype=float), np.array([1, 2, 3, 4]))
         d0 = st.seq_log_density(enc)
 
-        st_d = StreamingTransformer.from_dict(st.to_dict())
-        np.testing.assert_array_equal(st_d.seq_log_density(enc), d0)
+        with trusted_deserialization():  # embedded torch module: a self-produced, trusted round-trip
+            st_d = StreamingTransformer.from_dict(st.to_dict())
+            np.testing.assert_array_equal(st_d.seq_log_density(enc), d0)
 
-        st_j = from_json(to_json(st))
+            st_j = from_json(to_json(st))
         self.assertIsInstance(st_j, StreamingTransformer)
         np.testing.assert_array_equal(st_j.seq_log_density(enc), d0)
 
@@ -127,7 +128,7 @@ class LeafSerializationTest(unittest.TestCase):
     def test_dpo_model_to_dict_and_json_preserve_seq_log_density(self):
         from mixle.models.dpo_leaf import DPOModel
         from mixle.models.transformer import build_causal_lm
-        from mixle.utils.serialization import from_json, to_json
+        from mixle.utils.serialization import from_json, to_json, trusted_deserialization
 
         torch.manual_seed(0)
         policy = build_causal_lm(10, d_model=32, n_layer=2, n_head=4, block=8)
@@ -135,11 +136,12 @@ class LeafSerializationTest(unittest.TestCase):
         enc = (np.zeros((3, 8), dtype=float), np.array([1, 2, 3]), np.array([4, 5, 6]))
         e0 = dm.seq_log_density(enc)
 
-        dm_d = DPOModel.from_dict(dm.to_dict())
-        self.assertEqual(dm_d.beta, 0.1)
-        np.testing.assert_array_equal(dm_d.seq_log_density(enc), e0)
+        with trusted_deserialization():  # embedded torch module: a self-produced, trusted round-trip
+            dm_d = DPOModel.from_dict(dm.to_dict())
+            self.assertEqual(dm_d.beta, 0.1)
+            np.testing.assert_array_equal(dm_d.seq_log_density(enc), e0)
 
-        dm_j = from_json(to_json(dm))
+            dm_j = from_json(to_json(dm))
         self.assertIsInstance(dm_j, DPOModel)
         np.testing.assert_array_equal(dm_j.seq_log_density(enc), e0)
 

--- a/mixle/tests/neural_families_test.py
+++ b/mixle/tests/neural_families_test.py
@@ -84,17 +84,23 @@ def test_neural_density_estimator_is_directly_constructible():
 
 
 def test_family_json_round_trip_preserves_type_and_scores():
+    from mixle.utils.serialization import trusted_deserialization
+
     a = VAE(dim=4, latent=2)
-    b = from_json(to_json(a))
+    with trusted_deserialization():  # embedded torch module: a self-produced, trusted round-trip
+        b = from_json(to_json(a))
     assert type(b).__name__ == "VAE"
     xs = np.atleast_2d(np.asarray(_data(), dtype=float))
     assert np.allclose(a.seq_log_density(xs), b.seq_log_density(xs))
 
 
 def test_mixture_with_a_family_round_trips():
+    from mixle.utils.serialization import trusted_deserialization
+
     x = _data()
     g = MultivariateGaussianDistribution(np.zeros(4), np.eye(4))
     fitted = optimize(x, MixtureDistribution([VAE(dim=4, latent=2), g], [0.5, 0.5]).estimator(), max_its=2, out=None)
-    back = from_json(to_json(fitted))
+    with trusted_deserialization():  # embedded torch module: a self-produced, trusted round-trip
+        back = from_json(to_json(fitted))
     enc = fitted.dist_to_encoder().seq_encode(x)
     assert np.allclose(fitted.seq_log_density(enc), back.seq_log_density(back.dist_to_encoder().seq_encode(x)))

--- a/mixle/tests/neural_leaf_serialization_test.py
+++ b/mixle/tests/neural_leaf_serialization_test.py
@@ -115,11 +115,14 @@ class PickleRoundTripTest(unittest.TestCase):
 
 class DictJsonRoundTripTest(unittest.TestCase):
     def _check(self, cls, dist, enc):
+        from mixle.utils.serialization import trusted_deserialization
+
         ll = dist.seq_log_density(enc)
-        d = cls.from_dict(dist.to_dict())
-        self.assertTrue(np.allclose(d.seq_log_density(enc), ll, atol=1e-5), "to_dict")
-        j = cls.from_json(dist.to_json())
-        self.assertTrue(np.allclose(j.seq_log_density(enc), ll, atol=1e-5), "to_json")
+        with trusted_deserialization():  # embedded torch module: a self-produced, trusted round-trip
+            d = cls.from_dict(dist.to_dict())
+            self.assertTrue(np.allclose(d.seq_log_density(enc), ll, atol=1e-5), "to_dict")
+            j = cls.from_json(dist.to_json())
+            self.assertTrue(np.allclose(j.seq_log_density(enc), ll, atol=1e-5), "to_json")
 
     def test_unconditional_leaves_dict_json(self):
         classes = {"energy": EnergyModel}
@@ -140,9 +143,48 @@ class DictJsonRoundTripTest(unittest.TestCase):
         x = np.random.RandomState(0).randn(5, 2)
         enc = mix.dist_to_encoder().seq_encode([r for r in x])
         ll = mix.seq_log_density(enc)
-        m2 = st.MixtureDistribution.from_json(mix.to_json())
+        from mixle.utils.serialization import trusted_deserialization
+
+        with trusted_deserialization():  # embedded torch module: a self-produced, trusted round-trip
+            m2 = st.MixtureDistribution.from_json(mix.to_json())
         got = m2.seq_log_density(m2.dist_to_encoder().seq_encode([r for r in x]))
         self.assertTrue(np.allclose(got, ll, atol=1e-5))
+
+
+class ModuleDeserializationTrustGateTest(unittest.TestCase):
+    """A NeuralLeaf's JSON round-trip must refuse to execute its embedded module without explicit trust."""
+
+    def test_from_json_refuses_without_trusted_deserialization(self):
+        from mixle.utils.serialization import SerializationError
+
+        dist = NeuralGaussian(_mlp_gaussian())
+        payload = dist.to_json()
+        with self.assertRaises(SerializationError):
+            NeuralGaussian.from_json(payload)  # gate closed by default: no trust context entered
+
+    def test_module_from_bytes_refuses_directly(self):
+        from mixle.models._neural_serial import module_from_bytes, module_to_bytes
+        from mixle.utils.serialization import SerializationError
+
+        data = module_to_bytes(_mlp_gaussian())
+        with self.assertRaises(SerializationError):
+            module_from_bytes(data)
+
+    def test_module_from_bytes_succeeds_inside_trusted_deserialization(self):
+        from mixle.models._neural_serial import module_from_bytes, module_to_bytes
+        from mixle.utils.serialization import trusted_deserialization
+
+        module = _mlp_gaussian()
+        data = module_to_bytes(module)
+        with trusted_deserialization():
+            restored = module_from_bytes(data)
+        self.assertEqual(type(restored).__name__, type(module).__name__)
+
+
+def _mlp_gaussian():
+    from mixle.models.neural import make_mlp
+
+    return make_mlp(input_dim=1, hidden_dims=[4], output_dim=2)
 
 
 class NeuralCategoricalMinibatchTest(unittest.TestCase):

--- a/mixle/tests/pinn_test.py
+++ b/mixle/tests/pinn_test.py
@@ -168,7 +168,10 @@ class PINNRegressionSerializationTest(unittest.TestCase):
             name="ode-model",
         )
         payload = model.to_dict()
-        restored = PINNRegression.from_dict(payload)
+        from mixle.utils.serialization import trusted_deserialization
+
+        with trusted_deserialization():  # embedded torch module: a self-produced, trusted round-trip
+            restored = PINNRegression.from_dict(payload)
 
         grid = np.linspace(-2.0, 2.0, 5)[:, None]
         np.testing.assert_allclose(model._forward(grid), restored._forward(grid), atol=1e-6)

--- a/mixle/tests/provenance_test.py
+++ b/mixle/tests/provenance_test.py
@@ -135,6 +135,39 @@ class EncodedIoTest(unittest.TestCase):
             with self.assertRaises(ValueError):
                 load_encoded(path)
 
+    def test_header_is_json_not_pickle(self):
+        # The header carrying the digest must be plain JSON: parsing it must never itself be able to
+        # execute code, unlike the digest-verified pickle body that follows it.
+        import json
+
+        enc = GaussianDistribution(0, 1).dist_to_encoder().seq_encode([1.0, 2.0])
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "enc.pspenc")
+            save_encoded(enc, path, encoder=GaussianDistribution(0, 1).dist_to_encoder())
+            with open(path, "rb") as f:
+                magic = f.read(8)
+                header_line = f.readline()
+            self.assertEqual(magic, b"PSPENC1\n")
+            meta = json.loads(header_line)  # raises if this were pickle bytes, not JSON
+            self.assertEqual(len(meta["digest"]), 64)
+            self.assertIn("Gaussian", meta["encoder"])
+
+    def test_header_digest_mismatch_rejected(self):
+        # A header whose digest does not match the body must be rejected, including when the body
+        # itself is well-formed pickle -- proving the check gates on the digest, not on a parse error.
+        enc = GaussianDistribution(0, 1).dist_to_encoder().seq_encode([1.0, 2.0])
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "enc.pspenc")
+            save_encoded(enc, path)
+            with open(path, "rb") as f:
+                raw = f.read()
+            nl = raw.index(b"\n", 8)
+            tampered = raw[: nl + 1].replace(b'"digest": "', b'"digest": "0000000000000000') + raw[nl + 1 :]
+            with open(path, "wb") as f:
+                f.write(tampered)
+            with self.assertRaises(ValueError):
+                load_encoded(path)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/mixle/utils/serialization.py
+++ b/mixle/utils/serialization.py
@@ -9,12 +9,14 @@ mixle's own distribution modules.
 from __future__ import annotations
 
 import base64
+import contextlib
+import contextvars
 import importlib
 import inspect
 import json
 import math
 import pkgutil
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Iterator
 from typing import Any
 
 import numpy as np
@@ -34,9 +36,48 @@ _CALLABLE_IDS: dict[Callable[..., Any], str] = {}
 _REGISTRY_READY = False
 _OPTIONAL_IMPORT_NAMES = {"torch", "umap", "pyspark"}
 
+# Trust gate for code-executing deserialization (currently: an embedded torch module, persisted as a
+# full-object pickle -- see mixle.models._neural_serial). The type-tagged registry walk above this gate
+# is closed (only registered mixle classes are reconstructed, never an arbitrary imported class), but a
+# NeuralLeaf-family object's state embeds a pickle blob that DOES execute arbitrary code on load, which
+# defeats that guarantee wherever such a leaf is nested. Default-closed: any decode that reaches an
+# embedded module blob without this gate open raises SerializationError instead of silently unpickling
+# it, so "this artifact is JSON-format" is no longer a false safety claim. Callers that DO trust the
+# artifact's source open the gate explicitly with :func:`trusted_deserialization`.
+_TRUST_CODE_EXECUTION: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    "mixle_trust_code_execution", default=False
+)
+
 
 class SerializationError(ValueError):
     """Raised when an object cannot be serialized or decoded safely."""
+
+
+def deserialization_is_trusted() -> bool:
+    """Whether the current context has opted into code-executing deserialization.
+
+    Checked by :mod:`mixle.models._neural_serial` before unpickling an embedded torch module. Not
+    needed for the ordinary registry-based path (:func:`from_serializable` on a payload with no
+    embedded module blob), which never executes code regardless of this flag.
+    """
+    return _TRUST_CODE_EXECUTION.get()
+
+
+@contextlib.contextmanager
+def trusted_deserialization() -> Iterator[None]:
+    """Permit code-executing deserialization (an embedded torch module) for this ``with`` block.
+
+    Only enter this around an artifact whose SOURCE you trust: within the block, decoding a
+    NeuralLeaf-family object (or anything else that persists live code/objects via pickle) executes
+    that pickle's ``__reduce__``/``__setstate__`` arbitrarily, exactly like ``pickle.load`` on an
+    untrusted file. Nested/re-entrant use is safe (the gate stays open until the outermost block
+    exits); safe to use across threads/async tasks via ``contextvars`` propagation.
+    """
+    token = _TRUST_CODE_EXECUTION.set(True)
+    try:
+        yield
+    finally:
+        _TRUST_CODE_EXECUTION.reset(token)
 
 
 def _type_id(cls: type[Any]) -> str:


### PR DESCRIPTION
Three confirmed defects reported by an external code review, all sharing one root cause: a code path presented as safe (JSON format, or a digest-checked cache file) that silently executes arbitrary pickle content on load.

## 1. NeuralLeaf-family objects break the "JSON does not execute code" guarantee

Registered neural leaves persist their torch module via a full-object pickle (`mixle.models._neural_serial.module_to_bytes`/`module_from_bytes`), base64-embedded inside otherwise type-tagged-registry JSON. Any model containing one therefore executes arbitrary code on load, through the exact path `Model.load()`'s own docstring claimed was code-free.

`module_from_bytes` now refuses by default. A new `mixle.utils.serialization.trusted_deserialization()` context manager is the one way to open it. `Model.load()` gains `trust_code: bool = False` — required for *both* the legacy pickle format and any JSON artifact that turns out to contain an embedded module. `ProductionRegistry.get()`/`current()` get the same gate, since they reach the identical code path.

## 2. `encoded_io.load_encoded()` unpickled its header before any check ran

The metadata header (digest + encoder name) was itself pickled and unpickled unconditionally — with **zero digest protection** — before the body's digest was even checked. The header is now JSON (never pickle); only the digest-verified body is ever unpickled, and only after its digest passes.

## 3. `LM.load()` used `weights_only=False` where `weights_only=True` was sufficient

Unlike the neural leaves, `LM.to_dict()`'s payload is plain config scalars plus a tensor `state_dict` — never an arbitrary object graph. Switched to `weights_only=True`, which is strictly safer with no format change needed.

## Testing

- Existing round-trip tests for NeuralLeaf/DPO/streaming-transformer/VAE `to_dict`/`to_json` now open `trusted_deserialization()` around their self-produced round-trips (the new required usage for a trusted in-process round-trip).
- New tests pin: the trust gate refusing/succeeding directly, a neural JSON artifact requiring `trust_code=True` end to end, `encoded_io`'s header being JSON (not pickle) and its digest check rejecting tampering, and `LM.load()` rejecting a non-weights payload under `weights_only=True`.
- Full local gate: 5,180 passed. The 3 remaining failures (stale API/maturity manifests) are pre-existing on the unmodified base commit — verified via `git stash` — and unrelated to this change.
