### PR TITLE
Enable CI collection of the 35 test_*.py files it was silently skipping

### DIFF
--- a/mixle/tests/test_n2_habitat_constraints.py
+++ b/mixle/tests/test_n2_habitat_constraints.py
@@ -4,11 +4,19 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
-from mixle_knowledge.contracts import CriticalHabitatDesignation, ListedSpecies, SourceRef, SpatialBounds
 
-from mixle.analysis.habitat_constraints import apply_habitat_constraints, critical_habitat_exclusion
-from mixle.analysis.sdm import HabitatModel
-from mixle.relations import min_cost_flow
+# mixle_knowledge (PRJ-KNW) is a sibling repository, not a declared dependency of mixle core: these
+# fixture contract types are convenient here but must not make this file uncollectable in a plain
+# `pip install -e .` environment. See mixle/tests/test_substrate_knowledge_bundle.py for the same idiom.
+knowledge_contracts = pytest.importorskip("mixle_knowledge.contracts")
+CriticalHabitatDesignation = knowledge_contracts.CriticalHabitatDesignation
+ListedSpecies = knowledge_contracts.ListedSpecies
+SourceRef = knowledge_contracts.SourceRef
+SpatialBounds = knowledge_contracts.SpatialBounds
+
+from mixle.analysis.habitat_constraints import apply_habitat_constraints, critical_habitat_exclusion  # noqa: E402
+from mixle.analysis.sdm import HabitatModel  # noqa: E402
+from mixle.relations import min_cost_flow  # noqa: E402
 
 
 def _habitat_model(mean_targets: np.ndarray, *, prior_dominated: bool = False) -> HabitatModel:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -191,7 +191,7 @@ forbidden_modules = [
 
 [tool.pytest.ini_options]
 testpaths = ["mixle/tests"]
-python_files = ["*_test.py"]
+python_files = ["*_test.py", "test_*.py"]
 python_classes = ["*Test", "*TestCase"]
 python_functions = ["test_*"]
 # Fast + parallel by default: plain `pytest` runs the `fast` gate under `-n auto` in a few minutes on a


### PR DESCRIPTION
`pytest.ini_options.python_files` matched only `*_test.py`, so every file named `test_*.py` — **35 files, 165 tests** — was invisible to both the fast and full gates, with no signal that anything was excluded. Added `test_*.py` alongside the existing pattern.

One of the 35, `test_n2_habitat_constraints.py`, had an unconditional `from mixle_knowledge.contracts import ...`. `mixle_knowledge` (PRJ-KNW) is a sibling repository, not a declared dependency of mixle core, so this raises `ModuleNotFoundError` — which would have failed collection for the *entire run* the moment the pattern change let it be discovered. Wrapped it in `pytest.importorskip("mixle_knowledge.contracts")`, matching the identical existing idiom already used in `test_substrate_knowledge_bundle.py`.

## Testing

Ran the 33 previously-invisible `test_*.py` files that don't depend on `mixle_knowledge` in isolation: **153 passed**, matching the reviewer's own reproduction exactly.

The two `mixle_knowledge`-dependent files import-skip cleanly in an environment without that package. A local dev environment whose `mixle_knowledge` checkout is missing expected symbols is a separate, pre-existing environmental issue — it also affects the untouched `test_substrate_knowledge_bundle.py` identically, confirmed via `git stash`, and is out of scope here.

A handful of unrelated pre-existing failures surface in the combined full-suite run (`array_data_sources_test.py`, `context_spine_test.py`, `fused_codegen_test.py`, `inverse_test.py`, `neural_ppl_test.py`, plus the known stale-manifest trio) — confirmed identical with `git stash` against this one-line config change, single-process where relevant. Not addressed here.
