### PR TITLE
Fix registry version-id collision and non-atomic promote()

### DIFF
--- a/mixle/inference/production/registry.py
+++ b/mixle/inference/production/registry.py
@@ -88,7 +88,11 @@ class Registry:
         ``header`` defaults to ``model.header`` if present. The model is serialized with the safe mixle
         registry; the header (a :class:`Header` or dict) and ``metadata`` are stored alongside."""
         d = self._dir(name)
-        ver = f"v{len(self.versions(name)) + 1}"
+        # the NEXT version number, not the current COUNT: a deleted version (v2 removed from v1,v2,v3)
+        # must not free up its number for reuse, or the next register() overwrites the surviving v3.
+        existing = self.versions(name)
+        next_n = max((int(v[1:]) for v in existing if v[1:].isdigit()), default=0) + 1
+        ver = f"v{next_n}"
         attached = getattr(model, "header", None)
         if header is None:
             header = attached
@@ -183,11 +187,21 @@ class Registry:
             return json.load(f).get("metadata") or {}
 
     def promote(self, name: str, version: str, alias: str = "production") -> None:
-        """Point ``alias`` (e.g. ``"production"``) at ``version`` -- the atomic model swap."""
+        """Point ``alias`` (e.g. ``"production"``) at ``version`` -- the atomic model swap.
+
+        Written via a temp file + ``os.replace`` in the same directory (same filesystem, so the
+        rename is atomic): a concurrent reader of :meth:`current` either sees the old alias target or
+        the new one, never a truncated/partial write, and a crash mid-write leaves the old alias
+        file untouched rather than corrupted.
+        """
         if version not in self.versions(name):
             raise KeyError(f"{name!r} has no version {version!r}")
-        with open(os.path.join(self._dir(name), _safe_segment(alias, "alias") + ".alias"), "w") as f:
+        d = self._dir(name)
+        target = os.path.join(d, _safe_segment(alias, "alias") + ".alias")
+        tmp = os.path.join(d, f".{_safe_segment(alias, 'alias')}.{os.getpid()}.tmp")
+        with open(tmp, "w") as f:
             f.write(version)
+        os.replace(tmp, target)
 
     def current(self, name: str, alias: str = "production") -> tuple[Any, dict | None]:
         """Load the model an ``alias`` points at (falls back to ``latest`` if the alias is unset)."""

--- a/mixle/tests/registry_versioning_test.py
+++ b/mixle/tests/registry_versioning_test.py
@@ -1,0 +1,68 @@
+"""Regression tests for two fixed defects in mixle.inference.production.registry.Registry.
+
+1. ``register`` numbered the next version from ``len(versions())``, not the highest existing version
+   number -- so a registry missing a version (deleted out of band, or a future ``delete()``) reused
+   that number and the next ``register`` call silently overwrote a DIFFERENT, later version.
+2. ``promote`` wrote the alias file directly (``open(..., "w")``), not atomically -- a crash or a
+   concurrent reader mid-write could observe a truncated/partial alias file instead of the old or
+   new value.
+"""
+
+import os
+import tempfile
+
+import pytest
+
+import mixle.stats as st
+from mixle.inference.production.registry import Registry
+
+
+def test_register_after_a_missing_version_does_not_reuse_its_number():
+    with tempfile.TemporaryDirectory() as tmp:
+        reg = Registry(os.path.join(tmp, "root"))
+        v1 = reg.register(st.GaussianDistribution(0.0, 1.0), "m")
+        v2 = reg.register(st.GaussianDistribution(1.0, 1.0), "m")
+        v3 = reg.register(st.GaussianDistribution(2.0, 1.0), "m")
+        assert (v1, v2, v3) == ("v1", "v2", "v3")
+
+        # simulate v2 having been removed (deleted out of band; the class has no delete() of its own)
+        os.remove(os.path.join(reg._dir("m"), "v2.json"))
+        assert reg.versions("m") == ["v1", "v3"]
+
+        v4 = reg.register(st.GaussianDistribution(3.0, 1.0), "m")
+        assert v4 == "v4", "the next version must come from the highest existing number, not the count"
+
+        # v3 must still be exactly what it was -- never overwritten
+        model_v3, _ = reg.get("m", "v3")
+        assert model_v3.mu == 2.0
+        model_v4, _ = reg.get("m", "v4")
+        assert model_v4.mu == 3.0
+
+
+def test_promote_writes_the_alias_atomically():
+    with tempfile.TemporaryDirectory() as tmp:
+        reg = Registry(os.path.join(tmp, "root"))
+        reg.register(st.GaussianDistribution(0.0, 1.0), "m")
+        reg.register(st.GaussianDistribution(1.0, 1.0), "m")
+        reg.promote("m", "v2")
+
+        alias_path = os.path.join(reg._dir("m"), "production.alias")
+        assert os.path.exists(alias_path)
+        assert open(alias_path).read() == "v2"
+        # no leftover temp file from the atomic-write dance
+        assert [f for f in os.listdir(reg._dir("m")) if f.endswith(".tmp")] == []
+
+        model, _ = reg.current("m")
+        assert model.mu == 1.0
+
+
+def test_promote_rejects_an_unknown_version_without_touching_the_alias():
+    with tempfile.TemporaryDirectory() as tmp:
+        reg = Registry(os.path.join(tmp, "root"))
+        reg.register(st.GaussianDistribution(0.0, 1.0), "m")
+        reg.promote("m", "v1")
+        with pytest.raises(KeyError):
+            reg.promote("m", "v99")
+        # the failed promote must not have clobbered the existing alias
+        alias_path = os.path.join(reg._dir("m"), "production.alias")
+        assert open(alias_path).read() == "v1"


### PR DESCRIPTION
Two confirmed defects in `mixle.inference.production.registry.Registry`.

## 1. Version-id collision after a missing version

`register()` numbered the next version from `len(self.versions(name)) + 1` — the *count*, not the *highest existing number*. If `v2` is ever missing (deleted out of band; the class has no `delete()` of its own today, but nothing stops manual removal, and one may land later), `versions()` returns `[v1, v3]` (len 2), so the next `register()` computes `v3` — colliding with and silently overwriting the real `v3`.

Fixed to derive the next number from `max(existing version numbers) + 1`, which is correct regardless of gaps.

## 2. Non-atomic `promote()`

`promote()` wrote the alias file directly via `open(path, "w")`. A crash mid-write, or a concurrent `current()` read, could observe a truncated/partial alias file instead of the old or new value — despite the docstring's "atomic model swap" claim. Now writes to a temp file in the same directory and `os.replace()`s it into place (atomic on the same filesystem).

## Testing

New `mixle/tests/registry_versioning_test.py`: reproduces the collision (register 3, delete v2, register again → must be v4, not v3; v3's content must survive unchanged), confirms the atomic alias write leaves no temp-file residue, and confirms a rejected `promote()` (unknown version) never touches the existing alias. Existing registry hardening/maturity-registry tests still pass.

Full local gate: 5,175 passed. The 4 failures are pre-existing — 1 flaky torch-training test (passes single-process) and the 3 stale-manifest failures, confirmed via `git stash` against this branch and already being fixed in #486.
