### PR TITLE
Fix three DR-ALG J1/J2/J3/H4 correctness defects

### DIFF
--- a/mixle/analysis/real_options.py
+++ b/mixle/analysis/real_options.py
@@ -113,11 +113,15 @@ def real_option_value(
             mean is used; ``real_option_value`` prices the *option on top of* the point estimate, not a
             re-derivation of the distribution itself.
         volatility: fractional (per-sqrt-period) dispersion of NPV around its mean. Must be ``>= 0``;
-            ``0`` means no dispersion and the option collapses to the naive ``max(npv_dist.mean, 0)``.
+            ``0`` means no dispersion and the option collapses to immediate exercise of ``kind``'s own
+            payoff on ``npv_dist.mean`` (:func:`_intrinsic`) -- ``max(npv_dist.mean, 0)`` for
+            ``"defer"``/``"abandon"``, ``npv_dist.mean + expand_fraction * max(npv_dist.mean, 0)`` for
+            ``"expand"``.
         horizon: number of periods over which the option may be exercised. ``0`` means "decide now".
         kind: one of ``"defer"``, ``"expand"``, ``"abandon"``.
         rate: per-period discount rate applied to the continuation value.
-        n_steps: lattice steps (defaults to ``max(horizon, 1)``, i.e. one step per period).
+        n_steps: lattice steps (defaults to ``max(horizon, 1)``, i.e. one step per period). Must be a
+            positive integer when given explicitly.
         expand_fraction: for ``kind="expand"``, the fractional capacity bonus applied to a positive
             underlying value when the expansion is exercised.
 
@@ -130,6 +134,11 @@ def real_option_value(
         raise ValueError("real_option_value: volatility must be non-negative")
     if horizon < 0:
         raise ValueError("real_option_value: horizon must be non-negative")
+    if n_steps is not None and n_steps <= 0:
+        # n_steps=0 with horizon>0 divides by zero below; n_steps<0 builds an EMPTY lattice and then
+        # indexes boundary[n] == boundary[-1] on it, raising a confusing IndexError three lines later.
+        # One clear error at the boundary instead of two different internal crashes downstream.
+        raise ValueError(f"real_option_value: n_steps must be a positive integer, got {n_steps}")
 
     npv_mean = float(npv_dist.mean)
     n = int(n_steps) if n_steps is not None else max(int(horizon), 1)
@@ -138,9 +147,11 @@ def real_option_value(
     h = volatility * scale * float(np.sqrt(dt))
 
     if h == 0.0:
-        # No dispersion (or no time to disperse in): waiting has no upside, and discounting only makes it
-        # worse, so the optimal policy is "exercise now if positive, else never" -- the naive NPV floor.
-        value = max(npv_mean, 0.0)
+        # No dispersion (or no time to disperse in): waiting has no upside, and discounting only makes
+        # it worse, so the optimal policy is immediate exercise -- the SAME payoff _intrinsic gives
+        # every node of the lattice below, not a hardcoded max(npv_mean, 0.0) (which happens to match
+        # _intrinsic for "defer"/"abandon" but silently ignores "expand"'s expand_fraction bonus).
+        value = float(_intrinsic(np.array([npv_mean]), kind, expand_fraction)[0])
         boundary = np.full(n + 1, np.nan)
         return OptionValue(value=value, exercise_boundary=boundary, premium_over_npv=value - npv_mean)
 

--- a/mixle/analysis/valuation.py
+++ b/mixle/analysis/valuation.py
@@ -224,20 +224,31 @@ def _grade_per_period(grade: np.ndarray, n_periods: int, *, what: str) -> np.nda
 
 
 def _align_price_paths(price_paths: Any, n: int, n_periods: int, rng: np.random.Generator) -> np.ndarray:
-    """Coerce ``price_paths`` (J1 ``PriceForecast.paths``-shaped) to exactly ``(n, n_periods)``.
+    """Coerce ``price_paths`` to exactly ``(n, n_periods)`` -- accepting EITHER orientation of a J1
+    :class:`~mixle.inference.price_forecast.PriceForecast`.
 
-    Accepts a ``(m, n_periods)`` scenario matrix (one row per price path, one column per period) and
-    resamples with replacement to ``n`` rows when ``m != n`` (the "align" step of DR-ALG J2); a
+    A scenario-major ``(m, n_periods)`` matrix (one row per price path, one column per period) is used
+    as-is; ``mixle.inference.price_forecast.PriceForecast.paths`` is documented and produced as
+    ``(n_periods, m)`` (time-major, mirroring how ``forecast_price`` builds it one horizon step at a
+    time) -- passing ``pf.paths`` straight in used to raise, or (worse) silently score the wrong axis
+    as "period" whenever ``m`` happened to equal ``n_periods``. Detected here from ``n_periods``
+    (known independently, from ``schedule``) and transposed automatically; only genuinely ambiguous
+    when ``m == n_periods`` too, where a square matrix is accepted as scenario-major -- its existing,
+    tested behavior -- since no shape-only check can disambiguate a square matrix.
+
+    Resamples with replacement to ``n`` rows when ``m != n`` (the "align" step of DR-ALG J2); a
     ``(m,)`` vector is treated as ``m`` single-period draws when ``n_periods == 1``, or as one
     deterministic ``n_periods``-long path shared by every draw otherwise.
     """
     prices = np.asarray(price_paths, dtype=np.float64)
     if prices.ndim == 1:
         prices = prices[:, None] if n_periods == 1 else prices[None, :]
+    if prices.ndim == 2 and prices.shape[1] != n_periods and prices.shape[0] == n_periods:
+        prices = prices.T  # PriceForecast.paths orientation: (n_periods, m) -> (m, n_periods)
     if prices.ndim != 2 or prices.shape[1] != n_periods:
         raise ValueError(
             f"monte_carlo_npv: price_paths must be shaped (m, {n_periods}) (one row per scenario, one "
-            f"column per period); got {prices.shape}"
+            f"column per period) or its transpose ({n_periods}, m) (PriceForecast.paths); got {prices.shape}"
         )
     m = prices.shape[0]
     if m == n:
@@ -293,8 +304,10 @@ def monte_carlo_npv(
     - ``posterior``: an IC-1 `Posterior` (frozen `mixle.reason.posterior_protocol.Posterior`); its
       ``.samples(n, rng)`` are the grade draws. A single project-life grade (``d == 1``) broadcasts
       across every period; a per-period posterior (``d == len(schedule)``) is used period by period.
-    - ``price_paths``: a J1 ``PriceForecast.paths``-shaped array-like, ``(m, n_periods)`` (one row per
-      scenario). Resampled with replacement to ``n`` rows when ``m != n``.
+    - ``price_paths``: a scenario-major ``(m, n_periods)`` array-like (one row per scenario), OR a J1
+      ``PriceForecast.paths`` passed directly -- ``(n_periods, m)``, time-major -- detected and
+      transposed automatically (see :func:`_align_price_paths`). Resampled with replacement to ``n``
+      rows when ``m != n``.
     - ``cost_model``: called per period as ``cost_model(t, tonnage_t)`` (falling back to
       ``cost_model(t)``) to get that period's deterministic ``opex_t``.
     - ``schedule``: per-period ``tonnage`` (required) and ``capex`` (optional, default zero); see

--- a/mixle/stochastic_opt.py
+++ b/mixle/stochastic_opt.py
@@ -90,6 +90,8 @@ def cvar_epigraph(losses: Any, alpha: float) -> tuple[np.ndarray, np.ndarray, np
     if not (0.0 < alpha < 1.0):
         raise ValueError("alpha must be in (0, 1)")
     k_scenarios, n = loss.shape
+    if k_scenarios == 0:
+        raise ValueError("losses must have at least one scenario (K >= 1); CVaR of zero scenarios is undefined")
     coef = 1.0 / ((1.0 - alpha) * k_scenarios)
     var_index = n
     width = n + 1 + k_scenarios

--- a/mixle/tests/test_h4_stochastic.py
+++ b/mixle/tests/test_h4_stochastic.py
@@ -158,3 +158,9 @@ def test_cvar_epigraph_rejects_bad_alpha():
         cvar_epigraph(np.zeros((3, 2)), 1.5)
     with pytest.raises(ValueError):
         cvar_epigraph(np.zeros((3, 2)), 0.0)
+
+
+def test_cvar_epigraph_rejects_zero_scenarios():
+    # coef = 1 / ((1 - alpha) * K) divides by K with no guard -- K=0 must raise, not ZeroDivisionError.
+    with pytest.raises(ValueError):
+        cvar_epigraph(np.zeros((0, 2)), 0.95)

--- a/mixle/tests/test_j2_valuation.py
+++ b/mixle/tests/test_j2_valuation.py
@@ -160,3 +160,46 @@ def test_monte_carlo_npv_rejects_period_dimension_mismatch():
             n=N,
             rng=np.random.default_rng(0),
         )
+
+
+def test_monte_carlo_npv_accepts_price_forecast_paths_directly():
+    # The documented J1 -> J2 workflow is `monte_carlo_npv(..., price_paths=pf.paths, ...)`, and
+    # mixle.inference.price_forecast.PriceForecast.paths is (n_periods, m) -- time-major -- not the
+    # (m, n_periods) scenario-major shape monte_carlo_npv's own docstring required. A 5-period,
+    # non-square schedule makes the two orientations unambiguous (and would previously raise).
+    n_periods = 5
+    posterior = _LognormalGradePosterior(GRADE_MU, GRADE_SIGMA)
+    m = 777  # != n_periods and != N, so both resampling AND the transpose are exercised together
+    price_forecast_paths = np.random.default_rng(3).normal(PRICE_MEAN, PRICE_STD, size=(n_periods, m))
+
+    def cost_model(t: int, tonnage_t: float) -> float:
+        return OPEX_PER_TONNE * tonnage_t
+
+    schedule = {"tonnage": np.full(n_periods, TONNAGE), "capex": np.array([CAPEX] + [0.0] * (n_periods - 1))}
+
+    result = monte_carlo_npv(
+        posterior,
+        price_forecast_paths,  # (n_periods, m): PriceForecast.paths' own orientation, unmodified
+        cost_model,
+        schedule,
+        discount_rate=DISCOUNT_RATE,
+        n=N,
+        rng=np.random.default_rng(3),
+    )
+    assert isinstance(result, NPVDistribution)
+    assert result.samples.shape == (N,)
+    assert np.all(np.isfinite(result.samples))
+
+    # Passing the manually pre-transposed (m, n_periods) form must give the identical distribution
+    # (same seed): proves the auto-detected transpose is not just "doesn't crash" but scores the
+    # correct axis as "period", not merely a differently-shaped one.
+    result_pretransposed = monte_carlo_npv(
+        posterior,
+        price_forecast_paths.T,
+        cost_model,
+        schedule,
+        discount_rate=DISCOUNT_RATE,
+        n=N,
+        rng=np.random.default_rng(3),
+    )
+    np.testing.assert_array_equal(result.samples, result_pretransposed.samples)

--- a/mixle/tests/test_j3_real_options.py
+++ b/mixle/tests/test_j3_real_options.py
@@ -89,6 +89,39 @@ def test_unknown_kind_raises():
         real_option_value(npv_dist, volatility=0.3, horizon=4, kind="bogus", rate=0.05)
 
 
+def test_expand_option_collapses_to_its_own_intrinsic_at_zero_volatility():
+    # At zero dispersion every kind must collapse to ITS OWN immediate-exercise payoff, not a
+    # kind-independent max(mean, 0) -- "expand" pays mean + expand_fraction * max(mean, 0), strictly
+    # more than the naive floor whenever mean > 0.
+    npv_dist = _npv_dist(mean=100.0)
+    opt = real_option_value(npv_dist, volatility=1e-9, horizon=5, kind="expand", rate=0.05, expand_fraction=0.3)
+    expected = 100.0 + 0.3 * 100.0
+    assert opt.value == pytest.approx(expected, abs=1e-6)
+    assert opt.value != pytest.approx(max(npv_dist.mean, 0.0), abs=1e-3)
+
+
+def test_expand_option_collapses_to_its_own_intrinsic_at_zero_horizon():
+    # horizon=0 forces dt=0 -> h=0 through the SAME branch, independent of volatility.
+    npv_dist = _npv_dist(mean=100.0)
+    opt = real_option_value(npv_dist, volatility=0.6, horizon=0, kind="expand", rate=0.05, expand_fraction=0.3)
+    assert opt.value == pytest.approx(130.0, abs=1e-6)
+
+
+def test_defer_and_abandon_zero_volatility_intrinsic_is_unchanged():
+    # Regression guard: the fix must not change the already-correct defer/abandon zero-vol value.
+    npv_dist = _npv_dist(mean=10.0)
+    for kind in ("defer", "abandon"):
+        opt = real_option_value(npv_dist, volatility=1e-9, horizon=5, kind=kind, rate=0.05)
+        assert opt.value == pytest.approx(max(npv_dist.mean, 0.0), abs=1e-6)
+
+
+@pytest.mark.parametrize("bad_n_steps", [0, -1, -5])
+def test_non_positive_n_steps_raises_a_clear_error(bad_n_steps):
+    npv_dist = _npv_dist(mean=10.0)
+    with pytest.raises(ValueError, match="n_steps"):
+        real_option_value(npv_dist, volatility=0.3, horizon=5, kind="defer", rate=0.05, n_steps=bad_n_steps)
+
+
 class _ToyPosterior:
     """A minimal IC-1-conforming posterior: an independent Gaussian belief over one grade parameter."""
 


### PR DESCRIPTION
Three confirmed defects across the J1/J2/J3/H4 DR-ALG modules.

## 1. The documented forecast → NPV workflow was shape-incompatible

`monte_carlo_npv` rejected `PriceForecast.paths` passed directly, despite both modules' own docstrings framing exactly that as the intended workflow. `PriceForecast.paths` is `(n_periods, m)` — time-major, matching how `forecast_price` builds it one horizon step at a time; `monte_carlo_npv` required `(m, n_periods)` — scenario-major.

`_align_price_paths` now detects and transposes the `PriceForecast` orientation automatically, using `n_periods` (known independently, from the schedule) to disambiguate. Behavior is unchanged for a genuinely square matrix, where no shape-only check can tell the two orientations apart — that's the same accept-as-is behavior the code already had.

## 2. `real_option_value`'s zero-volatility shortcut was wrong for "expand"

The `h == 0` shortcut hardcoded `max(npv_mean, 0.0)` for every option kind, but that only matches `"defer"`/`"abandon"`'s own intrinsic payoff. `"expand"` silently lost its `expand_fraction` bonus: `mean=100, expand_fraction=0.3` returned `100` instead of the correct `130`. Now calls `_intrinsic` — the same function every other node of the lattice already uses.

Also validates `n_steps` is a positive integer up front: `n_steps=0` divided by zero, `n_steps<0` built an empty lattice and indexed it out of bounds. Both now raise one clear `ValueError`.

## 3. `cvar_epigraph` divided by the scenario count with no zero check

Added alongside the existing `alpha` validation.

## Testing

- `PriceForecast.paths` accepted directly and proven to score the *same axis* as an explicit transpose (not just "doesn't crash").
- `expand`'s zero-vol/zero-horizon intrinsic checked against its analytic value, plus a regression guard that `defer`/`abandon`'s already-correct zero-vol value is unchanged; `n_steps` ∈ {0, -1, -5} all raising.
- Zero-scenario CVaR raising instead of `ZeroDivisionError`.

Full local gate: **5,172 passed, 0 failed** (one flaky wall-clock timing test passes single-process; the pre-existing stale-manifest trio is fixed separately in #486).
