### PR TITLE
Validate cancer-risk inputs/outputs and gate CrossModalModel inference

### DIFF
--- a/mixle/analysis/carcinogenic_risk.py
+++ b/mixle/analysis/carcinogenic_risk.py
@@ -85,9 +85,29 @@ class RiskQuantity:
 
 def _lnt_risk(dose: np.ndarray, slope: np.ndarray | float) -> np.ndarray:
     """EPA-IRIS linear no-threshold form: ``dose * slope``, falling back to ``1 - exp(-dose*slope)``
-    once the linear approximation would exceed ~0.01 (the point EPA guidance treats it as unsafe)."""
+    once the linear approximation would exceed ~0.01 (the point EPA guidance treats it as unsafe).
+
+    A risk measure -- always in ``[0, 1)`` for a nonnegative ``dose * slope``, which is why callers
+    validate both factors are nonnegative before this runs: for a negative product this formula
+    returns a negative "risk" (the linear branch) or a risk above 1 is impossible by construction
+    once the ``exp`` branch engages, but the LINEAR branch has no such ceiling, so an unvalidated
+    caller could still see an unbounded, meaningless value from it."""
     product = dose * slope
     return np.where(product < 0.01, product, 1.0 - np.exp(-product))
+
+
+def _require_finite_nonnegative(value: np.ndarray | float, name: str) -> None:
+    """Raise a clear error for a negative or non-finite physical quantity (dose, slope, exposure).
+
+    These feed a risk model whose output is only meaningful as a probability in ``[0, 1]``; a
+    negative or non-finite input (a data error, not a valid domain value -- exposure and potency are
+    never negative) produces a negative or meaningless "risk" with no warning otherwise, exactly the
+    silent failure mode this validates against."""
+    arr = np.asarray(value, dtype=float)
+    if not np.all(np.isfinite(arr)):
+        raise ValueError(f"{name} must be finite, got {value!r}")
+    if np.any(arr < 0):
+        raise ValueError(f"{name} must be non-negative, got {value!r}")
 
 
 def excess_lifetime_cancer_risk(
@@ -108,8 +128,13 @@ def excess_lifetime_cancer_risk(
         exposure: the lifetime-average dose/concentration. An IC-1 ``Posterior`` (its
             ``derived_quantity`` pushforward is used, so ``prior_dominated`` propagates from the
             exposure posterior), a plain array of exposure samples (already representing exposure
-            uncertainty), or a single deterministic scalar.
-        sf: the chemical's :class:`SlopeFactor`.
+            uncertainty), or a single deterministic scalar. A scalar or array ``exposure`` must be
+            finite and non-negative (exposure cannot be negative); a ``Posterior``'s own draws are
+            NOT validated here (the posterior's support is the caller's modeling choice), so a
+            mis-specified exposure posterior with mass below zero can still yield a negative risk
+            sample from the linear branch of :func:`_lnt_risk`.
+        sf: the chemical's :class:`SlopeFactor`. Its potency coefficient for ``route`` must be finite
+            and non-negative.
         route: ``"oral"`` or ``"inhalation"``.
         n: number of posterior draws to take when ``exposure`` is a ``Posterior``, or the number of
             slope-factor draws to take when ``exposure`` is a bare scalar and ``sf.sigma_log > 0``.
@@ -123,6 +148,9 @@ def excess_lifetime_cancer_risk(
     csf = sf.oral_csf if route == "oral" else sf.inhalation_iur
     if csf is None:
         raise ValueError(f"SlopeFactor has no {route} potency coefficient set.")
+    _require_finite_nonnegative(csf, f"SlopeFactor.{'oral_csf' if route == 'oral' else 'inhalation_iur'}")
+    if not isinstance(exposure, Posterior):
+        _require_finite_nonnegative(exposure, "exposure")
     rng = rng if rng is not None else np.random.default_rng()
 
     def _apply(draws: np.ndarray) -> np.ndarray:
@@ -160,8 +188,13 @@ def radon_wlm_risk(
 ) -> DerivedQuantity:
     """Radon lung-cancer risk from cumulative working-level-months (BEIR-VI linear coefficient).
 
-    ``risk = wlm * risk_per_wlm``, the BEIR-VI committee's linear excess-relative-risk coefficient
-    per WLM of cumulative radon-progeny exposure (default ``5.38e-4`` per WLM).
+    ``risk = wlm * risk_per_wlm`` for small products (the BEIR-VI committee's linear
+    excess-relative-risk coefficient per WLM of cumulative radon-progeny exposure, default
+    ``5.38e-4`` per WLM), saturating via the same ``1 - exp(-x)`` low-dose-linear-no-threshold form
+    :func:`_lnt_risk` uses once that product would exceed ~0.01 -- without it, cumulative exposures
+    large enough to be realistic over a working lifetime push the bare linear form above 1, which is
+    not a valid probability. Both ``wlm`` and ``risk_per_wlm`` must be finite and non-negative
+    (exposure and potency are never negative).
 
     Args:
         wlm: cumulative working-level-months, a scalar or an array of samples (already representing
@@ -175,8 +208,10 @@ def radon_wlm_risk(
     """
     # n / rng are accepted for signature symmetry with excess_lifetime_cancer_risk and to leave room
     # for a future posterior-valued wlm; the deterministic BEIR-VI formula needs neither.
+    _require_finite_nonnegative(wlm, "wlm")
+    _require_finite_nonnegative(risk_per_wlm, "risk_per_wlm")
     if isinstance(wlm, np.ndarray):
-        samples = np.atleast_1d(np.asarray(wlm, dtype=float)) * risk_per_wlm
+        samples = _lnt_risk(np.atleast_1d(np.asarray(wlm, dtype=float)), risk_per_wlm)
     else:
-        samples = np.array([float(wlm) * risk_per_wlm])
+        samples = _lnt_risk(np.array([float(wlm)]), risk_per_wlm)
     return RiskQuantity(samples=samples, prior_dominated=False)

--- a/mixle/reason/model.py
+++ b/mixle/reason/model.py
@@ -161,7 +161,16 @@ class CrossModalModel:
 
     # -- inference ----------------------------------------------------------------------------
     def belief(self, obs: dict[str, Any]) -> GaussianBelief:
-        """The belief ``q(z | available modalities)`` as a :class:`GaussianBelief` (product of experts)."""
+        """The belief ``q(z | available modalities)`` as a :class:`GaussianBelief` (product of experts).
+
+        Requires a prior :meth:`fit` call. ``_fitted`` was tracked but never checked: a freshly
+        constructed model's encoders carry their random init weights, so every downstream consumer
+        of this method -- :meth:`encode`, :meth:`predict`, :meth:`calibrate`, :meth:`predict_interval`
+        -- could silently return a meaningless, randomly-initialized "belief" with no indication
+        anything was wrong. Checked here once, since all four route through this method.
+        """
+        if not self._fitted:
+            raise RuntimeError("CrossModalModel.belief() called before fit(): the encoders are untrained.")
         torch = _torch()
         if not obs:
             return GaussianBelief(np.zeros(self.latent_dim), np.eye(self.latent_dim))

--- a/mixle/tests/cross_modal_model_test.py
+++ b/mixle/tests/cross_modal_model_test.py
@@ -145,6 +145,31 @@ class CrossModalModelTest(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             m.predict_interval({"A": xA[0]}, target="B")
 
+    def test_inference_before_fit_raises_instead_of_scoring_random_weights(self):
+        # _fitted was tracked but never checked: a freshly constructed model's encoders/decoder
+        # carry their random init weights, so belief()/encode()/predict() could silently return a
+        # meaningless "result" that looks like real output. All four inference entry points route
+        # through belief(), so one check there covers them.
+        from mixle.reason import CrossModalModel
+
+        rng = np.random.RandomState(9)
+        _, xA, xB = _two_view_data(rng, 10, k=2, dA=4, dB=3)
+        m = CrossModalModel(latent_dim=3, seed=7)
+        m.add_modality("A", 4).add_modality("B", 3)
+
+        with self.assertRaises(RuntimeError):
+            m.belief({"A": xA[0]})
+        with self.assertRaises(RuntimeError):
+            m.encode({"A": xA[0]})
+        with self.assertRaises(RuntimeError):
+            m.predict({"A": xA[0]}, target="B")
+        with self.assertRaises(RuntimeError):
+            m.calibrate({"A": xA, "B": xB}, target="B")
+
+        # fit() clears the block; the model is usable afterward exactly as before
+        m.fit({"A": xA, "B": xB}, epochs=5)
+        m.belief({"A": xA[0]})  # no longer raises
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/mixle/tests/test_carcinogenic_risk.py
+++ b/mixle/tests/test_carcinogenic_risk.py
@@ -145,3 +145,37 @@ def test_radon_wlm_risk_matches_beir_vi_coefficient():
 
     custom_coefficient = radon_wlm_risk(4.0, risk_per_wlm=1e-3)
     assert custom_coefficient.mean == pytest.approx(4.0 * 1e-3)
+
+
+def test_radon_wlm_risk_saturates_instead_of_exceeding_one():
+    # A cumulative exposure large enough that the bare linear form would exceed 1 (a probability
+    # cannot). risk_per_wlm chosen so wlm * risk_per_wlm = 5.38, far past where the linear
+    # approximation is valid; the LNT exp form must cap it below 1.
+    huge = radon_wlm_risk(10_000.0, risk_per_wlm=5.38e-4)
+    assert 0.0 <= float(huge.mean) < 1.0
+    assert float(huge.mean) == pytest.approx(1.0 - np.exp(-10_000.0 * 5.38e-4), rel=1e-9)
+
+
+def test_radon_wlm_risk_rejects_negative_or_non_finite_inputs():
+    with pytest.raises(ValueError):
+        radon_wlm_risk(-1.0)
+    with pytest.raises(ValueError):
+        radon_wlm_risk(4.0, risk_per_wlm=-5.38e-4)
+    with pytest.raises(ValueError):
+        radon_wlm_risk(np.array([1.0, -2.0, 3.0]))
+    with pytest.raises(ValueError):
+        radon_wlm_risk(float("nan"))
+    with pytest.raises(ValueError):
+        radon_wlm_risk(float("inf"))
+
+
+def test_excess_lifetime_cancer_risk_rejects_negative_or_non_finite_inputs():
+    sf = SlopeFactor(oral_csf=1.5)
+    with pytest.raises(ValueError):
+        excess_lifetime_cancer_risk(-1e-4, sf, route="oral")
+    with pytest.raises(ValueError):
+        excess_lifetime_cancer_risk(np.array([1e-4, -1e-4]), sf, route="oral")
+    with pytest.raises(ValueError):
+        excess_lifetime_cancer_risk(1e-4, SlopeFactor(oral_csf=-1.5), route="oral")
+    with pytest.raises(ValueError):
+        excess_lifetime_cancer_risk(float("nan"), sf, route="oral")


### PR DESCRIPTION
Two confirmed defects in high-stakes risk/inference code.

## 1. Cancer-risk functions accepted impossible values

`excess_lifetime_cancer_risk` and `radon_wlm_risk` had no input validation: negative exposure or slope factors produced negative "risk" (reproduced: `-1.0`, `-0.0538`). `radon_wlm_risk`'s formula was also unbounded linear (`risk = wlm * risk_per_wlm`, no saturation), so a realistic cumulative exposure pushed it above 1 — impossible for a probability (reproduced: `5.38`).

Both now validate their scalar/array inputs are finite and non-negative, and `radon_wlm_risk` reuses the exact same LNT low-dose-linear/exp-saturating form `excess_lifetime_cancer_risk` already applies via `_lnt_risk`, so it stays in `[0, 1)` for any valid input instead of growing without bound. A `Posterior`-valued exposure's own draws are intentionally left unvalidated — the posterior's support is the caller's modeling choice — and that's documented explicitly rather than silently glossed over.

## 2. `CrossModalModel` ran inference before training

`_fitted` was set on `fit()` but never checked anywhere. A freshly constructed model's encoders/decoder carry random init weights, so `belief()` — and everything that routes through it (`encode`, `predict`, `calibrate`, `predict_interval`) — could silently return a meaningless result presented as real output. Checked once in `belief()`, since every other inference method calls it; the four downstream methods all inherit the guard for free.

## Testing

- Negative/non-finite exposure, slope factor, and WLM all raise for both risk functions; a large-but-valid WLM value is checked against the analytic saturating value directly (not just "stays under 1").
- All five `CrossModalModel` inference entry points raise before `fit()`; the model is fully usable immediately after `fit()` — existing tests (which always fit first) are unaffected.

Full local gate: **5,173 passed, 0 failed** (the pre-existing stale-manifest trio is fixed separately in #486).
