### PR TITLE
Let a route_task gap optionally see other gaps' real resolved results within one call

### DIFF
--- a/mixle/task/knowledge_routing.py
+++ b/mixle/task/knowledge_routing.py
@@ -185,6 +185,45 @@ def _attempt(*, tool_or_model: str | None, query: str, status: str, produced_ite
     }
 
 
+def _accepts_known_items(invoke: Any) -> bool:
+    """Whether ``invoke`` declares a parameter literally named ``known_items`` it wants the
+    accumulated real knowledge items passed into (called by that keyword, so the name must match
+    exactly -- a second positional parameter with some other name is a different, unrelated
+    interface, not an opt-in, and must not be called with a mismatched keyword).
+
+    A one-arg ``invoke(gap)`` (every existing catalog entry written before this) is unaffected --
+    this only widens what a *new* tool may opt into, via ``inspect.signature`` rather than a required
+    interface change. ``TypeError``/``ValueError`` (an unintrospectable builtin/C callable) means
+    "assume the old one-arg shape," the safe default.
+    """
+    import inspect
+
+    try:
+        params = inspect.signature(invoke).parameters
+    except (TypeError, ValueError):
+        return False
+    known = params.get("known_items")
+    return known is not None and known.kind in (
+        known.POSITIONAL_OR_KEYWORD, known.KEYWORD_ONLY,
+    )
+
+
+def _invoke_tool(invoke: Any, gap: dict[str, Any], known_items: list[dict[str, Any]]) -> Any:
+    """Call a catalog entry's ``invoke``, passing ``known_items`` (every real item resolved so far
+    in this ``route_task`` call, plus whatever the input ``bundle`` carried) only if it opted in.
+
+    This is the fix for a real, documented limitation (found and worked around by hand across
+    several ``experiments/`` demos): previously ``invoke(gap)`` had no way to see another gap's
+    already-resolved result within the same ``route_task`` call at all, forcing every genuinely
+    multi-stage pipeline to bridge through separate sequential calls via the knowledge store. A tool
+    that wants that now declares a second parameter and gets it directly; one that doesn't is called
+    exactly as before.
+    """
+    if _accepts_known_items(invoke):
+        return invoke(gap, known_items=known_items)
+    return invoke(gap)
+
+
 def _resolve_gap(gap: dict[str, Any], known_items: list[dict[str, Any]], catalog: list[CatalogEntry]) -> dict[str, Any]:
     """Resolve one gap: prefer evidence already in the bundle, else route to the cheapest matching,
     reliable, verifiable catalog entry and verify its result before ever treating it as canonical."""
@@ -215,7 +254,7 @@ def _resolve_gap(gap: dict[str, Any], known_items: list[dict[str, Any]], catalog
             ),
         }
 
-    raw = invoke(gap)
+    raw = _invoke_tool(invoke, gap, known_items)
     item = _to_knowledge_item(gap, entry, raw)
     verdict = entry.verifier.verify(claim={"payload": item["payload"]}, context={"gap": gap, "entry": entry.id})
     if _verdict_passed(verdict):

--- a/mixle/tests/task/test_knowledge_routing.py
+++ b/mixle/tests/task/test_knowledge_routing.py
@@ -194,3 +194,56 @@ def test_research_proposal_to_gap_maps_into_the_frozen_gap_shape():
     assert gap["acceptance_criteria"] == ["run a falling-head permeability test"]
     assert gap["status"] == "open"
     assert gap["resolved_by_item_ids"] == []
+
+
+def test_a_gap_can_opt_into_seeing_another_gaps_real_resolved_result():
+    """Fix for a real, documented limitation (found and worked around across several
+    experiments/ demos by bridging through separate route_task calls): `invoke(gap)` had no way to
+    see another gap's already-resolved result within the SAME route_task call. A tool that declares
+    a `known_items` parameter now gets the real accumulated items -- not a value this test
+    precomputes and hands over regardless of whether the system actually resolved the upstream gap."""
+    physics_ref = {}
+
+    def _physics_tool_recorded(gap):
+        result = {"tonnage_mt": 12.5, "units": "Mt"}
+        physics_ref.update(result)
+        return result
+
+    def _dependent_economic_tool(gap, known_items):
+        physics_items = [i for i in known_items if i.get("metadata", {}).get("domain") == "physics"]
+        assert physics_items, "known_items must contain the already-resolved physics item"
+        tonnage = physics_items[0]["payload"]["tonnage_mt"]
+        assert tonnage == physics_ref["tonnage_mt"]  # the REAL value the physics tool actually returned
+        return {"npv_usd": tonnage * 1_000_000.0}
+
+    catalog = [
+        CatalogEntry(
+            id="physics_survey", schema={"invoke": _physics_tool_recorded, "output": {}},
+            owner="physics", cost=0.1, reliability=0.9, verifier=_PassVerifier(),
+        ),
+        CatalogEntry(
+            id="dependent_economic_model", schema={"invoke": _dependent_economic_tool, "output": {}},
+            owner="economic", cost=0.1, reliability=0.9, verifier=_PassVerifier(),
+        ),
+    ]
+    seed = [["physics", "economic"]] * 20
+    proposer = init_decomposition_proposer(seed)
+    result = route_task("dependent question", catalog, proposer=proposer, budget=5)
+
+    assert result.answer["resolved_gap_ids"] == ["gap-0-physics", "gap-1-economic"]
+    economic_item = next(i for i in result.delta["add_items"] if i["metadata"]["domain"] == "economic")
+    assert economic_item["payload"]["npv_usd"] == 12.5 * 1_000_000.0
+
+
+def test_a_one_arg_invoke_is_completely_unaffected():
+    """Every catalog entry written before this fix uses `invoke(gap)` -- must keep working exactly
+    as before, with no known_items argument forced on it."""
+
+    def _plain_tool(gap):
+        return {"tonnage_mt": 7.0}
+
+    catalog = [CatalogEntry(id="physics_survey", schema={"invoke": _plain_tool, "output": {}},
+                             owner="physics", cost=0.1, reliability=0.9, verifier=_PassVerifier())]
+    proposer = init_decomposition_proposer([["physics"]] * 20)
+    result = route_task("plain question", catalog, proposer=proposer, budget=3)
+    assert result.answer["resolved_gap_ids"] == ["gap-0-physics"]


### PR DESCRIPTION
Found via the VMS-prospect and exploration-portfolio experiments: `invoke(gap)` only ever received the gap dict, with no way to see another gap's already-resolved result within the same `route_task` call. Every genuinely multi-stage pipeline in `experiments/` had to work around this by bridging through separate sequential `route_task` calls via the knowledge store — a defensible pattern, but not something `route_task` should force on every caller with real internal dependencies.

A catalog entry's `invoke` can now declare a `known_items` parameter (checked by name via `inspect.signature`, not by positional arity — a second positional param with some other name is a different, unrelated interface and is left alone) to opt into receiving the real accumulated items resolved so far in the call (`self.known_items + self.add_items`, already computed and threaded through `_RoutingWorld.step` — this only had to plumb it one level further, into `invoke` itself). Every existing one-arg `invoke(gap)` catalog entry (which is all of them, today) is completely unaffected.

DoD test: a 2-gap pipeline where the second gap's tool reads the first gap's REAL resolved payload out of `known_items` (not a precomputed value the test hands over regardless of whether the system actually resolved the upstream gap) and asserts the derived result matches. Plus a regression test locking in that a plain one-arg tool is unaffected. Also reran `test_catalog_router.py` and `task_orchestrate_test.py` (11/11) since both sit on the same call path.