### PR TITLE
Fix spurious slogdet warnings in expected_information_gain_linear via Sylvester's identity

### DIFF
--- a/mixle/doe/active.py
+++ b/mixle/doe/active.py
@@ -117,14 +117,28 @@ def expected_information_gain_linear(
     """Exact expected information gain of a linear-Gaussian design ``y = F.theta + eps`` (= Bayesian D-opt).
 
     For a Gaussian prior ``theta ~ N(0, Sigma0)`` and observation noise ``eps ~ N(0, noise^2 I)``, the
-    mutual information between the data and ``theta`` is ``0.5 * log det(I + noise^-2 Sigma0 F^T F)``.
+    mutual information between the data and ``theta`` is ``0.5 * log det(I_p + noise^-2 Sigma0 F^T F)``.
     ``model_matrix`` is the ``(n, p)`` design matrix ``F`` (e.g. from
     :func:`mixle.doe.optimal.polynomial_features`). Higher EIG = a more informative design.
+
+    By Sylvester's determinant identity, ``det(I_p + Sigma0 F^T F / noise^2) == det(I_n + F Sigma0 F^T
+    / noise^2)`` exactly -- the two sides differ only in which of the ``(p, p)`` or ``(n, n)`` matrix
+    gets formed and factorized. This function forms whichever is smaller. That matters beyond
+    speed: scoring a handful of candidate observations (``n`` small, e.g. a few new monitoring
+    sites) against a model with many parameters (``p`` large, e.g. hundreds of grid cells) is exactly
+    this function's typical caller (:mod:`mixle_pde.monitoring_design`,
+    :mod:`mixle_pde.geophysics`), and forming the full dense ``(p, p)`` matrix in that regime is
+    reliably ill-conditioned for ``slogdet`` -- verified to throw spurious divide-by-zero/overflow
+    ``RuntimeWarning``s on a real ``p=720`` case that the ``(n, n)`` formulation computes cleanly
+    (identical value, to float64 precision, with zero warnings).
     """
     f = np.asarray(model_matrix, dtype=np.float64)
-    p = f.shape[1]
+    n, p = f.shape
     sigma0 = np.eye(p) if prior_cov is None else np.asarray(prior_cov, dtype=np.float64)
-    m = np.eye(p) + (sigma0 @ (f.T @ f)) / (float(noise) ** 2)
+    if n <= p:
+        m = np.eye(n) + (f @ sigma0 @ f.T) / (float(noise) ** 2)
+    else:
+        m = np.eye(p) + (sigma0 @ (f.T @ f)) / (float(noise) ** 2)
     sign, logdet = np.linalg.slogdet(m)
     return float(0.5 * logdet) if sign > 0 else -np.inf
 

--- a/mixle/tests/doe_active_test.py
+++ b/mixle/tests/doe_active_test.py
@@ -20,6 +20,44 @@ class ExpectedInformationGainTest(unittest.TestCase):
             expected_information_gain_linear(clustered, noise=0.5),
         )
 
+    def test_large_p_small_n_does_not_warn_and_matches_the_pxp_formulation(self):
+        """Regression test for a real bug (found via experiments/adaptive-gravity-survey-design):
+        scoring a handful of candidate observations (n small) against a model with many parameters
+        (p large -- e.g. hundreds of grid cells) used to form the full dense (p, p) matrix and throw
+        spurious divide-by-zero/overflow RuntimeWarnings from slogdet. By Sylvester's identity the
+        (n, n) formulation is mathematically identical and must actually be used when it's smaller."""
+        rng = np.random.default_rng(0)
+        p, n = 720, 4
+        f = rng.normal(size=(n, p)) * 1e-5
+        prior_cov = np.eye(p) * (350.0**2)
+        noise = 0.02
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")  # any warning fails the test, not just RuntimeWarning
+            value = expected_information_gain_linear(f, noise=noise, prior_cov=prior_cov)
+
+        # cross-check against the direct (p, p) formulation computed independently in the test itself
+        # (not by calling back into the function under test) -- confirms the fast path is not just
+        # silent, it's correct.
+        m_pxp = np.eye(p) + (prior_cov @ (f.T @ f)) / (noise**2)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")  # the (p, p) path is EXPECTED to warn; that's the bug being fixed
+            _, logdet_pxp = np.linalg.slogdet(m_pxp)
+        self.assertAlmostEqual(value, 0.5 * logdet_pxp, places=6)
+
+    def test_small_p_large_n_still_matches_manual_pxp_computation(self):
+        """The other direction (n > p, the common textbook case) must still work -- confirms the
+        n<=p branch selection didn't regress the existing default path."""
+        rng = np.random.default_rng(1)
+        p, n = 3, 20
+        f = rng.normal(size=(n, p))
+        prior_cov = np.eye(p) * 2.0
+        noise = 0.5
+        value = expected_information_gain_linear(f, noise=noise, prior_cov=prior_cov)
+        m_pxp = np.eye(p) + (prior_cov @ (f.T @ f)) / (noise**2)
+        _, logdet_pxp = np.linalg.slogdet(m_pxp)
+        self.assertAlmostEqual(value, 0.5 * logdet_pxp, places=9)
+
     def test_nmc_matches_linear_gaussian_closed_form(self):
         f, sigma = 1.5, 0.7
         analytic = 0.5 * np.log(1 + f**2 / sigma**2)


### PR DESCRIPTION
Found via `experiments/adaptive-gravity-survey-design`: scoring a handful of candidate gravity stations (n=4-8) against a 720-cell density model (p=720) threw `divide by zero`/`overflow`/`invalid value` RuntimeWarnings from `np.linalg.slogdet` on the full dense (720, 720) information matrix — harmless in that run only because the identity term happened to keep the overall matrix full-rank, not because the computation was actually well-conditioned.

By Sylvester's determinant identity, `det(I_p + Sigma0 F^T F / noise^2) == det(I_n + F Sigma0 F^T / noise^2)` exactly. This function now forms whichever of the (n,n) or (p,p) matrices is smaller — for the "score a few candidate observations against a many-parameter model" case that `mixle_pde.monitoring_design`/`geophysics` actually call this for, that's almost always (n,n), which is both well-conditioned (verified: identical value to 6 decimal places, zero warnings under `warnings.simplefilter("error")`) and dramatically cheaper (720^3 -> 4^3 in the reproduced case).

Also fixes nothing behaviorally for the common small-p/large-n case (regression test confirms the branch selection still matches the direct dense computation to 9 decimal places there).