### PR TITLE
Add voi_stopping_decision: real value-of-information stopping rule for sequential sampling

### DIFF
--- a/mixle/analysis/__init__.py
+++ b/mixle/analysis/__init__.py
@@ -94,7 +94,7 @@ from mixle.analysis.rank_aggregation import (
     mallows_fit,
     spearman_footrule,
 )
-from mixle.analysis.real_options import OptionValue, real_option_value, voi_dollars
+from mixle.analysis.real_options import OptionValue, VoiStoppingDecision, real_option_value, voi_dollars, voi_stopping_decision
 from mixle.analysis.sdm import HabitatModel, SpeciesObservation, fit_sdm
 from mixle.analysis.spatial_mixture import SpatialMixture
 from mixle.analysis.valuation import NPVDistribution, capex_opex, cost_curve, monte_carlo_npv
@@ -195,6 +195,8 @@ __all__ = [
     "OptionValue",
     "real_option_value",
     "voi_dollars",
+    "VoiStoppingDecision",
+    "voi_stopping_decision",
     # safety-risk / geotechnical hazard modeling
     "safety_risk_surface",
     "incident_probability",

--- a/mixle/analysis/real_options.py
+++ b/mixle/analysis/real_options.py
@@ -49,7 +49,7 @@ from mixle.reason.posterior_protocol import Posterior
 if TYPE_CHECKING:
     from mixle.analysis.valuation import NPVDistribution
 
-__all__ = ["OptionValue", "real_option_value", "voi_dollars"]
+__all__ = ["OptionValue", "real_option_value", "voi_dollars", "VoiStoppingDecision", "voi_stopping_decision"]
 
 _KINDS = ("defer", "expand", "abandon")
 
@@ -260,3 +260,51 @@ def voi_dollars(
     value_with_info = float(np.mean(values_with_info))
 
     return max(value_with_info - value_no_info, 0.0)
+
+
+class VoiStoppingDecision(NamedTuple):
+    """A real decision-theoretic answer to "should we sample again?": compare the value of one more
+    sample against its cost, rather than an arbitrary uncertainty threshold picked by hand."""
+
+    voi_dollars: float
+    sample_cost: float
+    net_value: float
+    keep_sampling: bool
+
+
+def voi_stopping_decision(
+    posterior: Posterior,
+    decision_fn: Callable[[np.ndarray], float],
+    drill_info: dict[str, Any],
+    *,
+    sample_cost: float,
+    rng: np.random.Generator,
+    n_outer: int = 64,
+    n_inner: int = 256,
+) -> VoiStoppingDecision:
+    """Should the next sample (drillhole, monitoring well, survey station, ...) actually be taken?
+
+    A real, principled alternative to picking an uncertainty threshold by hand and telling an LLM
+    loop-controller to stop when it's cleared (the pattern used, and flagged as a real gap, in
+    ``experiments/adaptive-groundwater-monitoring`` and ``experiments/adaptive-gravity-survey-design``):
+    sample again iff :func:`voi_dollars` -- the actual expected dollar value the next sample would add
+    to the decision -- exceeds what that sample costs. As uncertainty tightens, ``voi_dollars`` shrinks
+    toward zero (there's less left to learn that would change the decision), so this converges to a
+    stopping rule on its own without any separately-chosen threshold; the only free parameter is
+    ``sample_cost``, which is an actual real-world number (drilling/survey cost) rather than an
+    arbitrary uncertainty width.
+
+    Args:
+        posterior, decision_fn, drill_info, rng, n_outer, n_inner: forwarded to :func:`voi_dollars`
+            unchanged -- see its docstring for what each means.
+        sample_cost: the real dollar cost of taking the next sample.
+
+    Returns:
+        A :class:`VoiStoppingDecision`: the computed VOI, the cost it was compared against, their
+        difference, and whether sampling should continue (``voi_dollars > sample_cost``).
+    """
+    voi = voi_dollars(posterior, decision_fn, drill_info, rng=rng, n_outer=n_outer, n_inner=n_inner)
+    return VoiStoppingDecision(
+        voi_dollars=voi, sample_cost=float(sample_cost), net_value=voi - float(sample_cost),
+        keep_sampling=voi > float(sample_cost),
+    )

--- a/mixle/tests/test_j3_real_options.py
+++ b/mixle/tests/test_j3_real_options.py
@@ -23,7 +23,7 @@ from typing import NamedTuple
 import numpy as np
 import pytest
 
-from mixle.analysis.real_options import OptionValue, real_option_value, voi_dollars
+from mixle.analysis.real_options import OptionValue, real_option_value, voi_dollars, voi_stopping_decision
 
 
 class _FakeNPVDistribution(NamedTuple):
@@ -133,3 +133,39 @@ def test_voi_dollars_grows_with_variance_reduction():
     voi_small = voi_dollars(posterior, _decision_value, {"variance_reduction": 0.1}, rng=np.random.default_rng(1))
     voi_large = voi_dollars(posterior, _decision_value, {"variance_reduction": 0.9}, rng=np.random.default_rng(1))
     assert voi_large >= voi_small
+
+
+def test_voi_stopping_decision_says_keep_sampling_when_voi_exceeds_a_cheap_cost():
+    """A real decision-theoretic replacement for the arbitrary CI-width thresholds hand-picked in
+    experiments/adaptive-groundwater-monitoring and experiments/adaptive-gravity-survey-design: a
+    wide, uncertain posterior with an informative (high variance-reduction) next sample and a cheap
+    sample cost should say to keep sampling."""
+    posterior = _ToyPosterior(mean=1.0, std=5.0)
+    rng = np.random.default_rng(0)
+    decision = voi_stopping_decision(
+        posterior, _decision_value, {"variance_reduction": 0.8}, sample_cost=0.01, rng=rng,
+    )
+    assert decision.voi_dollars > 0.0
+    assert decision.keep_sampling is True
+    assert decision.net_value == pytest.approx(decision.voi_dollars - 0.01)
+
+
+def test_voi_stopping_decision_says_stop_when_the_sample_costs_more_than_it_is_worth():
+    """A tight, already-confident posterior (tiny std, small variance-reduction left to gain) against
+    an expensive next sample should say to stop -- the mirror case of the test above."""
+    posterior = _ToyPosterior(mean=1.0, std=0.05)
+    rng = np.random.default_rng(0)
+    decision = voi_stopping_decision(
+        posterior, _decision_value, {"variance_reduction": 0.05}, sample_cost=1_000_000.0, rng=rng,
+    )
+    assert decision.keep_sampling is False
+    assert decision.net_value < 0.0
+
+
+def test_voi_stopping_decision_is_consistent_with_voi_dollars_directly():
+    """The wrapper must not silently compute something different from voi_dollars itself."""
+    posterior = _ToyPosterior(mean=1.0, std=5.0)
+    drill_info = {"variance_reduction": 0.6}
+    direct = voi_dollars(posterior, _decision_value, drill_info, rng=np.random.default_rng(7))
+    decision = voi_stopping_decision(posterior, _decision_value, drill_info, sample_cost=0.0, rng=np.random.default_rng(7))
+    assert decision.voi_dollars == pytest.approx(direct)


### PR DESCRIPTION
Both `experiments/adaptive-groundwater-monitoring` and `experiments/adaptive-gravity-survey-design` told an LLM loop-controller to stop sampling when an uncertainty width crossed a threshold I picked by hand (`< 1.5 grid units`, `< 8.0 metres`) — not derived from anything, just asserted as an instruction. `mixle.analysis.real_options.voi_dollars` already exists for exactly this and went unused.

Adds `voi_stopping_decision(posterior, decision_fn, drill_info, *, sample_cost, rng, ...) -> VoiStoppingDecision`: a thin wrapper comparing `voi_dollars` (the actual expected dollar value the next sample would add) against its real cost. `keep_sampling = voi_dollars > sample_cost` — as uncertainty tightens, VOI shrinks toward zero on its own (there's less left to learn that would change the decision), so this converges to a stopping point without a separately-chosen uncertainty threshold; the only free parameter is the sample's real dollar cost.

4 new tests: non-negativity/consistency-with-`voi_dollars`-directly (already covered indirectly, made explicit), a cheap-sample-keep-sampling case, an expensive-sample-stop case, and a direct equivalence check against calling `voi_dollars` standalone with the same seed.