### PR TITLE
Fix sampler batched= contract break: 138 DistributionSampler subclasses rejected the ABC's own keyword

### DIFF
--- a/api_manifest.json
+++ b/api_manifest.json
@@ -41,6 +41,7 @@
     "SpatialMixture",
     "SpeciesObservation",
     "Variogram",
+    "VoiStoppingDecision",
     "ace",
     "benchmark_dose",
     "borda_count",
@@ -104,7 +105,8 @@
     "transition_risk",
     "turing_coverage",
     "universal_kriging",
-    "voi_dollars"
+    "voi_dollars",
+    "voi_stopping_decision"
   ],
   "mixle.data": [
     "Boolean",

--- a/mixle/stats/bayes/conjugate.py
+++ b/mixle/stats/bayes/conjugate.py
@@ -127,7 +127,7 @@ class ConjugatePosteriorSampler:
         self.posterior = posterior
         self.rng = np.random.RandomState(seed)
 
-    def sample(self, size: int | None = None) -> dict[str, Any]:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> dict[str, Any]:
         """Draw one parameter set when ``size`` is ``None`` or a batch otherwise."""
         draws = self.posterior.sample(n=1 if size is None else int(size), rng=self.rng)
         if size is None:

--- a/mixle/stats/bayes/dict_dirichlet.py
+++ b/mixle/stats/bayes/dict_dirichlet.py
@@ -168,7 +168,7 @@ class DictDirichletSampler(DistributionSampler):
         self.dist = dist
         self.rng = np.random.RandomState(seed)
 
-    def sample(self, size: int | None = None) -> dict | list[dict]:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> dict | list[dict]:
         """Draw Dirichlet-distributed probability maps over the alpha keys (dict alpha only)."""
         if self.dist.is_unbounded:
             raise ValueError(

--- a/mixle/stats/bayes/dirichlet.py
+++ b/mixle/stats/bayes/dirichlet.py
@@ -536,7 +536,7 @@ class DirichletSampler(DistributionSampler):
         self.rng = RandomState(seed)
         self.dist = dist
 
-    def sample(self, size: int | None = None) -> np.ndarray:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> np.ndarray:
         """Draw iid samples from the Dirichlet distribution.
 
         Entries with non-positive alpha are fixed at zero and the remaining entries are sampled

--- a/mixle/stats/bayes/hierarchical_dirichlet_process_mixture.py
+++ b/mixle/stats/bayes/hierarchical_dirichlet_process_mixture.py
@@ -321,7 +321,7 @@ class HierarchicalDirichletProcessMixtureSampler(DistributionSampler):
         states = self.rng.choice(self.dist.num_components, size=n, p=pi)
         return [self.comp_samplers[k].sample() for k in states]
 
-    def sample(self, size: int | None = None) -> Any:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> Any:
         """Draw size groups (a single group when size is None)."""
         if size is None:
             return self.sample_group()

--- a/mixle/stats/bayes/multivariate_normal_gamma.py
+++ b/mixle/stats/bayes/multivariate_normal_gamma.py
@@ -188,7 +188,7 @@ class MultivariateNormalGammaSampler(DistributionSampler):
         self.grng = np.random.RandomState(self.rng.randint(0, 2**31 - 1))
         self.nrng = np.random.RandomState(self.rng.randint(0, 2**31 - 1))
 
-    def sample(self, size=None) -> Any:
+    def sample(self, size=None, *, batched: bool = True) -> Any:
         """Draw size samples (a single (mu, tau) pair when size is None)."""
         if size is None:
             t = self.grng.gamma(self.dist.a, 1 / self.dist.b)

--- a/mixle/stats/bayes/normal_gamma.py
+++ b/mixle/stats/bayes/normal_gamma.py
@@ -172,7 +172,7 @@ class NormalGammaSampler(DistributionSampler):
         self.grng = np.random.RandomState(self.rng.randint(0, 2**31 - 1))
         self.nrng = np.random.RandomState(self.rng.randint(0, 2**31 - 1))
 
-    def sample(self, size: int | None = None) -> Any:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> Any:
         """Draw size samples (a single (mu, tau) pair when size is None)."""
         if size is None:
             t = self.grng.gamma(self.dist.a, 1 / self.dist.b)

--- a/mixle/stats/bayes/normal_wishart.py
+++ b/mixle/stats/bayes/normal_wishart.py
@@ -191,7 +191,7 @@ class NormalWishartSampler(DistributionSampler):
         self.dist = dist
         self.rng = np.random.RandomState(seed)
 
-    def sample(self, size=None) -> Any:
+    def sample(self, size=None, *, batched: bool = True) -> Any:
         """Draw size samples (a single (mu, Lambda) pair when size is None).
 
         Lambda is drawn from the Wishart factor, then mu from

--- a/mixle/stats/bayes/pitman_yor.py
+++ b/mixle/stats/bayes/pitman_yor.py
@@ -174,7 +174,7 @@ class PitmanYorProcessSampler(DistributionSampler):
             labels.append(choice)
         return labels
 
-    def sample(self, size: int | None = None) -> list[int] | list[list[int]]:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> list[int] | list[list[int]]:
         """Draw partitions of ``num_elements`` elements; a single label vector when size is None."""
         n = self.dist.num_elements
         if n is None or n < 1:

--- a/mixle/stats/bayes/symmetric_dirichlet.py
+++ b/mixle/stats/bayes/symmetric_dirichlet.py
@@ -111,7 +111,7 @@ class SymmetricDirichletSampler(DistributionSampler):
         self.dist = dist
         self.rng = np.random.RandomState(seed)
 
-    def sample(self, size: int | None = None) -> np.ndarray:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> np.ndarray:
         """Draw symmetric-Dirichlet-distributed probability vectors (requires dist.dim)."""
         a = self.dist.alpha
         n = getattr(self.dist, "dim", None)

--- a/mixle/stats/combinator/censored.py
+++ b/mixle/stats/combinator/censored.py
@@ -167,7 +167,7 @@ class CensoredSampler(DistributionSampler):
         self.rng = RandomState(seed)
         self.base_sampler = dist.base.sampler(seed=self.rng.randint(0, 2**31 - 1))
 
-    def sample(self, size: int | None = None):
+    def sample(self, size: int | None = None, *, batched: bool = True):
         """Draw exact value(s) from the base distribution."""
         return self.base_sampler.sample(size=size)
 

--- a/mixle/stats/combinator/composite.py
+++ b/mixle/stats/combinator/composite.py
@@ -709,7 +709,7 @@ class CompositeSampler(DistributionSampler):
         self.rng = RandomState(seed)
         self.dist_samplers = [d.sampler(seed=self.rng.randint(maxrandint)) for d in dist.dists]
 
-    def sample(self, size: int | None = None) -> list[tuple[Any, ...]] | tuple[Any, ...]:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> list[tuple[Any, ...]] | tuple[Any, ...]:
         """Generate independent samples from a CompositeDistribution.
 
         If size is None, draw one sample and return as Tuple of length = len(dists). If size > 0,

--- a/mixle/stats/combinator/conditional.py
+++ b/mixle/stats/combinator/conditional.py
@@ -730,7 +730,7 @@ class ConditionalDistributionSampler(ConditionalSampler, DistributionSampler):
             x1 = self.default_sampler.sample()
         return x0, x1
 
-    def sample(self, size: int | None = None) -> tuple[Any, Any] | list[tuple[Any, Any]]:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> tuple[Any, Any] | list[tuple[Any, Any]]:
         """Sample 'size' independent samples from ConditionalDistribution.
 
         Sequence of 'size' calls to single_sample(). If size is None, size is taken to be 1.

--- a/mixle/stats/combinator/copula.py
+++ b/mixle/stats/combinator/copula.py
@@ -152,7 +152,7 @@ class CopulaSampler(DistributionSampler):
                 hi = mid
         return 0.5 * (lo + hi)
 
-    def sample(self, size: int | None = None) -> Any:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> Any:
         """Draw one joint observation or ``size`` iid observations."""
         n = 1 if size is None else int(size)
         u = np.atleast_2d(self._cop_sampler.sample(n)).reshape(n, self.dist.dim)

--- a/mixle/stats/combinator/exponential_tilt.py
+++ b/mixle/stats/combinator/exponential_tilt.py
@@ -322,7 +322,7 @@ class ExponentialTiltedSampler(DistributionSampler):
             else:
                 self.base_sampler = dist.base.sampler(seed=self.rng.randint(0, 2**31 - 1))
 
-    def sample(self, size: int | None = None):
+    def sample(self, size: int | None = None, *, batched: bool = True):
         """Draw one tilted value (or a list of ``size``)."""
         if size is not None:
             return [self.sample() for _ in range(size)]

--- a/mixle/stats/combinator/finite_stochastic_transform.py
+++ b/mixle/stats/combinator/finite_stochastic_transform.py
@@ -157,7 +157,7 @@ class FiniteStochasticTransformSampler(DistributionSampler):
         self.rng = RandomState(seed)
         self.source_sampler = dist.dist.sampler(seed=self.rng.randint(0, 2**31 - 1))
 
-    def sample(self, size: int | None = None):
+    def sample(self, size: int | None = None, *, batched: bool = True):
         """Draw one output (or a list of ``size`` outputs)."""
         if size is None:
             x = int(self.source_sampler.sample())

--- a/mixle/stats/combinator/hurdle.py
+++ b/mixle/stats/combinator/hurdle.py
@@ -116,7 +116,7 @@ class HurdleSampler(DistributionSampler):
         # the positive part is exactly a zero-truncated base; reuse the (batched-rejection) truncated sampler
         self._positive = TruncatedDistribution(dist.base, forbidden=[0]).sampler(seed=self.rng.randint(0, 2**31 - 1))
 
-    def sample(self, size: int | None = None):
+    def sample(self, size: int | None = None, *, batched: bool = True):
         """Draw one observation or a list of ``size`` observations."""
         if size is None:
             return 0 if self.rng.uniform() < self.dist.pi else self._positive.sample()

--- a/mixle/stats/combinator/ignored.py
+++ b/mixle/stats/combinator/ignored.py
@@ -169,7 +169,7 @@ class IgnoredSampler(DistributionSampler):
         self.dist_sampler = dist.dist.sampler(seed)
         self.null_sampler = isinstance(self.dist_sampler, NullSampler)
 
-    def sample(self, size: int | None = None):
+    def sample(self, size: int | None = None, *, batched: bool = True):
         """Draw from the wrapped sampler, preserving null-distribution ``None`` samples."""
         if self.null_sampler:
             if size is None:

--- a/mixle/stats/combinator/null_dist.py
+++ b/mixle/stats/combinator/null_dist.py
@@ -220,7 +220,7 @@ class NullSampler(DistributionSampler):
         self.rng = RandomState(seed)
         self.dist = dist
 
-    def sample(self, size: int | None = None) -> None:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> None:
         """Returns None for any requested size.
 
         Args:

--- a/mixle/stats/combinator/optional.py
+++ b/mixle/stats/combinator/optional.py
@@ -443,7 +443,7 @@ class OptionalSampler(DistributionSampler):
         self.dist = dist
         self.sampler = self.dist.dist.sampler(self.new_seed())
 
-    def sample(self, size: int | None = None):
+    def sample(self, size: int | None = None, *, batched: bool = True):
         """Draw one observation or a list of observations from the optional mixture."""
 
         sampler = self.sampler

--- a/mixle/stats/combinator/record.py
+++ b/mixle/stats/combinator/record.py
@@ -404,7 +404,7 @@ class RecordSampler(DistributionSampler):
         self.dist = dist
         self.samplers = [d.sampler(seed=self.new_seed()) for d in dist.dists]
 
-    def sample(self, size: int | None = None):
+    def sample(self, size: int | None = None, *, batched: bool = True):
         """Draw one record or a list of records from the child samplers."""
         if size is None:
             return {source: sampler.sample() for source, sampler in zip(self.dist.sources, self.samplers)}

--- a/mixle/stats/combinator/select.py
+++ b/mixle/stats/combinator/select.py
@@ -558,7 +558,7 @@ class SelectSampler(DistributionSampler):
         self.rng = RandomState(seed)
         self.dist_samplers = [d.sampler(seed=self.rng.randint(maxint)) for d in dist.dists]
 
-    def sample(self, size: int | None = None):
+    def sample(self, size: int | None = None, *, batched: bool = True):
         """Draw from the select distribution.
 
         Dispatch-mixture mode (``weights`` set): a branch is drawn from the weights and a single

--- a/mixle/stats/combinator/survival.py
+++ b/mixle/stats/combinator/survival.py
@@ -118,7 +118,7 @@ class SurvivalSampler(DistributionSampler):
         self.dist = dist
         self.base_sampler = dist.base.sampler(seed=self.rng.randint(0, 2**31 - 1))
 
-    def sample(self, size: int | None = None):
+    def sample(self, size: int | None = None, *, batched: bool = True):
         """Draw one uncensored event-time pair or a list of pairs."""
         if size is None:
             return (self.base_sampler.sample(), 1)

--- a/mixle/stats/combinator/transform.py
+++ b/mixle/stats/combinator/transform.py
@@ -398,7 +398,7 @@ class TransformSampler(DistributionSampler):
         self.dist = dist
         self.child_sampler = dist.dist.sampler(seed=self.new_seed())
 
-    def sample(self, size: int | None = None):
+    def sample(self, size: int | None = None, *, batched: bool = True):
         """Draw child samples and map them through the transform."""
         x = self.child_sampler.sample(size=size)
         if size is None:

--- a/mixle/stats/combinator/weighted.py
+++ b/mixle/stats/combinator/weighted.py
@@ -228,7 +228,9 @@ class WeightedSampler(DistributionSampler):
         super().__init__(dist, seed)
         self.dist_sampler = dist.dist.sampler(seed=self.new_seed())
 
-    def sample(self, size: int | None = None) -> tuple[Any, float] | Sequence[tuple[Any, float]]:
+    def sample(
+        self, size: int | None = None, *, batched: bool = True
+    ) -> tuple[Any, float] | Sequence[tuple[Any, float]]:
         """Draw iid (value, weight) samples, each with weight 1.0.
 
         Args:

--- a/mixle/stats/combinator/zero_inflated.py
+++ b/mixle/stats/combinator/zero_inflated.py
@@ -113,7 +113,7 @@ class ZeroInflatedSampler(DistributionSampler):
         self.rng = RandomState(seed)
         self.base_sampler = dist.base.sampler(seed=self.rng.randint(0, 2**31 - 1))
 
-    def sample(self, size: int | None = None):
+    def sample(self, size: int | None = None, *, batched: bool = True):
         """Draw one observation or a list of ``size`` observations."""
         if size is None:
             return 0 if self.rng.uniform() < self.dist.pi else self.base_sampler.sample()

--- a/mixle/stats/directional/bingham.py
+++ b/mixle/stats/directional/bingham.py
@@ -162,7 +162,7 @@ class BinghamSampler(DistributionSampler):
             filled += take
         return out
 
-    def sample(self, size: int | None = None) -> Any:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> Any:
         """Draw one axial unit vector or ``size`` iid vectors."""
         if size is None:
             return self._batch(1)[0]

--- a/mixle/stats/directional/kent.py
+++ b/mixle/stats/directional/kent.py
@@ -166,7 +166,7 @@ class KentSampler(DistributionSampler):
             filled += k
         return out
 
-    def sample(self, size: int | None = None) -> Any:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> Any:
         """Draw one unit vector or ``size`` iid unit vectors."""
         if size is None:
             return self._batch(1)[0]

--- a/mixle/stats/directional/projected_normal.py
+++ b/mixle/stats/directional/projected_normal.py
@@ -191,7 +191,7 @@ class ProjectedNormalSampler(DistributionSampler):
         self.rng = RandomState(seed)
         self.dist = dist
 
-    def sample(self, size: int | None = None) -> float | np.ndarray:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> float | np.ndarray:
         """Draw one angle or an array of iid angles."""
         d = self.dist
         n = 1 if size is None else int(size)

--- a/mixle/stats/directional/von_mises.py
+++ b/mixle/stats/directional/von_mises.py
@@ -284,7 +284,7 @@ class VonMisesSampler(DistributionSampler):
         self.dist = dist
         self.seed = seed
 
-    def sample(self, size: int | None = None) -> float | np.ndarray:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> float | np.ndarray:
         """Draw ``size`` iid angles in (-pi, pi] (a float when ``size`` is None)."""
         return self.rng.vonmises(self.dist.mu, self.dist.kappa, size=size)
 

--- a/mixle/stats/directional/von_mises_fisher.py
+++ b/mixle/stats/directional/von_mises_fisher.py
@@ -404,7 +404,7 @@ class VonMisesFisherSampler(DistributionSampler):
         self.rng = RandomState(seed)
         self.dist = dist
 
-    def sample(self, size: int | None = None) -> np.ndarray:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> np.ndarray:
         """Draw iid unit-norm vectors from the von Mises-Fisher distribution.
 
         Args:

--- a/mixle/stats/directional/watson.py
+++ b/mixle/stats/directional/watson.py
@@ -141,7 +141,7 @@ class WatsonSampler(DistributionSampler):
         u_, sv_, _ = np.linalg.svd(q)
         self._tangent = u_[:, sv_ > 1e-9]  # (p, p-1)
 
-    def sample(self, size: int | None = None) -> np.ndarray:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> np.ndarray:
         """Draw one unit vector or a stack of iid unit vectors."""
         d = self.dist
         n = 1 if size is None else int(size)

--- a/mixle/stats/directional/wrapped_cauchy.py
+++ b/mixle/stats/directional/wrapped_cauchy.py
@@ -183,7 +183,7 @@ class WrappedCauchySampler(DistributionSampler):
         self.rng = RandomState(seed)
         self.dist = dist
 
-    def sample(self, size: int | None = None) -> float | np.ndarray:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> float | np.ndarray:
         """Draw one angle or an array of iid angles."""
         d = self.dist
         n = 1 if size is None else int(size)

--- a/mixle/stats/directional/wrapped_normal.py
+++ b/mixle/stats/directional/wrapped_normal.py
@@ -144,7 +144,7 @@ class WrappedNormalSampler(DistributionSampler):
         self.rng = RandomState(seed)
         self.dist = dist
 
-    def sample(self, size: int | None = None) -> float | np.ndarray:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> float | np.ndarray:
         """Draw one angle or an array of iid angles."""
         d = self.dist
         n = 1 if size is None else int(size)

--- a/mixle/stats/graphs/erdos_renyi_graph.py
+++ b/mixle/stats/graphs/erdos_renyi_graph.py
@@ -271,7 +271,9 @@ class ErdosRenyiGraphSampler(DistributionSampler):
             np.fill_diagonal(mat, diag)
         return mat
 
-    def sample(self, size: int | None = None, num_nodes: int | None = None) -> np.ndarray | list[np.ndarray]:
+    def sample(
+        self, size: int | None = None, num_nodes: int | None = None, *, batched: bool = True
+    ) -> np.ndarray | list[np.ndarray]:
         """Draw one graph or a list of graphs."""
         if size is None:
             return self.sample_graph(num_nodes=num_nodes)

--- a/mixle/stats/graphs/knowledge_graph.py
+++ b/mixle/stats/graphs/knowledge_graph.py
@@ -213,7 +213,7 @@ class KnowledgeGraphSampler(DistributionSampler):
         self.dist = dist
         self.rng = RandomState(seed)
 
-    def sample(self, size: int | None = None) -> Any:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> Any:
         """Draw one triple or ``size`` iid triples."""
         sz = 1 if size is None else size
         out = []

--- a/mixle/stats/graphs/random_dot_product_graph.py
+++ b/mixle/stats/graphs/random_dot_product_graph.py
@@ -150,7 +150,7 @@ class RandomDotProductGraphSampler(DistributionSampler):
         upper = np.triu(draws, 1)
         return upper + upper.T
 
-    def sample(self, size: int | None = None) -> np.ndarray | list[np.ndarray]:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> np.ndarray | list[np.ndarray]:
         """Draw graphs (adjacency matrices); a single matrix when size is None."""
         if size is None:
             return self.sample_graph()

--- a/mixle/stats/graphs/stochastic_block_graph.py
+++ b/mixle/stats/graphs/stochastic_block_graph.py
@@ -366,6 +366,8 @@ class StochasticBlockGraphSampler(DistributionSampler):
         num_nodes: int | None = None,
         block_assignments: Any | None = None,
         return_assignments: bool = False,
+        *,
+        batched: bool = True,
     ) -> Any:
         """Draw one graph or a list of graphs from the SBM."""
         if size is None:

--- a/mixle/stats/graphs/temporal_graph_grammar.py
+++ b/mixle/stats/graphs/temporal_graph_grammar.py
@@ -507,7 +507,7 @@ class TemporalGraphGrammarSampler(DistributionSampler):
         cols = np.concatenate([ij[:, 1], ij[:, 0]])
         return sp.csr_array((np.ones(rows.size), (rows, cols)), shape=(n, n))
 
-    def sample(self, size: int | None = None, *, num_steps: int = 10, n_init: int = 5) -> Any:
+    def sample(self, size: int | None = None, *, num_steps: int = 10, n_init: int = 5, batched: bool = True) -> Any:
         """Draw one sequence or a list of sequences from the grammar."""
         if size is None:
             return self.sample_one(num_steps=num_steps, n_init=n_init)

--- a/mixle/stats/latent/dirac_length.py
+++ b/mixle/stats/latent/dirac_length.py
@@ -511,7 +511,7 @@ class DiracLengthMixtureSampler(DistributionSampler):
         self.len_dist_sampler = dist.len_dist.sampler(seed=self.rng.randint(maxrandint))
         self.v = dist.v
 
-    def sample(self, size: int | None = None) -> list[int] | int:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> list[int] | int:
         """Draw iid samples from a DiracLengthMixture distribution.
 
         Args:

--- a/mixle/stats/latent/gated_mixture.py
+++ b/mixle/stats/latent/gated_mixture.py
@@ -177,7 +177,7 @@ class GatedMixtureSampler(DistributionSampler):
         k = int(self.rng.choice(self.dist.num_components, p=gate_p / gate_p.sum()))
         return self._comp_samplers[k].sample()
 
-    def sample(self, size: int | None = None) -> Any:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> Any:
         """Raise because unconditional sampling requires caller-supplied covariates."""
         raise NotImplementedError("GatedMixture is conditional p(y|z); use sampler().sample_given(z).")
 

--- a/mixle/stats/latent/heterogeneous_pcfg.py
+++ b/mixle/stats/latent/heterogeneous_pcfg.py
@@ -758,7 +758,7 @@ class HeterogeneousPCFGSampler(DistributionSampler):
         right = int(self.dist.binary_right[rule_idx])
         return self._sample_nt(left, depth + 1, budget) + self._sample_nt(right, depth + 1, budget)
 
-    def sample(self, size: int | None = None) -> list[Any] | list[list[Any]]:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> list[Any] | list[list[Any]]:
         """Draw one sequence, or ``size`` independent sequences, from the grammar."""
         if size is not None:
             return [self.sample() for _ in range(size)]

--- a/mixle/stats/latent/hidden_association.py
+++ b/mixle/stats/latent/hidden_association.py
@@ -386,7 +386,7 @@ class HiddenAssociationSampler(DistributionSampler):
         self.given_sampler = self.dist.given_dist.sampler(seed=self.rng.randint(0, maxrandint))
 
     def sample(
-        self, size: int | None = None
+        self, size: int | None = None, *, batched: bool = True
     ) -> (
         Sequence[tuple[list[tuple[Any, float]], list[tuple[Any, float]]]]
         | tuple[list[tuple[Any, float]], list[tuple[Any, float]]]

--- a/mixle/stats/latent/hierarchical.py
+++ b/mixle/stats/latent/hierarchical.py
@@ -107,7 +107,7 @@ class HierarchicalNormalSampler(DistributionSampler):
         self.dist = dist
         self.rng = np.random.RandomState(seed)
 
-    def sample(self, sizes):
+    def sample(self, sizes, *, batched: bool = True):
         """Draw group(s) of given size(s): an int draws one group; a sequence draws one group per entry."""
         d = self.dist
         if np.ndim(sizes) == 0:

--- a/mixle/stats/latent/hierarchical_mixture.py
+++ b/mixle/stats/latent/hierarchical_mixture.py
@@ -515,7 +515,7 @@ class HierarchicalMixtureSampler(DistributionSampler):
         self.dist = dist
         self.sampler = dist.to_mixture().sampler(seed)
 
-    def sample(self, size: int | None = None) -> Sequence[Any] | Any:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> Sequence[Any] | Any:
         """Return samples from the underlying mixture sampler."""
         return self.sampler.sample(size=size)
 

--- a/mixle/stats/latent/hmm_determinize.py
+++ b/mixle/stats/latent/hmm_determinize.py
@@ -331,7 +331,7 @@ class DeterminizedSampler:
                 return out
             q = nxt[i]
 
-    def sample(self, size: int | None = None):
+    def sample(self, size: int | None = None, *, batched: bool = True):
         """Draw one terminal-ended sequence or a list of independent sequences."""
         if size is None:
             return self._one()

--- a/mixle/stats/latent/indian_buffet_process.py
+++ b/mixle/stats/latent/indian_buffet_process.py
@@ -388,7 +388,7 @@ class IndianBuffetProcessSampler(DistributionSampler):
             return list(np.flatnonzero(z).astype(int))
         return z.astype(int).tolist()
 
-    def sample(self, size: int | None = None) -> list[int] | list[list[int]]:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> list[int] | list[list[int]]:
         """Draw one feature row or ``size`` iid feature rows."""
         if size is None:
             z = self.rng.rand(self.dist.num_features) <= self.dist.feature_probs

--- a/mixle/stats/latent/integer_hidden_association.py
+++ b/mixle/stats/latent/integer_hidden_association.py
@@ -499,7 +499,9 @@ class IntegerHiddenAssociationSampler(DistributionSampler):
 
         return list(count_by_value(v2).items())
 
-    def sample(self, size: int | None = None) -> Sequence[list[tuple[int, float]]] | list[tuple[int, float]]:
+    def sample(
+        self, size: int | None = None, *, batched: bool = True
+    ) -> Sequence[list[tuple[int, float]]] | list[tuple[int, float]]:
         """Draw iid grouped-count observations from the integer hidden association model.
 
         Args:

--- a/mixle/stats/latent/integer_probabilistic_latent_semantic_indexing.py
+++ b/mixle/stats/latent/integer_probabilistic_latent_semantic_indexing.py
@@ -473,7 +473,7 @@ class IntegerProbabilisticLatentSemanticIndexingSampler(DistributionSampler):
         self.size_rng = self.dist.len_dist.sampler(self.rng.randint(0, maxrandint))
 
     def sample(
-        self, size: int | None = None
+        self, size: int | None = None, *, batched: bool = True
     ) -> tuple[int, Sequence[tuple[int, float]]] | Sequence[tuple[int, Sequence[tuple[int, float]]]]:
         """Generate iid samples from PLSI model.
 

--- a/mixle/stats/latent/joint_mixture.py
+++ b/mixle/stats/latent/joint_mixture.py
@@ -432,7 +432,7 @@ class JointMixtureSampler(DistributionSampler):
         self.comp_sampler1 = [d.sampler(seed=self.rng.randint(0, maxrandint)) for d in self.dist.components1]
         self.comp_sampler2 = [d.sampler(seed=self.rng.randint(0, maxrandint)) for d in self.dist.components2]
 
-    def sample(self, size: int | None = None) -> tuple[Any, Any] | Sequence[tuple[Any, Any]]:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> tuple[Any, Any] | Sequence[tuple[Any, Any]]:
         """Draw iid ``(X1, X2)`` samples from the joint mixture.
 
         The X1 component state is drawn from w1, X1 is sampled from that component, the X2

--- a/mixle/stats/latent/labeled_lda.py
+++ b/mixle/stats/latent/labeled_lda.py
@@ -403,7 +403,7 @@ class LabeledLDASampler(DistributionSampler):
         self.len_dist = self.dist.len_dist.sampler(seed=self.rng.randint(maxint))
         self.set_dist = self.dist.set_dist.sampler(seed=self.rng.randint(maxint))
 
-    def sample(self, size=None):
+    def sample(self, size=None, *, batched: bool = True):
         """Draw iid labeled documents from the LabeledLDA model.
 
         If size is None, a single Tuple[List[T], List[int]] is returned containing the sampled document

--- a/mixle/stats/latent/lookback_hidden_markov_model.py
+++ b/mixle/stats/latent/lookback_hidden_markov_model.py
@@ -563,7 +563,7 @@ class LookbackHiddenMarkovModelSampler(DistributionSampler):
 
         self.state_sampler = MarkovChainDistribution(p_map, t_map).sampler(seed=self.rng.randint(0, maxrandint))
 
-    def sample(self, size: int | None = None):
+    def sample(self, size: int | None = None, *, batched: bool = True):
         """Draw iid sequences from the lookback hidden Markov distribution.
 
         Args:

--- a/mixle/stats/latent/probabilistic_circuit.py
+++ b/mixle/stats/latent/probabilistic_circuit.py
@@ -274,7 +274,7 @@ class ProbabilisticCircuitSampler(DistributionSampler):
         descend(len(self.dist.nodes) - 1)
         return out
 
-    def sample(self, size: int | None = None) -> Any:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> Any:
         """Draw one observation or ``size`` iid observations from the circuit."""
         if size is None:
             return self._sample_one()

--- a/mixle/stats/latent/probabilistic_pca.py
+++ b/mixle/stats/latent/probabilistic_pca.py
@@ -156,7 +156,7 @@ class ProbabilisticPCASampler(DistributionSampler):
         self.rng = RandomState(seed)
         self.dist = dist
 
-    def sample(self, size: int | None = None) -> np.ndarray:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> np.ndarray:
         """Draw ``size`` iid vectors (shape (d,) when size is None, else (size, d))."""
         sz = 1 if size is None else size
         d, q = self.dist.dim, self.dist.latent_dim

--- a/mixle/stats/latent/segmental_hidden_markov_model.py
+++ b/mixle/stats/latent/segmental_hidden_markov_model.py
@@ -336,7 +336,7 @@ class SegmentalHiddenMarkovSampler(DistributionSampler):
         t_map = {i: {j: dist.transitions[i, j] for j in range(dist.n_states)} for i in range(dist.n_states)}
         self.state_sampler = MarkovChainDistribution(p_map, t_map).sampler(seed=self.rng.randint(0, maxrandint))
 
-    def sample(self, size: int | None = None) -> list[Any] | list[list[Any]]:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> list[Any] | list[list[Any]]:
         """Draw one segment sequence, or ``size`` iid segment sequences."""
         if size is not None:
             return [self.sample() for _ in range(size)]

--- a/mixle/stats/latent/semi_supervised_hidden_markov_model.py
+++ b/mixle/stats/latent/semi_supervised_hidden_markov_model.py
@@ -254,7 +254,7 @@ class SemiSupervisedHiddenMarkovSampler(DistributionSampler):
             states.append(z)
         return ([self.state_samplers[st].sample() for st in states], None)
 
-    def sample(self, size=None):
+    def sample(self, size=None, *, batched: bool = True):
         """Draw one observation or a list of observations with ``None`` state priors."""
         if self.dist.terminal_states is not None:
             return self._sample_terminal() if size is None else [self._sample_terminal() for _ in range(size)]

--- a/mixle/stats/latent/semi_supervised_mixture.py
+++ b/mixle/stats/latent/semi_supervised_mixture.py
@@ -431,7 +431,7 @@ class SemiSupervisedMixtureSampler(DistributionSampler):
         self.dist = dist
         self.comp_samplers = [d.sampler(seed=rng_loc.randint(0, maxrandint)) for d in self.dist.components]
 
-    def sample(self, size: int | None = None) -> Sequence[Any] | Any:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> Sequence[Any] | Any:
         """Draw 'size' component values from the mixture (no prior labels are generated).
 
         Args:

--- a/mixle/stats/latent/tree_hidden_markov_model.py
+++ b/mixle/stats/latent/tree_hidden_markov_model.py
@@ -891,7 +891,7 @@ class TreeHiddenMarkovSampler(DistributionSampler):
         else:
             return [self.sample_tree() for xx in range(size)]
 
-    def sample(self, size: int | None = None):
+    def sample(self, size: int | None = None, *, batched: bool = True):
         """Draw iid tree observations from the tree HMM.
 
         Args:

--- a/mixle/stats/matrix/inverse_wishart.py
+++ b/mixle/stats/matrix/inverse_wishart.py
@@ -104,7 +104,7 @@ class InverseWishartSampler(DistributionSampler):
             seed=self.rng.randint(0, 2**31 - 1)
         )
 
-    def sample(self, size: int | None = None) -> np.ndarray:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> np.ndarray:
         """Draw one or more inverse-Wishart SPD matrix samples."""
         w = self._wishart.sample(size=size)
         if size is None:

--- a/mixle/stats/matrix/lkj.py
+++ b/mixle/stats/matrix/lkj.py
@@ -135,7 +135,7 @@ class LKJSampler(DistributionSampler):
             corr = nxt
         return corr
 
-    def sample(self, size: int | None = None) -> Any:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> Any:
         """Draw one correlation matrix or a list of independent correlation matrices."""
         if size is None:
             return self._batch(1)[0]

--- a/mixle/stats/matrix/matrix_normal.py
+++ b/mixle/stats/matrix/matrix_normal.py
@@ -112,7 +112,7 @@ class MatrixNormalSampler(DistributionSampler):
         self.rng = RandomState(seed)
         self.dist = dist
 
-    def sample(self, size: int | None = None) -> np.ndarray:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> np.ndarray:
         """Draw one matrix or a batch of independent matrix-normal samples."""
         d = self.dist
         n = 1 if size is None else int(size)

--- a/mixle/stats/matrix/wishart.py
+++ b/mixle/stats/matrix/wishart.py
@@ -119,7 +119,7 @@ class WishartSampler(DistributionSampler):
         la = d._chol @ a
         return la @ la.T
 
-    def sample(self, size: int | None = None) -> np.ndarray:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> np.ndarray:
         """Draw one SPD matrix or a stacked batch of independent Wishart samples."""
         if size is None:
             return self._one()

--- a/mixle/stats/multivariate/categorical_multinomial.py
+++ b/mixle/stats/multivariate/categorical_multinomial.py
@@ -548,7 +548,9 @@ class MultinomialSampler(DistributionSampler):
         self.dist_sampler = self.dist.dist.sampler(seed=self.rng.randint(0, maxrandint))
         self.len_sampler = self.dist.len_dist.sampler(seed=self.rng.randint(0, maxrandint))
 
-    def sample(self, size: int | None = None) -> Sequence[Sequence[tuple[Any, float]]] | Sequence[tuple[Any, float]]:
+    def sample(
+        self, size: int | None = None, *, batched: bool = True
+    ) -> Sequence[Sequence[tuple[Any, float]]] | Sequence[tuple[Any, float]]:
         """Draw samples from multinomial distribution.
 
         Note: If len_sampler can draw n=0, an empty list is returned for that sample.

--- a/mixle/stats/multivariate/clayton_copula.py
+++ b/mixle/stats/multivariate/clayton_copula.py
@@ -77,7 +77,7 @@ class ClaytonCopulaSampler(DistributionSampler):
         self.dist = dist
         self.rng = RandomState(seed)
 
-    def sample(self, size: int | None = None) -> np.ndarray:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> np.ndarray:
         n = 1 if size is None else int(size)
         th = self.dist.theta
         v = self.rng.gamma(shape=1.0 / th, scale=1.0, size=(n, 1))

--- a/mixle/stats/multivariate/composition.py
+++ b/mixle/stats/multivariate/composition.py
@@ -151,7 +151,7 @@ class AitchisonNormalSampler(DistributionSampler):
         self.dist = dist
         self.gaussian_sampler = dist.gaussian.sampler(seed)
 
-    def sample(self, size: int | None = None) -> np.ndarray:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> np.ndarray:
         """Draw one composition or ``size`` iid compositions on the simplex."""
         y = self.gaussian_sampler.sample(size)
         return ilr_inv(np.atleast_2d(y))[0] if size is None else ilr_inv(np.asarray(y))

--- a/mixle/stats/multivariate/diagonal_gaussian.py
+++ b/mixle/stats/multivariate/diagonal_gaussian.py
@@ -441,7 +441,7 @@ class DiagonalGaussianSampler(DistributionSampler):
         self.rng = RandomState(seed)
         self.dist = dist
 
-    def sample(self, size: int | None = None) -> Sequence[np.ndarray] | np.ndarray:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> Sequence[np.ndarray] | np.ndarray:
         """Draw iid samples from the diagonal Gaussian distribution.
 
         Args:

--- a/mixle/stats/multivariate/dirichlet_multinomial.py
+++ b/mixle/stats/multivariate/dirichlet_multinomial.py
@@ -154,7 +154,7 @@ class DirichletMultinomialSampler(DistributionSampler):
         self.rng = RandomState(seed)
         self.dist = dist
 
-    def sample(self, size: int | None = None) -> np.ndarray:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> np.ndarray:
         """Draw one count vector or a stack of iid count vectors."""
         d = self.dist
         n_draws = 1 if size is None else int(size)

--- a/mixle/stats/multivariate/frank_copula.py
+++ b/mixle/stats/multivariate/frank_copula.py
@@ -78,7 +78,7 @@ class FrankCopulaSampler(DistributionSampler):
         self.dist = dist
         self.rng = RandomState(seed)
 
-    def sample(self, size: int | None = None) -> np.ndarray:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> np.ndarray:
         n = 1 if size is None else int(size)
         th = self.dist.theta
         u1 = self.rng.uniform(_CLIP, 1.0 - _CLIP, size=n)

--- a/mixle/stats/multivariate/gaussian_copula.py
+++ b/mixle/stats/multivariate/gaussian_copula.py
@@ -94,7 +94,7 @@ class GaussianCopulaSampler(DistributionSampler):
         self.rng = RandomState(seed)
         self.dist = dist
 
-    def sample(self, size: int | None = None) -> np.ndarray:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> np.ndarray:
         """Draw one copula sample or a batch of independent copula samples."""
         n = 1 if size is None else int(size)
         z = self.rng.multivariate_normal(np.zeros(self.dist.dim), self.dist.corr, size=n)

--- a/mixle/stats/multivariate/gumbel_copula.py
+++ b/mixle/stats/multivariate/gumbel_copula.py
@@ -100,7 +100,7 @@ class GumbelCopulaSampler(DistributionSampler):
         b = (np.sin((1.0 - alpha) * theta_u) / w) ** ((1.0 - alpha) / alpha)
         return a * b
 
-    def sample(self, size: int | None = None) -> np.ndarray:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> np.ndarray:
         n = 1 if size is None else int(size)
         th = self.dist.theta
         m = self._positive_stable(1.0 / th, n).reshape(n, 1)

--- a/mixle/stats/multivariate/integer_multinomial.py
+++ b/mixle/stats/multivariate/integer_multinomial.py
@@ -543,7 +543,9 @@ class IntegerMultinomialSampler(DistributionSampler):
         self.rng = np.random.RandomState(seed)
         self.len_sampler = self.dist.len_dist.sampler(seed=self.rng.randint(0, maxrandint))
 
-    def sample(self, size: int | None = None) -> list[tuple[int, float]] | list[list[tuple[int, float]]]:
+    def sample(
+        self, size: int | None = None, *, batched: bool = True
+    ) -> list[tuple[int, float]] | list[list[tuple[int, float]]]:
         """Draw independent samples from an integer multinomial distribution.
 
         Args:

--- a/mixle/stats/multivariate/multivariate_gaussian.py
+++ b/mixle/stats/multivariate/multivariate_gaussian.py
@@ -557,7 +557,7 @@ class MultivariateGaussianSampler(DistributionSampler):
         self.rng = RandomState(seed)
         self.dist = dist
 
-    def sample(self, size: int | None = None) -> np.ndarray:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> np.ndarray:
         """Draw iid samples from the multivariate Gaussian distribution.
 
         Args:

--- a/mixle/stats/multivariate/multivariate_student_t.py
+++ b/mixle/stats/multivariate/multivariate_student_t.py
@@ -293,7 +293,7 @@ class MultivariateStudentTSampler(DistributionSampler):
         self.dist = dist
         self.chol = np.linalg.cholesky(dist.shape)
 
-    def sample(self, size: int | None = None) -> np.ndarray:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> np.ndarray:
         """Draw ``size`` iid vectors (shape (p,) when size is None, else (size, p))."""
         sz = 1 if size is None else size
         p = self.dist.dim

--- a/mixle/stats/multivariate/rvine_copula.py
+++ b/mixle/stats/multivariate/rvine_copula.py
@@ -227,7 +227,7 @@ class RVineCopulaSampler(DistributionSampler):
         self.dist = dist
         self.rng = np.random.RandomState(seed)
 
-    def sample(self, size: int | None = None) -> np.ndarray:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> np.ndarray:
         # Generic (family-agnostic) inverse Rosenblatt: sample variables one at a time, inverting each new
         # variable's conditional CDF (built from the vine) against a uniform via bisection. O(d^2) h-evals
         # per accepted variable; correct for any pair-copula families.

--- a/mixle/stats/multivariate/student_t_copula.py
+++ b/mixle/stats/multivariate/student_t_copula.py
@@ -89,7 +89,7 @@ class StudentTCopulaSampler(DistributionSampler):
         self.dist = dist
         self.rng = RandomState(seed)
 
-    def sample(self, size: int | None = None) -> np.ndarray:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> np.ndarray:
         n = 1 if size is None else int(size)
         nu, d = self.dist.df, self.dist.dim
         g = self.rng.multivariate_normal(np.zeros(d), self.dist.corr, size=n)

--- a/mixle/stats/multivariate/vine_copula.py
+++ b/mixle/stats/multivariate/vine_copula.py
@@ -382,7 +382,7 @@ class CVineCopulaSampler(DistributionSampler):
         self.dist = dist
         self.rng = np.random.RandomState(seed)
 
-    def sample(self, size: int | None = None) -> np.ndarray:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> np.ndarray:
         n = 1 if size is None else int(size)
         d = self.dist.dim
         p = self.dist.pairs
@@ -550,7 +550,7 @@ class DVineCopulaSampler(DistributionSampler):
         self.dist = dist
         self.rng = np.random.RandomState(seed)
 
-    def sample(self, size: int | None = None) -> np.ndarray:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> np.ndarray:
         n = 1 if size is None else int(size)
         d = self.dist.dim
         p = self.dist.pairs

--- a/mixle/stats/processes/birth_death.py
+++ b/mixle/stats/processes/birth_death.py
@@ -191,7 +191,7 @@ class BirthDeathSamplingSampler(DistributionSampler):
                 events.append((t, _SAMPLING))
         return d.initial_population, d.horizon, events
 
-    def sample(self, size: int | None = None) -> Any:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> Any:
         """Draw one trajectory ``(n0, T, events)`` or a list of ``size`` trajectories."""
         if size is None:
             return self._sample_one()

--- a/mixle/stats/processes/chinese_restaurant_process.py
+++ b/mixle/stats/processes/chinese_restaurant_process.py
@@ -110,7 +110,7 @@ class ChineseRestaurantProcessSampler(DistributionSampler):
             labels[i] = t
         return labels
 
-    def sample(self, size: int | None = None):
+    def sample(self, size: int | None = None, *, batched: bool = True):
         """Draw one partition or a list of independent partitions."""
         if size is None:
             return self._one()

--- a/mixle/stats/processes/ctmc.py
+++ b/mixle/stats/processes/ctmc.py
@@ -152,7 +152,7 @@ class ContinuousTimeMarkovChainSampler(DistributionSampler):
             cur = nxt
         return d.initial_state, jumps
 
-    def sample(self, size: int | None = None) -> Any:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> Any:
         """Draw one trajectory or a list of trajectories over the configured horizon."""
         if size is None:
             return self._sample_one()

--- a/mixle/stats/processes/hawkes_process.py
+++ b/mixle/stats/processes/hawkes_process.py
@@ -220,7 +220,7 @@ class HawkesProcessSampler(DistributionSampler):
             )
         return np.asarray(events, dtype=np.float64)
 
-    def sample(self, size: int | None = None) -> np.ndarray | list[np.ndarray]:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> np.ndarray | list[np.ndarray]:
         """Draw one realization (event-time array) or a list of ``size`` realizations."""
         if size is None:
             return self._sample_one()

--- a/mixle/stats/processes/inhomogeneous_poisson.py
+++ b/mixle/stats/processes/inhomogeneous_poisson.py
@@ -193,7 +193,7 @@ class InhomogeneousPoissonProcessSampler(DistributionSampler):
         events.sort()
         return events
 
-    def sample(self, size: int | None = None) -> np.ndarray | list[np.ndarray]:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> np.ndarray | list[np.ndarray]:
         """Draw one realization (event-time array) or a list of ``size`` realizations."""
         if size is None:
             return self._sample_one()

--- a/mixle/stats/processes/multivariate_hawkes.py
+++ b/mixle/stats/processes/multivariate_hawkes.py
@@ -202,7 +202,7 @@ class MultivariateHawkesProcessSampler(DistributionSampler):
                 s[m] += 1.0
         return events
 
-    def sample(self, size: int | None = None):
+    def sample(self, size: int | None = None, *, batched: bool = True):
         """Draw one marked-event realization, or ``size`` iid realizations."""
         if size is None:
             return self._sample_one()

--- a/mixle/stats/processes/power_law_hawkes.py
+++ b/mixle/stats/processes/power_law_hawkes.py
@@ -159,7 +159,7 @@ class PowerLawHawkesSampler(DistributionSampler):
         order = np.argsort(times)
         return np.asarray(times)[order], np.asarray(marks)[order]
 
-    def sample(self, size: int | None = None):
+    def sample(self, size: int | None = None, *, batched: bool = True):
         """Draw one catalogue or a list of catalogues by the branching construction."""
         if size is None:
             return self._sample_one()

--- a/mixle/stats/processes/renewal_process.py
+++ b/mixle/stats/processes/renewal_process.py
@@ -134,7 +134,7 @@ class RenewalProcessSampler(DistributionSampler):
             events.append(t)
         return np.asarray(events, dtype=np.float64)
 
-    def sample(self, size: int | None = None) -> np.ndarray | list[np.ndarray]:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> np.ndarray | list[np.ndarray]:
         """Draw one realization, or ``size`` iid realizations, on the fixed window."""
         if size is None:
             return self._sample_one()

--- a/mixle/stats/processes/temporal.py
+++ b/mixle/stats/processes/temporal.py
@@ -150,7 +150,7 @@ class PeriodicTimeSampler(DistributionSampler):
         self.dist = dist
         self.von_mises_sampler = dist.von_mises.sampler(seed)
 
-    def sample(self, size: int | None = None) -> np.ndarray | float:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> np.ndarray | float:
         """Draw cycle position(s) in seconds, ``[0, period_seconds)`` (the phase mapped back to time)."""
         phi = self.von_mises_sampler.sample(size)
         secs = np.mod(np.asarray(phi), 2.0 * np.pi) / (2.0 * np.pi) * self.dist.period_s

--- a/mixle/stats/rankings/bradley_terry.py
+++ b/mixle/stats/rankings/bradley_terry.py
@@ -144,7 +144,7 @@ class BradleyTerrySampler(DistributionSampler):
         pi = 1.0 / (1.0 + math.exp(-(self.dist.log_w[i] - self.dist.log_w[j])))
         return (int(i), int(j)) if self.rng.rand() < pi else (int(j), int(i))
 
-    def sample(self, size: int | None = None) -> tuple[int, int] | list[tuple[int, int]]:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> tuple[int, int] | list[tuple[int, int]]:
         """Draw one comparison outcome or ``size`` iid comparison outcomes."""
         if size is None:
             return self._sample_one()

--- a/mixle/stats/rankings/ewens.py
+++ b/mixle/stats/rankings/ewens.py
@@ -157,7 +157,7 @@ class EwensSampler(DistributionSampler):
         self.dist = dist
         self.rng = RandomState(seed)
 
-    def sample(self, size: int | None = None) -> list[int] | list[list[int]]:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> list[int] | list[list[int]]:
         """Draw one permutation or ``size`` iid permutations."""
         k = 1 if size is None else size
         seed = int(self.rng.randint(0, 2**31 - 1))

--- a/mixle/stats/rankings/generalized_mallows.py
+++ b/mixle/stats/rankings/generalized_mallows.py
@@ -410,7 +410,7 @@ class GeneralizedMallowsSampler(DistributionSampler):
             out.append(perm)
         return out
 
-    def sample(self, size: int | None = None) -> list[int] | list[list[int]]:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> list[int] | list[list[int]]:
         """Draw one ordering or ``size`` iid orderings."""
         k = 1 if size is None else size
         if self.dist.metric == "kendall":

--- a/mixle/stats/rankings/generalized_mallows_model.py
+++ b/mixle/stats/rankings/generalized_mallows_model.py
@@ -172,7 +172,7 @@ class GeneralizedMallowsModelSampler(DistributionSampler):
             perm.insert(i - j, int(self.dist.sigma0[i]))
         return perm
 
-    def sample(self, size: int | None = None) -> list[int] | list[list[int]]:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> list[int] | list[list[int]]:
         """Draw one ordering or ``size`` iid orderings."""
         if size is None:
             return self._sample_one()

--- a/mixle/stats/rankings/low_rank_permutation.py
+++ b/mixle/stats/rankings/low_rank_permutation.py
@@ -165,7 +165,7 @@ class LowRankPermutationSampler(DistributionSampler):
         self.burn = burn
         self.thin = thin
 
-    def sample(self, size: int | None = None) -> list[int] | list[list[int]]:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> list[int] | list[list[int]]:
         """Draw one ordering or ``size`` approximate iid orderings."""
         k = 1 if size is None else size
         seed = int(self.rng.randint(0, 2**31 - 1))

--- a/mixle/stats/rankings/mallows.py
+++ b/mixle/stats/rankings/mallows.py
@@ -240,7 +240,7 @@ class MallowsSampler(DistributionSampler):
             perm.insert(i - j, int(self.dist.sigma0[i]))
         return perm
 
-    def sample(self, size: int | None = None) -> list[int] | list[list[int]]:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> list[int] | list[list[int]]:
         """Draw orderings (permutations of 0,...,n-1); a single list when size is None."""
         if size is None:
             return self._sample_one()

--- a/mixle/stats/rankings/matching.py
+++ b/mixle/stats/rankings/matching.py
@@ -214,7 +214,7 @@ class MatchingSampler(DistributionSampler):
             sigma[i] = available.pop(choice)
         return sigma
 
-    def sample(self, size: int | None = None) -> list[int] | list[list[int]]:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> list[int] | list[list[int]]:
         """Draw matchings (each a permutation); a single matching when size is None."""
         if size is None:
             return self._sample_one()

--- a/mixle/stats/rankings/paired_comparison.py
+++ b/mixle/stats/rankings/paired_comparison.py
@@ -113,7 +113,7 @@ class ThurstoneMostellerSampler(DistributionSampler):
         p = 0.5 * (1.0 + math.erf((self.dist.mu[i] - self.dist.mu[j]) / 2.0))  # Phi((mu_i-mu_j)/sqrt2)
         return (int(i), int(j)) if self.rng.rand() < p else (int(j), int(i))
 
-    def sample(self, size: int | None = None) -> tuple[int, int] | list[tuple[int, int]]:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> tuple[int, int] | list[tuple[int, int]]:
         """Draw one comparison or a list of comparisons."""
         if size is None:
             return self._sample_one()
@@ -386,7 +386,7 @@ class _TieSampler(DistributionSampler):
         i, j = sorted(self.rng.choice(k, size=2, replace=False))
         return (int(i), int(j), int(self.dist._sample_outcome(int(i), int(j), self.rng)))
 
-    def sample(self, size: int | None = None):
+    def sample(self, size: int | None = None, *, batched: bool = True):
         """Draw one comparison triple or a list of triples."""
         if size is None:
             return self._sample_one()

--- a/mixle/stats/rankings/plackett_luce.py
+++ b/mixle/stats/rankings/plackett_luce.py
@@ -213,7 +213,7 @@ class PlackettLuceSampler(DistributionSampler):
         self.rng = RandomState(seed)
         self.dist = dist
 
-    def sample(self, size: int | None = None) -> list[int] | list[list[int]]:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> list[int] | list[list[int]]:
         """Draw orderings (permutations of 0,...,K-1); a single list when size is None."""
         sz = 1 if size is None else size
         k = self.dist.dim

--- a/mixle/stats/rankings/spearman_rho.py
+++ b/mixle/stats/rankings/spearman_rho.py
@@ -347,7 +347,7 @@ class SpearmanRankingSampler(DistributionSampler):
         encoder = self.dist.dist_to_encoder()
         self.probs = np.exp(dist.seq_log_density(encoder.seq_encode(self.perms)))
 
-    def sample(self, size: int | None = None) -> list[int] | Sequence[list[int]]:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> list[int] | Sequence[list[int]]:
         """Draw iid samples (permutations of 0,...,K-1) from the Spearman ranking distribution.
 
         Args:

--- a/mixle/stats/rankings/thurstone.py
+++ b/mixle/stats/rankings/thurstone.py
@@ -212,7 +212,7 @@ class ThurstoneSampler(DistributionSampler):
         u = self.dist.mu + self.rng.standard_normal(self.dist.dim)
         return [int(i) for i in np.argsort(-u)]
 
-    def sample(self, size: int | None = None) -> list[int] | list[list[int]]:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> list[int] | list[list[int]]:
         """Draw one ordering or ``size`` iid orderings."""
         if size is None:
             return self._sample_one()

--- a/mixle/stats/sequences/markov_transform.py
+++ b/mixle/stats/sequences/markov_transform.py
@@ -326,7 +326,7 @@ class MarkovTransformSampler(DistributionSampler):
         # self.flat_sampler  = np.random.RandomState(self.rng.tomaxint())
         self.size_sampler = self.dist.len_dist.sampler(seed=self.rng.randint(0, maxrandint))
 
-    def sample(self, size: int | None = None):
+    def sample(self, size: int | None = None, *, batched: bool = True):
         """Draw 'size' iid observations from the Markov transform model.
 
         Each observation is a tuple (S1, S2, S3) of lists of (value, count) pairs. If size is None a single

--- a/mixle/stats/sequences/sparse_markov_transform.py
+++ b/mixle/stats/sequences/sparse_markov_transform.py
@@ -305,7 +305,7 @@ class SparseMarkovAssociationSampler(DistributionSampler):
         self.dist = dist
         self.size_sampler = self.dist.len_dist.sampler(seed=self.rng.randint(0, maxrandint))
 
-    def sample(self, size: int | None = None) -> T | Sequence[T]:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> T | Sequence[T]:
         """Draw 'size' iid observations from the sparse Markov association model.
 
         Each observation is a tuple (S1, S2) of lists of (value, count) pairs. If size is None a single

--- a/mixle/stats/sets/bernoulli_set.py
+++ b/mixle/stats/sets/bernoulli_set.py
@@ -492,7 +492,7 @@ class BernoulliSetSampler(DistributionSampler):
         self.rng = RandomState(seed)
         self.dist = dist
 
-    def sample(self, size: int | None = None) -> Sequence[Any] | list[Sequence[Any]]:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> Sequence[Any] | list[Sequence[Any]]:
         """Draw iid set observations from the BernoulliSetDistribution instance.
 
         Args:

--- a/mixle/stats/sets/integer_bernoulli_edit.py
+++ b/mixle/stats/sets/integer_bernoulli_edit.py
@@ -462,7 +462,9 @@ class IntegerBernoulliEditSampler(DistributionSampler):
         self.init_rng = dist.init_dist.sampler(self.rng.randint(0, maxrandint))
         self.next_rng = np.random.RandomState(self.rng.randint(0, maxrandint))
 
-    def sample(self, size: int | None = None) -> list[tuple[list[int], list[int]]] | tuple[list[int], list[int]]:
+    def sample(
+        self, size: int | None = None, *, batched: bool = True
+    ) -> list[tuple[list[int], list[int]]] | tuple[list[int], list[int]]:
         """Draw iid (prev set, next set) observations from the distribution.
 
         Args:

--- a/mixle/stats/sets/integer_bernoulli_set.py
+++ b/mixle/stats/sets/integer_bernoulli_set.py
@@ -286,7 +286,7 @@ class IntegerBernoulliSetSampler(DistributionSampler):
         self.rng = np.random.RandomState(seed)
         self.dist = dist
 
-    def sample(self, size: int | None = None) -> list[Sequence[int]] | Sequence[int]:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> list[Sequence[int]] | Sequence[int]:
         """Draw one subset or ``size`` iid subsets."""
         if size is None:
             log_u = np.log(self.rng.rand(self.dist.num_vals))

--- a/mixle/stats/trees/chow_liu_tree.py
+++ b/mixle/stats/trees/chow_liu_tree.py
@@ -298,7 +298,7 @@ class ChowLiuTreeSampler(DistributionSampler):
             None if d is None else d.sampler(seed=self.rng.randint(maxrandint)) for d in dist.default_dists
         ]
 
-    def sample(self, size: int | None = None) -> tuple[Any, ...] | list[tuple[Any, ...]]:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> tuple[Any, ...] | list[tuple[Any, ...]]:
         """Draw one tuple, or ``size`` iid tuples, from the tree."""
         if size is not None:
             return [self.sample() for _ in range(int(size))]

--- a/mixle/stats/trees/integer_chow_liu_tree.py
+++ b/mixle/stats/trees/integer_chow_liu_tree.py
@@ -287,7 +287,7 @@ class IntegerChowLiuTreeSampler(DistributionSampler):
         self.rng = RandomState(seed)
         self.dist = dist
 
-    def sample(self, size: int | None = None) -> list[int | None] | Sequence[list[int | None]]:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> list[int | None] | Sequence[list[int | None]]:
         """Draw iid integer vectors from the integer Chow-Liu tree distribution.
 
         Features are drawn in dependency order: the root from its marginal, each remaining

--- a/mixle/stats/trees/spanning_tree.py
+++ b/mixle/stats/trees/spanning_tree.py
@@ -229,7 +229,9 @@ class SpanningTreeSampler(DistributionSampler):
         edges = [(min(v, int(next_node[v])), max(v, int(next_node[v]))) for v in range(n) if v != 0]
         return sorted(edges)
 
-    def sample(self, size: int | None = None) -> list[tuple[int, int]] | list[list[tuple[int, int]]]:
+    def sample(
+        self, size: int | None = None, *, batched: bool = True
+    ) -> list[tuple[int, int]] | list[list[tuple[int, int]]]:
         """Draw spanning trees (each a sorted edge list); a single tree when size is None."""
         if size is None:
             return self._sample_one()

--- a/mixle/stats/univariate/continuous/beta.py
+++ b/mixle/stats/univariate/continuous/beta.py
@@ -291,7 +291,7 @@ class BetaSampler(DistributionSampler):
         self.rng = RandomState(seed)
         self.dist = dist
 
-    def sample(self, size: int | None = None) -> float | np.ndarray:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> float | np.ndarray:
         """Draw one sample or an array of iid samples."""
         return self.rng.beta(self.dist.a, self.dist.b, size=size)
 

--- a/mixle/stats/univariate/continuous/exgaussian.py
+++ b/mixle/stats/univariate/continuous/exgaussian.py
@@ -176,7 +176,7 @@ class ExponentiallyModifiedGaussianSampler(DistributionSampler):
         self.rng = RandomState(seed)
         self.dist = dist
 
-    def sample(self, size: int | None = None) -> float | np.ndarray:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> float | np.ndarray:
         """Draw ``size`` iid EMG samples (a single float if ``size`` is None)."""
         d = self.dist
         normal = self.rng.normal(loc=d.mu, scale=d.sigma, size=size)

--- a/mixle/stats/univariate/continuous/exponential.py
+++ b/mixle/stats/univariate/continuous/exponential.py
@@ -350,7 +350,7 @@ class ExponentialSampler(DistributionSampler):
         self.rng = RandomState(seed)
         self.dist = dist
 
-    def sample(self, size: int | None = None) -> float | np.ndarray:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> float | np.ndarray:
         """Draw iid samples from the exponential distribution.
 
         Args:

--- a/mixle/stats/univariate/continuous/gamma.py
+++ b/mixle/stats/univariate/continuous/gamma.py
@@ -404,7 +404,7 @@ class GammaSampler(DistributionSampler):
         self.dist = dist
         self.seed = seed
 
-    def sample(self, size: int | None = None) -> float | np.ndarray:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> float | np.ndarray:
         """Draw iid observations from the Gamma distribution.
 
         Args:

--- a/mixle/stats/univariate/continuous/gaussian.py
+++ b/mixle/stats/univariate/continuous/gaussian.py
@@ -411,7 +411,7 @@ class GaussianSampler(DistributionSampler):
         self.rng = RandomState(seed)
         self.dist = dist
 
-    def sample(self, size: int | None = None) -> float | np.ndarray:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> float | np.ndarray:
         """Draw iid samples from the Gaussian distribution.
 
         Args:

--- a/mixle/stats/univariate/continuous/generalized_extreme_value.py
+++ b/mixle/stats/univariate/continuous/generalized_extreme_value.py
@@ -263,7 +263,7 @@ class GeneralizedExtremeValueSampler(DistributionSampler):
         self.rng = RandomState(seed)
         self.dist = dist
 
-    def sample(self, size: int | None = None) -> float | np.ndarray:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> float | np.ndarray:
         """Draw one sample or an array of iid samples by inverse CDF."""
         d = self.dist
         e = -np.log(self.rng.uniform(size=size))  # -log U ~ Exp(1) = the standard Gumbel core

--- a/mixle/stats/univariate/continuous/generalized_gaussian.py
+++ b/mixle/stats/univariate/continuous/generalized_gaussian.py
@@ -159,7 +159,7 @@ class GeneralizedGaussianSampler(DistributionSampler):
         self.rng = RandomState(seed)
         self.dist = dist
 
-    def sample(self, size: int | None = None) -> float | np.ndarray:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> float | np.ndarray:
         """Draw one sample or an array of iid samples."""
         d = self.dist
         n = 1 if size is None else int(size)

--- a/mixle/stats/univariate/continuous/generalized_pareto.py
+++ b/mixle/stats/univariate/continuous/generalized_pareto.py
@@ -224,7 +224,7 @@ class GeneralizedParetoSampler(DistributionSampler):
         self.rng = RandomState(seed)
         self.dist = dist
 
-    def sample(self, size: int | None = None) -> float | np.ndarray:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> float | np.ndarray:
         """Draw one sample or an array of iid samples by inverse CDF."""
         d = self.dist
         u = self.rng.uniform(size=size)  # uniform; 1-U is also uniform, so use U directly below

--- a/mixle/stats/univariate/continuous/gumbel.py
+++ b/mixle/stats/univariate/continuous/gumbel.py
@@ -225,7 +225,7 @@ class GumbelSampler(DistributionSampler):
         self.dist = dist
         self.seed = seed
 
-    def sample(self, size: int | None = None) -> float | np.ndarray:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> float | np.ndarray:
         """Draw ``size`` iid observations (a float when ``size`` is None)."""
         return self.rng.gumbel(self.dist.loc, self.dist.scale, size=size)
 

--- a/mixle/stats/univariate/continuous/half_normal.py
+++ b/mixle/stats/univariate/continuous/half_normal.py
@@ -265,7 +265,7 @@ class HalfNormalSampler(DistributionSampler):
         self.dist = dist
         self.seed = seed
 
-    def sample(self, size: int | None = None) -> float | np.ndarray:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> float | np.ndarray:
         """Draw ``size`` iid observations (a float when ``size`` is None)."""
         return np.abs(self.rng.normal(0.0, self.dist.sigma, size=size))
 

--- a/mixle/stats/univariate/continuous/inverse_gamma.py
+++ b/mixle/stats/univariate/continuous/inverse_gamma.py
@@ -281,7 +281,7 @@ class InverseGammaSampler(DistributionSampler):
         self.dist = dist
         self.seed = seed
 
-    def sample(self, size: int | None = None) -> float | np.ndarray:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> float | np.ndarray:
         """Draw ``size`` iid observations (a float when ``size`` is None)."""
         return 1.0 / self.rng.gamma(shape=self.dist.alpha, scale=1.0 / self.dist.beta, size=size)
 

--- a/mixle/stats/univariate/continuous/inverse_gaussian.py
+++ b/mixle/stats/univariate/continuous/inverse_gaussian.py
@@ -320,7 +320,7 @@ class InverseGaussianSampler(DistributionSampler):
         self.dist = dist
         self.seed = seed
 
-    def sample(self, size: int | None = None) -> float | np.ndarray:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> float | np.ndarray:
         """Draw ``size`` iid observations (a float when ``size`` is None)."""
         return self.rng.wald(self.dist.mu, self.dist.lam, size=size)
 

--- a/mixle/stats/univariate/continuous/laplace.py
+++ b/mixle/stats/univariate/continuous/laplace.py
@@ -183,7 +183,7 @@ class LaplaceSampler(DistributionSampler):
         self.rng = RandomState(seed)
         self.dist = dist
 
-    def sample(self, size: int | None = None) -> float | np.ndarray:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> float | np.ndarray:
         """Draw one sample or an array of iid samples."""
         return self.rng.laplace(loc=self.dist.mu, scale=self.dist.b, size=size)
 

--- a/mixle/stats/univariate/continuous/log_gaussian.py
+++ b/mixle/stats/univariate/continuous/log_gaussian.py
@@ -422,7 +422,7 @@ class LogGaussianSampler(DistributionSampler):
         self.rng = RandomState(seed)
         self.dist = dist
 
-    def sample(self, size: int | None = None) -> float | np.ndarray:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> float | np.ndarray:
         """Draw iid samples from the log-Gaussian distribution.
 
         ``None`` returns a single float. A positive ``size`` returns a NumPy

--- a/mixle/stats/univariate/continuous/logistic.py
+++ b/mixle/stats/univariate/continuous/logistic.py
@@ -174,7 +174,7 @@ class LogisticSampler(DistributionSampler):
         self.rng = RandomState(seed)
         self.dist = dist
 
-    def sample(self, size: int | None = None) -> float | np.ndarray:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> float | np.ndarray:
         """Draw one sample or an array of iid samples."""
         return self.rng.logistic(loc=self.dist.loc, scale=self.dist.scale, size=size)
 

--- a/mixle/stats/univariate/continuous/nakagami.py
+++ b/mixle/stats/univariate/continuous/nakagami.py
@@ -173,7 +173,7 @@ class NakagamiSampler(DistributionSampler):
         self.rng = RandomState(seed)
         self.dist = dist
 
-    def sample(self, size: int | None = None) -> float | np.ndarray:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> float | np.ndarray:
         """Draw one sample or an array of iid samples."""
         d = self.dist
         n = 1 if size is None else int(size)

--- a/mixle/stats/univariate/continuous/pareto.py
+++ b/mixle/stats/univariate/continuous/pareto.py
@@ -226,7 +226,7 @@ class ParetoSampler(DistributionSampler):
         self.rng = RandomState(seed)
         self.dist = dist
 
-    def sample(self, size: int | None = None) -> float | np.ndarray:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> float | np.ndarray:
         """Draw one sample or an array of iid samples."""
         return self.dist.xm * (self.rng.pareto(self.dist.alpha, size=size) + 1.0)
 

--- a/mixle/stats/univariate/continuous/rayleigh.py
+++ b/mixle/stats/univariate/continuous/rayleigh.py
@@ -211,7 +211,7 @@ class RayleighSampler(DistributionSampler):
         self.rng = RandomState(seed)
         self.dist = dist
 
-    def sample(self, size: int | None = None) -> float | np.ndarray:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> float | np.ndarray:
         """Draw one sample or an array of iid samples."""
         return self.rng.rayleigh(scale=self.dist.sigma, size=size)
 

--- a/mixle/stats/univariate/continuous/rician.py
+++ b/mixle/stats/univariate/continuous/rician.py
@@ -197,7 +197,7 @@ class RicianSampler(DistributionSampler):
         self.rng = RandomState(seed)
         self.dist = dist
 
-    def sample(self, size: int | None = None) -> float | np.ndarray:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> float | np.ndarray:
         """Draw one sample or an array of iid samples."""
         d = self.dist
         n = 1 if size is None else int(size)

--- a/mixle/stats/univariate/continuous/skew_normal.py
+++ b/mixle/stats/univariate/continuous/skew_normal.py
@@ -146,7 +146,7 @@ class SkewNormalSampler(DistributionSampler):
         self.rng = RandomState(seed)
         self.dist = dist
 
-    def sample(self, size: int | None = None) -> float | np.ndarray:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> float | np.ndarray:
         """Draw one sample or an array of iid samples."""
         d = self.dist
         delta = d.shape / math.sqrt(1.0 + d.shape * d.shape)

--- a/mixle/stats/univariate/continuous/student_t.py
+++ b/mixle/stats/univariate/continuous/student_t.py
@@ -190,7 +190,7 @@ class StudentTSampler(DistributionSampler):
         self.rng = RandomState(seed)
         self.dist = dist
 
-    def sample(self, size: int | None = None) -> float | np.ndarray:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> float | np.ndarray:
         """Draw one sample or an array of iid samples."""
         return self.rng.standard_t(self.dist.df, size=size) * self.dist.scale + self.dist.loc
 

--- a/mixle/stats/univariate/continuous/tweedie.py
+++ b/mixle/stats/univariate/continuous/tweedie.py
@@ -208,7 +208,7 @@ class TweedieSampler(DistributionSampler):
         self.rng = RandomState(seed)
         self.dist = dist
 
-    def sample(self, size: int | None = None) -> float | np.ndarray:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> float | np.ndarray:
         """Draw ``size`` iid Tweedie samples (a single float if ``size`` is None).
 
         ``Y | N`` is a sum of ``N`` iid ``Gamma(shape, scale)``, which is ``Gamma(N*shape, scale)``;

--- a/mixle/stats/univariate/continuous/uniform.py
+++ b/mixle/stats/univariate/continuous/uniform.py
@@ -174,7 +174,7 @@ class UniformSampler(DistributionSampler):
         self.rng = RandomState(seed)
         self.dist = dist
 
-    def sample(self, size: int | None = None) -> float | np.ndarray:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> float | np.ndarray:
         """Draw one sample or an array of iid samples."""
         return self.rng.uniform(self.dist.low, self.dist.high, size=size)
 

--- a/mixle/stats/univariate/continuous/weibull.py
+++ b/mixle/stats/univariate/continuous/weibull.py
@@ -251,7 +251,7 @@ class WeibullSampler(DistributionSampler):
         self.rng = RandomState(seed)
         self.dist = dist
 
-    def sample(self, size: int | None = None) -> float | np.ndarray:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> float | np.ndarray:
         """Draw one sample or an array of iid samples."""
         return self.dist.scale * self.rng.weibull(self.dist.shape, size=size)
 

--- a/mixle/stats/univariate/discrete/bernoulli.py
+++ b/mixle/stats/univariate/discrete/bernoulli.py
@@ -304,7 +304,7 @@ class BernoulliSampler(DistributionSampler):
         self.rng = RandomState(seed)
         self.dist = dist
 
-    def sample(self, size: int | None = None) -> bool | Sequence[bool]:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> bool | Sequence[bool]:
         """Draw one sample or a list of iid samples."""
         rv = self.rng.rand() < self.dist.p if size is None else self.rng.rand(size) < self.dist.p
         return bool(rv) if size is None else rv.tolist()

--- a/mixle/stats/univariate/discrete/beta_binomial.py
+++ b/mixle/stats/univariate/discrete/beta_binomial.py
@@ -142,7 +142,7 @@ class BetaBinomialSampler(DistributionSampler):
         self.rng = RandomState(seed)
         self.dist = dist
 
-    def sample(self, size: int | None = None) -> int | np.ndarray:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> int | np.ndarray:
         """Draw one count or an array of iid counts."""
         d = self.dist
         p = self.rng.beta(d.a, d.b, size=size)

--- a/mixle/stats/univariate/discrete/binomial.py
+++ b/mixle/stats/univariate/discrete/binomial.py
@@ -622,7 +622,7 @@ class BinomialSampler(DistributionSampler):
         self.rng = RandomState(seed)
         self.dist = dist
 
-    def sample(self, size: int | None = None) -> int | list[int]:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> int | list[int]:
         """Draw samples from BinomialSampler.
 
         Args:

--- a/mixle/stats/univariate/discrete/categorical.py
+++ b/mixle/stats/univariate/discrete/categorical.py
@@ -523,7 +523,7 @@ class CategoricalSampler(DistributionSampler):
         self.probs = [u[1] for u in temp]
         self.num_levels = len(self.levels)
 
-    def sample(self, size: int | None = None) -> Any | list[Any]:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> Any | list[Any]:
         """Draw iid samples from the categorical distribution.
 
         Args:

--- a/mixle/stats/univariate/discrete/geometric.py
+++ b/mixle/stats/univariate/discrete/geometric.py
@@ -441,7 +441,7 @@ class GeometricSampler(DistributionSampler):
         self.rng = RandomState(seed)
         self.dist = dist
 
-    def sample(self, size: int | None = None) -> int | np.ndarray:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> int | np.ndarray:
         """Generate iid samples from geometric distribution.
 
         Generates a single geometric sample (int) if size is None, else a numpy array of integers of length size,

--- a/mixle/stats/univariate/discrete/integer_categorical.py
+++ b/mixle/stats/univariate/discrete/integer_categorical.py
@@ -476,7 +476,7 @@ class IntegerCategoricalSampler(DistributionSampler):
         self.rng = RandomState(seed)
         self.dist = dist
 
-    def sample(self, size: int | None = None) -> int | list[int]:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> int | list[int]:
         """Draw iid samples from the integer-categorical distribution.
 
         Args:

--- a/mixle/stats/univariate/discrete/integer_uniform_spike.py
+++ b/mixle/stats/univariate/discrete/integer_uniform_spike.py
@@ -342,7 +342,7 @@ class IntegerUniformSpikeSampler(DistributionSampler):
         self.dist = dist
         self.non_k = np.delete(np.arange(self.dist.min_val, self.dist.max_val + 1), self.dist.k - self.dist.min_val)
 
-    def sample(self, size: int | None = None) -> int | np.ndarray:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> int | np.ndarray:
         """Draw iid samples from the integer uniform spike distribution.
 
         Args:

--- a/mixle/stats/univariate/discrete/logseries.py
+++ b/mixle/stats/univariate/discrete/logseries.py
@@ -292,7 +292,7 @@ class LogSeriesSampler(DistributionSampler):
         self.dist = dist
         self.seed = seed
 
-    def sample(self, size: int | None = None) -> int | np.ndarray:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> int | np.ndarray:
         """Draw ``size`` iid positive integers (an int when ``size`` is None)."""
         rv = self.rng.logseries(self.dist.p, size=size)
         return int(rv) if size is None else rv

--- a/mixle/stats/univariate/discrete/negative_binomial.py
+++ b/mixle/stats/univariate/discrete/negative_binomial.py
@@ -306,7 +306,7 @@ class NegativeBinomialSampler(DistributionSampler):
         self.rng = RandomState(seed)
         self.dist = dist
 
-    def sample(self, size: int | None = None) -> int | np.ndarray:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> int | np.ndarray:
         """Draw one sample or an array of iid samples."""
         scale = (1.0 - self.dist.p) / self.dist.p
         lam = self.rng.gamma(shape=self.dist.r, scale=scale, size=size)

--- a/mixle/stats/univariate/discrete/point_mass.py
+++ b/mixle/stats/univariate/discrete/point_mass.py
@@ -156,7 +156,7 @@ class PointMassSampler(DistributionSampler):
         self.rng = RandomState(seed)
         self.dist = dist
 
-    def sample(self, size: int | None = None) -> Any | Sequence[Any]:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> Any | Sequence[Any]:
         """Return the fixed atom once or repeated ``size`` times."""
         if size is None:
             return self.dist.value

--- a/mixle/stats/univariate/discrete/poisson.py
+++ b/mixle/stats/univariate/discrete/poisson.py
@@ -484,7 +484,7 @@ class PoissonSampler(DistributionSampler):
         self.rng = RandomState(seed)
         self.dist = dist
 
-    def sample(self, size: int | None = None) -> int | np.ndarray:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> int | np.ndarray:
         """Draw iid samples from the Poisson distribution.
 
         Args:

--- a/mixle/stats/univariate/discrete/skellam.py
+++ b/mixle/stats/univariate/discrete/skellam.py
@@ -242,7 +242,7 @@ class SkellamSampler(DistributionSampler):
         self.rng = RandomState(seed)
         self.dist = dist
 
-    def sample(self, size: int | None = None) -> int | np.ndarray:
+    def sample(self, size: int | None = None, *, batched: bool = True) -> int | np.ndarray:
         """Draw ``size`` iid Skellam samples (a single int if ``size`` is None)."""
         n1 = self.rng.poisson(lam=self.dist.mu1, size=size)
         n2 = self.rng.poisson(lam=self.dist.mu2, size=size)

--- a/mixle/tests/sampler_batched_contract_test.py
+++ b/mixle/tests/sampler_batched_contract_test.py
@@ -1,0 +1,75 @@
+"""Every ``DistributionSampler`` subclass must accept the ABC's ``batched`` keyword.
+
+``DistributionSampler.sample``'s abstract signature is ``sample(self, size=None, *, batched=True)``
+(``mixle/stats/compute/pdist.py``). A concrete sampler that doesn't accept ``batched`` breaks its own
+base-class contract: any generic caller that does ``sampler.sample(n, batched=True)`` -- exactly what
+the vectorized-fast-path callers in ``markov_chain.py``/``sequence.py``/``hidden_markov.py`` already
+do against samplers they construct internally -- gets a ``TypeError`` instead of a value, the moment
+that caller is handed a sampler it didn't special-case. This walks every module under ``mixle.stats``
+and ``mixle.experimental``, collects every concrete (non-abstract) ``DistributionSampler`` subclass,
+and asserts each one's ``sample`` accepts ``batched`` as a keyword. It does not assert anything about
+*what* ``batched`` does for a given sampler -- per the ABC docstring, a sampler that is already fully
+vectorized (or has only one possible draw order) may legitimately accept and ignore the flag.
+"""
+
+import importlib
+import inspect
+import pkgutil
+import unittest
+from abc import ABC
+
+import mixle.experimental
+import mixle.stats
+from mixle.stats.compute.pdist import DistributionSampler
+
+
+def _iter_submodules(package):
+    prefix = package.__name__ + "."
+    for _finder, name, _is_pkg in pkgutil.walk_packages(package.__path__, prefix):
+        yield name
+
+
+def _collect_sampler_subclasses():
+    modules = list(_iter_submodules(mixle.stats)) + list(_iter_submodules(mixle.experimental))
+    classes = {}
+    for name in modules:
+        try:
+            module = importlib.import_module(name)
+        except ImportError:
+            # an optional dependency this environment doesn't have (mirrors the skip behavior in
+            # test_public_api_manifest_test.py's dynamic-package resolution).
+            continue
+        for attr_name, obj in vars(module).items():
+            if (
+                inspect.isclass(obj)
+                and issubclass(obj, DistributionSampler)
+                and obj is not DistributionSampler
+                and ABC not in obj.__bases__
+                and not inspect.isabstract(obj)
+            ):
+                classes[f"{obj.__module__}.{obj.__qualname__}"] = obj
+    return classes
+
+
+class SamplerBatchedContractTest(unittest.TestCase):
+    def test_every_concrete_sampler_accepts_batched(self):
+        classes = _collect_sampler_subclasses()
+        self.assertGreater(len(classes), 100, "sampler discovery found suspiciously few classes -- check the walk")
+
+        missing = []
+        for qualname, cls in sorted(classes.items()):
+            sig = inspect.signature(cls.sample)
+            params = sig.parameters
+            accepts = "batched" in params or any(p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values())
+            if not accepts:
+                missing.append(qualname)
+
+        self.assertEqual(
+            missing,
+            [],
+            f"{len(missing)} DistributionSampler subclass(es) don't accept the ABC's `batched` keyword: {missing}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

``DistributionSampler``'s abstract `sample()` signature is `sample(self, size=None, *, batched=True)` (`mixle/stats/compute/pdist.py`). Its docstring explicitly permits samplers that are already fully vectorized (or have only one possible draw order) to accept-and-ignore the flag. 138 concrete subclasses across `mixle/stats` and `mixle/experimental` didn't accept it at all — calling `sampler.sample(n, batched=True)` on any of them raised `TypeError`.

**Blast radius:** latent, not currently triggered. Every existing call site that passes `batched=` explicitly is a self-recursive call within one of the 27 already-conforming samplers (`markov_chain.py`, `sequence.py`, `hidden_markov.py`, `lda.py`) — none reach into the 138 broken ones. But any future generic caller handed an arbitrary sampler (e.g. a batching optimization in an inference loop) would hit `TypeError` across most of the sampler zoo.

**Fix scope:** this PR closes the contract break mechanically — every affected `sample()` now accepts `batched` as a keyword. None of the 138 have more than one code path today (no existing branch on `batched` anywhere in their bodies), so accepting-and-not-acting-on the flag is behaviorally *identical* to correctly honoring the contract for every one of them right now: `batched=True` and `batched=False` already produce the same output, because there's nothing yet to branch on.

**Explicitly out of scope:** wiring real vectorized fast paths through the ~35 combinator/wrapper samplers that fan out to child samplers (forwarding `batched` and adding a genuine batched-vs-loop distinction, matching the pattern already used by `GaussianMixtureSampler`/`HiddenMarkovSampler`) is a real speed opportunity but a separate, correctness-sensitive follow-up — not needed to close the TypeError-on-contract-use bug this PR targets.

Also includes a one-line `api_manifest.json` regen: `release/0.8.0`'s tip (PR #494, `voi_stopping_decision`) landed without regenerating the manifest, which left `public_api_manifest_test.py` failing independent of this change — same blocking-baseline-CI situation as PR #486 earlier in this series.

## Test plan
- [x] Added `mixle/tests/sampler_batched_contract_test.py`: walks every module under `mixle.stats`/`mixle.experimental`, collects every concrete `DistributionSampler` subclass, and asserts each accepts `batched` as a keyword — a regression guard for this exact bug class (found 138 violations before the fix, 0 after).
- [x] `ruff check`/`ruff format --check` clean on all touched files.
- [x] Full suite: `pytest mixle/tests -n auto` — 5176 passed (5177 incl. the unrelated pre-existing `substrate_knowledge_bundle_test.py` collection error, tracked separately — a stale `mixle_knowledge` cross-repo dependency, unrelated to this PR), 1 pre-existing xdist-contention timing flake (`backend_respecialization_test.py`, passes clean single-process), 14 skipped (environment-gated).

## Note
`mixle/tests/substrate_knowledge_bundle_test.py` fails to even *collect* in this environment (`AttributeError: module 'mixle_knowledge.contracts' has no attribute 'KnowledgeBundle'`) due to a stale/mismatched `mixle_knowledge` install — introduced by an already-merged PR (#`b891e5c9`/`1b6bb435`), unrelated to this change. Flagged separately for a follow-up fix; not addressed here to keep this PR scoped to the sampler contract.