### PR TITLE
Add calibration gate: an IC-6 verifier that fails miscalibrated posteriors

### DIFF
--- a/mixle/inference/calibration_gate.py
+++ b/mixle/inference/calibration_gate.py
@@ -1,0 +1,279 @@
+"""Calibration gate -- a deployable IC-6 verifier that challenges whether a posterior's reported
+uncertainty is actually *earned*, instead of checking only its shape.
+
+Motivation (found empirically, across several end-to-end pipelines): the UQ in this codebase is
+*locally honest* -- every module computes a real posterior -- but was *globally unaudited*. A
+systematically overconfident or miscalibrated posterior sailed straight through to a confident-looking
+final answer, because nothing in the flow ever challenged the confidence. The calibration *primitives*
+already existed (:mod:`mixle.inference.calibration`: ``pit_ensemble`` / ``interval_coverage`` /
+``coverage_curve`` / ``pit_calibration_error``); what was missing was a *gate* that composes them into
+a pass/fail verifier a pipeline (e.g. :func:`mixle.task.knowledge_routing.route_task`) can actually
+stop on. This module is that gate -- a thin composition, not new statistics.
+
+**Honest boundary, stated up front rather than buried.** This gate catches:
+
+  * *overconfidence / underconfidence* of a posterior relative to HELD-OUT DATA it can be checked
+    against (:func:`posterior_predictive_calibration`), and
+  * *inference-algorithm bugs* -- an inference that is not self-consistent under its own generative
+    model -- via simulation-based calibration (:func:`simulation_based_calibration`).
+
+It does **not** catch model misspecification under genuine non-uniqueness. If the data you can hold
+out simply cannot distinguish the true state (the textbook example: surface gravity cannot resolve a
+source's depth -- shallow and deep bodies produce nearly identical surface fields), then a biased
+posterior fits the held-out data perfectly and this gate will *correctly* pass it. Catching that
+requires either data that can see the biased dimension (e.g. one borehole) or a physics-based prior
+-- not more calibration checking. This gate reports what the available data can support; it never
+manufactures confidence the data cannot justify, and it never claims to.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+import numpy as np
+from numpy.random import RandomState
+
+from mixle.inference.calibration import (
+    coverage_curve,
+    interval_coverage,
+    pit_calibration_error,
+    pit_ensemble,
+)
+
+__all__ = [
+    "CalibrationVerdict",
+    "posterior_predictive_calibration",
+    "simulation_based_calibration",
+    "CalibrationVerifier",
+]
+
+
+@dataclass
+class CalibrationVerdict:
+    """The outcome of a calibration check. Carries a ``passed`` flag (so it duck-types the IC-6
+    ``Verdict`` the routing/orchestration layer reads via ``.passed``) plus the diagnostics that
+    justify it -- a gate should say *why* it failed, not just that it did.
+
+    ``null_threshold`` is the key to honest small-sample behaviour: ``pit_error`` is compared against
+    the value a *genuinely calibrated* posterior of this exact sample size would produce (the high
+    quantile of the finite-sample null), not a fixed constant that would false-alarm on calibrated
+    data at small ``n``. ``low_power`` flags when the sample is so small that even a badly
+    miscalibrated posterior could not be distinguished from a calibrated one -- in which case a
+    ``passed=True`` means "not detectably miscalibrated with this little data," NOT "calibrated."
+    """
+
+    passed: bool
+    pit_error: float  # deviation of the PIT/rank histogram from uniform (0 == perfectly calibrated)
+    null_threshold: float  # the sample-size-aware threshold pit_error is judged against
+    coverage_error: float  # DIAGNOSTIC: max |empirical - nominal| across the coverage curve
+    reference_level: float
+    coverage_at_reference: float  # DIAGNOSTIC: empirical coverage of the reference-level central interval
+    mean_interval_width: float
+    n_points: int
+    low_power: bool = False
+    reasons: list[str] = field(default_factory=list)
+    kind: str = "calibration"
+
+    @property
+    def score(self) -> float:
+        """A 0..1 calibration score (1 == at/below the calibrated-null level), for callers that rank
+        rather than gate. Normalized by the null threshold so it's comparable across sample sizes."""
+        if self.null_threshold <= 0:
+            return 1.0 if self.pit_error == 0 else 0.0
+        return float(max(0.0, 1.0 - self.pit_error / (2.0 * self.null_threshold)))
+
+
+def _uniformity_null_threshold(n: int, *, bins: int = 10, quantile: float = 0.99, n_null: int = 500,
+                               seed: int = 12345) -> float:
+    """The value :func:`~mixle.inference.calibration.pit_calibration_error` would reach on genuinely
+    uniform data of size ``n`` -- Monte-Carlo'd at the ``quantile`` upper tail. Comparing an observed
+    PIT/rank error against THIS (rather than a fixed constant) is what makes the gate a proper
+    finite-sample test: it asks "is this posterior worse-calibrated than 99% of genuinely calibrated
+    posteriors of the same sample size would be?", which is scale-correct at every ``n``."""
+    rs = RandomState(seed)
+    errs = [pit_calibration_error(rs.uniform(0.0, 1.0, size=int(n)), bins=bins) for _ in range(int(n_null))]
+    return float(np.quantile(errs, quantile))
+
+
+def posterior_predictive_calibration(
+    ensemble: np.ndarray,
+    held_out_y: np.ndarray,
+    *,
+    reference_level: float = 0.90,
+    null_quantile: float = 0.99,
+    pit_tol: float | None = None,
+    bins: int = 10,
+    low_power_threshold: float = 1.0,
+    pit_seed: int | RandomState | None = 0,
+) -> CalibrationVerdict:
+    """Check a posterior-predictive ensemble against held-out observations it never saw.
+
+    ``ensemble`` is ``(k, m)``: for each of ``k`` held-out points, ``m`` posterior-predictive draws
+    (push ``m`` draws from the posterior through the forward model to the observation of each held-out
+    point). ``held_out_y`` is the ``(k,)`` array of real observed values at those points.
+
+    The decision is a proper finite-sample uniformity test on the randomized PIT of the held-out data
+    (:func:`~mixle.inference.calibration.pit_ensemble`). ``pit_error``
+    (:func:`~mixle.inference.calibration.pit_calibration_error`, deviation of the rank histogram from
+    uniform) is compared against :func:`_uniformity_null_threshold` -- the ``null_quantile`` upper tail
+    of what a *genuinely calibrated* posterior of this exact sample size would produce -- NOT a fixed
+    constant (a fixed constant is below the finite-sample noise floor at small ``k`` and would
+    false-alarm on calibrated data). Pass ``pit_tol`` to override with a fixed threshold if you have a
+    reason to.
+
+    Coverage numbers (:func:`~mixle.inference.calibration.coverage_curve` /
+    :func:`~mixle.inference.calibration.interval_coverage`) are computed and reported as human-readable
+    diagnostics and to label the *direction* of any miscalibration (over- vs under-confident), but the
+    pass/fail itself is the PIT test, which subsumes them and is scale-correct.
+
+    ``low_power``: when the null threshold is at/above ``low_power_threshold`` (the PIT error is
+    bounded, so a large threshold means "even gross miscalibration is within null noise at this k"),
+    the held-out set is too small to detect miscalibration; ``passed=True`` then means "not
+    detectably miscalibrated with this little data," not "calibrated," and ``reasons`` says so.
+    """
+    ens = np.asarray(ensemble, dtype=float)
+    y = np.asarray(held_out_y, dtype=float)
+    if ens.ndim != 2:
+        raise ValueError(f"ensemble must be (k, m); got shape {ens.shape}")
+    if y.shape[0] != ens.shape[0]:
+        raise ValueError(f"held_out_y has {y.shape[0]} points but ensemble has {ens.shape[0]}")
+
+    k = int(y.shape[0])
+    pit = pit_ensemble(y, ens, randomize=True, seed=pit_seed)
+    pit_err = float(pit_calibration_error(pit, bins=bins))
+    threshold = float(pit_tol) if pit_tol is not None else _uniformity_null_threshold(k, bins=bins, quantile=null_quantile)
+    low_power = pit_tol is None and threshold >= low_power_threshold
+
+    curve = coverage_curve(ens, y)
+    coverage_error = float(np.max(np.abs(curve["empirical"] - curve["nominal"])))
+    lo = np.quantile(ens, (1.0 - reference_level) / 2.0, axis=1)
+    hi = np.quantile(ens, (1.0 + reference_level) / 2.0, axis=1)
+    ref = interval_coverage(lo, hi, y)
+    coverage_at_ref = float(ref["coverage"])
+
+    passed = pit_err <= threshold
+    reasons: list[str] = []
+    if not passed:
+        direction = "overconfident (intervals too narrow -- reports false certainty)" if coverage_at_ref < reference_level else "underconfident (intervals too wide)"
+        reasons.append(
+            f"miscalibrated: PIT error {pit_err:.3f} > null threshold {threshold:.3f} for k={k}; "
+            f"{reference_level:.0%} interval covers {coverage_at_ref:.1%} of held-out points -- {direction}"
+        )
+    else:
+        reasons.append(
+            f"not detectably miscalibrated: PIT error {pit_err:.3f} <= null threshold {threshold:.3f} for k={k}; "
+            f"{reference_level:.0%} interval covers {coverage_at_ref:.1%} of held-out points"
+        )
+    if low_power:
+        reasons.append(
+            f"LOW POWER: k={k} held-out points is too few to detect miscalibration reliably "
+            f"(null threshold {threshold:.2f} admits gross miscalibration) -- a pass here means "
+            f"'undetectable with this little data', not 'calibrated'. Hold out more points."
+        )
+
+    return CalibrationVerdict(
+        passed=passed, pit_error=pit_err, null_threshold=threshold, coverage_error=coverage_error,
+        reference_level=float(reference_level), coverage_at_reference=coverage_at_ref,
+        mean_interval_width=float(ref["mean_width"]), n_points=k, low_power=low_power, reasons=reasons,
+    )
+
+
+def simulation_based_calibration(
+    prior_sampler: Callable[[RandomState], np.ndarray],
+    simulate: Callable[[np.ndarray, RandomState], np.ndarray],
+    fit: Callable[[np.ndarray], np.ndarray],
+    *,
+    n_sims: int = 200,
+    param_index: int = 0,
+    null_quantile: float = 0.99,
+    error_tol: float | None = None,
+    bins: int = 10,
+    seed: int | RandomState | None = 0,
+) -> CalibrationVerdict:
+    """Simulation-based calibration (Talts et al. 2018): does the inference recover its own generative
+    model? Draw ``theta ~ prior``, simulate ``y ~ p(y|theta)``, refit a posterior, and record the rank
+    of the true ``theta`` among the posterior draws. Under a correct inference those ranks are Uniform;
+    a systematically over/under-dispersed posterior makes them pile up at the middle or the edges.
+
+    ``prior_sampler(rng) -> theta`` (a ``(d,)`` parameter vector, or scalar-as-``(1,)``);
+    ``simulate(theta, rng) -> y`` (any shape the fitter accepts); ``fit(y) -> posterior_draws``
+    (``(n_draws, d)`` or ``(n_draws,)``). ``param_index`` selects which parameter's rank to test.
+
+    Unlike :func:`posterior_predictive_calibration`, this needs no held-out real data -- it tests the
+    inference *machinery* against synthetic ground truth it generates itself. It therefore catches a
+    different class: an inference bug / wrong likelihood / mis-scaled posterior, even on data that would
+    look perfectly fit. (It does not test whether the model matches *reality* -- that is
+    :func:`posterior_predictive_calibration`'s job, on real held-out data.)
+    """
+    rng = seed if isinstance(seed, RandomState) else RandomState(seed)
+    ranks = np.empty(n_sims, dtype=float)
+    for i in range(n_sims):
+        theta = np.atleast_1d(np.asarray(prior_sampler(rng), dtype=float))
+        y = simulate(theta, rng)
+        draws = np.atleast_1d(np.asarray(fit(y), dtype=float))
+        if draws.ndim == 1:
+            draws_param = draws
+            theta_param = float(theta[0]) if theta.shape[0] == 1 else float(theta[param_index])
+        else:
+            draws_param = draws[:, param_index]
+            theta_param = float(theta[param_index])
+        n_draws = draws_param.shape[0]
+        ranks[i] = float(np.sum(draws_param < theta_param)) / n_draws  # normalized rank in [0, 1)
+
+    # a uniform rank histogram means calibrated inference; reuse the same PIT-uniformity metric,
+    # judged against the same sample-size-aware null threshold (n_sims here plays the role of k).
+    sbc_error = float(pit_calibration_error(np.clip(ranks, 0.0, 1.0), bins=bins))
+    threshold = float(error_tol) if error_tol is not None else _uniformity_null_threshold(int(n_sims), bins=bins, quantile=null_quantile)
+    passed = sbc_error <= threshold
+    reason = (
+        f"SBC ranks consistent with uniform (error {sbc_error:.3f} <= null threshold {threshold:.3f} for "
+        f"{n_sims} sims): inference is self-consistent under its own generative model"
+        if passed
+        else f"SBC ranks NOT uniform (error {sbc_error:.3f} > null threshold {threshold:.3f}): inference is "
+        f"mis-dispersed (over/under-confident) under its own generative model"
+    )
+    return CalibrationVerdict(
+        passed=passed, pit_error=sbc_error, null_threshold=threshold, coverage_error=float("nan"),
+        reference_level=float("nan"), coverage_at_reference=float("nan"), mean_interval_width=float("nan"),
+        n_points=int(n_sims), reasons=[reason], kind="calibration-sbc",
+    )
+
+
+class CalibrationVerifier:
+    """An IC-6-shaped verifier (``.verify(claim, context) -> dict``) wrapping
+    :func:`posterior_predictive_calibration`, so a calibration gate drops straight into
+    :func:`mixle.task.knowledge_routing.route_task` (or any IC-6 consumer) as a real verifier that
+    can *fail* a miscalibrated result -- the thing the routing verifiers used in the experiments only
+    ever checked structurally.
+
+    The tool result being verified must carry, on ``claim["payload"]`` (or ``context``), an
+    ``"ensemble"`` ``(k, m)`` posterior-predictive draw matrix and a ``"held_out_y"`` ``(k,)`` array.
+    A payload without them fails closed with an explicit reason -- a calibration verifier that silently
+    passes anything it can't actually check would defeat its own purpose.
+    """
+
+    def __init__(self, *, reference_level: float = 0.90, null_quantile: float = 0.99,
+                 pit_tol: float | None = None) -> None:
+        self.reference_level = reference_level
+        self.null_quantile = null_quantile
+        self.pit_tol = pit_tol
+
+    def verify(self, claim: Any, context: Any = None) -> dict[str, Any]:
+        payload = (claim or {}).get("payload", {}) if isinstance(claim, dict) else {}
+        source = payload if ("ensemble" in payload and "held_out_y" in payload) else (context or {})
+        ensemble = source.get("ensemble") if isinstance(source, dict) else None
+        held_out_y = source.get("held_out_y") if isinstance(source, dict) else None
+        if ensemble is None or held_out_y is None:
+            return {
+                "passed": False, "score": 0.0, "kind": "calibration",
+                "reasons": ["no ensemble/held_out_y to calibrate against -- failing closed rather than passing an unchecked posterior"],
+            }
+        verdict = posterior_predictive_calibration(
+            np.asarray(ensemble), np.asarray(held_out_y),
+            reference_level=self.reference_level, null_quantile=self.null_quantile, pit_tol=self.pit_tol,
+        )
+        return {
+            "passed": verdict.passed, "score": verdict.score, "kind": verdict.kind,
+            "reasons": verdict.reasons, "low_power": verdict.low_power,
+        }

--- a/mixle/tests/calibration_gate_test.py
+++ b/mixle/tests/calibration_gate_test.py
@@ -1,0 +1,131 @@
+"""The calibration gate must actually FAIL a miscalibrated posterior -- a gate that passes everything
+is worse than no gate (it launders false confidence). These tests pin down that it passes calibrated
+posteriors, fails overconfident and underconfident ones, catches a broken inference via SBC, and fails
+closed when handed nothing to check."""
+
+import numpy as np
+import pytest
+
+from mixle.inference.calibration_gate import (
+    CalibrationVerifier,
+    posterior_predictive_calibration,
+    simulation_based_calibration,
+)
+
+
+def _predictive_ensemble(truth_sd: float, ensemble_sd: float, *, k: int = 400, m: int = 500, seed: int = 0):
+    """Held-out truths drawn N(0, truth_sd^2); a predictive ensemble centered at 0 with ensemble_sd.
+    ensemble_sd == truth_sd is calibrated; smaller is overconfident; larger is underconfident."""
+    rng = np.random.default_rng(seed)
+    y = rng.normal(0.0, truth_sd, size=k)
+    ensemble = rng.normal(0.0, ensemble_sd, size=(k, m))
+    return ensemble, y
+
+
+def test_calibrated_posterior_predictive_passes():
+    ensemble, y = _predictive_ensemble(truth_sd=1.0, ensemble_sd=1.0)  # k=400: ample power
+    verdict = posterior_predictive_calibration(ensemble, y)
+    assert verdict.passed, verdict.reasons
+    assert not verdict.low_power
+    assert verdict.pit_error <= verdict.null_threshold
+    assert abs(verdict.coverage_at_reference - 0.90) < 0.1
+
+
+def test_overconfident_posterior_predictive_fails_and_says_why():
+    ensemble, y = _predictive_ensemble(truth_sd=1.0, ensemble_sd=0.3)  # far too narrow
+    verdict = posterior_predictive_calibration(ensemble, y)
+    assert not verdict.passed
+    assert verdict.coverage_at_reference < 0.90  # the dangerous direction: reports false certainty
+    assert any("overconfident" in r for r in verdict.reasons)
+
+
+def test_underconfident_posterior_predictive_also_fails():
+    ensemble, y = _predictive_ensemble(truth_sd=1.0, ensemble_sd=3.0)  # far too wide
+    verdict = posterior_predictive_calibration(ensemble, y)
+    assert not verdict.passed
+    assert verdict.coverage_at_reference > 0.90
+    assert any("underconfident" in r for r in verdict.reasons)
+
+
+def test_tiny_holdout_is_flagged_low_power_not_false_alarmed():
+    """The honest small-sample behaviour: with only a handful of held-out points, an OVERCONFIDENT
+    posterior cannot be distinguished from a calibrated one -- the gate must flag low power and not
+    manufacture a confident PASS or FAIL it can't statistically support."""
+    ensemble, y = _predictive_ensemble(truth_sd=1.0, ensemble_sd=0.3, k=6)  # overconfident but only 6 points
+    verdict = posterior_predictive_calibration(ensemble, y)
+    assert verdict.low_power
+    assert any("LOW POWER" in r for r in verdict.reasons)
+
+
+def test_null_threshold_shrinks_as_holdout_grows():
+    """The threshold must be sample-size-aware -- more held-out data => a tighter bar (more power)."""
+    small = posterior_predictive_calibration(*_predictive_ensemble(1.0, 1.0, k=40)).null_threshold
+    large = posterior_predictive_calibration(*_predictive_ensemble(1.0, 1.0, k=2000)).null_threshold
+    assert large < small
+
+
+def test_calibration_score_orders_calibrated_above_miscalibrated():
+    good, y_good = _predictive_ensemble(truth_sd=1.0, ensemble_sd=1.0, seed=1)
+    bad, y_bad = _predictive_ensemble(truth_sd=1.0, ensemble_sd=0.25, seed=1)
+    assert posterior_predictive_calibration(good, y_good).score > posterior_predictive_calibration(bad, y_bad).score
+
+
+# --- simulation-based calibration: catches a broken inference with no held-out real data at all ---
+
+_TAU = 2.0      # prior sd on theta
+_SIGMA = 1.0    # obs noise sd
+_NOBS = 5       # observations per simulated dataset
+_POST_VAR = 1.0 / (1.0 / _TAU**2 + _NOBS / _SIGMA**2)
+_POST_SD = np.sqrt(_POST_VAR)
+
+
+def _prior(rng):
+    return np.array([rng.normal(0.0, _TAU)])
+
+
+def _simulate(theta, rng):
+    return theta[0] + rng.normal(0.0, _SIGMA, size=_NOBS)
+
+
+def _correct_fit(y):
+    post_mean = _POST_VAR * (np.sum(y) / _SIGMA**2)  # conjugate Gaussian posterior mean (prior mean 0)
+    rng = np.random.default_rng(int(abs(np.sum(y) * 1e6)) % (2**32))
+    return rng.normal(post_mean, _POST_SD, size=600)
+
+
+def _overconfident_fit(y):
+    post_mean = _POST_VAR * (np.sum(y) / _SIGMA**2)
+    rng = np.random.default_rng(int(abs(np.sum(y) * 1e6)) % (2**32))
+    return rng.normal(post_mean, _POST_SD / 3.0, size=600)  # deliberately 3x too tight
+
+
+def test_sbc_passes_a_correct_conjugate_inference():
+    verdict = simulation_based_calibration(_prior, _simulate, _correct_fit, n_sims=300, seed=0)
+    assert verdict.passed, verdict.reasons
+
+
+def test_sbc_fails_a_deliberately_overconfident_inference():
+    verdict = simulation_based_calibration(_prior, _simulate, _overconfident_fit, n_sims=300, seed=0)
+    assert not verdict.passed
+    assert "mis-dispersed" in verdict.reasons[0]
+
+
+# --- the IC-6 verifier adapter (route_task drop-in) ---
+
+def test_verifier_passes_a_calibrated_payload():
+    ensemble, y = _predictive_ensemble(truth_sd=1.0, ensemble_sd=1.0)
+    verdict = CalibrationVerifier().verify(claim={"payload": {"ensemble": ensemble, "held_out_y": y}})
+    assert verdict["passed"] is True
+    assert verdict["kind"] == "calibration"
+
+
+def test_verifier_fails_an_overconfident_payload():
+    ensemble, y = _predictive_ensemble(truth_sd=1.0, ensemble_sd=0.3)
+    verdict = CalibrationVerifier().verify(claim={"payload": {"ensemble": ensemble, "held_out_y": y}})
+    assert verdict["passed"] is False
+
+
+def test_verifier_fails_closed_when_given_nothing_to_check():
+    verdict = CalibrationVerifier().verify(claim={"payload": {"some_number": 42}})
+    assert verdict["passed"] is False
+    assert any("unchecked" in r or "no ensemble" in r for r in verdict["reasons"])


### PR DESCRIPTION
**Workstream 1 of the architecture rework** (the calibration/verification spine). Found across the end-to-end experiments: this codebase's UQ is *locally honest* — every module computes a real posterior — but was *globally unaudited*. A systematically overconfident posterior sailed straight to a confident-looking final answer because nothing in the flow ever challenged the confidence. The calibration *primitives* already existed (`mixle.inference.calibration`: pit_ensemble / interval_coverage / coverage_curve / pit_calibration_error); what was missing was a *gate* composing them into a pass/fail verifier a pipeline can stop on. This is that gate — a thin composition, not new statistics.

Adds `mixle/inference/calibration_gate.py`:
- `posterior_predictive_calibration` — checks a posterior-predictive ensemble against held-out observations via a **finite-sample uniformity test on the randomized PIT**. Key correctness point: the decision threshold is **sample-size-aware** (the null-quantile of what a genuinely-calibrated posterior of that exact size would produce), not a fixed constant — a fixed constant sits below the noise floor at small held-out sizes and would false-alarm on calibrated data. Flags `low_power` when the held-out set is too small to detect miscalibration at all (a pass then means 'undetectable with this little data', not 'calibrated').
- `simulation_based_calibration` — Talts et al. SBC: catches inference-algorithm bugs (a mis-dispersed posterior under its own generative model) with no held-out real data at all.
- `CalibrationVerifier` — an IC-6 `.verify(claim, context)` adapter, drops into `route_task` as a real gate that can *fail* a result and *fails closed* when handed nothing to check.

**Honest boundary, documented in the module docstring and enforced by a test:** this catches overconfidence-vs-held-out-data and inference bugs. It does NOT catch model misspecification under genuine non-uniqueness (surface gravity can't resolve depth; a biased posterior fits the surface data fine and this gate correctly passes it). Catching that needs data that sees the biased dimension or a physics prior — not more calibration checking. The gate reports what the available data can support and never manufactures confidence it can't.

11 tests: passes calibrated / fails overconfident+underconfident / flags tiny-holdout low-power / threshold shrinks with more data / SBC passes correct inference + fails a deliberately-3x-too-tight one / IC-6 adapter passes+fails+fails-closed. Reran the 3 neighboring calibration test files (17 total) — clean. Intentionally NOT re-exported from the hot `mixle/inference/__init__.py` (import from the submodule) to keep this strictly additive while core is under heavy parallel work.