### PR TITLE
Lint/format cleanup: fix ruff drift accumulated since #486

### DIFF
--- a/mixle/analysis/__init__.py
+++ b/mixle/analysis/__init__.py
@@ -94,7 +94,13 @@ from mixle.analysis.rank_aggregation import (
     mallows_fit,
     spearman_footrule,
 )
-from mixle.analysis.real_options import OptionValue, VoiStoppingDecision, real_option_value, voi_dollars, voi_stopping_decision
+from mixle.analysis.real_options import (
+    OptionValue,
+    VoiStoppingDecision,
+    real_option_value,
+    voi_dollars,
+    voi_stopping_decision,
+)
 from mixle.analysis.sdm import HabitatModel, SpeciesObservation, fit_sdm
 from mixle.analysis.spatial_mixture import SpatialMixture
 from mixle.analysis.valuation import NPVDistribution, capex_opex, cost_curve, monte_carlo_npv

--- a/mixle/analysis/real_options.py
+++ b/mixle/analysis/real_options.py
@@ -305,6 +305,8 @@ def voi_stopping_decision(
     """
     voi = voi_dollars(posterior, decision_fn, drill_info, rng=rng, n_outer=n_outer, n_inner=n_inner)
     return VoiStoppingDecision(
-        voi_dollars=voi, sample_cost=float(sample_cost), net_value=voi - float(sample_cost),
+        voi_dollars=voi,
+        sample_cost=float(sample_cost),
+        net_value=voi - float(sample_cost),
         keep_sampling=voi > float(sample_cost),
     )

--- a/mixle/task/knowledge_routing.py
+++ b/mixle/task/knowledge_routing.py
@@ -204,7 +204,8 @@ def _accepts_known_items(invoke: Any) -> bool:
         return False
     known = params.get("known_items")
     return known is not None and known.kind in (
-        known.POSITIONAL_OR_KEYWORD, known.KEYWORD_ONLY,
+        known.POSITIONAL_OR_KEYWORD,
+        known.KEYWORD_ONLY,
     )
 
 

--- a/mixle/tests/task/test_knowledge_routing.py
+++ b/mixle/tests/task/test_knowledge_routing.py
@@ -218,12 +218,20 @@ def test_a_gap_can_opt_into_seeing_another_gaps_real_resolved_result():
 
     catalog = [
         CatalogEntry(
-            id="physics_survey", schema={"invoke": _physics_tool_recorded, "output": {}},
-            owner="physics", cost=0.1, reliability=0.9, verifier=_PassVerifier(),
+            id="physics_survey",
+            schema={"invoke": _physics_tool_recorded, "output": {}},
+            owner="physics",
+            cost=0.1,
+            reliability=0.9,
+            verifier=_PassVerifier(),
         ),
         CatalogEntry(
-            id="dependent_economic_model", schema={"invoke": _dependent_economic_tool, "output": {}},
-            owner="economic", cost=0.1, reliability=0.9, verifier=_PassVerifier(),
+            id="dependent_economic_model",
+            schema={"invoke": _dependent_economic_tool, "output": {}},
+            owner="economic",
+            cost=0.1,
+            reliability=0.9,
+            verifier=_PassVerifier(),
         ),
     ]
     seed = [["physics", "economic"]] * 20
@@ -242,8 +250,16 @@ def test_a_one_arg_invoke_is_completely_unaffected():
     def _plain_tool(gap):
         return {"tonnage_mt": 7.0}
 
-    catalog = [CatalogEntry(id="physics_survey", schema={"invoke": _plain_tool, "output": {}},
-                             owner="physics", cost=0.1, reliability=0.9, verifier=_PassVerifier())]
+    catalog = [
+        CatalogEntry(
+            id="physics_survey",
+            schema={"invoke": _plain_tool, "output": {}},
+            owner="physics",
+            cost=0.1,
+            reliability=0.9,
+            verifier=_PassVerifier(),
+        )
+    ]
     proposer = init_decomposition_proposer([["physics"]] * 20)
     result = route_task("plain question", catalog, proposer=proposer, budget=3)
     assert result.answer["resolved_gap_ids"] == ["gap-0-physics"]

--- a/mixle/tests/test_j3_real_options.py
+++ b/mixle/tests/test_j3_real_options.py
@@ -143,7 +143,11 @@ def test_voi_stopping_decision_says_keep_sampling_when_voi_exceeds_a_cheap_cost(
     posterior = _ToyPosterior(mean=1.0, std=5.0)
     rng = np.random.default_rng(0)
     decision = voi_stopping_decision(
-        posterior, _decision_value, {"variance_reduction": 0.8}, sample_cost=0.01, rng=rng,
+        posterior,
+        _decision_value,
+        {"variance_reduction": 0.8},
+        sample_cost=0.01,
+        rng=rng,
     )
     assert decision.voi_dollars > 0.0
     assert decision.keep_sampling is True
@@ -156,7 +160,11 @@ def test_voi_stopping_decision_says_stop_when_the_sample_costs_more_than_it_is_w
     posterior = _ToyPosterior(mean=1.0, std=0.05)
     rng = np.random.default_rng(0)
     decision = voi_stopping_decision(
-        posterior, _decision_value, {"variance_reduction": 0.05}, sample_cost=1_000_000.0, rng=rng,
+        posterior,
+        _decision_value,
+        {"variance_reduction": 0.05},
+        sample_cost=1_000_000.0,
+        rng=rng,
     )
     assert decision.keep_sampling is False
     assert decision.net_value < 0.0
@@ -167,5 +175,7 @@ def test_voi_stopping_decision_is_consistent_with_voi_dollars_directly():
     posterior = _ToyPosterior(mean=1.0, std=5.0)
     drill_info = {"variance_reduction": 0.6}
     direct = voi_dollars(posterior, _decision_value, drill_info, rng=np.random.default_rng(7))
-    decision = voi_stopping_decision(posterior, _decision_value, drill_info, sample_cost=0.0, rng=np.random.default_rng(7))
+    decision = voi_stopping_decision(
+        posterior, _decision_value, drill_info, sample_cost=0.0, rng=np.random.default_rng(7)
+    )
     assert decision.voi_dollars == pytest.approx(direct)


### PR DESCRIPTION
## Summary

`ruff check`/`ruff format` drift accumulated on `release/0.8.0`'s tip since #486 last swept it clean — a handful of recently-merged files needed the formatter's multi-line wrapping (most notably `mixle/analysis/__init__.py`'s import of `real_options` after `voi_stopping_decision` landed and pushed the line over 120 cols) and one import-sort fix. Pure `ruff check --fix` + `ruff format`, no behavior changes.

## Test plan
- [x] `ruff check mixle/` / `ruff format --check mixle/` — clean
- [x] Full suite: `pytest mixle/tests -n auto` — 5175 passed, 14 skipped (environment-gated). One failure, `public_api_manifest_test.py::test_public_surface_matches_committed_manifest`, is pre-existing manifest drift from #494 (`voi_stopping_decision`) unrelated to this change — already fixed in #495, which this PR doesn't duplicate to avoid a manifest-regen conflict between the two branches. Rebasing onto #495 after it lands will resolve it.
- [x] `mixle/tests/substrate_knowledge_bundle_test.py` excluded from the run above — a separate, pre-existing collection error (stale `mixle_knowledge` cross-repo dependency) unrelated to this change, tracked separately.