### PR TITLE
Core: add canonical causal semantics

### DIFF
--- a/api_manifest.json
+++ b/api_manifest.json
@@ -4,6 +4,7 @@
     "__version__",
     "capabilities",
     "catalog",
+    "causal",
     "contracts",
     "describe",
     "dist",

--- a/maturity_manifest.json
+++ b/maturity_manifest.json
@@ -13,6 +13,10 @@
       "maturity": "provisional",
       "status": "Unclassified (provisional by default)"
     },
+    "mixle.causal": {
+      "maturity": "provisional",
+      "status": "Unclassified (provisional by default)"
+    },
     "mixle.contracts": {
       "maturity": "provisional",
       "status": "Unclassified (provisional by default)"

--- a/mixle/__init__.py
+++ b/mixle/__init__.py
@@ -40,6 +40,7 @@ _NAMESPACES = (
     "ops",
     "contracts",
     "semantics",
+    "causal",
 )
 
 

--- a/mixle/causal.py
+++ b/mixle/causal.py
@@ -1,0 +1,234 @@
+"""Canonical, dependency-free causal semantics for cross-project science contracts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from dataclasses import asdict, dataclass, is_dataclass
+from enum import StrEnum
+from typing import Any
+
+SCHEMA_VERSION = "mixle.causal/v1"
+
+
+class CausalContractError(ValueError):
+    """Raised when a causal record would overstate what is identified."""
+
+
+class CausalEvidenceKind(StrEnum):
+    PREDICTION = "prediction"
+    ASSOCIATION = "association"
+    MECHANISM = "mechanism"
+    INTERVENTION = "intervention"
+
+
+class IdentificationStatus(StrEnum):
+    IDENTIFIED = "identified"
+    PARTIALLY_IDENTIFIED = "partially_identified"
+    NOT_IDENTIFIED = "not_identified"
+
+
+class AssumptionStatus(StrEnum):
+    ASSERTED = "asserted"
+    CHALLENGED = "challenged"
+    FAILED = "failed"
+
+
+def _required(value: str, label: str) -> None:
+    if not value or not value.strip():
+        raise CausalContractError(f"{label} must be non-empty")
+
+
+def _json_value(value: Any) -> Any:
+    if isinstance(value, StrEnum):
+        return value.value
+    if is_dataclass(value):
+        return {key: _json_value(item) for key, item in asdict(value).items()}
+    if isinstance(value, dict):
+        return {str(key): _json_value(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_value(item) for item in value]
+    return value
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(_json_value(value), sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def semantic_id(value: Any) -> str:
+    return hashlib.sha256(canonical_json(value).encode()).hexdigest()
+
+
+@dataclass(frozen=True)
+class Estimand:
+    id: str
+    treatment: str
+    outcome: str
+    target_population: str
+    contrast: str
+    time_horizon: str | None = None
+    schema_version: str = SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        for value, label in (
+            (self.id, "estimand id"),
+            (self.treatment, "treatment"),
+            (self.outcome, "outcome"),
+            (self.target_population, "target population"),
+            (self.contrast, "contrast"),
+        ):
+            _required(value, label)
+        if self.schema_version != SCHEMA_VERSION:
+            raise CausalContractError("unsupported causal schema version")
+
+    @property
+    def identity(self) -> str:
+        return semantic_id(self)
+
+    def as_dict(self) -> dict[str, Any]:
+        return _json_value(self)
+
+    @classmethod
+    def from_dict(cls, value: dict[str, Any]) -> Estimand:
+        return cls(**value)
+
+
+@dataclass(frozen=True)
+class CausalAssumption:
+    id: str
+    kind: str
+    statement: str
+    status: AssumptionStatus = AssumptionStatus.ASSERTED
+    testable: bool = False
+    evidence_refs: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        _required(self.id, "assumption id")
+        _required(self.kind, "assumption kind")
+        _required(self.statement, "assumption statement")
+        object.__setattr__(self, "status", AssumptionStatus(self.status))
+        if len(self.evidence_refs) != len(set(self.evidence_refs)):
+            raise CausalContractError("assumption evidence references must be unique")
+
+    def as_dict(self) -> dict[str, Any]:
+        return _json_value(self)
+
+    @classmethod
+    def from_dict(cls, value: dict[str, Any]) -> CausalAssumption:
+        return cls(**{**value, "evidence_refs": tuple(value.get("evidence_refs", ()))})
+
+
+@dataclass(frozen=True)
+class InterventionSpec:
+    id: str
+    treatment: str
+    value: float
+    minimum: float
+    maximum: float
+    authority_ref: str | None
+    safety_constraints: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        _required(self.id, "intervention id")
+        _required(self.treatment, "intervention treatment")
+        if not all(math.isfinite(item) for item in (self.value, self.minimum, self.maximum)):
+            raise CausalContractError("intervention range must be finite")
+        if self.minimum > self.maximum or not self.minimum <= self.value <= self.maximum:
+            raise CausalContractError("intervention value is outside its declared safe range")
+
+    @property
+    def authorized(self) -> bool:
+        return bool(self.authority_ref and self.authority_ref.strip())
+
+    def as_dict(self) -> dict[str, Any]:
+        return _json_value(self)
+
+
+@dataclass(frozen=True)
+class CounterfactualQuery:
+    id: str
+    estimand_ref: str
+    intervention: InterventionSpec
+    evidence_kind: CausalEvidenceKind = CausalEvidenceKind.INTERVENTION
+
+    def __post_init__(self) -> None:
+        _required(self.id, "counterfactual query id")
+        _required(self.estimand_ref, "estimand reference")
+        object.__setattr__(self, "evidence_kind", CausalEvidenceKind(self.evidence_kind))
+        if self.evidence_kind is not CausalEvidenceKind.INTERVENTION:
+            raise CausalContractError("counterfactual queries require intervention semantics")
+
+    def as_dict(self) -> dict[str, Any]:
+        return _json_value(self)
+
+
+@dataclass(frozen=True)
+class IdentificationResult:
+    estimand_ref: str
+    status: IdentificationStatus
+    assumptions: tuple[CausalAssumption, ...]
+    evidence_kind: CausalEvidenceKind
+    identifying_expression: str | None = None
+    lower_bound: float | None = None
+    upper_bound: float | None = None
+    diagnostics: tuple[str, ...] = ()
+    schema_version: str = SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        _required(self.estimand_ref, "estimand reference")
+        object.__setattr__(self, "status", IdentificationStatus(self.status))
+        object.__setattr__(self, "evidence_kind", CausalEvidenceKind(self.evidence_kind))
+        if self.schema_version != SCHEMA_VERSION:
+            raise CausalContractError("unsupported causal schema version")
+        if len({item.id for item in self.assumptions}) != len(self.assumptions):
+            raise CausalContractError("identification assumptions must have unique ids")
+        failed = [item.id for item in self.assumptions if item.status is AssumptionStatus.FAILED]
+        if self.status is IdentificationStatus.IDENTIFIED:
+            if not self.identifying_expression:
+                raise CausalContractError("identified results require an identifying expression")
+            if failed:
+                raise CausalContractError("identified results cannot rely on failed assumptions")
+            if self.lower_bound is not None or self.upper_bound is not None:
+                raise CausalContractError("identified results cannot also claim partial bounds")
+        elif self.status is IdentificationStatus.PARTIALLY_IDENTIFIED:
+            bounds = (self.lower_bound, self.upper_bound)
+            if any(item is None or not math.isfinite(item) for item in bounds):
+                raise CausalContractError("partial identification requires finite bounds")
+            if self.lower_bound > self.upper_bound:
+                raise CausalContractError("partial identification bounds are reversed")
+            if self.identifying_expression:
+                raise CausalContractError("partial identification cannot claim a point expression")
+        else:
+            if self.identifying_expression or self.lower_bound is not None or self.upper_bound is not None:
+                raise CausalContractError("not-identified results cannot claim an expression or bounds")
+            if not self.diagnostics:
+                raise CausalContractError("not-identified results require a diagnostic")
+
+    @property
+    def identity(self) -> str:
+        return semantic_id(self)
+
+    def as_dict(self) -> dict[str, Any]:
+        return _json_value(self)
+
+    @classmethod
+    def from_dict(cls, value: dict[str, Any]) -> IdentificationResult:
+        assumptions = tuple(CausalAssumption.from_dict(item) for item in value.get("assumptions", ()))
+        return cls(**{**value, "assumptions": assumptions, "diagnostics": tuple(value.get("diagnostics", ()))})
+
+
+__all__ = [
+    "SCHEMA_VERSION",
+    "AssumptionStatus",
+    "CausalAssumption",
+    "CausalContractError",
+    "CausalEvidenceKind",
+    "CounterfactualQuery",
+    "Estimand",
+    "IdentificationResult",
+    "IdentificationStatus",
+    "InterventionSpec",
+    "canonical_json",
+    "semantic_id",
+]

--- a/mixle/tests/causal_contract_test.py
+++ b/mixle/tests/causal_contract_test.py
@@ -1,0 +1,72 @@
+"""Focused contract tests for canonical causal semantics."""
+
+import unittest
+
+from mixle.causal import (
+    AssumptionStatus,
+    CausalAssumption,
+    CausalContractError,
+    CausalEvidenceKind,
+    Estimand,
+    IdentificationResult,
+    IdentificationStatus,
+    InterventionSpec,
+)
+
+
+class CausalContractTest(unittest.TestCase):
+    def setUp(self):
+        self.estimand = Estimand("ate", "dose", "response", "eligible adults", "E[Y(1)-Y(0)]")
+        self.exchangeability = CausalAssumption("a1", "exchangeability", "no unmeasured confounding")
+
+    def test_estimand_identity_and_round_trip_are_deterministic(self):
+        restored = Estimand.from_dict(self.estimand.as_dict())
+        self.assertEqual(restored, self.estimand)
+        self.assertEqual(restored.identity, self.estimand.identity)
+
+    def test_identified_result_requires_expression_and_live_assumptions(self):
+        result = IdentificationResult(
+            self.estimand.identity,
+            IdentificationStatus.IDENTIFIED,
+            (self.exchangeability,),
+            CausalEvidenceKind.INTERVENTION,
+            identifying_expression="E[Y|do(dose=1)]-E[Y|do(dose=0)]",
+        )
+        self.assertEqual(IdentificationResult.from_dict(result.as_dict()), result)
+        failed = CausalAssumption("a1", "exchangeability", "no unmeasured confounding", status=AssumptionStatus.FAILED)
+        with self.assertRaisesRegex(CausalContractError, "failed assumptions"):
+            IdentificationResult(
+                self.estimand.identity,
+                IdentificationStatus.IDENTIFIED,
+                (failed,),
+                CausalEvidenceKind.ASSOCIATION,
+                identifying_expression="invalid",
+            )
+
+    def test_partial_and_not_identified_results_cannot_fabricate_certainty(self):
+        partial = IdentificationResult(
+            self.estimand.identity,
+            IdentificationStatus.PARTIALLY_IDENTIFIED,
+            (self.exchangeability,),
+            CausalEvidenceKind.ASSOCIATION,
+            lower_bound=-0.2,
+            upper_bound=0.7,
+        )
+        self.assertEqual(partial.as_dict()["status"], "partially_identified")
+        with self.assertRaisesRegex(CausalContractError, "diagnostic"):
+            IdentificationResult(
+                self.estimand.identity,
+                IdentificationStatus.NOT_IDENTIFIED,
+                (self.exchangeability,),
+                CausalEvidenceKind.ASSOCIATION,
+            )
+
+    def test_intervention_range_and_authority_are_distinct(self):
+        intervention = InterventionSpec("dose-1", "dose", 0.5, 0.0, 1.0, None, ("interlock",))
+        self.assertFalse(intervention.authorized)
+        with self.assertRaisesRegex(CausalContractError, "safe range"):
+            InterventionSpec("dose-2", "dose", 2.0, 0.0, 1.0, "authority://1")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/module_ownership.json
+++ b/module_ownership.json
@@ -5,6 +5,7 @@
     "mixle.analysis": {"decision": "narrow", "owner": "PRJ-CORE", "destination": null},
     "mixle.blending": {"decision": "narrow", "owner": "PRJ-CORE", "destination": null},
     "mixle.capability": {"decision": "retain", "owner": "PRJ-CORE", "destination": null},
+    "mixle.causal": {"decision": "retain", "owner": "PRJ-CORE", "destination": null},
     "mixle.contracts": {"decision": "retain", "owner": "PRJ-CORE", "destination": null},
     "mixle.data": {"decision": "migrate", "owner": "PRJ-CORE", "destination": "PRJ-DATA"},
     "mixle.dist": {"decision": "retain", "owner": "PRJ-CORE", "destination": null},


### PR DESCRIPTION
## Summary\n- add canonical estimand, assumption, intervention, counterfactual, and identification records\n- distinguish prediction, association, mechanism, intervention, partial identification, and not identified\n- reject failed assumptions and fabricated point certainty\n\n## Governance\n- Work-Id: WORK-20260715-0047\n- Change-Id: CHG-20260715-0053\n- Target-Release: 0.8.0\n- Requirements: REQ-CAUSAL-EXPERIMENTAL, REQ-UNKNOWN-EXPLICIT, REQ-TRACEABILITY\n\n## Focused validation\n- Ruff format/check on changed source\n- 11 focused causal and manifest tests passed in 5.37s\n\n## Limits and rollback\nThis adds semantics, not a universal identification algorithm or authority to run experiments. Revert this commit before dependent consumers if the contract is rejected.

Replaces #505 after branch-name normalization; commit content is unchanged.

Release-Milestone: 0.8.0
Release-Scope: included
