### PR TITLE
Fix float32/float64 dtype mismatch in task.regress's MLP student

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,12 @@ to post-0.8 or kept under `mixle.experimental` per the feature freeze.
   treating density time as the whole block cost; learned controllers receive the same measured cost.
 - Dirichlet-prior block and freeze/roll-up updates now use the exact MAP objective and carry the
   posterior weight prior; nested homogeneous mixtures preserve heterogeneous encoding depth.
+- `task.regress`'s internal MLP student (`solve_regression`, `RegressionSolution.improve`, and any
+  downstream distillation built on it, e.g. `mixle_pde.surrogate.distill_forward`) now builds its
+  network at an explicit float32 instead of following `torch.get_default_dtype()`. A caller that had
+  changed the process-global default dtype (mixle-pde's PDE code routinely does, for numerical
+  precision) left the student's own weights at that ambient dtype while its inputs stayed explicitly
+  float32, crashing with "mat1 and mat2 must have the same dtype, but got Float and Double".
 
 ### Fixed
 

--- a/mixle/task/regress.py
+++ b/mixle/task/regress.py
@@ -121,9 +121,17 @@ def _fit_reg_mlp(x: np.ndarray, y: np.ndarray, hidden: Sequence[int], epochs: in
 
     torch.manual_seed(seed)
     dims = [x.shape[1], *hidden, 1]
+    # Build every layer at an explicit float32, independent of torch's process-global default
+    # dtype. Leaving `dtype` unset makes `Linear` follow `torch.get_default_dtype()`, and callers
+    # (mixle_pde in particular sets `torch.set_default_dtype(torch.float64)` throughout its own PDE
+    # code, both in production paths and dozens of test files) routinely leave that global at
+    # float64 -- `xt`/`yt` below are already explicitly float32, so an ambient float64 default only
+    # poisons the net's own weights, and `net(xt)` then dies with "mat1 and mat2 must have the same
+    # dtype, but got Float and Double". Pinning the layer dtype here makes this function's contract
+    # (always trains and returns a float32 module) hold regardless of any caller's ambient state.
     layers: list[Any] = []
     for i in range(len(dims) - 1):
-        layers.append(torch.nn.Linear(dims[i], dims[i + 1]))
+        layers.append(torch.nn.Linear(dims[i], dims[i + 1], dtype=torch.float32))
         if i < len(dims) - 2:
             layers.append(torch.nn.ReLU())
     net = torch.nn.Sequential(*layers)


### PR DESCRIPTION
## Summary

- `mixle.task.regress._fit_reg_mlp` built its `Linear` layers with no explicit `dtype`, so they silently followed `torch.get_default_dtype()` instead of the float32 the function's own `xt`/`yt` tensors are explicitly cast to.
- Any caller running with `torch.set_default_dtype(torch.float64)` active got a student whose weights were float64 while its inputs stayed float32, crashing `net(xt)` with `RuntimeError: mat1 and mat2 must have the same dtype, but got Float and Double`.
- `solve_regression`, `RegressionSolution.improve`, and `mixle_pde.surrogate.distill_forward` (via `_fit_scaled`) all funnel through this same helper and were equally exposed — this is not specific to how `distill_forward` prepares its inputs, which were already correctly float32 well before reaching `_fit_reg_mlp`.

## Root cause

Confirmed by direct reproduction outside of pytest: setting `torch.set_default_dtype(torch.float64)` in-process (which `mixle_pde` does pervasively — in production scenario code such as `capabilities.py`, not only in tests) and then calling `_fit_reg_mlp`/`_fit_scaled`/`distill_forward` reproduces the exact reported error. mixle-pde's own `tests/conftest.py` (added earlier today in mixle-pde#80) isolates torch's default dtype across tests *within* `tests/`, but several `mixle_pde/*_test.py` files that also call `torch.set_default_dtype(torch.float64)` live outside `tests/` and are not covered by that fixture — and more importantly, no test-only fixture protects real (non-test) callers. The robust fix is in this shared helper itself.

Adversarial end-to-end repro (mixle-pde, before this fix, editable-installed `mixle`):
```
pytest mixle_pde/c7_coupling_test.py tests/hybrid_inversion_test.py -n0 -m "" -q
...
FAILED tests/hybrid_inversion_test.py::HybridSurrogateIntegrationTest::test_real_distilled_surrogate_is_accepted_and_used
1 failed, 14 passed
```
Same command, same order, with this fix's `regress.py` available: `15 passed`.

## Fix

Pin `torch.nn.Linear(..., dtype=torch.float32)` explicitly in `_fit_reg_mlp`, so the function's contract (always trains and returns a float32 module) holds regardless of any caller's ambient torch state. No behavior change for the common case (default dtype already float32); purely additive robustness.

## Test plan

- [x] `pytest mixle/tests/task_regress_test.py -m "" -n0` — 6 passed (regress.py's own suite).
- [x] `pytest -k regress -m ""` broader sweep — 142 passed, 6 skipped (pre-existing optional-dependency skips), 1 failed + 10 errors — confirmed via `git stash` against the unmodified baseline that these are pre-existing and unrelated to this change (`neural_ppl_test.py` NLL-threshold flake, `substrate_knowledge_bundle_test.py` AttributeError).
- [x] Reproduced the exact mixle-pde failure adversarially (see above) and confirmed this fix resolves it.
- [x] mixle-pde targeted sweep with this fix available (`tests/hybrid_inversion_test.py`, `tests/test_e6_surrogate.py`, `tests/test_p4_surrogate.py`, `tests/operator_surrogate_test.py`, `tests/design_of_experiments_test.py`): 59 passed.
- [x] mixle-pde broader `-k surrogate` sweep with this fix available: 21 passed.
- [x] `ruff check` / `ruff format --diff` clean on the touched file.

CHANGELOG.md updated under `[0.8.0] — Unreleased` / `Fixed`.