### PR TITLE
Generalize the MCMC parameter-posterior bridge past 7 families

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,18 @@ with a regression test that fails on the unfixed code):
   entropies filled across the univariate catalog; `mixle.ppl` exports `waic`/`loo`;
   `ScheduledHMM.estimator()` restores the prototype convention (F-1, F-2, F-4, F-6, F-7, F-9, F-11,
   F-12; #434).
+- The MCMC parameter-posterior bridge (`sample_parameter_posterior`, reachable through
+  `inference.posterior(..., over="params")`) hardcoded exactly 7 scalar families
+  (`mcmc/parameter_bridge.py:287-290`) and raised `NotImplementedError` for every other
+  distribution, despite the README reading as general ("a `prior=` is the only switch"). It now
+  dispatches generically against each family's existing
+  `mixle.stats.compute.declarations.DistributionDeclaration` -- the same per-parameter
+  `constraint`/`differentiable` metadata `mixle.inference.gradient_fit` already uses for autograd
+  fitting -- covering 33 families total (the 7 original plus 26 more, spanning continuous,
+  discrete, and vector/multivariate families). Families with no declaration, a declaration
+  describing a natural/scoring parameterization instead of the constructor's (e.g. von Mises), or
+  an exotic constraint with no generic reparameterization yet (a covariance matrix, a coupled
+  bound) still raise a clear `NotImplementedError` rather than silently guessing (F-5; #TBD).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,7 +104,7 @@ with a regression test that fails on the unfixed code):
   discrete, and vector/multivariate families). Families with no declaration, a declaration
   describing a natural/scoring parameterization instead of the constructor's (e.g. von Mises), or
   an exotic constraint with no generic reparameterization yet (a covariance matrix, a coupled
-  bound) still raise a clear `NotImplementedError` rather than silently guessing (F-5; #TBD).
+  bound) still raise a clear `NotImplementedError` rather than silently guessing (F-5; #510).
 
 ### Changed
 

--- a/mixle/inference/mcmc/parameter_bridge.py
+++ b/mixle/inference/mcmc/parameter_bridge.py
@@ -7,10 +7,23 @@ by running Metropolis-Hastings or Hamiltonian Monte Carlo in an unconstrained
 reparameterization (log for positive scales, stick-breaking for probability
 simplices) and mapping the retained samples back to parameter space (or to
 rebuilt distribution objects).
+
+Seven families (Gaussian, Gamma, Beta, Exponential, Poisson, Bernoulli,
+Categorical) get a hand-tuned bridge below.  Every other family that declares a
+:class:`~mixle.stats.compute.declarations.DistributionDeclaration` -- the same
+per-parameter ``constraint``/``differentiable`` metadata
+:mod:`mixle.inference.gradient_fit` already reads for autograd fitting -- is
+bridged generically by :func:`_generic_declared_bridge`, so adding a new
+supported family here is a matter of the family declaring itself, not editing
+this module.  See :func:`build_parameter_bridge`'s docstring for exactly which
+constraints have a generic reparameterization and why some declared families
+(a covariance matrix, a coupled bound, a natural/scoring parameterization that
+differs from the constructor) are still excluded.
 """
 
 from __future__ import annotations
 
+import inspect
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from typing import Any
@@ -102,6 +115,23 @@ def _stick_breaking_log_det(phi: np.ndarray) -> float:
     return float(total)
 
 
+def _stick_breaking_inverse(p: np.ndarray) -> np.ndarray:
+    """Return the ``phi`` that :func:`_stick_breaking_forward` maps to ``p``.
+
+    ``p`` must be a length-``k`` probability vector (strictly positive,
+    summing to one); the returned vector has length ``k - 1``.
+    """
+    k = p.shape[0]
+    phi = np.empty(k - 1, dtype=float)
+    remaining = 1.0
+    for i in range(k - 1):
+        z = p[i] / remaining
+        z = min(max(z, 1.0e-12), 1.0 - 1.0e-12)
+        phi[i] = np.log(z) - np.log1p(-z) + np.log(float(k - 1 - i))
+        remaining = remaining - p[i]
+    return phi
+
+
 def _seq_log_density_sum(dist: Any, encoded: Any) -> float:
     """Return ``sum_i log p(x_i | dist)`` for a stats distribution."""
     return float(np.sum(dist.seq_log_density(encoded)))
@@ -131,7 +161,7 @@ def _make_builder(prototype: Any, ctor_kwargs: dict[str, Any]) -> Callable[..., 
 def build_parameter_bridge(prototype: Any) -> ParameterBridge:
     """Build a :class:`ParameterBridge` for a prototype distribution.
 
-    Supported ``mixle.stats`` families:
+    Seven families get a hand-tuned bridge below:
 
     * Gaussian ``(mu, sigma2)`` -> ``(mu, log sigma2)``
     * Gamma ``(k, theta)`` -> ``(log k, log theta)``
@@ -140,6 +170,30 @@ def build_parameter_bridge(prototype: Any) -> ParameterBridge:
     * Bernoulli ``p`` -> ``logit p``
     * Beta ``(a, b)`` -> ``(log a, log b)``
     * Categorical probability map -> stick-breaking over the simplex
+
+    Every other family falls through to :func:`_generic_declared_bridge`, which reads the
+    same :class:`~mixle.stats.compute.declarations.DistributionDeclaration` that
+    :mod:`mixle.inference.gradient_fit` already uses for autograd fitting. A declared
+    parameter is sampled -- included in ``theta`` (a ``{name: value}`` dict here, unlike the
+    tuple/scalar shapes above) -- when it is ``differentiable`` and its ``constraint`` is one
+    of ``real`` (identity), ``positive``/``positive_vector`` (log), ``unit_interval`` (logit),
+    ``real_vector`` (identity), or ``simplex_vector``/``simplex_map`` (stick-breaking);
+    non-differentiable declared parameters (e.g. a Binomial's ``n``) are carried as fixed
+    constructor keywords taken from ``prototype``, the same nuisance-parameter treatment
+    :mod:`mixle.stats.bayes.conjugate` uses. This covers 33 families as of this writing
+    (the 7 above plus 26 more -- see ``mcmc_test.py``'s ``GenericParameterBridgeTestCase``
+    for the current list).
+
+    Still unsupported, deliberately: families with no declaration at all (compositional/
+    structured models -- mixtures, HMMs, copulas, ... -- for which a single flat parameter
+    vector isn't the right shape); families whose declaration describes an exponential-family
+    natural/scoring parameterization rather than the constructor's (e.g. von Mises' ``eta1``/
+    ``eta2``/``log_const`` vs. its ``mu``/``kappa`` constructor -- the declared names aren't
+    constructor keywords, so there's nothing safe to dispatch on); and declared-but-exotic
+    constraints with no generic reparameterization yet (a covariance/precision matrix's
+    ``positive_matrix``, or a coupled ``greater_than:``/``less_than:`` bound such as Uniform's
+    ``high``). These need a family-specific bridge (or a matrix/coupled-bound generalization)
+    rather than a generic one and are out of scope here.
 
     Raises:
         NotImplementedError: if the family or a parameter shape is unsupported.
@@ -260,15 +314,7 @@ def build_parameter_bridge(prototype: Any) -> ParameterBridge:
             p = np.asarray([float(theta[label]) for label in labels], dtype=float)
             p = np.clip(p, 1.0e-12, None)
             p = p / p.sum()
-            # invert stick-breaking
-            phi = np.empty(k - 1, dtype=float)
-            remaining = 1.0
-            for i in range(k - 1):
-                z = p[i] / remaining
-                z = min(max(z, 1.0e-12), 1.0 - 1.0e-12)
-                phi[i] = np.log(z) - np.log1p(-z) + np.log(float(k - 1 - i))
-                remaining = remaining - p[i]
-            return phi
+            return _stick_breaking_inverse(p)
 
         def from_u(phi):
             p = _stick_breaking_forward(np.asarray(phi, dtype=float))
@@ -284,20 +330,262 @@ def build_parameter_bridge(prototype: Any) -> ParameterBridge:
             initial_theta={label: float(prob_map[label]) for label in labels},
         )
 
+    generic = _generic_declared_bridge(prototype, kw)
+    if generic is not None:
+        return generic
+
     raise NotImplementedError(
-        "sample_parameter_posterior does not support %s; supported families are "
-        "Gaussian, Gamma, Exponential, Poisson, Bernoulli, Beta, and Categorical." % cls_name
+        "sample_parameter_posterior does not support %s. Explicitly hand-tuned: Gaussian, Gamma, "
+        "Exponential, Poisson, Bernoulli, Beta, Categorical. Every other distribution that declares a "
+        "mixle.stats.compute.declarations.DistributionDeclaration is bridged automatically as long as "
+        "every declared parameter name is also a constructor keyword and every differentiable "
+        "parameter's constraint is one of real/positive/unit_interval/real_vector/positive_vector/"
+        "simplex_vector/simplex_map (see build_parameter_bridge's docstring). %s has none of a "
+        "declaration, or fails one of those two conditions -- most likely because it has no "
+        "declaration at all, its declaration describes a natural/scoring parameterization rather than "
+        "its constructor's, or a differentiable parameter's constraint (e.g. a covariance matrix or a "
+        "coupled bound) has no generic reparameterization yet." % (cls_name, cls_name)
     )
 
 
 def _ctor_param_names(prototype: Any) -> tuple[str, ...]:
-    import inspect
-
     try:
         sig = inspect.signature(type(prototype).__init__)
         return tuple(sig.parameters.keys())
     except (TypeError, ValueError):
         return ()
+
+
+# ---------------------------------------------------------------------------
+# Generic bridge: dispatch against the mixle.stats declaration registry
+# ---------------------------------------------------------------------------
+#
+# mixle.stats.compute.declarations.DistributionDeclaration already records, per family,
+# the constructor parameters generated scoring kernels need: a name, a `constraint` (its
+# domain -- "positive", "unit_interval", a simplex, ...), and a `differentiable` flag that
+# mixle.inference.gradient_fit already uses to separate free parameters from cached/nuisance
+# ones for autograd fitting. That is exactly the metadata this module's hand-written 7-family
+# table was duplicating per family, so a declared family is bridged generically instead of
+# needing its own branch above.
+
+
+@dataclass(frozen=True)
+class _ParamBlock:
+    """One sampled parameter's slice of the combined unconstrained ``phi`` vector."""
+
+    name: str
+    dim: int
+    to_unconstrained: Callable[[Any], np.ndarray]
+    from_unconstrained: Callable[[np.ndarray], Any]
+    log_abs_det_jacobian: Callable[[np.ndarray], float]
+
+
+def _real_block(name: str, length: int | None) -> _ParamBlock:
+    if length is None:
+        return _ParamBlock(
+            name=name,
+            dim=1,
+            to_unconstrained=lambda v: np.asarray([float(v)], dtype=float),
+            from_unconstrained=lambda phi: float(phi[0]),
+            log_abs_det_jacobian=lambda phi: 0.0,
+        )
+    return _ParamBlock(
+        name=name,
+        dim=length,
+        to_unconstrained=lambda v: np.asarray(v, dtype=float).reshape(-1),
+        from_unconstrained=lambda phi: np.asarray(phi, dtype=float).copy(),
+        log_abs_det_jacobian=lambda phi: 0.0,
+    )
+
+
+def _positive_block(name: str, length: int | None) -> _ParamBlock:
+    if length is None:
+        return _ParamBlock(
+            name=name,
+            dim=1,
+            to_unconstrained=lambda v: np.asarray([float(np.log(v))], dtype=float),
+            from_unconstrained=lambda phi: float(np.exp(phi[0])),
+            log_abs_det_jacobian=lambda phi: float(phi[0]),
+        )
+    return _ParamBlock(
+        name=name,
+        dim=length,
+        to_unconstrained=lambda v: np.log(np.asarray(v, dtype=float)),
+        from_unconstrained=lambda phi: np.exp(np.asarray(phi, dtype=float)),
+        log_abs_det_jacobian=lambda phi: float(np.sum(phi)),
+    )
+
+
+def _unit_interval_block(name: str) -> _ParamBlock:
+    def to_u(v: Any) -> np.ndarray:
+        v = float(v)
+        return np.asarray([np.log(v) - np.log1p(-v)], dtype=float)
+
+    def from_u(phi: np.ndarray) -> float:
+        return float(1.0 / (1.0 + np.exp(-phi[0])))
+
+    def log_det(phi: np.ndarray) -> float:
+        # d p / d logit = p (1 - p); log = -softplus(-phi) - softplus(phi)
+        return float(-_softplus(-phi[0]) - _softplus(phi[0]))
+
+    return _ParamBlock(name=name, dim=1, to_unconstrained=to_u, from_unconstrained=from_u, log_abs_det_jacobian=log_det)
+
+
+def _simplex_vector_block(name: str, length: int) -> _ParamBlock | None:
+    if length < 2:
+        return None
+
+    def to_u(v: Any) -> np.ndarray:
+        p = np.clip(np.asarray(v, dtype=float), 1.0e-12, None)
+        p = p / p.sum()
+        return _stick_breaking_inverse(p)
+
+    return _ParamBlock(
+        name=name,
+        dim=length - 1,
+        to_unconstrained=to_u,
+        from_unconstrained=lambda phi: _stick_breaking_forward(np.asarray(phi, dtype=float)),
+        log_abs_det_jacobian=lambda phi: _stick_breaking_log_det(np.asarray(phi, dtype=float)),
+    )
+
+
+def _simplex_map_block(name: str, labels: tuple[Any, ...]) -> _ParamBlock | None:
+    if len(labels) < 2:
+        return None
+
+    def to_u(prob_map: Any) -> np.ndarray:
+        p = np.asarray([float(prob_map[label]) for label in labels], dtype=float)
+        p = np.clip(p, 1.0e-12, None)
+        p = p / p.sum()
+        return _stick_breaking_inverse(p)
+
+    def from_u(phi: np.ndarray) -> dict[Any, float]:
+        p = _stick_breaking_forward(np.asarray(phi, dtype=float))
+        return {label: float(p[i]) for i, label in enumerate(labels)}
+
+    return _ParamBlock(
+        name=name,
+        dim=len(labels) - 1,
+        to_unconstrained=to_u,
+        from_unconstrained=from_u,
+        log_abs_det_jacobian=lambda phi: _stick_breaking_log_det(np.asarray(phi, dtype=float)),
+    )
+
+
+def _declared_parameter_block(name: str, constraint: str, value: Any) -> _ParamBlock | None:
+    """Return the unconstrained-space block for one declared, differentiable parameter.
+
+    Returns ``None`` when ``constraint`` has no generic reparameterization yet (a matrix, a
+    coupled ``greater_than:``/``less_than:`` bound, or anything else outside the set below).
+    """
+    if constraint == "real":
+        return _real_block(name, None)
+    if constraint == "positive":
+        return _positive_block(name, None)
+    if constraint == "unit_interval":
+        return _unit_interval_block(name)
+    if constraint == "real_vector":
+        return _real_block(name, len(value))
+    if constraint == "positive_vector":
+        return _positive_block(name, len(value))
+    if constraint == "simplex_vector":
+        return _simplex_vector_block(name, len(value))
+    if constraint == "simplex_map":
+        if not isinstance(value, Mapping):
+            return None
+        return _simplex_map_block(name, tuple(value.keys()))
+    return None
+
+
+def _generic_declared_bridge(prototype: Any, kw: dict[str, Any]) -> ParameterBridge | None:
+    """Build a :class:`ParameterBridge` from ``prototype``'s ``DistributionDeclaration``, or
+    return ``None`` (never raise) when the family cannot be bridged generically.
+
+    A family is bridged when (1) it has a declaration, (2) every declared parameter name is
+    also a constructor keyword of ``type(prototype)`` -- ruling out families whose declaration
+    describes an exponential-family natural/scoring parameterization instead (e.g. von Mises
+    declares ``eta1``/``eta2``/``log_const`` for generated scoring kernels, but its constructor
+    takes ``mu``/``kappa``: nothing here would be safe to dispatch on), (3) every constructor
+    argument the declaration doesn't cover has a default, and (4) every *differentiable*
+    declared parameter's constraint has a generic transform (see
+    :func:`_declared_parameter_block`). Non-differentiable declared parameters (e.g. a
+    Binomial's ``n``, an ErdosRenyiGraph's ``directed``) are carried as fixed constructor
+    keywords taken from ``prototype`` rather than sampled -- the same treatment
+    :mod:`mixle.stats.bayes.conjugate` gives a known nuisance parameter.
+    """
+    from mixle.stats.compute.declarations import declaration_for
+
+    cls = type(prototype)
+    declaration = declaration_for(prototype)
+    if declaration is None:
+        return None
+
+    try:
+        ctor_params = inspect.signature(cls.__init__).parameters
+    except (TypeError, ValueError):
+        return None
+
+    declared_names = {spec.name for spec in declaration.parameters}
+    for pname, param in ctor_params.items():
+        if pname == "self" or param.kind in (inspect.Parameter.VAR_KEYWORD, inspect.Parameter.VAR_POSITIONAL):
+            continue
+        if param.kind == inspect.Parameter.POSITIONAL_ONLY and pname in declared_names:
+            return None  # can't pass a positional-only constructor argument by keyword
+        if param.default is inspect.Parameter.empty and pname not in declared_names and pname != "name":
+            return None  # a required constructor argument the declaration doesn't cover
+
+    fixed_kwargs: dict[str, Any] = {}
+    blocks: list[_ParamBlock] = []
+    for spec in declaration.parameters:
+        if spec.name not in ctor_params:
+            return None  # declaration describes a natural/scoring parameterization, not the ctor
+        value = getattr(prototype, spec.name)
+        if not spec.differentiable:
+            fixed_kwargs[spec.name] = value
+            continue
+        block = _declared_parameter_block(spec.name, spec.constraint, value)
+        if block is None:
+            return None
+        blocks.append(block)
+
+    if not blocks:
+        return None  # nothing to sample a posterior over
+
+    offsets: list[int] = []
+    total = 0
+    for block in blocks:
+        offsets.append(total)
+        total += block.dim
+
+    def to_u(theta: dict[str, Any]) -> np.ndarray:
+        parts = [block.to_unconstrained(theta[block.name]) for block in blocks]
+        return np.concatenate(parts) if parts else np.zeros(0, dtype=float)
+
+    def from_u(phi: np.ndarray) -> dict[str, Any]:
+        phi = np.asarray(phi, dtype=float)
+        return {
+            block.name: block.from_unconstrained(phi[offset : offset + block.dim])
+            for block, offset in zip(blocks, offsets)
+        }
+
+    def log_det(phi: np.ndarray) -> float:
+        phi = np.asarray(phi, dtype=float)
+        return float(
+            sum(block.log_abs_det_jacobian(phi[offset : offset + block.dim]) for block, offset in zip(blocks, offsets))
+        )
+
+    def build(theta: dict[str, Any]) -> Any:
+        return cls(**fixed_kwargs, **theta, **kw)
+
+    return ParameterBridge(
+        dim=total,
+        to_unconstrained=to_u,
+        from_unconstrained=from_u,
+        log_abs_det_jacobian=log_det,
+        build=build,
+        param_names=tuple(block.name for block in blocks),
+        initial_theta={block.name: getattr(prototype, block.name) for block in blocks},
+    )
 
 
 def _coerce_prior_logpdf(prior: Any, bridge: ParameterBridge) -> Callable[[Any], float]:

--- a/mixle/tests/mcmc_test.py
+++ b/mixle/tests/mcmc_test.py
@@ -2,6 +2,7 @@ import unittest
 
 import numpy as np
 
+from mixle.inference import optimize
 from mixle.inference.mcmc import (
     AdaptiveCovarianceProposal,
     AdaptiveRandomWalkProposal,
@@ -23,10 +24,22 @@ from mixle.inference.mcmc import (
 )
 from mixle.stats import (
     BernoulliDistribution,
+    BinomialDistribution,
     CategoricalDistribution,
+    DiagonalGaussianDistribution,
+    DirichletDistribution,
     GammaDistribution,
     GaussianDistribution,
+    GeometricDistribution,
+    GumbelDistribution,
+    HalfNormalDistribution,
+    IntegerCategoricalDistribution,
+    LaplaceDistribution,
+    NegativeBinomialDistribution,
     PoissonDistribution,
+    StudentTDistribution,
+    UniformDistribution,
+    WeibullDistribution,
 )
 
 
@@ -632,6 +645,254 @@ class ParameterPosteriorTestCase(unittest.TestCase):
                     self.assertAlmostEqual(a, b, places=8)
             else:
                 self.assertAlmostEqual(theta, bridge.initial_theta, places=8)
+
+
+class GenericParameterBridgeTestCase(unittest.TestCase):
+    """Real posterior-sampling scenarios for families reachable only through the generic
+    declaration-driven bridge (``_generic_declared_bridge`` in ``parameter_bridge.py``), not one
+    of the 7 hand-tuned branches in ``build_parameter_bridge``. Each test fits an independent
+    reference -- the generalized-EM ``optimize()`` MLE, or (for Binomial, where ``optimize()``
+    also estimates the trial count ``n``) a closed-form formula -- and checks the MCMC posterior
+    mean agrees with it within a comfortable multiple of the posterior's own standard error, plus
+    domain-validity checks (positivity, unit interval, simplex). This is meant to catch a wrong
+    Jacobian sign or a wrong reparameterization, not just confirm dispatch doesn't raise."""
+
+    def test_weibull_shape_scale_posterior_matches_mle(self):
+        truth = WeibullDistribution(2.0, 3.0)
+        data = truth.sampler(1).sample(800)
+        fitted = optimize(data, truth.estimator(), max_its=100)
+
+        result = sample_parameter_posterior(
+            WeibullDistribution(1.0, 1.0),
+            data,
+            prior=None,
+            sampler="mh",
+            steps=5000,
+            burn_in=2000,
+            seed=27,
+            proposal=RandomWalkProposal(scale=[0.05, 0.05]),
+        )
+        shapes = np.asarray([t["shape"] for t in result.samples], dtype=float)
+        scales = np.asarray([t["scale"] for t in result.samples], dtype=float)
+        self.assertTrue(np.all(shapes > 0.0))
+        self.assertTrue(np.all(scales > 0.0))
+        self.assertLess(abs(float(shapes.mean()) - fitted.shape), 6.0 * float(shapes.std()))
+        self.assertLess(abs(float(scales.mean()) - fitted.scale), 6.0 * float(scales.std()))
+
+    def test_student_t_df_loc_scale_posterior_matches_mle(self):
+        truth = StudentTDistribution(6.0, 1.0, 2.0)
+        data = truth.sampler(2).sample(1500)
+        fitted = optimize(data, truth.estimator(), max_its=100)
+
+        result = sample_parameter_posterior(
+            StudentTDistribution(3.0, 0.0, 1.0),
+            data,
+            prior=None,
+            sampler="mh",
+            steps=5000,
+            burn_in=2000,
+            seed=22,
+            proposal=RandomWalkProposal(scale=[0.05, 0.05, 0.05]),
+        )
+        dfs = np.asarray([t["df"] for t in result.samples], dtype=float)
+        locs = np.asarray([t["loc"] for t in result.samples], dtype=float)
+        scales = np.asarray([t["scale"] for t in result.samples], dtype=float)
+        self.assertTrue(np.all(dfs > 0.0))
+        self.assertTrue(np.all(scales > 0.0))
+        self.assertLess(abs(float(dfs.mean()) - fitted.df), 6.0 * float(dfs.std()))
+        self.assertLess(abs(float(locs.mean()) - fitted.loc), 6.0 * float(locs.std()))
+        self.assertLess(abs(float(scales.mean()) - fitted.scale), 6.0 * float(scales.std()))
+
+    def test_laplace_posterior_matches_mle(self):
+        truth = LaplaceDistribution(1.0, 2.0)
+        data = truth.sampler(3).sample(800)
+        fitted = optimize(data, truth.estimator(), max_its=100)
+
+        result = sample_parameter_posterior(
+            LaplaceDistribution(0.0, 1.0), data, prior=None, sampler="mh", steps=4000, burn_in=2000, seed=29
+        )
+        mus = np.asarray([t["mu"] for t in result.samples], dtype=float)
+        bs = np.asarray([t["b"] for t in result.samples], dtype=float)
+        self.assertTrue(np.all(bs > 0.0))
+        self.assertLess(abs(float(mus.mean()) - fitted.mu), 6.0 * float(mus.std()))
+        self.assertLess(abs(float(bs.mean()) - fitted.b), 6.0 * float(bs.std()))
+
+    def test_gumbel_posterior_matches_mle(self):
+        truth = GumbelDistribution(0.0, 1.5)
+        data = truth.sampler(4).sample(800)
+        fitted = optimize(data, truth.estimator(), max_its=100)
+
+        result = sample_parameter_posterior(
+            GumbelDistribution(1.0, 1.0), data, prior=None, sampler="mh", steps=4000, burn_in=2000, seed=28
+        )
+        locs = np.asarray([t["loc"] for t in result.samples], dtype=float)
+        scales = np.asarray([t["scale"] for t in result.samples], dtype=float)
+        self.assertTrue(np.all(scales > 0.0))
+        self.assertLess(abs(float(locs.mean()) - fitted.loc), 6.0 * float(locs.std()))
+        self.assertLess(abs(float(scales.mean()) - fitted.scale), 6.0 * float(scales.std()))
+
+    def test_geometric_posterior_matches_mle(self):
+        truth = GeometricDistribution(0.3)
+        data = truth.sampler(5).sample(800)
+        fitted = optimize(data, truth.estimator(), max_its=100)
+
+        result = sample_parameter_posterior(
+            GeometricDistribution(0.5), data, prior=None, sampler="mh", steps=4000, burn_in=2000, seed=30
+        )
+        ps = np.asarray([t["p"] for t in result.samples], dtype=float)
+        self.assertTrue(np.all(ps > 0.0))
+        self.assertTrue(np.all(ps < 1.0))
+        self.assertLess(abs(float(ps.mean()) - fitted.p), 6.0 * float(ps.std()))
+
+    def test_negative_binomial_posterior_matches_mle(self):
+        truth = NegativeBinomialDistribution(4.0, 0.4)
+        data = truth.sampler(6).sample(1500)
+        fitted = optimize(data, truth.estimator(), max_its=100)
+
+        result = sample_parameter_posterior(
+            NegativeBinomialDistribution(2.0, 0.5),
+            data,
+            prior=None,
+            sampler="mh",
+            steps=5000,
+            burn_in=2000,
+            seed=31,
+            proposal=RandomWalkProposal(scale=[0.05, 0.05]),
+        )
+        rs = np.asarray([t["r"] for t in result.samples], dtype=float)
+        ps = np.asarray([t["p"] for t in result.samples], dtype=float)
+        self.assertTrue(np.all(rs > 0.0))
+        self.assertTrue(np.all((ps > 0.0) & (ps < 1.0)))
+        self.assertLess(abs(float(rs.mean()) - fitted.r), 6.0 * float(rs.std()))
+        self.assertLess(abs(float(ps.mean()) - fitted.p), 6.0 * float(ps.std()))
+
+    def test_binomial_posterior_matches_analytic_with_fixed_trial_count(self):
+        # Binomial's n is a non-differentiable (fixed) declared parameter: the bridge must hold
+        # it at the prototype's value rather than sample it, so every rebuilt distribution keeps
+        # n == 20 and the posterior mean of p should track the closed-form flat-prior-on-logit(p)
+        # reference sum(data) / (n * count). optimize() is not used as the reference here because
+        # Binomial's estimator also fits n from data (a much noisier joint problem).
+        truth = BinomialDistribution(0.35, 20)
+        data = truth.sampler(7).sample(800)
+        reference_p = float(np.sum(data)) / (20.0 * len(data))
+
+        result = sample_parameter_posterior(
+            BinomialDistribution(0.5, 20),
+            data,
+            prior=None,
+            sampler="mh",
+            steps=4000,
+            burn_in=2000,
+            seed=26,
+            return_distributions=True,
+        )
+        ps = np.asarray([d.p for d in result.samples], dtype=float)
+        ns = {int(d.n) for d in result.samples}
+        self.assertEqual(ns, {20})  # fixed nuisance parameter never moves
+        self.assertTrue(np.all(ps > 0.0))
+        self.assertTrue(np.all(ps < 1.0))
+        self.assertLess(abs(float(ps.mean()) - reference_p), 0.03)
+
+    def test_dirichlet_posterior_matches_mle(self):
+        truth = DirichletDistribution([2.0, 3.0, 4.0])
+        data = truth.sampler(8).sample(1000)
+        fitted = optimize(data, truth.estimator(), max_its=100)
+
+        result = sample_parameter_posterior(
+            DirichletDistribution([1.0, 1.0, 1.0]),
+            data,
+            prior=None,
+            sampler="mh",
+            steps=5000,
+            burn_in=2000,
+            seed=23,
+            proposal=RandomWalkProposal(scale=[0.04, 0.04, 0.04]),
+        )
+        alphas = np.stack([np.asarray(t["alpha"], dtype=float) for t in result.samples])
+        self.assertTrue(np.all(alphas > 0.0))
+        post_mean = alphas.mean(axis=0)
+        post_std = alphas.std(axis=0)
+        np.testing.assert_array_less(np.abs(post_mean - np.asarray(fitted.alpha)), 6.0 * post_std)
+
+    def test_diagonal_gaussian_posterior_matches_mle(self):
+        truth = DiagonalGaussianDistribution([1.0, -1.0], [1.0, 2.0])
+        data = truth.sampler(9).sample(1000)
+        fitted = optimize(data, truth.estimator(), max_its=100)
+
+        result = sample_parameter_posterior(
+            DiagonalGaussianDistribution([0.0, 0.0], [1.0, 1.0]),
+            data,
+            prior=None,
+            sampler="mh",
+            steps=5000,
+            burn_in=2000,
+            seed=24,
+            proposal=RandomWalkProposal(scale=[0.05, 0.05, 0.05, 0.05]),
+        )
+        mus = np.stack([np.asarray(t["mu"], dtype=float) for t in result.samples])
+        covars = np.stack([np.asarray(t["covar"], dtype=float) for t in result.samples])
+        self.assertTrue(np.all(covars > 0.0))
+        np.testing.assert_array_less(np.abs(mus.mean(axis=0) - np.asarray(fitted.mu)), 6.0 * mus.std(axis=0))
+        np.testing.assert_array_less(np.abs(covars.mean(axis=0) - np.asarray(fitted.covar)), 6.0 * covars.std(axis=0))
+
+    def test_integer_categorical_posterior_matches_mle(self):
+        truth = IntegerCategoricalDistribution(0, [0.2, 0.3, 0.5])
+        data = truth.sampler(10).sample(1000)
+        fitted = optimize(data, truth.estimator(), max_its=100)
+
+        result = sample_parameter_posterior(
+            IntegerCategoricalDistribution(0, [1.0 / 3, 1.0 / 3, 1.0 / 3]),
+            data,
+            prior=None,
+            sampler="mh",
+            steps=4000,
+            burn_in=2000,
+            seed=25,
+        )
+        p_vecs = np.stack([np.asarray(t["p_vec"], dtype=float) for t in result.samples])
+        self.assertTrue(np.all(p_vecs > 0.0))
+        np.testing.assert_allclose(p_vecs.sum(axis=1), 1.0, atol=1.0e-9)
+        post_mean = p_vecs.mean(axis=0)
+        post_std = p_vecs.std(axis=0)
+        np.testing.assert_array_less(np.abs(post_mean - np.asarray(fitted.p_vec)), 6.0 * post_std)
+
+    def test_half_normal_posterior_matches_mle(self):
+        truth = HalfNormalDistribution(2.0)
+        data = truth.sampler(11).sample(800)
+        fitted = optimize(data, truth.estimator(), max_its=100)
+
+        result = sample_parameter_posterior(
+            HalfNormalDistribution(1.0), data, prior=None, sampler="mh", steps=4000, burn_in=2000, seed=32
+        )
+        sigmas = np.asarray([t["sigma"] for t in result.samples], dtype=float)
+        self.assertTrue(np.all(sigmas > 0.0))
+        self.assertLess(abs(float(sigmas.mean()) - fitted.sigma), 6.0 * float(sigmas.std()))
+
+    def test_return_distributions_rebuilds_generic_family(self):
+        truth = WeibullDistribution(2.0, 3.0)
+        data = truth.sampler(35).sample(100)
+        result = sample_parameter_posterior(
+            WeibullDistribution(1.0, 1.0),
+            data,
+            sampler="mh",
+            steps=50,
+            burn_in=50,
+            seed=35,
+            return_distributions=True,
+            proposal=RandomWalkProposal(scale=[0.05, 0.05]),
+        )
+        self.assertEqual(len(result.samples), 50)
+        for dist in result.samples:
+            self.assertIsInstance(dist, WeibullDistribution)
+            self.assertGreater(dist.shape, 0.0)
+            self.assertGreater(dist.scale, 0.0)
+
+    def test_declared_family_with_coupled_bound_still_raises(self):
+        # UniformDistribution declares a coupled `greater_than:low` bound on `high`; the generic
+        # bridge deliberately excludes coupled bounds (see build_parameter_bridge's docstring),
+        # so this must still raise -- a regression guard against silently mis-dispatching it.
+        with self.assertRaisesRegex(NotImplementedError, "does not support"):
+            build_parameter_bridge(UniformDistribution(0.0, 1.0))
 
 
 class ConjugatePosteriorTestCase(unittest.TestCase):


### PR DESCRIPTION
## Summary

`sample_parameter_posterior`'s `build_parameter_bridge` hardcoded exactly 7 scalar families
(`mcmc/parameter_bridge.py:287-290` on `release/0.8.0`'s prior tip) and raised
`NotImplementedError` for every other distribution, even though the module's own docs and the
README read as general ("a `prior=` is the only switch"). Tracked as **F-5** in the 2026-07-13
full-tree review's audit ledger (local-only, not committed): "The MCMC parameter-posterior bridge
supports exactly 7 scalar families ...; the other ~150 raise."

The library already declares per-parameter domain metadata for a much larger set of families than
the hand-written table covered:
`mixle.stats.compute.declarations.DistributionDeclaration` (`constraint` + `differentiable` per
parameter) is the same metadata `mixle.inference.gradient_fit` already reads to separate free
parameters from cached/nuisance ones for autograd fitting.

## What changed

Added a generic fallback (`_generic_declared_bridge`) that dispatches against that declaration
instead of adding more `if cls_name == ...:` branches:

- A **differentiable** declared parameter is sampled with the unconstrained reparameterization its
  `constraint` calls for: `real`/`real_vector` (identity), `positive`/`positive_vector` (log),
  `unit_interval` (logit), `simplex_vector`/`simplex_map` (stick-breaking).
- A **non-differentiable** declared parameter (e.g. a Binomial's `n`) is carried as a fixed
  constructor keyword taken from the prototype -- the same nuisance-parameter treatment
  `mixle.stats.bayes.conjugate` already gives a Binomial's `n`.
- The fallback only fires when every declared parameter name is also a constructor keyword. This
  is the load-bearing check: some families' declarations describe an exponential-family
  natural/scoring parameterization instead of the constructor's (von Mises declares
  `eta1`/`eta2`/`log_const` for generated scoring kernels, but its constructor takes
  `mu`/`kappa` -- nothing there is safe to dispatch on). Verified empirically, not assumed.

The 7 original branches are untouched -- same tuple/scalar `theta` shapes, same math. The new
families return `theta` as a `{name: value}` dict, matching the existing Categorical branch's
shape. Extracted Categorical's inline stick-breaking inversion into a shared
`_stick_breaking_inverse` helper reused by the new simplex blocks (identical math, no behavior
change to the existing branch).

## Honest scope: 33 of 170, not "all distributions"

Walked every `SequenceEncodableProbabilityDistribution` `mixle.stats` exports (170 total) and
classified each by whether it's safely generic-bridgeable:

| Count | Status | Why |
|---|---|---|
| 33 | **Bridged** (7 original + 26 new) | Has a declaration; every declared name is a constructor keyword; every differentiable parameter's constraint has a generic transform. |
| 123 | Still excluded -- no declaration at all | Mixtures, HMMs, copulas, CRP, trees, ... -- compositional/structured models for which a single flat parameter vector isn't the right shape to begin with. |
| 9 | Still excluded -- declaration != constructor | VonMises, VonMisesFisher, InverseGamma, SpearmanRanking, WrappedCauchy, LogSeries, MultivariateGaussian, MultivariateStudentT, IntegerChowLiuTree: the declaration exposes a natural/scoring parameterization (e.g. `log_const`, `eta1`/`eta2`) that isn't a constructor argument. |
| 3 | Still excluded -- exotic constraint | IndianBuffetProcess (`positive_matrix`), IntegerBernoulliSet (`log_unit_interval_vector`), Uniform (`greater_than:low`, a coupled bound) -- no generic reparameterization for a matrix or a coupled bound yet. |
| 2 | Still excluded -- zero free parameters | NullDistribution, PointMassDistribution -- nothing to sample a posterior over. |

Every one of these boundaries is enforced in code (`_generic_declared_bridge` returns `None`, not
a wrong answer) and locked in by `test_declared_family_with_coupled_bound_still_raises`. The
original ledger filed the *fully* generic version (deriving the bridge from exp-family
declarations for every family, replacing the table outright) as a post-0.8.0 capability item; this
PR is the more conservative "extend, don't replace" version that's safe to land now -- it adds
coverage without touching the 7 proven branches or claiming coverage the constraint vocabulary
doesn't actually have yet.

## Test plan

- 13 new tests in `mcmc_test.py`'s `GenericParameterBridgeTestCase`:
  - 11 real end-to-end posterior-sampling scenarios spanning continuous (Weibull, StudentT,
    Laplace, Gumbel, HalfNormal), discrete (Geometric, NegativeBinomial, Binomial), and
    vector/multivariate (Dirichlet, DiagonalGaussian, IntegerCategorical) families. Each generates
    data from a known distribution, fits an independent MLE reference via `optimize()` (for
    Binomial, a closed-form `sum(data)/(n*count)` formula instead, since `optimize()`'s own
    Binomial estimator also fits the trial count `n` -- a different, noisier problem than holding
    it fixed), and checks the MCMC posterior mean agrees within a comfortable multiple of the
    posterior's own standard error, plus domain-validity checks (positivity, unit interval,
    simplex-sums-to-one, and -- for Binomial -- that the fixed nuisance `n` never moves across
    samples). This is meant to catch a wrong Jacobian sign or reparameterization, not just confirm
    dispatch doesn't raise.
  - 1 `return_distributions=True` regression test for a new family (Weibull).
  - 1 regression guard that a declared-but-excluded family (Uniform's coupled bound) still raises
    `NotImplementedError`.
- All pre-existing `mcmc_test.py`/`mcmc_autograd_test.py` tests pass unchanged (38 tests,
  including `test_unsupported_family_raises_not_implemented` and `test_bridge_round_trips_parameters`).
- `ruff format --check` / `ruff check` clean on both changed files.
- `public_api_manifest_test.py` passes -- no public API surface change (every new name is
  underscore-prefixed).
- Full suite: `pytest mixle/tests -n auto -m "not optional and not benchmark"` (6778 collected) ->
  **6755 passed, 5 failed, 23 skipped**. All 5 failures are pre-existing and unrelated to this PR
  (none of the 5 files reference `parameter_bridge`/`sample_parameter_posterior` at all -- checked):
  `geoscience_inversion_report_test.py`, `inverse_test.py`, and both failures in
  `neural_ppl_test.py` reproduce identically on the unmodified pre-change commit (`198b3694`);
  `context_spine_test.py::test_wallclock_linear_in_total_length` is a wallclock-timing assertion
  that passes in isolation single-process on both the pre-change commit and this branch, and only
  flakes under `-n auto` on this machine, which is running many concurrent, unrelated sessions
  (same class of pre-existing xdist-contention flake as `backend_respecialization_test.py`,
  noted on earlier PRs in this series).

CHANGELOG.md updated under `[0.8.0] Unreleased -> Fixed` (F-5).
