### PR TITLE
Add to_dataframe()/to_parquet() result egress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,13 @@ to post-0.8 or kept under `mixle.experimental` per the feature freeze.
 - `CompiledEM` as a reusable fused full-mixture strategy, automatically selected by `optimize()` for
   eligible partially fusible heterogeneous mixtures; recursive SQUAREM packing for nested
   mixtures/composites; and function-preserving shared-trunk/residual-expert MoE upcycling.
+- Write-side result egress: `to_dataframe()`/`to_parquet()` on `ParameterPosterior` (posterior
+  parameter draws, one row per draw), `CalibrationReport` (its PIT histogram, one row per bin, or a
+  one-row summary when there is no scalar predictive CDF), and `MarkovChainLatentPosterior` (an HMM's
+  per-position state posterior -- the Viterbi state and every state's smoothing probability). mixle
+  had nine read-side data connectors and no supported way to move a result back into
+  pandas/Parquet; `pandas` is an optional extra (`pip install mixle[pandas]`), guarded the same way
+  as the other optional dependencies and never imported by the base install.
 
 ### Fixed
 

--- a/docs/data.rst
+++ b/docs/data.rst
@@ -212,6 +212,35 @@ For distributed sources, record sampling policy and partition boundaries. A
 small local sample is useful for model shape, but it is not evidence that the
 distributed source has the same schema everywhere.
 
+Result Egress
+-------------
+
+The adapters above move data *into* mixle. Three result types move data back *out*, into a
+``pandas.DataFrame`` or a Parquet file, for the callers who need to hand a result to
+ordinary data-science tooling instead of consuming it in Python:
+
+.. code-block:: python
+
+   from mixle.inference import posterior, calibration_report
+
+   # posterior parameter draws -> one row per draw
+   theta = posterior(model, data, over="params")
+   theta.to_dataframe(1000).describe()
+   theta.to_parquet("theta.parquet", 1000)
+
+   # a calibration report's PIT histogram -> one row per bin
+   calibration_report(model, holdout).to_dataframe()
+
+   # an HMM's per-position state posterior -> one row per sequence position
+   model.latent_posterior(sequence).to_dataframe()
+
+``to_dataframe``/``to_parquet`` are methods on :class:`~mixle.inference.ParameterPosterior`,
+:class:`~mixle.inference.CalibrationReport`, and
+:class:`~mixle.stats.compute.posterior.MarkovChainLatentPosterior` -- not a general
+``sample(n)``-to-DataFrame facility across every distribution family yet. Both need the
+``pandas`` extra (``pip install mixle[pandas]``); ``to_parquet`` additionally needs a Parquet
+engine (``pip install mixle[arrow]`` for pyarrow, or fastparquet).
+
 Graph Data
 ----------
 

--- a/mixle/inference/calibrate_fit.py
+++ b/mixle/inference/calibrate_fit.py
@@ -17,6 +17,8 @@ from typing import Any
 
 import numpy as np
 
+from mixle.utils.optional_deps import HAS_PANDAS, pandas, require
+
 __all__ = ["CalibrationReport", "calibration_report"]
 
 
@@ -59,6 +61,48 @@ class CalibrationReport:
             "note": self.note,
         }
         return d
+
+    def to_dataframe(self) -> Any:
+        """Return this report as a ``pandas.DataFrame``.
+
+        When a PIT histogram was computed (``method == "PIT"``), returns one row per bin --
+        ``bin_left``, ``bin_right``, ``count``, ``density``, ``uniform`` -- the natural columnar shape
+        of a calibration report (a table you'd plot). Otherwise (no scalar predictive CDF, so no PIT
+        histogram) returns a single summary row with the same unrounded fields as :meth:`as_dict`.
+        Requires the ``pandas`` extra (``pip install mixle[pandas]``).
+        """
+        if not HAS_PANDAS:
+            require("pandas", "pandas")
+        if self.pit_histogram is not None:
+            edges = np.asarray(self.pit_histogram["edges"], dtype=float)
+            return pandas.DataFrame(
+                {
+                    "bin_left": edges[:-1],
+                    "bin_right": edges[1:],
+                    "count": np.asarray(self.pit_histogram["counts"]),
+                    "density": np.asarray(self.pit_histogram["density"], dtype=float),
+                    "uniform": np.asarray(self.pit_histogram["uniform"], dtype=float),
+                }
+            )
+        return pandas.DataFrame(
+            [
+                {
+                    "n": self.n,
+                    "mean_log_density": self.mean_log_density,
+                    "pit_error": self.pit_error,
+                    "method": self.method,
+                    "note": self.note,
+                }
+            ]
+        )
+
+    def to_parquet(self, path: Any, **kwargs: Any) -> None:
+        """Write this report to a Parquet file; see :meth:`to_dataframe`.
+
+        ``kwargs`` forward to ``DataFrame.to_parquet`` (e.g. ``engine=``, ``compression=``). Needs a
+        Parquet engine in addition to pandas -- ``pip install mixle[arrow]`` (pyarrow) or fastparquet.
+        """
+        self.to_dataframe().to_parquet(path, **kwargs)
 
     def __str__(self) -> str:
         pit = "n/a (no CDF)" if self.pit_error is None else f"{self.pit_error:.4f}"

--- a/mixle/inference/posterior.py
+++ b/mixle/inference/posterior.py
@@ -25,6 +25,7 @@ from mixle.engines.arithmetic import maxrandint
 from mixle.inference.mcmc.parameter_bridge import sample_parameter_posterior
 from mixle.stats.bayes.conjugate import ConjugatePosterior, conjugate_posterior, is_conjugate_family
 from mixle.stats.compute.posterior import Posterior
+from mixle.utils.optional_deps import HAS_PANDAS, pandas, require
 
 __all__ = ["ParameterPosterior", "PredictivePosterior", "posterior"]
 
@@ -35,6 +36,38 @@ def _as_rng(rng: Any) -> RandomState:
 
 def _seed_from(rng: Any) -> int:
     return int(_as_rng(rng).randint(maxrandint))
+
+
+def _params_to_dataframe(draws: Any) -> Any:
+    """Tabulate a batch of parameter draws (whatever :meth:`ParameterPosterior.samples` returned).
+
+    Handles the shapes the two backing paths actually produce: a dict of length-``n`` arrays
+    (conjugate; also MCMC over a family with named parameters, e.g. ``CategoricalDistribution``), or a
+    plain list of per-draw values (MCMC over the other bridged families, see
+    ``mixle.inference.mcmc.parameter_bridge.build_parameter_bridge``) -- a tuple/array per draw becomes
+    columns ``param_0..param_{d-1}``, a bare scalar per draw becomes a single ``param_0`` column.
+    Raises ``TypeError`` for draws that are not numeric/dict (e.g. ``return_distributions=True``
+    rebuilt distribution objects) rather than forcing a column shape onto them.
+    """
+    if isinstance(draws, dict):
+        return pandas.DataFrame(draws)
+    draws = list(draws)
+    if draws and isinstance(draws[0], dict):
+        return pandas.DataFrame(draws)
+    try:
+        arr = np.asarray(draws, dtype=float)
+    except (TypeError, ValueError) as e:
+        raise TypeError(
+            "to_dataframe() needs numeric or dict-valued parameter draws; got a sequence of "
+            f"{type(draws[0]).__name__ if draws else type(draws).__name__} (e.g. "
+            "sample_parameter_posterior(..., return_distributions=True) rebuilds distribution objects, "
+            "which have no natural tabular form)."
+        ) from e
+    if arr.ndim == 1:
+        return pandas.DataFrame({"param_0": arr})
+    if arr.ndim == 2:
+        return pandas.DataFrame(arr, columns=[f"param_{i}" for i in range(arr.shape[1])])
+    raise TypeError(f"to_dataframe() cannot tabulate parameter draws of shape {arr.shape}.")
 
 
 class ParameterPosterior(Posterior):
@@ -115,6 +148,29 @@ class ParameterPosterior(Posterior):
             return np.quantile(self._chain, [lo, hi], axis=0)
         draws = self._draw_many(2000, 0)
         return {k: np.quantile(np.asarray(v, dtype=float), [lo, hi], axis=0) for k, v in draws.items()}
+
+    def to_dataframe(self, n: int, rng: Any = None) -> Any:
+        """Return ``n`` posterior parameter draws as a ``pandas.DataFrame``, one row per draw.
+
+        Draws through :meth:`samples`, so an MCMC-backed posterior resamples (with replacement) from
+        its retained chain and a conjugate posterior draws exact iid samples. Columns are the
+        parameter names when the sampler kept them (conjugate; MCMC over
+        ``CategoricalDistribution``); otherwise generic ``param_0..param_{d-1}`` (a single ``param_0``
+        for a scalar family) since the other bridged MCMC families map to unnamed positional theta --
+        see ``mixle.inference.mcmc.parameter_bridge``. Requires the ``pandas`` extra
+        (``pip install mixle[pandas]``).
+        """
+        if not HAS_PANDAS:
+            require("pandas", "pandas")
+        return _params_to_dataframe(self.samples(int(n), rng))
+
+    def to_parquet(self, path: Any, n: int, rng: Any = None, **kwargs: Any) -> None:
+        """Write ``n`` posterior parameter draws to a Parquet file; see :meth:`to_dataframe`.
+
+        ``kwargs`` forward to ``DataFrame.to_parquet`` (e.g. ``engine=``, ``compression=``). Needs a
+        Parquet engine in addition to pandas -- ``pip install mixle[arrow]`` (pyarrow) or fastparquet.
+        """
+        self.to_dataframe(n, rng).to_parquet(path, **kwargs)
 
 
 class PredictivePosterior(Posterior):

--- a/mixle/stats/compute/posterior.py
+++ b/mixle/stats/compute/posterior.py
@@ -31,6 +31,8 @@ import numpy as np
 from numpy.random import RandomState
 from scipy.special import digamma, gammaln, logsumexp
 
+from mixle.utils.optional_deps import HAS_PANDAS, pandas, require
+
 # Canonical guarded softmax (all-(-inf) slices -> uniform). For the finite 1-D inputs used here this
 # matches the previous local `_softmax`; the guard only changes the degenerate all-(-inf) case.
 from mixle.utils.special import softmax as _softmax
@@ -227,6 +229,31 @@ class MarkovChainLatentPosterior(LatentPosterior):
                 h_k = -np.sum(np.where(cond > 0.0, cond * np.log(cond), 0.0), axis=0)  # (k,)
             h += float(np.sum(gamma[t + 1] * h_k))
         return h
+
+    def to_dataframe(self) -> Any:
+        """Return the per-position state posterior as a ``pandas.DataFrame``.
+
+        One row per sequence position ``t`` with columns ``t`` (position), ``state`` (the Viterbi MAP
+        state from :meth:`mode`), and one ``state_{k}_prob`` column per latent state holding the
+        forward-backward smoothing probability from :meth:`marginals`. Deterministic: unlike
+        :meth:`sample`, ``mode``/``marginals`` are exact closed-form quantities, not random draws.
+        Requires the ``pandas`` extra (``pip install mixle[pandas]``).
+        """
+        if not HAS_PANDAS:
+            require("pandas", "pandas")
+        marginals = self.marginals()
+        data = {"t": np.arange(self.t), "state": self.mode()}
+        for k in range(self.k):
+            data[f"state_{k}_prob"] = marginals[:, k]
+        return pandas.DataFrame(data)
+
+    def to_parquet(self, path: Any, **kwargs: Any) -> None:
+        """Write the per-position state posterior to a Parquet file; see :meth:`to_dataframe`.
+
+        ``kwargs`` forward to ``DataFrame.to_parquet`` (e.g. ``engine=``, ``compression=``). Needs a
+        Parquet engine in addition to pandas -- ``pip install mixle[arrow]`` (pyarrow) or fastparquet.
+        """
+        self.to_dataframe().to_parquet(path, **kwargs)
 
 
 class MeanFieldLDAPosterior(LatentPosterior):

--- a/mixle/tests/calibrate_fit_test.py
+++ b/mixle/tests/calibrate_fit_test.py
@@ -1,12 +1,16 @@
 """Calibration as a post-condition of fit (B2): the PIT test tells if the model's UQ is honest."""
 
+import tempfile
 import unittest
+from pathlib import Path
 
 import numpy as np
 
 import mixle.stats as st
 from mixle import Model
 from mixle.inference import CalibrationReport, calibration_report, optimize
+from mixle.utils.optional_deps import HAS_PANDAS
+from mixle.utils.optional_deps import pandas as pd
 
 
 class PITCalibrationTest(unittest.TestCase):
@@ -43,6 +47,80 @@ class NoCDFTest(unittest.TestCase):
         self.assertIsNone(rep.pit_error)  # no scalar CDF -> PIT not applicable
         self.assertFalse(rep.is_calibrated())  # unknown -> conservatively not calibrated
         self.assertTrue(np.isfinite(rep.mean_log_density))  # but the proper score is always reported
+
+
+@unittest.skipUnless(HAS_PANDAS, "pandas not installed; pip install mixle[pandas]")
+class CalibrationReportToDataFrameTest(unittest.TestCase):
+    def test_pit_histogram_becomes_one_row_per_bin(self):
+        # Hand-specified pit_histogram (as pit_histogram() itself would shape it for bins=4): edges has
+        # bins+1 entries, counts/density/uniform have bins entries. to_dataframe() must split edges into
+        # bin_left/bin_right and pass every other field straight through unrounded.
+        rep = CalibrationReport(
+            n=20,
+            mean_log_density=-1.5,
+            pit_error=0.1,
+            pit_histogram={
+                "counts": np.array([2, 3, 5, 10]),
+                "density": np.array([0.4, 0.6, 1.0, 2.0]),
+                "edges": np.array([0.0, 0.25, 0.5, 0.75, 1.0]),
+                "uniform": np.array([1.0, 1.0, 1.0, 1.0]),
+            },
+            bins=4,
+            method="PIT",
+        )
+        df = rep.to_dataframe()
+        self.assertIsInstance(df, pd.DataFrame)
+        self.assertEqual(list(df.columns), ["bin_left", "bin_right", "count", "density", "uniform"])
+        self.assertEqual(df.shape, (4, 5))
+        np.testing.assert_array_equal(df["bin_left"].to_numpy(), [0.0, 0.25, 0.5, 0.75])
+        np.testing.assert_array_equal(df["bin_right"].to_numpy(), [0.25, 0.5, 0.75, 1.0])
+        np.testing.assert_array_equal(df["count"].to_numpy(), [2, 3, 5, 10])
+        np.testing.assert_array_equal(df["density"].to_numpy(), [0.4, 0.6, 1.0, 2.0])
+        np.testing.assert_array_equal(df["uniform"].to_numpy(), [1.0, 1.0, 1.0, 1.0])
+        # a real PIT report's bin table integrates to 1 over [0, 1] by construction (density * width)
+        self.assertAlmostEqual(float(((df["bin_right"] - df["bin_left"]) * df["density"]).sum()), 1.0, places=9)
+
+    def test_real_pit_report_dataframe_matches_its_own_histogram(self):
+        train = [float(x) for x in np.random.RandomState(0).normal(5.0, 2.0, 800)]
+        hold = [float(x) for x in np.random.RandomState(1).normal(5.0, 2.0, 400)]
+        rep = calibration_report(optimize(train, st.GaussianEstimator(), out=None), hold)
+        df = rep.to_dataframe()
+        self.assertEqual(df.shape, (rep.bins, 5))
+        np.testing.assert_array_equal(df["count"].to_numpy(), rep.pit_histogram["counts"])
+        np.testing.assert_allclose(df["density"].to_numpy(), rep.pit_histogram["density"])
+        self.assertEqual(int(df["count"].sum()), rep.n)  # every held-out point lands in exactly one bin
+
+    def test_no_histogram_becomes_one_row_summary_matching_fields(self):
+        rep = CalibrationReport(n=100, mean_log_density=-2.3, pit_error=None, method="log-density", note="no CDF")
+        df = rep.to_dataframe()
+        self.assertEqual(list(df.columns), ["n", "mean_log_density", "pit_error", "method", "note"])
+        self.assertEqual(df.shape, (1, 5))
+        row = df.iloc[0]
+        self.assertEqual(int(row["n"]), 100)
+        self.assertEqual(float(row["mean_log_density"]), -2.3)
+        self.assertIsNone(row["pit_error"])
+        self.assertEqual(row["method"], "log-density")
+        self.assertEqual(row["note"], "no CDF")
+
+    def test_to_parquet_roundtrips(self):
+        rep = CalibrationReport(
+            n=8,
+            mean_log_density=-0.5,
+            pit_error=0.02,
+            pit_histogram={
+                "counts": np.array([4, 4]),
+                "density": np.array([1.0, 1.0]),
+                "edges": np.array([0.0, 0.5, 1.0]),
+                "uniform": np.array([1.0, 1.0]),
+            },
+            bins=2,
+            method="PIT",
+        )
+        with tempfile.TemporaryDirectory() as d:
+            path = Path(d) / "calibration_report.parquet"
+            rep.to_parquet(path)
+            roundtrip = pd.read_parquet(path)
+            pd.testing.assert_frame_equal(roundtrip, rep.to_dataframe())
 
 
 class ModelFacadeTest(unittest.TestCase):

--- a/mixle/tests/latent_posterior_test.py
+++ b/mixle/tests/latent_posterior_test.py
@@ -1,7 +1,9 @@
 """LatentPosterior: q(z|x) as a first-class object -- the mixture (exact categorical) realization."""
 
 import itertools
+import tempfile
 import unittest
+from pathlib import Path
 
 import numpy as np
 from scipy.stats import dirichlet
@@ -17,6 +19,10 @@ from mixle.stats import (
     MeanFieldLDAPosterior,
     MixtureDistribution,
 )
+from mixle.utils.optional_deps import HAS_PANDAS
+from mixle.utils.optional_deps import pandas as pd
+
+_SKIP_NO_PANDAS = unittest.skipUnless(HAS_PANDAS, "pandas not installed; pip install mixle[pandas]")
 
 
 class MixtureLatentPosteriorTest(unittest.TestCase):
@@ -124,6 +130,63 @@ class HmmChainLatentPosteriorTest(unittest.TestCase):
         emp = np.array([[np.mean(s[:, t] == k) for k in range(3)] for t in range(len(self.x))])
         np.testing.assert_allclose(emp, self.q.marginals(), atol=0.03)
         self.assertTrue(np.array_equal(self.q.sample(rng=3), self.q.sample(rng=3)))  # repeatable
+
+    @_SKIP_NO_PANDAS
+    def test_to_dataframe_matches_brute_force_marginals_and_mode(self):
+        gamma, mode, _entropy = self._brute_force()
+        df = self.q.to_dataframe()
+        self.assertIsInstance(df, pd.DataFrame)
+        self.assertEqual(list(df.columns), ["t", "state", "state_0_prob", "state_1_prob", "state_2_prob"])
+        self.assertEqual(df.shape, (len(self.x), 5))
+        np.testing.assert_array_equal(df["t"].to_numpy(), np.arange(len(self.x)))
+        np.testing.assert_array_equal(df["state"].to_numpy(), np.array(mode))
+        np.testing.assert_array_equal(df["state"].to_numpy(), self.q.mode())  # matches the class's own mode()
+        prob_cols = df[["state_0_prob", "state_1_prob", "state_2_prob"]].to_numpy()
+        np.testing.assert_allclose(prob_cols, gamma, atol=1e-9)
+        np.testing.assert_allclose(prob_cols.sum(axis=1), 1.0)  # each row is a proper distribution
+
+    @_SKIP_NO_PANDAS
+    def test_to_parquet_roundtrips(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = Path(d) / "hmm_latent_posterior.parquet"
+            self.q.to_parquet(path)
+            roundtrip = pd.read_parquet(path)
+            pd.testing.assert_frame_equal(roundtrip, self.q.to_dataframe())
+
+
+@_SKIP_NO_PANDAS
+class MarkovChainLatentPosteriorToDataFrameHandComputedTest(unittest.TestCase):
+    """A from-scratch, hand-derived check independent of ``HiddenMarkovModelDistribution``/brute force.
+
+    2 states, 2 steps, uniform prior and uniform-row transitions (``A[j, k] = 0.5`` for every ``j, k``):
+    the chain carries no information across time (the prior over ``(z_0, z_1)`` is exactly uniform and
+    independent), so the joint posterior factorizes into independent per-step terms and both the
+    smoothing marginals and the Viterbi path collapse to each step's own row-normalized emission
+    likelihood -- ``b[t] / sum(b[t])`` -- worked out below by hand, not read off the implementation.
+    """
+
+    def setUp(self):
+        self.log_pi = np.log([0.5, 0.5])
+        self.log_A = np.log([[0.5, 0.5], [0.5, 0.5]])
+        self.b = np.array([[0.8, 0.2], [0.3, 0.7]])  # t=0 favors state 0, t=1 favors state 1
+        self.q = MarkovChainLatentPosterior(self.log_pi, self.log_A, np.log(self.b))
+
+    def test_to_dataframe_matches_hand_derivation(self):
+        df = self.q.to_dataframe()
+        self.assertEqual(list(df.columns), ["t", "state", "state_0_prob", "state_1_prob"])
+        self.assertEqual(df.shape, (2, 4))
+        np.testing.assert_array_equal(df["t"].to_numpy(), [0, 1])
+        # forward alpha_0 = pi*b[0] = [0.4, 0.1]; alpha_1,k = b[1,k]*0.25 = [0.075, 0.175];
+        # backward beta_0 = [0.5, 0.5]; p(x) = sum(alpha_1) = 0.25 -- worked out in the PR description.
+        # gamma_0 = alpha_0*beta_0/p(x) = [0.8, 0.2] == b[0] itself (already row-normalized);
+        # gamma_1 = alpha_1*beta_1/p(x) = [0.3, 0.7] == b[1] itself.
+        np.testing.assert_allclose(df["state_0_prob"].to_numpy(), [0.8, 0.3], atol=1e-12)
+        np.testing.assert_allclose(df["state_1_prob"].to_numpy(), [0.2, 0.7], atol=1e-12)
+        # MAP path = per-step argmax of the (independent) posterior = argmax of each row of b
+        np.testing.assert_array_equal(df["state"].to_numpy(), [0, 1])
+        # cross-check the hand derivation against the class's own (independently implemented) methods
+        np.testing.assert_allclose(self.q.marginals(), self.b, atol=1e-12)
+        self.assertEqual(list(self.q.mode()), [0, 1])
 
 
 class LDAMeanFieldPosteriorTest(unittest.TestCase):

--- a/mixle/tests/optional_import_guard_test.py
+++ b/mixle/tests/optional_import_guard_test.py
@@ -28,6 +28,7 @@ _OPTIONAL_TOP_LEVEL = frozenset(
         "gmpy2",
         "zarr",
         "h5py",
+        "pandas",
         "mpi4py",
         "torch",
         "jax",

--- a/mixle/tests/posterior_test.py
+++ b/mixle/tests/posterior_test.py
@@ -1,15 +1,23 @@
 """The Posterior algebra: the posterior() factory over latent / parameter / predictive variables."""
 
+import tempfile
 import unittest
+from pathlib import Path
 
 import numpy as np
 
 from mixle.inference import ParameterPosterior, PredictivePosterior, posterior
+from mixle.inference.mcmc.parameter_bridge import sample_parameter_posterior
 from mixle.stats import sample
 from mixle.stats.compute.posterior import LatentPosterior, Posterior
 from mixle.stats.latent.mixture import MixtureDistribution
 from mixle.stats.univariate.continuous.gaussian import GaussianDistribution
 from mixle.stats.univariate.discrete.bernoulli import BernoulliDistribution
+from mixle.stats.univariate.discrete.poisson import PoissonDistribution
+from mixle.utils.optional_deps import HAS_PANDAS
+from mixle.utils.optional_deps import pandas as pd
+
+_SKIP_NO_PANDAS = unittest.skipUnless(HAS_PANDAS, "pandas not installed; pip install mixle[pandas]")
 
 
 class PredictivePosteriorTest(unittest.TestCase):
@@ -50,6 +58,30 @@ class ParameterPosteriorConjugateTest(unittest.TestCase):
     def test_auto_picks_conjugate(self):
         self.assertEqual(posterior(BernoulliDistribution(0.5), self.data, over="params").kind, "conjugate")
 
+    @_SKIP_NO_PANDAS
+    def test_to_dataframe_matches_analytic_beta_posterior(self):
+        # Beta(1, 1) prior + 400 Bernoulli(0.7) draws (289 successes, seed 0) -> Beta(290, 112) exactly;
+        # to_dataframe(n, rng) must equal an independent rng.beta(290, 112, size=n) draw column-for-column.
+        s = int(sum(self.data))
+        a, b = 1.0 + s, 1.0 + len(self.data) - s
+        self.assertEqual((a, b), (290.0, 112.0))  # pins the fixture so a future data change is caught here
+        df = self.post.to_dataframe(25, rng=np.random.RandomState(2))
+        self.assertIsInstance(df, pd.DataFrame)
+        self.assertEqual(list(df.columns), ["p"])
+        self.assertEqual(df.shape, (25, 1))
+        expected = np.random.RandomState(2).beta(a, b, size=25)
+        np.testing.assert_array_equal(df["p"].to_numpy(), expected)
+        self.assertTrue(bool((df["p"] > 0.0).all() and (df["p"] < 1.0).all()))  # Beta(290, 112) support
+
+    @_SKIP_NO_PANDAS
+    def test_to_parquet_roundtrips(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = Path(d) / "beta_posterior.parquet"
+            self.post.to_parquet(path, 15, rng=np.random.RandomState(3))
+            roundtrip = pd.read_parquet(path)
+            expected = self.post.to_dataframe(15, rng=np.random.RandomState(3))
+            pd.testing.assert_frame_equal(roundtrip, expected)
+
 
 class ParameterPosteriorMCMCTest(unittest.TestCase):
     def test_mcmc_path_when_forced(self):
@@ -64,6 +96,49 @@ class ParameterPosteriorMCMCTest(unittest.TestCase):
         self.assertEqual(len(draws), 10)
         mean = np.asarray(post.mean(), dtype=float)
         self.assertAlmostEqual(float(mean[0]), 3.0, delta=0.5)  # posterior mean of mu near 3
+
+    @_SKIP_NO_PANDAS
+    def test_to_dataframe_two_param_family_gets_positional_columns(self):
+        # GaussianDistribution's parameter_bridge maps theta -> the tuple (mu, sigma2) -- no names
+        # travel through MCMCResult, so to_dataframe() must fall back to generic param_0/param_1,
+        # column-for-column identical to a direct call to .samples() with the same rng.
+        rng = np.random.RandomState(0)
+        data = (rng.normal(3.0, 1.0, size=200)).tolist()
+        post = posterior(
+            GaussianDistribution(0.0, 1.0), data, over="params", method="mcmc", steps=300, burn_in=100, seed=0
+        )
+        df = post.to_dataframe(20, rng=np.random.RandomState(3))
+        self.assertEqual(list(df.columns), ["param_0", "param_1"])
+        self.assertEqual(df.shape, (20, 2))
+        expected = np.asarray(post.samples(20, rng=np.random.RandomState(3)), dtype=float)
+        np.testing.assert_array_equal(df.to_numpy(), expected)
+
+    @_SKIP_NO_PANDAS
+    def test_to_dataframe_scalar_family_gets_single_column(self):
+        # PoissonDistribution's bridge maps theta -> a bare float (not even a 1-tuple); to_dataframe()
+        # must still produce exactly one column, matching the raw samples exactly.
+        rng = np.random.RandomState(0)
+        data = rng.poisson(4.0, size=200).tolist()
+        post = posterior(PoissonDistribution(1.0), data, over="params", method="mcmc", steps=300, burn_in=100, seed=0)
+        df = post.to_dataframe(12, rng=np.random.RandomState(4))
+        self.assertEqual(list(df.columns), ["param_0"])
+        self.assertEqual(df.shape, (12, 1))
+        expected = np.asarray(post.samples(12, rng=np.random.RandomState(4)), dtype=float)
+        np.testing.assert_array_equal(df["param_0"].to_numpy(), expected)
+        self.assertTrue(bool((df["param_0"] > 0.0).all()))  # Poisson rate posterior support
+
+    @_SKIP_NO_PANDAS
+    def test_to_dataframe_rejects_rebuilt_distribution_samples(self):
+        # return_distributions=True maps each MCMC draw to a rebuilt distribution object -- there is no
+        # natural tabular form for that, so to_dataframe() must refuse rather than fabricate columns.
+        rng = np.random.RandomState(0)
+        data = (rng.normal(3.0, 1.0, size=50)).tolist()
+        result = sample_parameter_posterior(
+            GaussianDistribution(0.0, 1.0), data, steps=50, burn_in=10, seed=0, return_distributions=True
+        )
+        post = ParameterPosterior.from_mcmc(result)
+        with self.assertRaises(TypeError):
+            post.to_dataframe(5, rng=np.random.RandomState(0))
 
 
 class LatentPosteriorFactoryTest(unittest.TestCase):

--- a/mixle/utils/optional_deps.py
+++ b/mixle/utils/optional_deps.py
@@ -19,6 +19,15 @@ on-disk zarr and HDF5 volumes without materializing them. Both are ``None`` when
 instead of an ``ImportError`` on import. numpy-memmap volumes need no extra dependency. Install with:
 
     pip install mixle[arrays]
+
+pandas: ``mixle.data.sources.pandas_source`` reads a caller-supplied DataFrame by duck-typing (it never
+imports pandas itself), but the write-side result-egress methods (``ParameterPosterior.to_dataframe``,
+``CalibrationReport.to_dataframe``, ``MarkovChainLatentPosterior.to_dataframe``, and each type's
+``to_parquet``) construct a real ``pandas.DataFrame``, so they need the library itself. ``pandas`` is
+``None`` when missing and ``HAS_PANDAS`` is ``False``, so those methods raise the standard
+``require(...)`` message at call time instead of an ``ImportError`` on import. Install with:
+
+    pip install mixle[pandas]
 """
 
 __all__ = [
@@ -33,6 +42,8 @@ __all__ = [
     "HAS_ZARR",
     "h5py",
     "HAS_H5PY",
+    "pandas",
+    "HAS_PANDAS",
     "MPI",
     "HAS_MPI4PY",
     "require",
@@ -111,6 +122,15 @@ try:
 except ImportError:
     h5py = None
     HAS_H5PY = False
+
+
+try:
+    import pandas
+
+    HAS_PANDAS = True
+except ImportError:
+    pandas = None
+    HAS_PANDAS = False
 
 
 # mpi4py: the "mpi" distributed backend (mixle.utils.parallel.mpi) needs an actual MPI runtime to do

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,8 +53,10 @@ dependencies = [
 # -- and it must stay platform-gated: Intel TBB ships no arm64 (Apple Silicon) wheels, so an
 # unconditional floor here makes `pip install mixle[numba]` uninstallable on that platform.
 numba = ["numba>=0.59", "tbb>=2021.6; platform_machine == 'x86_64'"]
-# pandas is only used by the DataFrame data adapter (which duck-types and never imports pandas);
-# it is optional so the base install stays lean.
+# The read-side DataFrame data adapter duck-types and never imports pandas; the write-side result
+# egress (ParameterPosterior/CalibrationReport/MarkovChainLatentPosterior .to_dataframe/.to_parquet)
+# constructs a real pandas.DataFrame, so it needs the library itself (mixle.utils.optional_deps).
+# Either way it stays optional so the base install stays lean.
 pandas = ["pandas>=2.0"]
 # data-layer connectors (mixle.data.sources) -- each lazy + optional.
 arrow = ["pyarrow>=14"]


### PR DESCRIPTION
## The gap

mixle has nine read-side data connectors (`mixle.data.sources`: pandas, arrow, sql,
mongo, hadoop, arrays, graph, text) and no write-side path back out:

```
grep -rn "to_dataframe\|to_pandas\|to_parquet" --include=*.py . 
```

outside `tests/` returns zero hits. A posterior, a calibration report, or an HMM's
decoded state sequence had no supported way to become a `pandas.DataFrame` or a
Parquet file -- a user had to hand-assemble one from raw attributes to hand a
result to ordinary data-science tooling.

## The fix

Adds `to_dataframe()`/`to_parquet()` to the three central result types actually
reachable from the public API (checked against `mixle/__init__.py`'s surface and
what the flagship entry points return, not guessed):

- **`ParameterPosterior`** (`mixle.inference`) -- posterior parameter draws, one
  row per draw. Named columns when the sampler kept them (the conjugate path's
  dict-of-arrays; MCMC over `CategoricalDistribution`); generic `param_0..` for
  the other bridged MCMC families, which map theta to unnamed tuples/scalars (see
  `mixle.inference.mcmc.parameter_bridge`). Raises `TypeError` rather than
  fabricate columns for `return_distributions=True` draws (rebuilt distribution
  objects have no natural tabular form).
- **`CalibrationReport`** (`mixle.inference`) -- the PIT histogram as one row per
  bin, or a one-row summary when there is no scalar predictive CDF.
- **`MarkovChainLatentPosterior`** (`mixle.stats`) -- an HMM's per-position state
  posterior: the Viterbi MAP state plus every state's smoothing probability, one
  row per sequence position (`model.latent_posterior(x).to_dataframe()`).

`pandas` is a new optional-dependency usage in `mixle.utils.optional_deps`
(`HAS_PANDAS`), matching the existing numba/pyspark/zarr/h5py/mpi4py guard
convention -- never imported by the base install (`optional_import_guard_test.py`
and `collection_hygiene_test.py` both still pass; the latter required the
`HAS_PANDAS` + `@unittest.skipUnless` pattern already used by
`array_data_sources_test.py` rather than a bare top-level `import pandas` in the
new test files). `to_parquet` additionally needs a Parquet engine (`pyarrow` via
`mixle[arrow]`, or fastparquet).

Docs (`docs/data.rst`, a new "Result Egress" section) and `CHANGELOG.md` describe
exactly these three methods -- not a general `sample(n)`-to-DataFrame facility,
which this PR does not build.

## Testing

Hand-derived expected values, not just "doesn't crash":

- An independently computed Beta(290, 112) posterior (closed-form from the fixture's
  own data) compared column-for-column against `to_dataframe()`.
- A from-scratch forward-backward derivation for a 2-state/2-step HMM (marginals
  and the Viterbi path worked out by hand in the test comments) cross-checked
  against `MarkovChainLatentPosterior.to_dataframe()`.
- A hand-built PIT histogram compared bin-for-bin against `CalibrationReport.to_dataframe()`.
- Parquet round-trips for all three types.
- An MCMC theta-shape sweep (Gaussian: 2-tuple -> `param_0`/`param_1`; Poisson: bare
  scalar -> single column; `return_distributions=True` -> `TypeError`).

Full fast suite: **5246 passed, 0 failed**. `api_manifest.json` /
`maturity_manifest.json` / `serialization_schema_manifest.json` regenerated with
zero drift (no new top-level names -- only methods on classes already in the
public surface).

## Not merging

Leaving this open for review rather than self-merging, per the pattern on this
repo's recent audit-ledger-derived core fixes (e.g. #484, #486, #487, #489, #490,
#491, #495, #497, #508 are all open; the PRs that self-merged quickly in the same
window are either small additive capabilities or one-line numeric fixes, not new
public-surface additions like this one).