### PR TITLE
Add entropy() to the six F-9 families #434 left unfinished

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,15 @@ with a regression test that fails on the unfixed code):
   entropies filled across the univariate catalog; `mixle.ppl` exports `waic`/`loo`;
   `ScheduledHMM.estimator()` restores the prototype convention (F-1, F-2, F-4, F-6, F-7, F-9, F-11,
   F-12; #434).
+- Completeness follow-up: #434's "entropies filled across the univariate catalog" covered 5 of the
+  11 families F-9 actually names. `SkewNormal`, `NegativeBinomial`, `Rician`, `Nakagami`, `Skellam`,
+  and `LogSeries` now have `entropy()` too -- a closed form for Nakagami (via the Gamma-entropy
+  identity under `X = sqrt(Y)`), a closed-form reduction plus one adaptively-quadrated term for
+  SkewNormal, adaptive quadrature for Rician, and exact series summation (truncated at each
+  distribution's own quantile, not a fixed-width heuristic) for NegativeBinomial/Skellam/LogSeries.
+  Verified against independent numerical integration/Monte Carlo, not only scipy: scipy's own
+  generic `entropy()` silently returns a wrong value ("sum did not converge") for NegativeBinomial
+  and LogSeries at strongly over-dispersed parameters (F-9; #512).
 
 ### Changed
 

--- a/mixle/stats/univariate/continuous/nakagami.py
+++ b/mixle/stats/univariate/continuous/nakagami.py
@@ -153,6 +153,25 @@ class NakagamiDistribution(SequenceEncodableProbabilityDistribution):
         mu = self.mean()
         return float(self.omega - mu * mu)
 
+    def entropy(self) -> float:
+        """Differential entropy m + lgamma(m) + (1/2 - m) psi(m) + (1/2) log(omega/m) - log(2).
+
+        Derived via the entropy of a monotone transform: ``X = sqrt(Y)`` with
+        ``Y = X^2 ~ Gamma(m, omega/m)`` (Nakagami, 'The m-distribution', 1960), so
+        ``h(X) = h(Y) - log(2) - E[log X] = h(Y) - log(2) - (1/2)(E[log Y])`` and both ``h(Y)``
+        and ``E[log Y]`` are standard Gamma-distribution identities. Reduces exactly to the
+        Rayleigh entropy at ``m = 1``.
+        """
+        from scipy.special import digamma
+
+        return float(
+            self.m
+            + gammaln(self.m)
+            + (0.5 - self.m) * digamma(self.m)
+            + 0.5 * math.log(self.omega / self.m)
+            - math.log(2.0)
+        )
+
     def sampler(self, seed: int | None = None) -> "NakagamiSampler":
         """Return a sampler (``X = sqrt(Gamma(m, omega/m))``)."""
         return NakagamiSampler(self, seed)

--- a/mixle/stats/univariate/continuous/rician.py
+++ b/mixle/stats/univariate/continuous/rician.py
@@ -177,6 +177,27 @@ class RicianDistribution(SequenceEncodableProbabilityDistribution):
         mu = self.mean()
         return float(self.nu * self.nu + 2.0 * self._sig2 - mu * mu)
 
+    def entropy(self) -> float:
+        """Differential entropy in nats, by adaptive quadrature of -f(x) log f(x) over x > 0.
+
+        At ``nu = 0`` the Rician is exactly the Rayleigh, whose entropy is the closed form
+        ``1 + log(sigma / sqrt(2)) + euler_gamma / 2``. For ``nu > 0`` the density's
+        ``log I0(x nu / sigma^2)`` term has no closed-form expectation (Rice, 'Mathematical
+        analysis of random noise', 1944/1945), so the integral is evaluated numerically against
+        the exact log-density.
+        """
+        if self.nu == 0.0:
+            return float(1.0 + math.log(self.sigma / math.sqrt(2.0)) + np.euler_gamma / 2.0)
+
+        from scipy import integrate
+
+        def integrand(x: float) -> float:
+            logf = self.log_density(x)
+            return 0.0 if not np.isfinite(logf) else -math.exp(logf) * logf
+
+        val, _ = integrate.quad(integrand, 0.0, np.inf, limit=200)
+        return float(val)
+
     def sampler(self, seed: int | None = None) -> "RicianSampler":
         """Return a sampler (the envelope of a 2-D Gaussian offset by ``nu``)."""
         return RicianSampler(self, seed)

--- a/mixle/stats/univariate/continuous/skew_normal.py
+++ b/mixle/stats/univariate/continuous/skew_normal.py
@@ -126,6 +126,28 @@ class SkewNormalDistribution(SequenceEncodableProbabilityDistribution):
         delta = self.shape / math.sqrt(1.0 + self.shape * self.shape)
         return float(self.scale * self.scale * (1.0 - 2.0 * delta * delta / math.pi))
 
+    def entropy(self) -> float:
+        """Differential entropy log(scale) + 0.5 log(2 pi e) - log(2) - E[log Phi(alpha Y)].
+
+        ``Y`` is the standard skew-normal(alpha); ``E[Y^2] = 1`` for every alpha (a property of the
+        two-Gaussian stochastic representation) collapses the Gaussian part of the log-density to a
+        closed form, leaving ``E[log Phi(alpha Y)]``. That term has no closed form for general alpha
+        (Arellano-Valle, Contreras-Reyes & Genton, 'Shannon entropy and mutual information for
+        multivariate skew-elliptical distributions', Scand. J. Statist. 40 (2013)), so it is
+        evaluated by adaptive quadrature against the standard skew-normal density itself.
+        """
+        from scipy import integrate
+
+        alpha = self.shape
+
+        def integrand(y: float) -> float:
+            log_phi = -_HALF_LOG_2PI - 0.5 * y * y
+            log_cdf = float(log_ndtr(alpha * y))
+            return 2.0 * math.exp(log_phi + log_cdf) * log_cdf
+
+        e_log_cdf, _ = integrate.quad(integrand, -np.inf, np.inf, limit=200)
+        return float(self.log_scale + 0.5 * math.log(2.0 * math.pi * math.e) - math.log(2.0) - e_log_cdf)
+
     def sampler(self, seed: int | None = None) -> "SkewNormalSampler":
         """Return a sampler for drawing observations from this distribution."""
         return SkewNormalSampler(self, seed)

--- a/mixle/stats/univariate/discrete/logseries.py
+++ b/mixle/stats/univariate/discrete/logseries.py
@@ -230,6 +230,19 @@ class LogSeriesDistribution(SequenceEncodableProbabilityDistribution):
         l1m = math.log(1.0 - p)
         return float(-p * (p + l1m) / ((1.0 - p) ** 2 * l1m * l1m))
 
+    def entropy(self) -> float:
+        """Shannon entropy in nats, by exact summation of the standard series.
+
+        The log-series entropy ``-sum_k p_k log p_k`` has no closed form (Fisher, Corbet &
+        Williams, 1943). The series is summed from ``k = 1`` up to this distribution's own
+        quantile at ``1 - 1e-16`` (plus a safety margin), beyond which the remaining tail mass is
+        far below double rounding.
+        """
+        kmax = int(self.quantile(1.0 - 1.0e-16)) + 50
+        k = np.arange(1, kmax + 1, dtype=np.float64)
+        lp = k * self.log_p - np.log(k) - self.log_norm
+        return float(-np.sum(np.exp(lp) * lp))
+
     def cdf(self, x: float) -> float:
         """Cumulative distribution function P(X <= x), support x >= 1 (via scipy logser)."""
         import math

--- a/mixle/stats/univariate/discrete/negative_binomial.py
+++ b/mixle/stats/univariate/discrete/negative_binomial.py
@@ -231,6 +231,21 @@ class NegativeBinomialDistribution(SequenceEncodableProbabilityDistribution):
         """Variance Var[X]: r(1-p)/p^2."""
         return float(self.r * (1.0 - self.p) / (self.p * self.p))
 
+    def entropy(self) -> float:
+        """Shannon entropy in nats, by exact summation of the standard series.
+
+        The negative-binomial entropy ``-sum_k p_k log p_k`` has no closed form (Johnson, Kemp &
+        Kotz, *Univariate Discrete Distributions*, ch. 5). The series is summed over the support
+        up to this distribution's own quantile at ``1 - 1e-16`` (plus a safety margin), beyond
+        which the tail mass is far below double rounding -- the same effective-support truncation
+        PoissonDistribution.entropy() uses, but driven by the exact CDF (via ``betainc``) rather
+        than a Gaussian-tail heuristic, since the negative binomial can be heavy-tailed.
+        """
+        kmax = int(self.quantile(1.0 - 1.0e-16)) + 50
+        k = np.arange(kmax + 1, dtype=np.float64)
+        lp = gammaln(k + self.r) - self.log_gamma_r - gammaln(k + 1.0) + self.r * self.log_p + k * self.log_1p
+        return float(-np.sum(np.exp(lp) * lp))
+
     def cdf(self, x: float) -> float:
         """Cumulative distribution function P(X <= x) = I_p(r, floor(x)+1)."""
         import math

--- a/mixle/stats/univariate/discrete/skellam.py
+++ b/mixle/stats/univariate/discrete/skellam.py
@@ -114,6 +114,29 @@ class SkellamDistribution(SequenceEncodableProbabilityDistribution):
         """Variance Var[X] = mu1 + mu2."""
         return float(self.mu1 + self.mu2)
 
+    def entropy(self) -> float:
+        """Shannon entropy in nats, by exact two-sided summation of the standard series.
+
+        The Skellam entropy ``-sum_k p_k log p_k`` has no closed form. The sum runs over the
+        support between this distribution's own quantiles at ``1e-16`` and ``1 - 1e-16`` (plus a
+        safety margin on each side), beyond which the remaining tail mass on both sides is far
+        below double rounding. Terms where the scaled Bessel term underflows to exactly zero
+        (mass indistinguishable from 0 at double precision) are dropped, matching the ``p log p
+        -> 0`` limit.
+        """
+        from scipy.special import ive
+
+        tol = 1.0e-16
+        lo = int(self.quantile(tol)) - 20
+        hi = int(self.quantile(1.0 - tol)) + 20
+        k = np.arange(lo, hi + 1, dtype=np.float64)
+        bessel = ive(np.abs(k), self.two_sqrt_prod)
+        with np.errstate(divide="ignore"):
+            log_bessel = np.log(bessel)
+        lp = -self.sqrt_diff_sq + k * self.log_ratio_half + log_bessel
+        finite = np.isfinite(lp)
+        return float(-np.sum(np.exp(lp[finite]) * lp[finite]))
+
     # --- compute-engine backend (numpy + torch/GPU), SCORING only: the moment accumulator stays
     # host-side (it is plain count/sum/sum2 already). torch has no ``iv(k, .)``, so ``log I_k(z)``
     # is evaluated engine-side as the ascending series (A&S 9.6.10) under logsumexp — every term is

--- a/mixle/tests/entropy_completeness_test.py
+++ b/mixle/tests/entropy_completeness_test.py
@@ -1,0 +1,238 @@
+"""F-9 completion: entropy() for the six families PR #434 left unfinished.
+
+PR #434 (2026-07-13) added closed-form entropy() to StudentT, Poisson, GEV, GPD, and
+InverseGaussian (see completeness_review_fixes_test.py) but its own commit message overstated
+the ledger item: audit/CODEBASE_REVIEW_LEDGER.md F-9 also names SkewNormal, NegativeBinomial,
+Rician, Nakagami, Skellam, and LogSeries, none of which gained entropy() in that PR. This module
+finishes F-9 for those six.
+
+Every check here is independent of the closed-form derivation used in the source: the
+"numerical reference" tests recompute the entropy integral/series from scratch (fresh quadrature
+or truncated summation, not a call into the production formula), and the "monte carlo" tests use
+only sampler() + log_density()/seq_log_density() -- never entropy() itself -- so a wrong constant,
+sign, or parameterization in the shipped formula cannot pass silently. This matters here: scipy's
+own generic ``.entropy()`` (a numerical fallback via ``rv_discrete.expect``) turns out to raise
+"sum did not converge" and returns a silently wrong value for NegativeBinomial/LogSeries at
+strongly over-dispersed parameters (see test_extreme_parameters_where_scipy_entropy_is_unreliable),
+which is exactly the failure mode a pure scipy cross-check (as entropy_methods_test.py otherwise
+uses) would miss.
+"""
+
+import math
+import unittest
+
+import numpy as np
+from scipy import integrate
+from scipy.special import gammaln, ive
+
+from mixle.stats.univariate.continuous.nakagami import NakagamiDistribution
+from mixle.stats.univariate.continuous.rician import RicianDistribution
+from mixle.stats.univariate.continuous.skew_normal import SkewNormalDistribution
+from mixle.stats.univariate.discrete.logseries import LogSeriesDistribution
+from mixle.stats.univariate.discrete.negative_binomial import NegativeBinomialDistribution
+from mixle.stats.univariate.discrete.skellam import SkellamDistribution
+
+MC_N = 300_000  # at this size the plug-in MC estimator's standard error is ~0.001-0.003 nats
+MC_SEED = 0
+MC_DELTA = 0.02  # >= 6x the empirically observed standard error for every case below
+
+
+def _mc_entropy(dist, n: int = MC_N, seed: int = MC_SEED) -> float:
+    """Plug-in Monte Carlo entropy estimate -mean(log f(X)) for X ~ dist.sampler().
+
+    Independent of ``dist.entropy()``: it only exercises the (separately tested) sampler and
+    log-density paths, so it cannot be fooled by a bug that is only inside entropy() itself.
+    """
+    data = np.asarray(dist.sampler(seed=seed).sample(n))
+    enc = dist.dist_to_encoder().seq_encode(data)
+    logp = np.asarray(dist.seq_log_density(enc), dtype=np.float64)
+    return float(-np.mean(logp))
+
+
+def _nb_log_pmf(k: np.ndarray, r: float, p: float) -> np.ndarray:
+    """Negative-binomial log-pmf, coded fresh from the textbook definition (Johnson, Kemp & Kotz)."""
+    return gammaln(k + r) - gammaln(r) - gammaln(k + 1.0) + r * math.log(p) + k * math.log1p(-p)
+
+
+def _skellam_log_pmf(k: np.ndarray, mu1: float, mu2: float) -> np.ndarray:
+    """Skellam log-pmf, coded fresh from the textbook definition (Skellam, 1946)."""
+    log_ratio_half = 0.5 * (math.log(mu1) - math.log(mu2))
+    sqrt_diff_sq = (math.sqrt(mu1) - math.sqrt(mu2)) ** 2
+    two_sqrt_prod = 2.0 * math.sqrt(mu1 * mu2)
+    with np.errstate(divide="ignore"):
+        log_bessel = np.log(ive(np.abs(k), two_sqrt_prod))
+    return -sqrt_diff_sq + k * log_ratio_half + log_bessel
+
+
+def _logseries_log_pmf(k: np.ndarray, p: float) -> np.ndarray:
+    """Log-series log-pmf, coded fresh from the textbook definition (Fisher, Corbet & Williams)."""
+    return k * math.log(p) - np.log(k) - math.log(-math.log1p(-p))
+
+
+class SkewNormalEntropyTest(unittest.TestCase):
+    def test_matches_independent_quadrature(self):
+        for loc, scale, alpha in [
+            (0.0, 1.0, 0.0),
+            (0.5, 1.5, 2.0),
+            (-1.0, 0.7, -3.0),
+            (2.0, 2.0, 20.0),
+            (0.0, 1.0, -0.3),
+        ]:
+            d = SkewNormalDistribution(loc, scale, alpha)
+
+            def f(x, d=d):
+                logf = d.log_density(x)
+                return -math.exp(logf) * logf
+
+            ref, _ = integrate.quad(f, -np.inf, np.inf, limit=200)
+            with self.subTest(loc=loc, scale=scale, alpha=alpha):
+                self.assertAlmostEqual(d.entropy(), ref, places=6)
+
+    def test_matches_monte_carlo(self):
+        for loc, scale, alpha in [(0.5, 1.5, 2.0), (2.0, 2.0, 20.0), (-1.0, 0.7, -3.0)]:
+            d = SkewNormalDistribution(loc, scale, alpha)
+            with self.subTest(loc=loc, scale=scale, alpha=alpha):
+                self.assertAlmostEqual(d.entropy(), _mc_entropy(d), delta=MC_DELTA)
+
+
+class NegativeBinomialEntropyTest(unittest.TestCase):
+    def test_matches_independent_truncated_sum(self):
+        for r, p in [(1.0, 0.5), (5.0, 0.3), (20.0, 0.6), (2.0, 0.05), (0.5, 0.2)]:
+            d = NegativeBinomialDistribution(r, p)
+            kmax = int(d.quantile(1.0 - 1.0e-16)) + 200
+            k = np.arange(kmax + 1, dtype=np.float64)
+            lp = _nb_log_pmf(k, r, p)
+            ref = float(-np.sum(np.exp(lp) * lp))
+            with self.subTest(r=r, p=p):
+                self.assertAlmostEqual(d.entropy(), ref, places=6)
+
+    def test_matches_monte_carlo(self):
+        for r, p in [(5.0, 0.3), (2.0, 0.05)]:
+            d = NegativeBinomialDistribution(r, p)
+            with self.subTest(r=r, p=p):
+                self.assertAlmostEqual(d.entropy(), _mc_entropy(d), delta=MC_DELTA)
+
+
+class RicianEntropyTest(unittest.TestCase):
+    def test_matches_independent_quadrature(self):
+        for nu, sigma in [(0.0, 1.0), (0.0, 2.5), (1.0, 1.0), (3.0, 1.0), (5.0, 2.0), (0.1, 0.5)]:
+            d = RicianDistribution(nu, sigma)
+
+            def f(x, d=d):
+                logf = d.log_density(x)
+                return 0.0 if not np.isfinite(logf) else -math.exp(logf) * logf
+
+            ref, _ = integrate.quad(f, 0.0, np.inf, limit=200)
+            with self.subTest(nu=nu, sigma=sigma):
+                self.assertAlmostEqual(d.entropy(), ref, places=6)
+
+    def test_nu_zero_matches_rayleigh_closed_form(self):
+        for sigma in [1.0, 2.5, 0.3]:
+            d = RicianDistribution(0.0, sigma)
+            rayleigh = 1.0 + math.log(sigma / math.sqrt(2.0)) + np.euler_gamma / 2.0
+            with self.subTest(sigma=sigma):
+                self.assertAlmostEqual(d.entropy(), rayleigh, places=10)
+
+    def test_matches_monte_carlo(self):
+        for nu, sigma in [(3.0, 1.0), (5.0, 2.0)]:
+            d = RicianDistribution(nu, sigma)
+            with self.subTest(nu=nu, sigma=sigma):
+                self.assertAlmostEqual(d.entropy(), _mc_entropy(d), delta=MC_DELTA)
+
+
+class NakagamiEntropyTest(unittest.TestCase):
+    def test_matches_independent_quadrature(self):
+        for m, omega in [(0.5, 1.0), (1.0, 1.0), (1.0, 3.0), (2.5, 2.0), (5.0, 0.7), (0.7, 4.5)]:
+            d = NakagamiDistribution(m, omega)
+
+            def f(x, d=d):
+                logf = d.log_density(x)
+                return -math.exp(logf) * logf
+
+            ref, _ = integrate.quad(f, 0.0, np.inf, limit=200)
+            with self.subTest(m=m, omega=omega):
+                self.assertAlmostEqual(d.entropy(), ref, places=6)
+
+    def test_m_one_matches_rayleigh_closed_form(self):
+        # Nakagami(m=1, omega) is exactly Rayleigh(sigma=sqrt(omega/2)).
+        for omega in [1.0, 3.0, 0.5]:
+            d = NakagamiDistribution(1.0, omega)
+            sigma = math.sqrt(omega / 2.0)
+            rayleigh = 1.0 + math.log(sigma / math.sqrt(2.0)) + np.euler_gamma / 2.0
+            with self.subTest(omega=omega):
+                self.assertAlmostEqual(d.entropy(), rayleigh, places=10)
+
+    def test_matches_monte_carlo(self):
+        for m, omega in [(2.5, 2.0), (0.7, 4.5)]:
+            d = NakagamiDistribution(m, omega)
+            with self.subTest(m=m, omega=omega):
+                self.assertAlmostEqual(d.entropy(), _mc_entropy(d), delta=MC_DELTA)
+
+
+class SkellamEntropyTest(unittest.TestCase):
+    def test_matches_independent_truncated_sum(self):
+        for mu1, mu2 in [(2.0, 1.0), (5.0, 5.0), (0.5, 8.0), (15.0, 3.0)]:
+            d = SkellamDistribution(mu1, mu2)
+            tol = 1.0e-16
+            lo = int(d.quantile(tol)) - 50
+            hi = int(d.quantile(1.0 - tol)) + 50
+            k = np.arange(lo, hi + 1, dtype=np.float64)
+            lp = _skellam_log_pmf(k, mu1, mu2)
+            finite = np.isfinite(lp)
+            ref = float(-np.sum(np.exp(lp[finite]) * lp[finite]))
+            with self.subTest(mu1=mu1, mu2=mu2):
+                self.assertAlmostEqual(d.entropy(), ref, places=6)
+
+    def test_matches_monte_carlo(self):
+        for mu1, mu2 in [(5.0, 5.0), (15.0, 3.0)]:
+            d = SkellamDistribution(mu1, mu2)
+            with self.subTest(mu1=mu1, mu2=mu2):
+                self.assertAlmostEqual(d.entropy(), _mc_entropy(d), delta=MC_DELTA)
+
+
+class LogSeriesEntropyTest(unittest.TestCase):
+    def test_matches_independent_truncated_sum(self):
+        for p in [0.1, 0.5, 0.7, 0.9]:
+            d = LogSeriesDistribution(p)
+            kmax = int(d.quantile(1.0 - 1.0e-16)) + 200
+            k = np.arange(1, kmax + 1, dtype=np.float64)
+            lp = _logseries_log_pmf(k, p)
+            ref = float(-np.sum(np.exp(lp) * lp))
+            with self.subTest(p=p):
+                self.assertAlmostEqual(d.entropy(), ref, places=6)
+
+    def test_matches_monte_carlo(self):
+        for p in [0.5, 0.9]:
+            d = LogSeriesDistribution(p)
+            with self.subTest(p=p):
+                self.assertAlmostEqual(d.entropy(), _mc_entropy(d), delta=MC_DELTA)
+
+
+class ExtremeParametersWhereScipyEntropyIsUnreliableTest(unittest.TestCase):
+    """scipy.stats.{nbinom,logser}.entropy() falls back to a generic numerical series (via
+    ``rv_discrete.expect``) that raises "sum did not converge" and returns a value off by more
+    than 1.5 nats at these parameters -- so these two cases are checked only against the
+    from-scratch truncated sum and Monte Carlo, which agree with each other and with mixle.
+    """
+
+    def test_negative_binomial_heavy_tailed(self):
+        d = NegativeBinomialDistribution(0.5, 0.01)
+        kmax = int(d.quantile(1.0 - 1.0e-16)) + 200
+        k = np.arange(kmax + 1, dtype=np.float64)
+        lp = _nb_log_pmf(k, 0.5, 0.01)
+        ref = float(-np.sum(np.exp(lp) * lp))
+        self.assertAlmostEqual(d.entropy(), ref, places=6)
+        self.assertAlmostEqual(d.entropy(), _mc_entropy(d, n=500_000), delta=MC_DELTA)
+
+    def test_logseries_near_boundary(self):
+        d = LogSeriesDistribution(0.99)
+        kmax = int(d.quantile(1.0 - 1.0e-16)) + 200
+        k = np.arange(1, kmax + 1, dtype=np.float64)
+        lp = _logseries_log_pmf(k, 0.99)
+        ref = float(-np.sum(np.exp(lp) * lp))
+        self.assertAlmostEqual(d.entropy(), ref, places=6)
+        self.assertAlmostEqual(d.entropy(), _mc_entropy(d, n=500_000), delta=MC_DELTA)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mixle/tests/entropy_methods_test.py
+++ b/mixle/tests/entropy_methods_test.py
@@ -1,5 +1,6 @@
 """WS-13/WS-4: base distributions expose closed-form entropy() (nats), cross-checked against scipy."""
 
+import math
 import unittest
 
 import scipy.stats as ss
@@ -15,12 +16,18 @@ from mixle.stats.univariate.continuous.half_normal import HalfNormalDistribution
 from mixle.stats.univariate.continuous.laplace import LaplaceDistribution
 from mixle.stats.univariate.continuous.log_gaussian import LogGaussianDistribution
 from mixle.stats.univariate.continuous.logistic import LogisticDistribution
+from mixle.stats.univariate.continuous.nakagami import NakagamiDistribution
 from mixle.stats.univariate.continuous.pareto import ParetoDistribution
 from mixle.stats.univariate.continuous.rayleigh import RayleighDistribution
+from mixle.stats.univariate.continuous.rician import RicianDistribution
+from mixle.stats.univariate.continuous.skew_normal import SkewNormalDistribution
 from mixle.stats.univariate.continuous.uniform import UniformDistribution
 from mixle.stats.univariate.continuous.weibull import WeibullDistribution
 from mixle.stats.univariate.discrete.bernoulli import BernoulliDistribution
 from mixle.stats.univariate.discrete.geometric import GeometricDistribution
+from mixle.stats.univariate.discrete.logseries import LogSeriesDistribution
+from mixle.stats.univariate.discrete.negative_binomial import NegativeBinomialDistribution
+from mixle.stats.univariate.discrete.skellam import SkellamDistribution
 
 # (mixle instance, scipy frozen with the same parameters)
 CASES = [
@@ -39,6 +46,14 @@ CASES = [
     (LogGaussianDistribution(0.0, 0.25), ss.lognorm(s=0.5, scale=1.0)),
     (BernoulliDistribution(0.3), ss.bernoulli(0.3)),
     (GeometricDistribution(0.4), ss.geom(0.4)),
+    # F-9 completion (PR #434 left these six unfinished; see entropy_completeness_test.py for the
+    # from-scratch numerical-integration/Monte-Carlo verification these scipy cross-checks don't cover).
+    (SkewNormalDistribution(0.5, 1.5, 2.0), ss.skewnorm(2.0, loc=0.5, scale=1.5)),
+    (NegativeBinomialDistribution(5.0, 0.3), ss.nbinom(5.0, 0.3)),
+    (RicianDistribution(3.0, 1.0), ss.rice(3.0, scale=1.0)),
+    (NakagamiDistribution(2.5, 2.0), ss.nakagami(2.5, scale=math.sqrt(2.0))),
+    (SkellamDistribution(5.0, 5.0), ss.skellam(5.0, 5.0)),
+    (LogSeriesDistribution(0.7), ss.logser(0.7)),
 ]
 
 


### PR DESCRIPTION
## The gap

`audit/CODEBASE_REVIEW_LEDGER.md` F-9 ("Univariate moments/entropy potholes") named 11 families
missing `entropy()`: StudentT, SkewNormal, Poisson, NegBin, GEV, GPD, Rician, Nakagami,
InverseGaussian, Skellam, LogSeries. PR #434 (2026-07-13) added `entropy()` to 5 of them
(StudentT, Poisson, GEV, GPD, InverseGaussian) but its own commit message claimed the ledger line
outright ("closed-form moments and entropies filled across the univariate catalog"). A fresh
`hasattr` sweep today (the same method the original review used) confirms 6 families still had no
`entropy()`: `SkewNormalDistribution`, `NegativeBinomialDistribution`, `RicianDistribution`,
`NakagamiDistribution`, `SkellamDistribution`, `LogSeriesDistribution`. `mean`/`variance` are
already present on all six (added in #434 or earlier WS-13 work) -- only `entropy()` was missing.

## The fix

Adds `entropy()` to all six, in each file's existing method order (right after `variance()`,
matching where the five already-fixed families put it) and each cited against a standard
reference:

| Family | Approach | Reference |
|---|---|---|
| **Nakagami** | Genuine closed form: `m + lgamma(m) + (1/2 - m) psi(m) + (1/2) log(omega/m) - log(2)`, derived via the Gamma-distribution entropy under the monotone transform `X = sqrt(Y)`, `Y = X^2 ~ Gamma(m, omega/m)`. Reduces exactly to the Rayleigh entropy at `m = 1` (checked in both directions). | Nakagami (1960) |
| **SkewNormal** | Closed-form reduction: `E[Y^2] = 1` for every shape (a property of the two-Gaussian stochastic representation) collapses the Gaussian part of the log-density to a closed form, leaving one term, `E[log Phi(alpha Y)]`, with no closed form for general `alpha`. Evaluated by adaptive quadrature against the standard skew-normal density. | Azzalini (1985, already cited in the file); Arellano-Valle, Contreras-Reyes & Genton (2013) for the no-closed-form term |
| **Rician** | No closed form for `nu > 0`. Evaluated by adaptive quadrature of `-f(x) log f(x)` against the exact log-density; `nu = 0` (the Rayleigh limit) uses the exact closed form directly. | Rice (1944/1945) |
| **NegativeBinomial** | No closed form (same as Poisson, already in this codebase). Exact series summation, truncated at the distribution's own `quantile(1 - 1e-16)` rather than a fixed-width heuristic -- needed because NegativeBinomial can be heavy-tailed (see below). | Johnson, Kemp & Kotz, *Univariate Discrete Distributions* |
| **Skellam** | No closed form. Two-sided exact summation between `quantile(1e-16)` and `quantile(1 - 1e-16)`. | Skellam (1946, already cited in the file) |
| **LogSeries** | No closed form. Exact summation from `k=1` to `quantile(1 - 1e-16)`. | Fisher, Corbet & Williams (1943, already cited in the file) |

I derived the Nakagami and SkewNormal formulas from scratch (the Gamma-entropy-under-transform
identity for Nakagami; the `E[Y^2]=1` reduction for SkewNormal) and verified both numerically
before writing any source -- worth flagging that my first pass at the SkewNormal reduction had a
real bug (weighted the residual expectation by the plain Gaussian density instead of the
skew-normal's own density), caught by comparing against independent quadrature before it ever
reached this diff.

### Why quantile-based truncation, not a fixed multiplier of the std

Poisson's existing `entropy()` truncates at `lam + 40*sqrt(lam) + 40` because the Poisson tail is
sub-Gaussian -- safe under a fixed multiplier. NegativeBinomial/Skellam/LogSeries can be
heavy-tailed (e.g. NegativeBinomial with small `r` and small `p` is close to geometric), where a
fixed-multiplier-of-std bound under-covers. Each of these three already has an exact `quantile()`
(via `betainc`/scipy `ppf`), so truncation is instead driven by that exact inverse-CDF, which
stays correct regardless of tail weight.

### scipy's own `entropy()` is not reliable everywhere here

`entropy_completeness_test.py::ExtremeParametersWhereScipyEntropyIsUnreliableTest` documents a
real finding: `scipy.stats.nbinom(0.5, 0.01).entropy()` and `scipy.stats.logser(0.99).entropy()`
raise `RuntimeWarning: expect(): sum did not converge` and return values off by more than 1.5 nats
from the true entropy (confirmed independently via truncated summation *and* Monte Carlo, which
agree with each other and with this PR's `entropy()` to within Monte Carlo noise). A pure
scipy-cross-check test, which is what PR #434's own F-9 test does, would not have caught a bug in
this regime. Both extreme cases are asserted directly in this PR's test suite.

## Test plan

- `entropy_methods_test.py`: the six families added to the existing scipy-cross-check `CASES`
  table at moderate (scipy-reliable) parameters -- `test_entropy_matches_scipy` and
  `test_has_entropy_capability` now cover them too, unchanged test logic.
- `entropy_completeness_test.py` (new): from-scratch verification, independent of the shipped
  formula --
  - Continuous families (SkewNormal, Rician, Nakagami): `dist.entropy()` vs. `scipy.integrate.quad`
    of `-f(x) log f(x)` coded fresh in the test, across 4-6 parameter settings each, `places=6`.
  - Discrete families (NegativeBinomial, Skellam, LogSeries): `dist.entropy()` vs. a truncated
    exact sum of the textbook log-pmf coded fresh in the test (not calling into the production
    formula), across 4-5 parameter settings each, `places=6`.
  - All six: `dist.entropy()` vs. a Monte Carlo plug-in estimate
    (`-mean(log_density(sampler.sample(300_000)))`, seeded, `delta=0.02` -- empirically >=6x the
    observed Monte Carlo standard error at that sample size) at 2-3 parameter settings each.
  - Rayleigh special-case checks for both Rician (`nu=0`) and Nakagami (`m=1`) against the
    closed-form Rayleigh entropy, `places=10`.
  - The two scipy-unreliable extreme cases above, checked against truncated-sum and Monte Carlo.
  - 18 test methods, 70 subtests, all passing.
- Targeted re-run of every directly related existing test file (`skew_normal_test.py`,
  `automatic_skew_normal_test.py`, `negative_binomial_estimator_test.py`,
  `automatic_negative_binomial_test.py`, `rician_test.py`, `nakagami_test.py`, `skellam_test.py`,
  `skellam_logseries_methods_test.py`, `logseries_test.py`, `completeness_review_fixes_test.py`,
  `generalized_gaussian_test.py`): 61 passed, 217 subtests passed.
- Full suite: `pytest` (default fast gate, `-m fast -n auto`) -> **5250 passed, 5 skipped, 0
  failed**. The 5 skips are pre-existing optional-dependency guards (`mixle_knowledge`, `zarr`,
  `h5py`, multi-GPU), unrelated to this change.
- `ruff check` / `ruff format --check` clean on all 8 changed files.
- This PR touches only `entropy()` additions (new methods, no edits to existing methods) on 6
  leaf distribution classes plus 2 test files -- no constructor, `log_density`, sampler,
  estimator, or serialization changes, so no other subsystem should be able to regress from this
  diff.

CHANGELOG.md updated under `[0.8.0] Unreleased -> Fixed` (F-9 follow-up).
