### PR TITLE
Collect all supported Core test filenames

### DIFF
--- a/mixle/tests/test_n2_habitat_constraints.py
+++ b/mixle/tests/test_n2_habitat_constraints.py
@@ -4,7 +4,15 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
-from mixle_knowledge.contracts import CriticalHabitatDesignation, ListedSpecies, SourceRef, SpatialBounds
+
+knowledge_contracts = pytest.importorskip(
+    "mixle_knowledge.contracts",
+    reason="cross-project habitat contracts require the optional mixle-knowledge package",
+)
+CriticalHabitatDesignation = knowledge_contracts.CriticalHabitatDesignation
+ListedSpecies = knowledge_contracts.ListedSpecies
+SourceRef = knowledge_contracts.SourceRef
+SpatialBounds = knowledge_contracts.SpatialBounds
 
 from mixle.analysis.habitat_constraints import apply_habitat_constraints, critical_habitat_exclusion
 from mixle.analysis.sdm import HabitatModel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -192,7 +192,7 @@ forbidden_modules = [
 
 [tool.pytest.ini_options]
 testpaths = ["mixle/tests"]
-python_files = ["*_test.py"]
+python_files = ["*_test.py", "test_*.py"]
 python_classes = ["*Test", "*TestCase"]
 python_functions = ["test_*"]
 # Fast + parallel by default: plain `pytest` runs the `fast` gate under `-n auto` in a few minutes on a


### PR DESCRIPTION
## Summary

- Collect both supported Python test filename conventions.
- Preserve the existing test class and function conventions.
- Restore ordinary discovery for 33 prefix-only modules.
- Explicitly skip the cross-project habitat checks when their companion package is absent from the base environment.

## Focused validation

- Pytest configuration parse: passed.
- test-prefixed routing module: 6 tests collected in 26.49 seconds.
- suffix-named documentation module: 12 tests collected in 0.24 seconds.
- Habitat module without its optional companion: explicit module skip in 0.49 seconds.
- Ruff check and format check: passed for the disposition change.
- No full local suite was run.

Target-Release: REL-PRJ-CORE-0.8.0
Release-Milestone: 0.8.0
Release-Scope: included
Work-Id: WORK-20260717-0002
Change-Id: CHG-20260717-0002