### PR TITLE
Harden Core scientific input contracts

### DIFF
--- a/mixle/inference/calibration_gate.py
+++ b/mixle/inference/calibration_gate.py
@@ -98,6 +98,23 @@ def _uniformity_null_threshold(
     return float(np.quantile(errs, quantile))
 
 
+def _validate_gate_parameters(
+    *,
+    reference_level: float | None = None,
+    null_quantile: float,
+    tolerance: float | None,
+    bins: int,
+) -> None:
+    if reference_level is not None and (not np.isfinite(reference_level) or not 0.0 < reference_level < 1.0):
+        raise ValueError("reference_level must be finite and strictly between 0 and 1")
+    if not np.isfinite(null_quantile) or not 0.0 < null_quantile < 1.0:
+        raise ValueError("null_quantile must be finite and strictly between 0 and 1")
+    if tolerance is not None and (not np.isfinite(tolerance) or tolerance < 0.0):
+        raise ValueError("calibration tolerance must be finite and nonnegative")
+    if isinstance(bins, bool) or not isinstance(bins, (int, np.integer)) or bins < 2:
+        raise ValueError("bins must be an integer greater than one")
+
+
 def posterior_predictive_calibration(
     ensemble: np.ndarray,
     held_out_y: np.ndarray,
@@ -136,10 +153,26 @@ def posterior_predictive_calibration(
     """
     ens = np.asarray(ensemble, dtype=float)
     y = np.asarray(held_out_y, dtype=float)
+    _validate_gate_parameters(
+        reference_level=reference_level,
+        null_quantile=null_quantile,
+        tolerance=pit_tol,
+        bins=bins,
+    )
+    if not np.isfinite(low_power_threshold) or low_power_threshold < 0.0:
+        raise ValueError("low_power_threshold must be finite and nonnegative")
     if ens.ndim != 2:
         raise ValueError(f"ensemble must be (k, m); got shape {ens.shape}")
+    if y.ndim != 1:
+        raise ValueError(f"held_out_y must be a one-dimensional (k,) array; got shape {y.shape}")
+    if ens.shape[0] == 0:
+        raise ValueError("calibration requires at least one held-out point")
+    if ens.shape[1] == 0:
+        raise ValueError("calibration requires at least one posterior-predictive draw per point")
     if y.shape[0] != ens.shape[0]:
         raise ValueError(f"held_out_y has {y.shape[0]} points but ensemble has {ens.shape[0]}")
+    if not np.all(np.isfinite(ens)) or not np.all(np.isfinite(y)):
+        raise ValueError("ensemble and held_out_y must contain only finite values")
 
     k = int(y.shape[0])
     pit = pit_ensemble(y, ens, randomize=True, seed=pit_seed)
@@ -221,16 +254,40 @@ def simulation_based_calibration(
     look perfectly fit. (It does not test whether the model matches *reality* -- that is
     :func:`posterior_predictive_calibration`'s job, on real held-out data.)
     """
+    _validate_gate_parameters(
+        null_quantile=null_quantile,
+        tolerance=error_tol,
+        bins=bins,
+    )
+    if isinstance(n_sims, bool) or not isinstance(n_sims, (int, np.integer)) or n_sims <= 0:
+        raise ValueError("n_sims must be a positive integer")
+    if isinstance(param_index, bool) or not isinstance(param_index, (int, np.integer)) or param_index < 0:
+        raise ValueError("param_index must be a nonnegative integer")
+
     rng = seed if isinstance(seed, RandomState) else RandomState(seed)
     ranks = np.empty(n_sims, dtype=float)
     for i in range(n_sims):
         theta = np.atleast_1d(np.asarray(prior_sampler(rng), dtype=float))
+        if theta.ndim != 1 or theta.size == 0 or not np.all(np.isfinite(theta)):
+            raise ValueError("prior_sampler must return a non-empty finite scalar or one-dimensional vector")
+        if param_index >= theta.size:
+            raise ValueError(f"param_index {param_index} is outside the sampled parameter vector")
         y = simulate(theta, rng)
+        try:
+            simulated = np.asarray(y, dtype=float)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("simulate must return numeric data") from exc
+        if simulated.size == 0 or not np.all(np.isfinite(simulated)):
+            raise ValueError("simulate must return non-empty finite data")
         draws = np.atleast_1d(np.asarray(fit(y), dtype=float))
+        if draws.ndim not in (1, 2) or draws.size == 0 or not np.all(np.isfinite(draws)):
+            raise ValueError("fit must return non-empty finite one- or two-dimensional posterior draws")
         if draws.ndim == 1:
             draws_param = draws
             theta_param = float(theta[0]) if theta.shape[0] == 1 else float(theta[param_index])
         else:
+            if param_index >= draws.shape[1]:
+                raise ValueError(f"param_index {param_index} is outside the fitted posterior draws")
             draws_param = draws[:, param_index]
             theta_param = float(theta[param_index])
         n_draws = draws_param.shape[0]
@@ -300,13 +357,21 @@ class CalibrationVerifier:
                     "no ensemble/held_out_y to calibrate against -- failing closed rather than passing an unchecked posterior"
                 ],
             }
-        verdict = posterior_predictive_calibration(
-            np.asarray(ensemble),
-            np.asarray(held_out_y),
-            reference_level=self.reference_level,
-            null_quantile=self.null_quantile,
-            pit_tol=self.pit_tol,
-        )
+        try:
+            verdict = posterior_predictive_calibration(
+                np.asarray(ensemble),
+                np.asarray(held_out_y),
+                reference_level=self.reference_level,
+                null_quantile=self.null_quantile,
+                pit_tol=self.pit_tol,
+            )
+        except (TypeError, ValueError, FloatingPointError) as exc:
+            return {
+                "passed": False,
+                "score": 0.0,
+                "kind": "calibration",
+                "reasons": [f"calibration input rejected: {exc}"],
+            }
         return {
             "passed": verdict.passed,
             "score": verdict.score,

--- a/mixle/reason/posterior_schema.py
+++ b/mixle/reason/posterior_schema.py
@@ -80,12 +80,23 @@ class PosteriorSchema:
     def validate(self, mean: np.ndarray, cov: np.ndarray) -> None:
         """Raise if ``mean``/``cov`` don't match this schema's arity -- the check that turns a silent
         convention mismatch into a loud, early error."""
-        mean = np.asarray(mean)
-        cov = np.asarray(cov)
+        try:
+            mean = np.asarray(mean, dtype=float)
+            cov = np.asarray(cov, dtype=float)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("posterior mean and covariance must be numeric") from exc
         if mean.shape != (self.arity,):
             raise ValueError(f"mean has shape {mean.shape} but schema declares {self.arity} axes {self.names}")
         if cov.shape != (self.arity, self.arity):
             raise ValueError(f"cov has shape {cov.shape} but schema declares {self.arity} axes {self.names}")
+        if not np.all(np.isfinite(mean)) or not np.all(np.isfinite(cov)):
+            raise ValueError("posterior mean and covariance must contain only finite values")
+        if not np.allclose(cov, cov.T, rtol=1e-10, atol=1e-12):
+            raise ValueError("posterior covariance must be symmetric")
+        eigenvalues = np.linalg.eigvalsh((cov + cov.T) / 2.0)
+        tolerance = 1e-12 * max(1.0, float(np.max(np.abs(eigenvalues))))
+        if float(np.min(eigenvalues)) < -tolerance:
+            raise ValueError("posterior covariance must be positive semidefinite")
 
 
 @dataclass
@@ -110,8 +121,10 @@ class SchematizedPosterior:
     def credible_interval(self, level: float) -> tuple[np.ndarray, np.ndarray]:
         from scipy.stats import norm
 
+        if not np.isfinite(level) or not 0.0 < level < 1.0:
+            raise ValueError("credible interval level must be finite and strictly between 0 and 1")
         z = float(norm.ppf(0.5 + level / 2.0))
-        sd = np.sqrt(np.clip(np.diag(self.cov), 0.0, None))
+        sd = np.sqrt(np.diag(self.cov))
         return self.mean - z * sd, self.mean + z * sd
 
     def derived_quantity(self, fn: Any, n: int, rng: np.random.Generator) -> Any:
@@ -128,6 +141,8 @@ class _SchemaDerivedQuantity:
     prior_dominated: bool = False
 
     def credible_interval(self, level: float) -> tuple[np.ndarray, np.ndarray]:
+        if not np.isfinite(level) or not 0.0 < level < 1.0:
+            raise ValueError("credible interval level must be finite and strictly between 0 and 1")
         a = (1.0 - level) / 2.0
         return np.quantile(self.samples, a, axis=0), np.quantile(self.samples, 1.0 - a, axis=0)
 

--- a/mixle/semantics.py
+++ b/mixle/semantics.py
@@ -15,6 +15,7 @@ import math
 import re
 from collections.abc import Mapping
 from dataclasses import dataclass, field
+from datetime import datetime
 from enum import StrEnum
 from importlib.resources import files
 from typing import Any, Protocol, runtime_checkable
@@ -170,6 +171,8 @@ class TransformSpec:
             raise ValueError("logit transform requires lower < upper")
 
     def forward(self, value: float) -> float:
+        if not math.isfinite(value):
+            raise ValueError("transform input must be finite")
         if self.kind is TransformKind.IDENTITY:
             return float(value)
         if self.kind is TransformKind.LOG:
@@ -183,17 +186,26 @@ class TransformSpec:
         return self.scale * value + self.offset
 
     def inverse(self, value: float) -> float:
+        if not math.isfinite(value):
+            raise ValueError("transform input must be finite")
         if self.kind is TransformKind.IDENTITY:
             return float(value)
         if self.kind is TransformKind.LOG:
             return math.exp(value)
         if self.kind is TransformKind.LOGIT:
-            probability = 1.0 / (1.0 + math.exp(-value))
+            if value >= 0.0:
+                exp_neg = math.exp(-value)
+                probability = 1.0 / (1.0 + exp_neg)
+            else:
+                exp_pos = math.exp(value)
+                probability = exp_pos / (1.0 + exp_pos)
             return self.lower + (self.upper - self.lower) * probability
         return (value - self.offset) / self.scale
 
     def log_abs_det_jacobian(self, value: float) -> float:
         """Log absolute derivative of ``forward`` at a natural-space value."""
+        if not math.isfinite(value):
+            raise ValueError("transform input must be finite")
         if self.kind is TransformKind.IDENTITY:
             return 0.0
         if self.kind is TransformKind.LOG:
@@ -330,8 +342,10 @@ class ObservationSpec:
             raise ValueError("observation content digest and data reference are required")
         if self.id not in self.likelihood.observation_ids:
             raise ValueError("observation likelihood must reference the observation id")
-        if self.measurement_uncertainty is not None and self.measurement_uncertainty < 0:
-            raise ValueError("measurement uncertainty cannot be negative")
+        if self.measurement_uncertainty is not None and (
+            not math.isfinite(self.measurement_uncertainty) or self.measurement_uncertainty < 0
+        ):
+            raise ValueError("measurement uncertainty must be finite and nonnegative")
 
     @classmethod
     def from_record(cls, value: Mapping[str, Any]) -> ObservationSpec:
@@ -467,6 +481,8 @@ class DecisionArtifact:
             raise ValueError("decision selection and utility must close over the alternatives")
         if not _SHA256.fullmatch(self.posterior_identity) or not self.risk_measure:
             raise ValueError("decision posterior identity and risk measure are required")
+        if any(not math.isfinite(value) for value in self.utility.values()):
+            raise ValueError("decision utility values must be finite")
 
 
 @dataclass(frozen=True)
@@ -478,6 +494,13 @@ class CapabilityExtension:
     maturity: str
     schema_version: str = SEMANTICS_SCHEMA_VERSION
 
+    def __post_init__(self) -> None:
+        _require_id(self.id, "capability extension id")
+        _require_id(self.owner_project, "capability extension owner")
+        _require_id(self.maturity, "capability extension maturity")
+        if not self.input_schema_uri.strip() or not self.output_schema_uri.strip():
+            raise ValueError("capability extension input and output schema URIs are required")
+
 
 @dataclass(frozen=True)
 class TraceEvent:
@@ -488,6 +511,21 @@ class TraceEvent:
     payload: Mapping[str, Any]
     occurred_at: str
     schema_version: str = SEMANTICS_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        _require_id(self.trace_id, "trace id")
+        _require_id(self.event_type, "trace event type")
+        if isinstance(self.sequence, bool) or not isinstance(self.sequence, int) or self.sequence < 0:
+            raise ValueError("trace sequence must be a nonnegative integer")
+        if not _SHA256.fullmatch(self.semantic_identity):
+            raise ValueError("trace semantic identity must be SHA-256")
+        canonical_json(self.payload)
+        try:
+            timestamp = datetime.fromisoformat(self.occurred_at.replace("Z", "+00:00"))
+        except (AttributeError, ValueError) as exc:
+            raise ValueError("trace occurred_at must be an RFC 3339 timestamp") from exc
+        if timestamp.tzinfo is None or timestamp.utcoffset() is None:
+            raise ValueError("trace occurred_at must include a timezone")
 
 
 @runtime_checkable

--- a/mixle/tests/calibration_gate_test.py
+++ b/mixle/tests/calibration_gate_test.py
@@ -4,6 +4,7 @@ posteriors, fails overconfident and underconfident ones, catches a broken infere
 closed when handed nothing to check."""
 
 import numpy as np
+import pytest
 
 from mixle.inference.calibration_gate import (
     CalibrationVerifier,
@@ -129,3 +130,31 @@ def test_verifier_fails_closed_when_given_nothing_to_check():
     verdict = CalibrationVerifier().verify(claim={"payload": {"some_number": 42}})
     assert verdict["passed"] is False
     assert any("unchecked" in r or "no ensemble" in r for r in verdict["reasons"])
+
+
+@pytest.mark.parametrize(
+    ("ensemble", "held_out_y", "message"),
+    [
+        (np.empty((0, 4)), np.empty(0), "at least one held-out"),
+        (np.empty((2, 0)), np.zeros(2), "at least one posterior"),
+        (np.ones((2, 3)), np.array(1.0), "one-dimensional"),
+        (np.array([[1.0, np.nan]]), np.ones(1), "finite"),
+    ],
+)
+def test_predictive_calibration_rejects_malformed_inputs(ensemble, held_out_y, message):
+    with pytest.raises(ValueError, match=message):
+        posterior_predictive_calibration(ensemble, held_out_y)
+
+
+def test_verifier_fails_closed_on_malformed_calibration_data():
+    verdict = CalibrationVerifier().verify(claim={"payload": {"ensemble": [[1.0, float("nan")]], "held_out_y": [1.0]}})
+    assert verdict["passed"] is False
+    assert verdict["score"] == 0.0
+    assert any("rejected" in reason and "finite" in reason for reason in verdict["reasons"])
+
+
+def test_sbc_rejects_empty_simulations_and_draws():
+    with pytest.raises(ValueError, match="n_sims"):
+        simulation_based_calibration(_prior, _simulate, _correct_fit, n_sims=0)
+    with pytest.raises(ValueError, match="posterior draws"):
+        simulation_based_calibration(_prior, _simulate, lambda _y: np.array([]), n_sims=1)

--- a/mixle/tests/posterior_schema_test.py
+++ b/mixle/tests/posterior_schema_test.py
@@ -112,3 +112,24 @@ def test_join_independent_rejects_duplicate_axis_names():
     s = PosteriorSchema((AxisSpec("x"),))
     with pytest.raises(ValueError, match="duplicate axis name"):
         join_independent((np.array([1.0]), np.array([[1.0]]), s), (np.array([2.0]), np.array([[1.0]]), s))
+
+
+@pytest.mark.parametrize(
+    "covariance",
+    [
+        np.array([[-1.0]]),
+        np.array([[1.0, 0.5], [0.1, 1.0]]),
+        np.array([[float("nan")]]),
+    ],
+)
+def test_schematized_posterior_rejects_invalid_covariance(covariance):
+    schema = PosteriorSchema(tuple(AxisSpec(f"x{i}") for i in range(covariance.shape[0])))
+    with pytest.raises(ValueError, match="covariance|finite"):
+        SchematizedPosterior(np.zeros(covariance.shape[0]), covariance, schema)
+
+
+@pytest.mark.parametrize("level", [-0.1, 0.0, 1.0, 1.1, float("nan")])
+def test_credible_interval_rejects_invalid_levels(level):
+    posterior = SchematizedPosterior(np.zeros(1), np.ones((1, 1)), PosteriorSchema((AxisSpec("x"),)))
+    with pytest.raises(ValueError, match="strictly between"):
+        posterior.credible_interval(level)

--- a/mixle/tests/semantics_test.py
+++ b/mixle/tests/semantics_test.py
@@ -207,3 +207,36 @@ def test_extension_and_trace_contracts_are_structural_and_provider_neutral():
     )
     sink.emit(event)
     assert sink.event.semantic_identity == semantic_digest(extension)
+
+
+def test_quantitative_contracts_reject_nonfinite_values():
+    _, _, _, observation = _fixture_contracts()
+    with pytest.raises(ValueError, match="finite and nonnegative"):
+        dataclasses.replace(observation, measurement_uncertainty=float("nan"))
+    posterior = _posterior()
+    with pytest.raises(ValueError, match="utility values must be finite"):
+        DecisionArtifact(
+            "decision",
+            ("monitor", "stop"),
+            "monitor",
+            {"monitor": float("nan"), "stop": 1.0},
+            posterior.identity,
+            "expected-utility",
+        )
+
+
+def test_extensions_and_trace_events_reject_invalid_identity_fields():
+    with pytest.raises(ValueError, match="extension id"):
+        CapabilityExtension("", "PRJ-INQUIRY", "input", "output", "development")
+    with pytest.raises(ValueError, match="schema URIs"):
+        CapabilityExtension("reader", "PRJ-INQUIRY", "", "output", "development")
+    with pytest.raises(ValueError, match="sequence"):
+        TraceEvent("trace", -1, "read", "a" * 64, {}, "2026-07-15T00:00:00Z")
+    with pytest.raises(ValueError, match="RFC 3339"):
+        TraceEvent("trace", 0, "read", "a" * 64, {}, "yesterday")
+
+
+def test_logit_inverse_is_stable_for_extreme_finite_inputs():
+    transform = TransformSpec(TransformKind.LOGIT)
+    assert transform.inverse(-1000.0) == 0.0
+    assert transform.inverse(1000.0) == 1.0


### PR DESCRIPTION
## Summary

- Reject empty, non-finite, and malformed calibration inputs before statistics are computed.
- Make the verifier return a structured failed result for invalid payloads.
- Validate portable semantic records and posterior covariance contracts.
- Keep finite extreme logit inversion stable.

## Focused validation

- New negative and boundary checks: 17 passed in 24.04 seconds.
- Complete semantic and posterior-schema modules: 35 passed in 6.79 seconds.
- Positive calibration checks: 2 passed in 7.22 seconds.
- Ruff check and format check: passed for all changed files.
- No full local suite was run.

Target-Release: REL-PRJ-CORE-0.8.0
Release-Milestone: 0.8.0
Release-Scope: included
Work-Id: WORK-20260717-0002
Change-Id: CHG-20260717-0003