### PR TITLE
Stabilize reproducibility-sensitive Core APIs

### DIFF
--- a/mixle/__init__.py
+++ b/mixle/__init__.py
@@ -28,7 +28,6 @@ try:
 except PackageNotFoundError:  # running from a source tree with no installed distribution metadata
     __version__ = "0+unknown"
 
-# Top-level namespaces resolved lazily so ``import mixle`` stays cheap and ``mixle.dist`` / ``mixle.ops``
 # Top-level namespaces resolved lazily so ``import mixle`` stays lightweight and ``mixle.dist`` / ``mixle.ops``
 # / ``mixle.enumeration`` work without importing the whole tree up front.
 _NAMESPACES = (
@@ -51,10 +50,12 @@ def __getattr__(name: str):  # PEP 562 — resolve any mixle submodule (incl. th
     if not name.startswith("_"):
         import importlib
 
+        module_name = "mixle." + name
         try:
-            return importlib.import_module("mixle." + name)
-        except ModuleNotFoundError:
-            pass
+            return importlib.import_module(module_name)
+        except ModuleNotFoundError as exc:
+            if exc.name != module_name:
+                raise
     raise AttributeError("module 'mixle' has no attribute %r" % name)
 
 

--- a/mixle/doe/sequential.py
+++ b/mixle/doe/sequential.py
@@ -93,15 +93,20 @@ def sequential_design(
             ``stopped_reason`` is then ``"no_proposal"``.
         acquire: action -> the new observation(s) from actually taking that sample.
         combine: (data, new_data) -> the updated dataset for the next round.
-        max_rounds: hard cap on rounds (the loop always terminates).
+        max_rounds: maximum number of adaptive acquisitions after the initial fit. The audit trail
+            therefore contains at most max_rounds + 1 fitted states: index 0 for the initial data,
+            followed by one state per acquired sample.
 
     Returns:
         A :class:`SequentialDesignResult` -- every :class:`DesignRound` in order plus ``stopped_reason``.
     """
+    if isinstance(max_rounds, bool) or not isinstance(max_rounds, int) or max_rounds < 0:
+        raise ValueError("max_rounds must be a nonnegative integer")
+
     result = SequentialDesignResult()
     data = initial_data
 
-    for i in range(int(max_rounds) + 1):  # +1: round 0 is the initial fit before any adaptive sample
+    for i in range(max_rounds + 1):  # round 0 is the initial fit before any adaptive sample
         state = fit(data)
         summary = summarize(state, i)
         this_round = DesignRound(index=i, state=state, summary=summary, decision={}, proposed_action=None)
@@ -113,7 +118,7 @@ def sequential_design(
         if not decision.get("keep_going", False):
             result.stopped_reason = "controller_stop"
             return result
-        if i >= int(max_rounds):
+        if i >= max_rounds:
             result.stopped_reason = "budget_exhausted"
             return result
 

--- a/mixle/reason/zero_shot_bootstrap.py
+++ b/mixle/reason/zero_shot_bootstrap.py
@@ -33,6 +33,7 @@ field -- so every other modality's fitted parameters are bitwise identical befor
 
 from __future__ import annotations
 
+import hashlib
 import math
 from collections.abc import Sequence
 from typing import Any
@@ -319,7 +320,8 @@ def _generic_scalar_reduction(sample: Any) -> float:
     vec = _extract_numeric_vector(sample)
     if vec is not None and vec.size:
         return float(np.mean(vec))
-    return float(abs(hash(repr(sample))) % 1000) / 1000.0
+    digest = hashlib.sha256(repr(sample).encode("utf-8")).digest()
+    return float(int.from_bytes(digest[:8], "big") % 1000) / 1000.0
 
 
 def _model_typicality(model: Any, value: float) -> float:

--- a/mixle/task/data_mixture.py
+++ b/mixle/task/data_mixture.py
@@ -33,6 +33,7 @@ that score is produced.
 
 from __future__ import annotations
 
+import hashlib
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Any
@@ -269,17 +270,22 @@ def optimize_mixture(
 # --- corpus dedup / quality receipt --------------------------------------------------------------------
 
 
+def _stable_token_hash(tokens: Sequence[str]) -> int:
+    payload = "\x1f".join(tokens).encode("utf-8")
+    return int.from_bytes(hashlib.sha256(payload).digest()[:8], "big")
+
+
 def _shingles(text: str, k: int) -> frozenset[int]:
     toks = text.lower().split()
     if len(toks) < k:
-        return frozenset({hash(tuple(toks))})
-    return frozenset(hash(tuple(toks[i : i + k])) for i in range(len(toks) - k + 1))
+        return frozenset({_stable_token_hash(toks)})
+    return frozenset(_stable_token_hash(toks[i : i + k]) for i in range(len(toks) - k + 1))
 
 
 def _minhash_signature(shingle_set: frozenset[int], a: np.ndarray, b: np.ndarray, prime: int) -> np.ndarray:
     if not shingle_set:
         return np.zeros(len(a), dtype=np.int64)
-    hashes = np.array([abs(hash(s)) % prime for s in shingle_set], dtype=np.int64)
+    hashes = np.array([s % prime for s in shingle_set], dtype=np.int64)
     sig = (np.outer(a, hashes) + b[:, None]) % prime  # (num_hashes, n_shingles)
     return sig.min(axis=1)
 
@@ -302,6 +308,12 @@ def estimate_near_duplicate_rate(
     fine for the receipt-sized corpora this is meant for, not a production LSH dedup pipeline.
     """
     docs = list(corpus)
+    if isinstance(shingle_size, bool) or not isinstance(shingle_size, int) or shingle_size <= 0:
+        raise ValueError("shingle_size must be a positive integer")
+    if isinstance(num_hashes, bool) or not isinstance(num_hashes, int) or num_hashes <= 0:
+        raise ValueError("num_hashes must be a positive integer")
+    if not np.isfinite(threshold) or not 0.0 <= threshold <= 1.0:
+        raise ValueError("threshold must be finite and between 0 and 1")
     n = len(docs)
     if n == 0:
         return 0.0

--- a/mixle/tests/data_mixture_test.py
+++ b/mixle/tests/data_mixture_test.py
@@ -162,6 +162,14 @@ class NearDuplicateReceiptTest(unittest.TestCase):
         self.assertEqual(estimate_near_duplicate_rate(["only one document here"]), 0.0)
         self.assertEqual(estimate_near_duplicate_rate([]), 0.0)
 
+    def test_invalid_minhash_parameters_are_rejected(self):
+        with self.assertRaisesRegex(ValueError, "shingle_size"):
+            estimate_near_duplicate_rate(["one", "two"], shingle_size=0)
+        with self.assertRaisesRegex(ValueError, "num_hashes"):
+            estimate_near_duplicate_rate(["one", "two"], num_hashes=0)
+        with self.assertRaisesRegex(ValueError, "threshold"):
+            estimate_near_duplicate_rate(["one", "two"], threshold=float("nan"))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/mixle/tests/doe_sequential_test.py
+++ b/mixle/tests/doe_sequential_test.py
@@ -4,6 +4,7 @@ composes with the real voi_stopping_decision rule from mixle.analysis.real_optio
 session's decision machinery snaps together instead of being hand-wired per demo."""
 
 import numpy as np
+import pytest
 
 from mixle.doe.sequential import DesignRound, sequential_design
 
@@ -96,6 +97,21 @@ def test_budget_exhausted_when_threshold_is_never_reached():
     )
     assert result.stopped_reason == "budget_exhausted"
     assert result.n_rounds == 4  # round 0 (initial) + 3 adaptive rounds
+
+
+@pytest.mark.parametrize("max_rounds", [-1, 1.5, True])
+def test_invalid_round_budgets_are_rejected(max_rounds):
+    with pytest.raises(ValueError, match="nonnegative integer"):
+        sequential_design(
+            _initial(),
+            fit=_fit,
+            summarize=_summarize,
+            should_continue=_threshold_controller(0.15),
+            propose=_propose_next_measurement,
+            acquire=_acquire,
+            combine=_combine,
+            max_rounds=max_rounds,
+        )
 
 
 def test_no_proposal_stops_the_loop_even_if_controller_wants_to_continue():

--- a/mixle/tests/namespaces_test.py
+++ b/mixle/tests/namespaces_test.py
@@ -1,6 +1,9 @@
 """The concern-oriented namespace structure resolves and re-exports faithfully (no behavior change)."""
 
 import importlib
+from unittest.mock import patch
+
+import pytest
 
 
 def test_object_namespaces_alias_the_families():
@@ -56,3 +59,17 @@ def test_pysp_dir_advertises_the_namespaces():
 
     for ns in ("dist", "process", "models", "enumeration", "inference", "ops", "contracts"):
         assert ns in dir(mixle)
+
+
+def test_lazy_import_only_translates_a_missing_requested_module():
+    import mixle
+
+    requested = ModuleNotFoundError("missing requested module", name="mixle.not_present")
+    with patch("importlib.import_module", side_effect=requested):
+        with pytest.raises(AttributeError):
+            mixle.__getattr__("not_present")
+
+    nested = ModuleNotFoundError("missing nested dependency", name="required_dependency")
+    with patch("importlib.import_module", side_effect=nested):
+        with pytest.raises(ModuleNotFoundError, match="nested dependency"):
+            mixle.__getattr__("broken")

--- a/mixle/tests/reproducibility_hash_test.py
+++ b/mixle/tests/reproducibility_hash_test.py
@@ -1,0 +1,31 @@
+"""Cross-process regression checks for reproducibility-sensitive hashes."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+
+def _run_with_hash_seed(source: str, seed: str) -> str:
+    environment = dict(os.environ)
+    environment["PYTHONHASHSEED"] = seed
+    return subprocess.check_output(
+        [sys.executable, "-c", source],
+        env=environment,
+        text=True,
+        timeout=10,
+    ).strip()
+
+
+def test_scalar_reduction_is_stable_across_hash_seeds():
+    source = (
+        "from mixle.reason.zero_shot_bootstrap import _generic_scalar_reduction;"
+        "print(_generic_scalar_reduction('new modality sample'))"
+    )
+    assert _run_with_hash_seed(source, "1") == _run_with_hash_seed(source, "2")
+
+
+def test_shingles_are_stable_across_hash_seeds():
+    source = "from mixle.task.data_mixture import _shingles;print(sorted(_shingles('the same document text', 2)))"
+    assert _run_with_hash_seed(source, "1") == _run_with_hash_seed(source, "2")


### PR DESCRIPTION
## Summary

- Replace process-randomized reductions with stable SHA-256-derived values.
- Validate MinHash controls and sequential acquisition budgets.
- Document the initial-fit budget convention explicitly.
- Preserve nested import failures instead of translating them into missing attributes.

## Focused validation

- Scalar reduction across two hash seeds: passed in 25.24 seconds.
- Shingle hashing across two hash seeds: passed in 25.20 seconds.
- Budget, MinHash, duplicate-detection, and import-boundary checks: 7 passed in 10.25 seconds.
- Ruff check and format check: passed for all changed files.
- No full local suite was run.

Target-Release: REL-PRJ-CORE-0.8.0
Release-Milestone: 0.8.0
Release-Scope: included
Work-Id: WORK-20260717-0002
Change-Id: CHG-20260717-0004