### PR TITLE
Independently confirm discovered empirical laws

### DIFF
--- a/mixle/experimental/law_discovery.py
+++ b/mixle/experimental/law_discovery.py
@@ -3,11 +3,11 @@
 
 Distinct from :mod:`mixle.experimental.equation_discovery` (SINDy recovery of a *known* ODE operator,
 graded against ground truth): this takes a real simulator you can only *call* -- ``simulate(x) -> y``
--- sweeps its input, fits a small library of candidate functional forms, and selects the winner by
-**out-of-sample validation on held-out inputs the fit never saw**. That held-out score is the whole
-point: it is what separates a *discovered law* (predicts new inputs) from an *overfit* (memorizes the
-sweep). If no form generalizes, that is reported honestly (a low held-out R^2), not dressed up as a
-discovery -- verification is the referee, exactly as it must be for anything calling itself discovery.
+-- sweeps its input, fits a small library of candidate functional forms, selects the winner on a
+validation split, and confirms that winner once on an untouched holdout split. The independent
+confirmation score is the whole point: it is what separates a *discovered law* (predicts new inputs)
+from a model that merely won a finite candidate search. If no form generalizes, that is reported
+honestly, not dressed up as a discovery.
 
 Exploratory ``mixle.experimental`` code.
 """
@@ -36,8 +36,9 @@ CANDIDATE_FORMS: dict[str, tuple[Callable[..., np.ndarray], int, str, bool]] = {
 class DiscoveredLaw:
     """A discovered relationship + the verification that earns the word 'discovered'.
 
-    ``holdout_r2`` (out-of-sample, on inputs the fit never saw) is the referee: high means the law
-    generalizes; low means no clean law was found at this budget, and ``passed`` says so honestly.
+    The candidate library is ranked by ``selection_r2`` on a validation split. ``holdout_r2``
+    is then computed once for the winner on an untouched confirmation split and is the referee for
+    ``passed``.
     """
 
     form: str
@@ -48,7 +49,9 @@ class DiscoveredLaw:
     n_train: int
     n_holdout: int
     passed: bool  # holdout_r2 >= min_holdout_r2 -- did any form actually generalize?
-    ranking: list[tuple[str, float]] = field(default_factory=list)  # (form, holdout_r2), best first
+    ranking: list[tuple[str, float]] = field(default_factory=list)  # (form, selection_r2), best first
+    selection_r2: float = float("-inf")
+    n_selection: int = 0
 
 
 def _r2(y_true: np.ndarray, y_pred: np.ndarray) -> float:
@@ -71,41 +74,77 @@ def discover_law(
     seed: int = 0,
 ) -> DiscoveredLaw:
     """Sweep ``simulate`` over ``input_range``, fit candidate functional forms, and return the one that
-    best predicts a held-out slice of inputs.
+    wins validation and then passes an independent holdout confirmation.
 
     Args:
         simulate: the black-box ``x -> y`` (a real simulator wrapped to scalar in/out).
         input_range: ``(lo, hi)`` to sweep the input over.
         n_samples: total simulator evaluations across the sweep.
-        holdout_fraction: fraction of the swept points reserved for out-of-sample validation. The
-            held-out points are taken *interleaved* across the range (every k-th), so validation spans
-            the whole domain rather than only its far end -- a law must generalize everywhere.
-        min_holdout_r2: the bar the best form's held-out R^2 must clear for ``passed=True``.
+        holdout_fraction: fraction reserved for each of validation and independent confirmation.
+            The remainder is used for fitting. A seeded partition keeps the two evaluation sets
+            disjoint from fitting and from each other.
+        min_holdout_r2: the bar the selected form's independent holdout R^2 must clear.
         forms: restrict the candidate library (default: all of :data:`CANDIDATE_FORMS` whose positivity
             requirement the input range satisfies).
         log_spaced: sweep inputs geometrically (for laws probed over decades, e.g. resistivity).
-        seed: unused here (the sweep is deterministic); kept for interface parity with the rest of the
-            discovery API.
+        seed: controls the deterministic train/validation/confirmation partition.
 
     Returns:
-        A :class:`DiscoveredLaw` -- the winning form, its fitted params, train and (the referee)
-        held-out R^2, and the full ranking. ``passed`` is honest: if nothing generalizes, it is False.
+        A :class:`DiscoveredLaw` -- the winning form, its refitted params, train, selection, and
+        independent holdout R^2 values. ``passed`` is false when confirmation misses the threshold.
     """
     from scipy.optimize import curve_fit
 
+    if not callable(simulate):
+        raise TypeError("simulate must be callable")
+    if len(input_range) != 2:
+        raise ValueError("input_range must contain exactly (lo, hi)")
     lo, hi = float(input_range[0]), float(input_range[1])
+    if not np.isfinite(lo) or not np.isfinite(hi) or lo >= hi:
+        raise ValueError("input_range bounds must be finite with lo < hi")
+    if isinstance(n_samples, bool) or not isinstance(n_samples, int) or n_samples < 1:
+        raise ValueError("n_samples must be a positive integer")
+    if not np.isfinite(holdout_fraction) or not 0.0 < holdout_fraction < 0.5:
+        raise ValueError("holdout_fraction must be finite and strictly between 0 and 0.5")
+    if not np.isfinite(min_holdout_r2) or min_holdout_r2 > 1.0:
+        raise ValueError("min_holdout_r2 must be finite and no greater than 1")
+    if isinstance(seed, bool) or not isinstance(seed, int):
+        raise ValueError("seed must be an integer")
+    if log_spaced and lo <= 0.0:
+        raise ValueError("log_spaced discovery requires a strictly positive input range")
+
+    candidate_names = tuple(CANDIDATE_FORMS) if forms is None else tuple(forms)
+    if not candidate_names:
+        raise ValueError("forms must contain at least one candidate")
+    unknown_forms = [name for name in candidate_names if name not in CANDIDATE_FORMS]
+    if unknown_forms:
+        raise ValueError(f"unknown candidate forms: {unknown_forms}")
+    if len(set(candidate_names)) != len(candidate_names):
+        raise ValueError("forms must not contain duplicates")
+
+    n_evaluation = int(round(n_samples * holdout_fraction))
+    if n_evaluation < 2:
+        raise ValueError("holdout_fraction and n_samples must allocate at least two validation points")
+    n_fit = n_samples - 2 * n_evaluation
+    max_params = max(CANDIDATE_FORMS[name][1] for name in candidate_names)
+    if n_fit <= max_params:
+        raise ValueError("n_samples leaves too few fitting points after independent validation and holdout splits")
+
     xs = np.geomspace(max(lo, 1e-9), hi, n_samples) if log_spaced else np.linspace(lo, hi, n_samples)
     ys = np.array([float(simulate(float(x))) for x in xs], dtype=float)
+    if not np.all(np.isfinite(ys)):
+        raise ValueError("simulate must return finite scalar values")
 
-    # interleaved holdout: every k-th point spans the whole domain, so validation isn't just extrapolation.
-    k = max(2, int(round(1.0 / max(holdout_fraction, 1e-6))))
-    is_holdout = np.arange(n_samples) % k == 1
-    x_tr, y_tr = xs[~is_holdout], ys[~is_holdout]
-    x_ho, y_ho = xs[is_holdout], ys[is_holdout]
+    order = np.random.RandomState(seed).permutation(n_samples)
+    selection_idx = order[:n_evaluation]
+    holdout_idx = order[n_evaluation : 2 * n_evaluation]
+    train_idx = order[2 * n_evaluation :]
+    x_tr, y_tr = xs[train_idx], ys[train_idx]
+    x_sel, y_sel = xs[selection_idx], ys[selection_idx]
+    x_ho, y_ho = xs[holdout_idx], ys[holdout_idx]
 
     positive_domain = lo > 0
-    candidate_names = forms or tuple(CANDIDATE_FORMS)
-    results: list[tuple[str, float, float, dict[str, float]]] = []  # (form, train_r2, holdout_r2, params)
+    results: list[tuple[str, float, float, np.ndarray]] = []  # form, train_r2, selection_r2, parameters
     for name in candidate_names:
         fn, n_params, _expr, needs_pos = CANDIDATE_FORMS[name]
         if needs_pos and not positive_domain:
@@ -115,23 +154,52 @@ def discover_law(
         except Exception:  # noqa: BLE001 -- a non-converging form is simply not the law; skip it
             continue
         train_r2 = _r2(y_tr, fn(x_tr, *popt))
-        holdout_r2 = _r2(y_ho, fn(x_ho, *popt))
-        param_names = list("abcdefg")[:n_params]
-        results.append((name, train_r2, holdout_r2, dict(zip(param_names, (round(float(p), 6) for p in popt)))))
+        selection_prediction = fn(x_sel, *popt)
+        if not np.all(np.isfinite(selection_prediction)):
+            continue
+        selection_r2 = _r2(y_sel, selection_prediction)
+        if np.isfinite(train_r2) and np.isfinite(selection_r2):
+            results.append((name, train_r2, selection_r2, popt))
 
     if not results:
-        return DiscoveredLaw("none", "no candidate form fit", {}, 0.0, float("-inf"), len(x_tr), len(x_ho), False, [])
+        return DiscoveredLaw(
+            "none",
+            "no candidate form fit",
+            {},
+            0.0,
+            float("-inf"),
+            len(x_tr),
+            len(x_ho),
+            False,
+            [],
+            float("-inf"),
+            len(x_sel),
+        )
 
-    results.sort(key=lambda r: r[2], reverse=True)  # rank by the referee: held-out R^2
-    best_name, best_train, best_holdout, best_params = results[0]
+    results.sort(key=lambda result: result[2], reverse=True)
+    best_name, _initial_train, best_selection, initial_params = results[0]
+    best_fn, n_params, _expression, _needs_positive = CANDIDATE_FORMS[best_name]
+    x_refit = np.concatenate([x_tr, x_sel])
+    y_refit = np.concatenate([y_tr, y_sel])
+    best_params, _ = curve_fit(best_fn, x_refit, y_refit, p0=initial_params, maxfev=10000)
+    train_prediction = best_fn(x_refit, *best_params)
+    holdout_prediction = best_fn(x_ho, *best_params)
+    if not np.all(np.isfinite(train_prediction)) or not np.all(np.isfinite(holdout_prediction)):
+        raise ValueError("selected form produced non-finite predictions during independent confirmation")
+    best_train = _r2(y_refit, train_prediction)
+    best_holdout = _r2(y_ho, holdout_prediction)
+    param_names = list("abcdefg")[:n_params]
+    rounded_params = dict(zip(param_names, (round(float(param), 6) for param in best_params)))
     return DiscoveredLaw(
         form=best_name,
         expression=CANDIDATE_FORMS[best_name][2],
-        params=best_params,
+        params=rounded_params,
         train_r2=round(best_train, 4),
         holdout_r2=round(best_holdout, 4),
-        n_train=len(x_tr),
+        n_train=len(x_refit),
         n_holdout=len(x_ho),
         passed=best_holdout >= min_holdout_r2,
-        ranking=[(n, round(h, 4)) for n, _t, h, _p in results],
+        ranking=[(name, round(selection, 4)) for name, _train, selection, _params in results],
+        selection_r2=round(best_selection, 4),
+        n_selection=len(x_sel),
     )

--- a/mixle/tests/law_discovery_test.py
+++ b/mixle/tests/law_discovery_test.py
@@ -1,6 +1,4 @@
-"""discover_law recovers a validated functional relationship from a black-box simulator, selects by
-OUT-OF-SAMPLE fit (so it's a discovered law, not an overfit), and honestly reports failure when no
-form generalizes. The out-of-sample selection is the referee -- these tests pin that it's real."""
+"""Law discovery selects on validation and confirms once on untouched held-out inputs."""
 
 import numpy as np
 import pytest
@@ -29,7 +27,7 @@ def test_recovers_a_logarithmic_law():
     assert abs(law.params["a"] - 2.5) < 0.3
 
 
-def test_selection_is_by_holdout_not_train_fit():
+def test_selection_is_by_validation_not_train_fit():
     # a straight line: linear must win on held-out data; an over-flexible quadratic may tie on TRAIN
     # but shouldn't beat it out-of-sample. Confirm the winner generalizes.
     law = discover_law(lambda x: 4.0 * x - 7.0, (0.0, 20.0), n_samples=24)
@@ -45,8 +43,62 @@ def test_reports_failure_honestly_when_no_form_generalizes():
     assert law.holdout_r2 < 0.9  # honest: no discovery claimed
 
 
-def test_ranking_covers_the_candidate_forms_and_is_ordered_by_holdout():
+def test_ranking_covers_the_candidate_forms_and_is_ordered_by_selection():
     law = discover_law(lambda x: 3.0 * x**2, (1.0, 10.0), n_samples=30)
-    holdouts = [h for _, h in law.ranking]
-    assert holdouts == sorted(holdouts, reverse=True)  # best (referee) first
+    selection_scores = [score for _, score in law.ranking]
+    assert selection_scores == sorted(selection_scores, reverse=True)
     assert law.ranking[0][0] == law.form
+    assert law.ranking[0][1] == law.selection_r2
+
+
+def test_winner_is_confirmed_on_inputs_not_used_for_selection():
+    n_samples = 24
+    seed = 11
+    fraction = 1.0 / 3.0
+    xs = np.linspace(0.0, 10.0, n_samples)
+    count = int(round(n_samples * fraction))
+    order = np.random.RandomState(seed).permutation(n_samples)
+    confirmation_x = xs[order[count : 2 * count]]
+
+    def simulator(x):
+        offset = 50.0 if np.any(np.isclose(x, confirmation_x)) else 0.0
+        return 2.0 * x + 1.0 + offset
+
+    law = discover_law(
+        simulator,
+        (0.0, 10.0),
+        n_samples=n_samples,
+        holdout_fraction=fraction,
+        forms=("linear",),
+        min_holdout_r2=0.9,
+        seed=seed,
+    )
+    assert law.selection_r2 == pytest.approx(1.0)
+    assert law.holdout_r2 < 0.9
+    assert not law.passed
+    assert law.n_selection == count
+    assert law.n_holdout == count
+
+
+@pytest.mark.parametrize("fraction", [0.0, -0.1, 0.5, 1.0, float("nan")])
+def test_invalid_holdout_fractions_are_rejected(fraction):
+    with pytest.raises(ValueError, match="holdout_fraction"):
+        discover_law(lambda x: x, (0.0, 1.0), holdout_fraction=fraction)
+
+
+def test_invalid_domains_forms_and_simulator_outputs_are_rejected():
+    with pytest.raises(ValueError, match="lo < hi"):
+        discover_law(lambda x: x, (1.0, 1.0))
+    with pytest.raises(ValueError, match="strictly positive"):
+        discover_law(lambda x: x, (-1.0, 1.0), log_spaced=True)
+    with pytest.raises(ValueError, match="unknown candidate"):
+        discover_law(lambda x: x, (0.0, 1.0), forms=("not-a-form",))
+    with pytest.raises(ValueError, match="finite scalar"):
+        discover_law(lambda _x: float("nan"), (0.0, 1.0))
+
+
+def test_sample_budget_must_support_three_way_evaluation():
+    with pytest.raises(ValueError, match="at least two validation"):
+        discover_law(lambda x: x, (0.0, 1.0), n_samples=6, holdout_fraction=0.1)
+    with pytest.raises(ValueError, match="too few fitting"):
+        discover_law(lambda x: x, (0.0, 1.0), n_samples=7, holdout_fraction=0.3)


### PR DESCRIPTION
## Summary

- Use disjoint fit, validation, and confirmation partitions.
- Rank candidate forms only on validation data.
- Refit the selected form before one untouched holdout confirmation.
- Reject invalid ranges, budgets, forms, thresholds, and simulator outputs.

## Focused validation

- Complete law-discovery module: 13 passed in 6.00 seconds.
- Ruff check and format check: passed for both changed files.
- No full local suite was run.

Target-Release: REL-PRJ-CORE-0.8.0
Release-Milestone: 0.8.0
Release-Scope: included
Work-Id: WORK-20260717-0002
Change-Id: CHG-20260717-0005