### PR TITLE
Complete F10.2: seed stability, runtime/memory, emissions, OOD test

### DIFF
--- a/examples/flagship_temporal_sunspots.py
+++ b/examples/flagship_temporal_sunspots.py
@@ -13,14 +13,39 @@ forward pass, so the series is cut into fixed-length subsequences (as any HMM to
 transition/initial distributions are smoothed (``pseudo_count``) so a held-out subsequence never hits a
 zero-probability transition.
 
-Run: ``python examples/flagship_temporal_sunspots.py`` (fetches ~2.8k monthly observations once).
+Beyond the headline number, this flagship also demonstrates (worklist F10.2):
+
+  - **Seed stability**: :func:`seed_stability` refits the SAME estimator/data across multiple random
+    seeds and reports the actual spread of held-out log-likelihood. EM is a local method -- most seeds
+    land in a common, apparently-dominant optimum, but a real fraction land in a different (sometimes
+    better, sometimes worse) one. That is genuine, reported behavior, not asserted stability.
+  - **Runtime/memory characterization**: :func:`run` times and ``tracemalloc``-measures the core
+    ``optimize`` call in isolation (a few hundred milliseconds, a few MB at this data scale). The
+    end-to-end script itself runs tens of seconds, but that is dominated by one-time Python import
+    overhead (``mixle`` + ``hmmlearn`` + their dependency graphs) and the network fetch, not by fitting
+    -- reported separately so a reader is not misled about what scales with data size.
+  - **Emission inspection**: :func:`describe_emissions` reports each hidden state's most probable
+    symbols, emission entropy, self-transition probability, and implied expected sojourn length -- the
+    3 states resolve into interpretable low/mid/high sunspot-activity regimes, not just a converged
+    number.
+  - **Impossible-observation handling**: :func:`check_impossible_observation` splices a symbol outside
+    the fitted discretization's support into an otherwise-valid sequence and confirms the model
+    assigns it exactly ``-inf`` (via the same ``seq_log_density`` path used for scoring) rather than
+    silently returning a finite-but-wrong number.
+
+Run: ``python examples/flagship_temporal_sunspots.py`` (fetches ~2.8k monthly observations once; runs
+the headline fit + comparison, then a 10-seed stability sweep).
 """
 
 from __future__ import annotations
 
 import csv
 import io
+import math
+import time
+import tracemalloc
 import urllib.request
+from collections.abc import Iterable
 
 import numpy as np
 
@@ -32,15 +57,16 @@ def _load_series() -> np.ndarray:
     return np.array([float(row[1]) for row in list(csv.reader(io.StringIO(raw)))[1:]])
 
 
-def run(*, n_states: int = 3, n_symbols: int = 8, seq_len: int = 60, verbose: bool = True) -> dict:
-    """Fit a discrete-emission HMM on real sunspot data and compare held-out LL to hmmlearn.
+def _prepare_data(n_symbols: int = 8, seq_len: int = 60) -> tuple[list[list[int]], list[list[int]], int, int]:
+    """Fetch the real sunspot series once and discretize/chunk it into train/test sequences.
 
-    Returns ``{"n_states", "n_symbols", "n_train_seqs", "n_test_seqs", "mixle_test_ll_per_obs",
-    "hmmlearn_test_ll_per_obs"}`` (the hmmlearn value is ``None`` if hmmlearn is not installed).
+    Quantile bin edges are computed from the TRAIN split only (no test leakage into the
+    discretization), then applied to the whole series. Each split is cut into fixed-length
+    ``seq_len``-step subsequences (a single multi-thousand-step sequence underflows the plain
+    forward pass).
+
+    Returns ``(train, test, n_test_obs, n_raw_obs)``.
     """
-    from mixle.inference import optimize
-    from mixle.stats import CategoricalEstimator, HiddenMarkovEstimator
-
     series = _load_series()
     split = int(0.8 * len(series))
     edges = np.quantile(series[:split], np.linspace(0, 1, n_symbols + 1)[1:-1])  # bins from train only
@@ -51,24 +77,244 @@ def run(*, n_states: int = 3, n_symbols: int = 8, seq_len: int = 60, verbose: bo
 
     train, test = chunk(symbols[:split]), chunk(symbols[split:])
     n_test_obs = sum(len(s) for s in test)
+    return train, test, n_test_obs, len(series)
+
+
+def _fit_mixle(
+    train: list[list[int]],
+    test: list[list[int]],
+    n_test_obs: int,
+    *,
+    n_states: int = 3,
+    seed: int | None = None,
+    max_its: int = 10,
+    delta: float | None = 1.0e-9,
+) -> dict:
+    """Fit the discrete-emission HMM with ONE ``optimize`` call and score held-out log-likelihood.
+
+    Wraps the fit in ``tracemalloc`` plus a wall-clock timer so callers (:func:`run`,
+    :func:`seed_stability`) can report the core fitting procedure's own runtime and peak memory,
+    isolated from import time, the network fetch, and the (optional) hmmlearn comparison.
+
+    Returns ``{"model", "test_ll_per_obs", "fit_wall_time_sec", "fit_peak_memory_mb"}``.
+    """
+    from mixle.inference import optimize
+    from mixle.stats import CategoricalEstimator, HiddenMarkovEstimator
 
     est = HiddenMarkovEstimator(
         [CategoricalEstimator(pseudo_count=1.0) for _ in range(n_states)], pseudo_count=(1.0, 1.0)
     )
-    model = optimize(train, est, out=None)
-    mixle_ll = float(np.sum(model.seq_log_density(model.dist_to_encoder().seq_encode(test)))) / n_test_obs
+    tracemalloc.start()
+    tracemalloc.reset_peak()
+    t0 = time.perf_counter()
+    model = optimize(train, est, out=None, seed=seed, max_its=max_its, delta=delta)
+    fit_wall_time_sec = time.perf_counter() - t0
+    _, peak_bytes = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+
+    encoder = model.dist_to_encoder()
+    test_ll = float(np.sum(model.seq_log_density(encoder.seq_encode(test)))) / n_test_obs
+    n_train_obs = sum(len(s) for s in train)
+    train_ll = float(np.sum(model.seq_log_density(encoder.seq_encode(train)))) / n_train_obs
+    return {
+        "model": model,
+        "test_ll_per_obs": test_ll,
+        "train_ll_per_obs": train_ll,
+        "fit_wall_time_sec": fit_wall_time_sec,
+        "fit_peak_memory_mb": peak_bytes / 1.0e6,
+    }
+
+
+def describe_emissions(model, *, top_k: int = 4) -> list[dict]:
+    """Summarize what each hidden state actually learned.
+
+    For every state: its emission distribution's ``top_k`` most probable symbols (descending by
+    probability, ties broken by symbol), the (Shannon) entropy of the full emission distribution in
+    nats, its self-transition probability, and the implied expected sojourn length
+    (``1 / (1 - self_transition)``) -- so a reader can see the states are interpretable regimes
+    (e.g. persistent low/mid/high-activity phases), not just an opaque converged number.
+    """
+    out = []
+    for i in range(model.n_states):
+        pmap = model.topics[i].pmap
+        items = sorted(pmap.items(), key=lambda kv: (-kv[1], kv[0]))
+        probs = np.array([p for _, p in items], dtype=float)
+        nonzero = probs[probs > 0]
+        entropy = float(-np.sum(nonzero * np.log(nonzero)))
+        self_p = float(model.transitions[i, i])
+        out.append(
+            {
+                "state": i,
+                "top_symbols": items[:top_k],
+                "entropy_nats": entropy,
+                "self_transition": self_p,
+                "expected_sojourn_steps": float("inf") if self_p >= 1.0 else 1.0 / (1.0 - self_p),
+            }
+        )
+    return out
+
+
+def _print_emissions(emissions: list[dict]) -> None:
+    """Shared formatting for :func:`describe_emissions` output (used by ``run`` and ``seed_stability``)."""
+    for e in emissions:
+        top = ", ".join(f"sym {sym}={p:.3f}" for sym, p in e["top_symbols"])
+        print(
+            f"  state {e['state']}: {top}  |  entropy {e['entropy_nats']:.3f} nats, "
+            f"self-transition {e['self_transition']:.3f} (~{e['expected_sojourn_steps']:.1f} steps)"
+        )
+
+
+def check_impossible_observation(model, valid_seq: list[int], n_symbols: int) -> dict:
+    """Verify the fitted HMM assigns ``-inf`` -- not NaN, not a crash, not a silently-finite number
+    -- to a sequence containing an observation outside the discretization's support.
+
+    Splices the sentinel symbol ``n_symbols`` (one past the valid ``[0, n_symbols)`` quantile-bin
+    range produced by ``np.digitize``, so it is guaranteed never to have been observed) into the
+    middle of a copy of ``valid_seq``, and rescores both sequences through the SAME
+    ``seq_log_density`` path the flagship uses for held-out scoring.
+
+    Returns ``{"impossible_symbol", "valid_ll", "impossible_ll", "valid_is_finite",
+    "correctly_flagged"}``.
+    """
+    encoder = model.dist_to_encoder()
+    impossible_symbol = n_symbols
+    valid_ll = float(model.seq_log_density(encoder.seq_encode([valid_seq]))[0])
+    spliced = list(valid_seq)
+    spliced[len(spliced) // 2] = impossible_symbol
+    spliced_ll = float(model.seq_log_density(encoder.seq_encode([spliced]))[0])
+    return {
+        "impossible_symbol": impossible_symbol,
+        "valid_ll": valid_ll,
+        "impossible_ll": spliced_ll,
+        "valid_is_finite": math.isfinite(valid_ll),
+        "correctly_flagged": spliced_ll == float("-inf"),
+    }
+
+
+def seed_stability(
+    seeds: Iterable[int] = range(10),
+    *,
+    n_states: int = 3,
+    n_symbols: int = 8,
+    seq_len: int = 60,
+    max_its: int = 200,
+    delta: float | None = 1.0e-8,
+    verbose: bool = True,
+) -> dict:
+    """Refit the SAME estimator on the SAME data across multiple random seeds and report the spread
+    of held-out log-likelihood.
+
+    EM is a local method: different random initializations can converge to different fixed points.
+    This uses ``max_its=200`` (vs. :func:`run`'s quick-demo default of 10) because 10 iterations is
+    not enough to converge for most seeds -- empirically, several seeds are still improving by
+    dozens to hundreds of nats at iteration 10, but every seed tried is bit-identical from iteration
+    200 through 1000. Sweeping seeds at the quick demo's own (under-converged) 10-iteration budget
+    would conflate "hasn't converged yet" with "genuinely different optimum"; using a
+    verified-converged budget isolates the real answer instead: on this data, most random
+    initializations converge to the same optimum, but a real fraction land in a different (sometimes
+    better, sometimes worse) one. That is reported here, not hidden behind a single lucky/unlucky
+    default seed.
+
+    Model selection across seeds (when wanted) is by TRAINING log-likelihood, never held-out test
+    log-likelihood -- picking among candidates by test performance is a subtle test-set leak. The
+    best-by-training-likelihood seed's learned emissions are included in the summary so a reader can
+    see what a properly-converged fit looks like (contrast this with :func:`run`'s quick-demo
+    emissions, which are printed from the under-converged 10-iteration default).
+
+    Returns ``{"per_seed": [{"seed", "test_ll_per_obs", "train_ll_per_obs"}, ...], "mean", "std",
+    "min", "max", "range", "best_seed", "best_seed_emissions"}``.
+    """
+    train, test, n_test_obs, _ = _prepare_data(n_symbols=n_symbols, seq_len=seq_len)
+    per_seed = []
+    fits = []
+    for s in seeds:
+        fit = _fit_mixle(train, test, n_test_obs, n_states=n_states, seed=s, max_its=max_its, delta=delta)
+        per_seed.append(
+            {"seed": s, "test_ll_per_obs": fit["test_ll_per_obs"], "train_ll_per_obs": fit["train_ll_per_obs"]}
+        )
+        fits.append(fit)
+
+    lls = np.array([r["test_ll_per_obs"] for r in per_seed], dtype=float)
+    best_idx = int(np.argmax([f["train_ll_per_obs"] for f in fits]))
+    best_seed = per_seed[best_idx]["seed"]
+    best_emissions = describe_emissions(fits[best_idx]["model"])
+    summary = {
+        "per_seed": per_seed,
+        "mean": float(lls.mean()),
+        "std": float(lls.std()),
+        "min": float(lls.min()),
+        "max": float(lls.max()),
+        "range": float(lls.max() - lls.min()),
+        "best_seed": best_seed,
+        "best_seed_emissions": best_emissions,
+    }
+    if verbose:
+        print(f"seed stability -- {len(per_seed)} seeds, {n_states}-state HMM, max_its={max_its} (verified converged):")
+        for r in per_seed:
+            print(
+                f"  seed={r['seed']!s:>3}: test_ll_per_obs={r['test_ll_per_obs']:.4f}  train_ll_per_obs={r['train_ll_per_obs']:.4f}"
+            )
+        print(
+            f"  mean={summary['mean']:.4f}  std={summary['std']:.4f}  "
+            f"range=[{summary['min']:.4f}, {summary['max']:.4f}]  spread={summary['range']:.4f}"
+        )
+        print(
+            f"learned emissions of the best-by-training-likelihood seed ({best_seed}) -- interpretable regimes at convergence:"
+        )
+        _print_emissions(best_emissions)
+    return summary
+
+
+def run(
+    *,
+    n_states: int = 3,
+    n_symbols: int = 8,
+    seq_len: int = 60,
+    seed: int | None = None,
+    max_its: int = 10,
+    delta: float | None = 1.0e-9,
+    compare_hmmlearn: bool = True,
+    verbose: bool = True,
+) -> dict:
+    """Fit a discrete-emission HMM on real sunspot data and compare held-out LL to hmmlearn.
+
+    ``seed``/``max_its``/``delta`` default to exactly what the original flagship always used
+    (unseeded, 10 EM iterations) so this call's headline number and the pre-existing regression gate
+    (``flagship_temporal_sunspots_smoke_test.py``) are unchanged. Pass ``max_its=200`` (or use
+    :func:`seed_stability`, which does) to reproduce the properly-converged fit documented in the
+    module docstring and in ``seed_stability``'s own docstring.
+
+    Returns ``{"n_states", "n_symbols", "n_train_seqs", "n_test_seqs", "mixle_test_ll_per_obs",
+    "hmmlearn_test_ll_per_obs"}`` (the hmmlearn value is ``None`` if hmmlearn is not installed or
+    ``compare_hmmlearn=False``), plus:
+
+      - ``fit_wall_time_sec`` / ``fit_peak_memory_mb``: the core ``optimize`` call's own wall-clock
+        time and ``tracemalloc``-measured peak memory at this data scale (isolated from import,
+        network, and hmmlearn overhead -- see the module docstring).
+      - ``emissions``: per-state learned-emission summary from :func:`describe_emissions`.
+      - ``impossible_observation_check``: result of :func:`check_impossible_observation` against the
+        fitted model.
+    """
+    train, test, n_test_obs, n_raw_obs = _prepare_data(n_symbols=n_symbols, seq_len=seq_len)
+    fit = _fit_mixle(train, test, n_test_obs, n_states=n_states, seed=seed, max_its=max_its, delta=delta)
+    model = fit["model"]
+    mixle_ll = fit["test_ll_per_obs"]
 
     hmmlearn_ll = None
-    try:
-        from hmmlearn.hmm import CategoricalHMM
+    if compare_hmmlearn:
+        try:
+            from hmmlearn.hmm import CategoricalHMM
 
-        x_tr = np.concatenate([np.array(s) for s in train]).reshape(-1, 1)
-        x_te = np.concatenate([np.array(s) for s in test]).reshape(-1, 1)
-        hl = CategoricalHMM(n_components=n_states, n_iter=50, random_state=0)
-        hl.fit(x_tr, [len(s) for s in train])
-        hmmlearn_ll = hl.score(x_te, [len(s) for s in test]) / n_test_obs
-    except ImportError:
-        pass
+            x_tr = np.concatenate([np.array(s) for s in train]).reshape(-1, 1)
+            x_te = np.concatenate([np.array(s) for s in test]).reshape(-1, 1)
+            hl = CategoricalHMM(n_components=n_states, n_iter=50, random_state=0)
+            hl.fit(x_tr, [len(s) for s in train])
+            hmmlearn_ll = hl.score(x_te, [len(s) for s in test]) / n_test_obs
+        except ImportError:
+            pass
+
+    emissions = describe_emissions(model)
+    impossible_check = check_impossible_observation(model, test[0], n_symbols)
 
     receipt = {
         "n_states": n_states,
@@ -77,18 +323,36 @@ def run(*, n_states: int = 3, n_symbols: int = 8, seq_len: int = 60, verbose: bo
         "n_test_seqs": len(test),
         "mixle_test_ll_per_obs": mixle_ll,
         "hmmlearn_test_ll_per_obs": hmmlearn_ll,
+        "fit_wall_time_sec": fit["fit_wall_time_sec"],
+        "fit_peak_memory_mb": fit["fit_peak_memory_mb"],
+        "emissions": emissions,
+        "impossible_observation_check": impossible_check,
     }
     if verbose:
-        print(f"real monthly sunspots: {len(series)} obs -> {n_symbols} quantile symbols, {seq_len}-step sequences")
+        print(f"real monthly sunspots: {n_raw_obs} obs -> {n_symbols} quantile symbols, {seq_len}-step sequences")
         print(f"{n_states}-state discrete HMM, held-out mean log-likelihood per obs:")
-        print(f"  mixle    : {mixle_ll:.4f}")
+        print(
+            f"  mixle    : {mixle_ll:.4f}   "
+            f"(fit: {fit['fit_wall_time_sec']:.3f}s wall, {fit['fit_peak_memory_mb']:.1f} MB peak)"
+        )
         if hmmlearn_ll is not None:
             print(f"  hmmlearn : {hmmlearn_ll:.4f}   (independent baseline; agreement is the receipt)")
+        quick_note = " (quick demo fit -- see seed_stability() for a properly-converged model)" if max_its <= 10 else ""
+        print(f"learned state emissions{quick_note}, top symbols | self-transition, expected sojourn:")
+        _print_emissions(emissions)
+        flag = "correctly -inf" if impossible_check["correctly_flagged"] else "NOT flagged -- investigate"
+        print(
+            f"impossible-observation check: valid seq ll={impossible_check['valid_ll']:.2f} (finite); "
+            f"splicing in out-of-support symbol {impossible_check['impossible_symbol']} -> "
+            f"ll={impossible_check['impossible_ll']} ({flag})"
+        )
     return receipt
 
 
 def main() -> None:
     run()
+    print()
+    seed_stability()
 
 
 if __name__ == "__main__":

--- a/mixle/tests/conftest.py
+++ b/mixle/tests/conftest.py
@@ -460,6 +460,14 @@ FILE_MARKERS: dict[str, MarkerTuple] = {
     "distill_methods_test.py": ("torch", "integration", "slow"),
     "doe_amplify_test.py": ("doe", "stochastic", "slow"),
     "duplicate_body_scan_test.py": ("integration", "slow"),
+    # Network-gated real-data flagship (worklist F10.2): fetches the real sunspot series and, when
+    # hmmlearn is installed, refits an independent HMM baseline; a seed-stability sweep and a
+    # runtime/memory characterization each do several more real EM fits on top of that. Explicitly
+    # triaged (matching real_receipt_banking77_smoke_test.py, F10.3's sibling flagship) rather than
+    # relying solely on skipUnless/skipTest, so it stays out of the default fast gate even in an
+    # environment where hmmlearn happens to be installed. CI's optional lane still runs it in full via
+    # its own explicit `-m ""` invocation.
+    "flagship_temporal_sunspots_smoke_test.py": ("optional", "slow"),
     "frontier_family_showcase_smoke_test.py": ("torch", "integration", "slow"),
     "geoscience_inversion_report_test.py": ("integration", "slow"),
     "hmm_steady_state_test.py": ("hmm", "slow"),

--- a/mixle/tests/flagship_temporal_sunspots_inspection_test.py
+++ b/mixle/tests/flagship_temporal_sunspots_inspection_test.py
@@ -1,0 +1,156 @@
+"""Fast, network-free coverage for the temporal flagship's inspection helpers (worklist F10.2).
+
+``examples/flagship_temporal_sunspots.py`` adds ``describe_emissions`` (emission inspection) and
+``check_impossible_observation`` (impossible-observation handling). Both are pure functions of a
+fitted :class:`~mixle.stats.latent.hidden_markov.HiddenMarkovModelDistribution`, so their logic is
+exercised here against small, hand-built models with known parameters -- no network fetch, no EM fit,
+no ``hmmlearn`` dependency, so this file runs unconditionally in the default fast gate. The real,
+network-gated end-to-end exercise of these same functions against the actual fitted sunspots model
+lives in ``flagship_temporal_sunspots_smoke_test.py``.
+"""
+
+from __future__ import annotations
+
+import math
+import sys
+import unittest
+from pathlib import Path
+
+from mixle.stats import CategoricalDistribution, HiddenMarkovModelDistribution
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "examples"))
+
+from flagship_temporal_sunspots import check_impossible_observation, describe_emissions  # noqa: E402
+
+
+def _two_state_model(default_value: float = 0.0) -> HiddenMarkovModelDistribution:
+    """A hand-built 2-state, 3-symbol HMM with known emission/transition parameters."""
+    return HiddenMarkovModelDistribution(
+        topics=[
+            CategoricalDistribution(pmap={0: 0.7, 1: 0.2, 2: 0.1}, default_value=default_value),
+            CategoricalDistribution(pmap={0: 0.1, 1: 0.1, 2: 0.8}, default_value=default_value),
+        ],
+        w=[0.5, 0.5],
+        transitions=[[0.9, 0.1], [0.25, 0.75]],
+    )
+
+
+class DescribeEmissionsTest(unittest.TestCase):
+    def test_top_symbols_sorted_descending_by_probability(self):
+        model = _two_state_model()
+        out = describe_emissions(model, top_k=2)
+        self.assertEqual(len(out), 2)
+        # state 0's two most probable symbols, in descending-probability order
+        self.assertEqual(out[0]["state"], 0)
+        self.assertEqual(out[0]["top_symbols"], [(0, 0.7), (1, 0.2)])
+        # state 1's two most probable symbols
+        self.assertEqual(out[1]["top_symbols"], [(2, 0.8), (0, 0.1)])
+
+    def test_top_symbols_ties_broken_by_symbol_ascending(self):
+        model = HiddenMarkovModelDistribution(
+            topics=[CategoricalDistribution(pmap={5: 0.5, 2: 0.5}, default_value=0.0)],
+            w=[1.0],
+            transitions=[[1.0]],
+        )
+        out = describe_emissions(model, top_k=2)
+        # equal probability -> lower symbol index sorts first
+        self.assertEqual(out[0]["top_symbols"], [(2, 0.5), (5, 0.5)])
+
+    def test_entropy_matches_hand_computed_shannon_entropy(self):
+        model = _two_state_model()
+        out = describe_emissions(model)
+        expected_state0 = -(0.7 * math.log(0.7) + 0.2 * math.log(0.2) + 0.1 * math.log(0.1))
+        expected_state1 = -(0.1 * math.log(0.1) + 0.1 * math.log(0.1) + 0.8 * math.log(0.8))
+        self.assertAlmostEqual(out[0]["entropy_nats"], expected_state0, places=10)
+        self.assertAlmostEqual(out[1]["entropy_nats"], expected_state1, places=10)
+
+    def test_uniform_emission_hits_max_entropy(self):
+        model = HiddenMarkovModelDistribution(
+            topics=[CategoricalDistribution(pmap={0: 0.25, 1: 0.25, 2: 0.25, 3: 0.25}, default_value=0.0)],
+            w=[1.0],
+            transitions=[[1.0]],
+        )
+        out = describe_emissions(model)
+        self.assertAlmostEqual(out[0]["entropy_nats"], math.log(4), places=10)
+
+    def test_self_transition_and_expected_sojourn(self):
+        model = _two_state_model()
+        out = describe_emissions(model)
+        self.assertAlmostEqual(out[0]["self_transition"], 0.9, places=12)
+        self.assertAlmostEqual(out[0]["expected_sojourn_steps"], 1.0 / (1.0 - 0.9), places=10)
+        self.assertAlmostEqual(out[1]["self_transition"], 0.75, places=12)
+        self.assertAlmostEqual(out[1]["expected_sojourn_steps"], 1.0 / (1.0 - 0.75), places=10)
+
+    def test_zero_self_transition_gives_unit_sojourn(self):
+        model = HiddenMarkovModelDistribution(
+            topics=[
+                CategoricalDistribution(pmap={0: 1.0}, default_value=0.0),
+                CategoricalDistribution(pmap={1: 1.0}, default_value=0.0),
+            ],
+            w=[0.5, 0.5],
+            transitions=[[0.0, 1.0], [1.0, 0.0]],
+        )
+        out = describe_emissions(model)
+        self.assertEqual(out[0]["self_transition"], 0.0)
+        self.assertEqual(out[0]["expected_sojourn_steps"], 1.0)
+
+    def test_absorbing_state_gives_infinite_sojourn(self):
+        model = HiddenMarkovModelDistribution(
+            topics=[CategoricalDistribution(pmap={0: 1.0}, default_value=0.0)],
+            w=[1.0],
+            transitions=[[1.0]],
+        )
+        out = describe_emissions(model)
+        self.assertEqual(out[0]["self_transition"], 1.0)
+        self.assertEqual(out[0]["expected_sojourn_steps"], float("inf"))
+
+
+class CheckImpossibleObservationTest(unittest.TestCase):
+    def test_valid_sequence_scores_finite(self):
+        model = _two_state_model()
+        result = check_impossible_observation(model, [0, 1, 2, 0, 1], n_symbols=3)
+        self.assertTrue(result["valid_is_finite"])
+        self.assertTrue(math.isfinite(result["valid_ll"]))
+
+    def test_out_of_support_symbol_is_flagged_as_exactly_negative_infinity(self):
+        model = _two_state_model()
+        result = check_impossible_observation(model, [0, 1, 2, 0, 1, 2, 0, 1], n_symbols=3)
+        self.assertEqual(result["impossible_symbol"], 3)
+        self.assertTrue(result["correctly_flagged"])
+        self.assertEqual(result["impossible_ll"], float("-inf"))
+        # not NaN, not some other non-finite value masquerading as -inf
+        self.assertFalse(math.isnan(result["impossible_ll"]))
+
+    def test_does_not_raise_for_out_of_support_symbol(self):
+        # a KeyError/IndexError here would be the "silently wrong" failure mode this guards against;
+        # unittest turns an uncaught exception into a test error, so simply calling it is the check.
+        model = _two_state_model()
+        check_impossible_observation(model, [0, 1, 2], n_symbols=3)
+
+    def test_negative_control_nonzero_default_value_is_not_flagged(self):
+        # if the emission model assigns nonzero mass OUTSIDE its pmap (default_value > 0), the
+        # "impossible" sentinel is not actually impossible for this model, and the checker must say
+        # so -- proving the assertion above is a real behavioral check, not a vacuous True.
+        model = _two_state_model(default_value=0.05)
+        result = check_impossible_observation(model, [0, 1, 2, 0, 1], n_symbols=3)
+        self.assertFalse(result["correctly_flagged"])
+        self.assertTrue(math.isfinite(result["impossible_ll"]))
+
+    def test_multi_state_model_flags_impossible_regardless_of_which_state_is_active(self):
+        # every state's pmap excludes the sentinel, so the sequence is impossible under ANY hidden
+        # path, not just the most likely one -- the whole point of scoring via seq_log_density.
+        model = HiddenMarkovModelDistribution(
+            topics=[
+                CategoricalDistribution(pmap={0: 0.9, 1: 0.1}, default_value=0.0),
+                CategoricalDistribution(pmap={0: 0.1, 1: 0.9}, default_value=0.0),
+                CategoricalDistribution(pmap={0: 0.5, 1: 0.5}, default_value=0.0),
+            ],
+            w=[1 / 3, 1 / 3, 1 / 3],
+            transitions=[[0.8, 0.1, 0.1], [0.1, 0.8, 0.1], [0.1, 0.1, 0.8]],
+        )
+        result = check_impossible_observation(model, [0, 1, 0, 1, 0, 1], n_symbols=2)
+        self.assertTrue(result["correctly_flagged"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mixle/tests/flagship_temporal_sunspots_smoke_test.py
+++ b/mixle/tests/flagship_temporal_sunspots_smoke_test.py
@@ -7,6 +7,12 @@ number is validated by an independent implementation, not just asserted).
 
 Needs network to fetch the series and ``hmmlearn`` for the baseline; skips cleanly when either is
 missing, so it never fails a base-install run. It runs for real in the optional CI lane.
+
+The three test classes below exercise the flagship's other worklist F10.2 pieces -- seed stability,
+runtime/memory characterization, and impossible-observation handling against the REAL fitted model.
+None of these need ``hmmlearn`` (they only exercise mixle's own fit), so they are not gated by
+``_HAS_HMMLEARN``; they need only network, handled the same way as the class above. All four classes
+are triaged ``("optional", "slow")`` in ``conftest.py`` so they stay out of the default fast gate.
 """
 
 import importlib.util
@@ -20,15 +26,28 @@ _HAS_HMMLEARN = importlib.util.find_spec("hmmlearn") is not None
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "examples"))
 
 
+def _run_or_skip(test_case: unittest.TestCase, **kwargs):
+    from flagship_temporal_sunspots import run
+
+    try:
+        return run(**kwargs)
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        test_case.skipTest(f"sunspots series unavailable (offline?): {type(exc).__name__}: {exc}")
+
+
+def _seed_stability_or_skip(test_case: unittest.TestCase, **kwargs):
+    from flagship_temporal_sunspots import seed_stability
+
+    try:
+        return seed_stability(**kwargs)
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        test_case.skipTest(f"sunspots series unavailable (offline?): {type(exc).__name__}: {exc}")
+
+
 @unittest.skipUnless(_HAS_HMMLEARN, "hmmlearn not installed")
 class TemporalSunspotsFlagshipSmokeTest(unittest.TestCase):
     def test_mixle_hmm_matches_hmmlearn_on_held_out(self):
-        from flagship_temporal_sunspots import run
-
-        try:
-            receipt = run(n_states=3, n_symbols=8, seq_len=60, verbose=False)
-        except (urllib.error.URLError, TimeoutError, OSError) as exc:
-            self.skipTest(f"sunspots series unavailable (offline?): {type(exc).__name__}: {exc}")
+        receipt = _run_or_skip(self, n_states=3, n_symbols=8, seq_len=60, verbose=False)
 
         mixle_ll = receipt["mixle_test_ll_per_obs"]
         hmmlearn_ll = receipt["hmmlearn_test_ll_per_obs"]
@@ -41,6 +60,74 @@ class TemporalSunspotsFlagshipSmokeTest(unittest.TestCase):
             0.5,
             f"mixle ({mixle_ll:.4f}) and hmmlearn ({hmmlearn_ll:.4f}) disagree on held-out log-likelihood",
         )
+
+
+class TemporalSunspotsSeedStabilityTest(unittest.TestCase):
+    """Worklist F10.2 seed-stability characterization: does NOT need hmmlearn."""
+
+    def test_seed_stability_all_finite_and_spread_is_bounded(self):
+        summary = _seed_stability_or_skip(self, seeds=range(6), verbose=False)
+
+        per_seed = summary["per_seed"]
+        self.assertEqual(len(per_seed), 6)
+        for r in per_seed:
+            ll = r["test_ll_per_obs"]
+            self.assertTrue(math.isfinite(ll), f"non-finite held-out LL for seed {r['seed']}: {ll}")
+            # a discrete 8-symbol categorical HMM's held-out LL/obs is <= 0 (log of a probability),
+            # and should not be catastrophically below the uniform-model floor log(1/8) = -2.079 if
+            # EM is behaving.
+            self.assertLess(ll, 0.0)
+            self.assertGreater(ll, -3.0, f"seed {r['seed']}: held-out LL {ll:.4f} implausibly low")
+
+        # EM is a local method: seeds are NOT expected to be identical (see seed_stability's own
+        # docstring), but the spread must stay within an empirically-justified bound. A regression
+        # that made fits wildly seed-dependent (e.g. a broken initialization) would blow this open;
+        # the real local-optima spread observed during development (~0.83 over 10 seeds at max_its=200)
+        # comfortably clears it.
+        self.assertLess(
+            summary["range"],
+            2.0,
+            f"seed-to-seed spread {summary['range']:.4f} exceeds the expected bound (per-seed results: {per_seed})",
+        )
+        print(
+            f"F10.2 seed stability (6 seeds): mean={summary['mean']:.4f} std={summary['std']:.4f} "
+            f"range=[{summary['min']:.4f}, {summary['max']:.4f}] spread={summary['range']:.4f}"
+        )
+
+
+class TemporalSunspotsRuntimeMemoryTest(unittest.TestCase):
+    """Worklist F10.2 runtime/memory characterization: does NOT need hmmlearn."""
+
+    def test_fit_runtime_and_peak_memory_are_reported_and_bounded(self):
+        receipt = _run_or_skip(self, compare_hmmlearn=False, verbose=False)
+
+        wall = receipt["fit_wall_time_sec"]
+        peak_mb = receipt["fit_peak_memory_mb"]
+        self.assertTrue(math.isfinite(wall) and wall > 0.0, f"fit_wall_time_sec not a positive finite value: {wall}")
+        self.assertTrue(
+            math.isfinite(peak_mb) and peak_mb > 0.0, f"fit_peak_memory_mb not a positive finite value: {peak_mb}"
+        )
+        # generous ceilings -- catch a true perf/memory regression without being flaky on a slow runner
+        self.assertLess(wall, 60.0, f"core fit took {wall:.2f}s -- expected well under a minute at this data scale")
+        self.assertLess(peak_mb, 500.0, f"core fit peaked at {peak_mb:.1f} MB -- expected a few MB at this data scale")
+        print(
+            f"F10.2 runtime/memory (n_states=3, n_symbols=8, seq_len=60): fit_wall_time_sec={wall:.4f} fit_peak_memory_mb={peak_mb:.2f}"
+        )
+
+
+class TemporalSunspotsImpossibleObservationIntegrationTest(unittest.TestCase):
+    """Worklist F10.2 impossible-observation check against the REAL fitted sunspots model, does NOT
+    need hmmlearn. Complements the synthetic-data unit tests in
+    ``flagship_temporal_sunspots_inspection_test.py``, which exercise the same function without
+    network."""
+
+    def test_real_fitted_model_rejects_out_of_support_symbol(self):
+        receipt = _run_or_skip(self, compare_hmmlearn=False, verbose=False)
+
+        check = receipt["impossible_observation_check"]
+        self.assertTrue(check["valid_is_finite"], "a fully in-support sequence must still score finite")
+        self.assertTrue(check["correctly_flagged"], "an out-of-support symbol must be scored -inf, not silently finite")
+        self.assertEqual(check["impossible_ll"], float("-inf"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

`notes/0.8.0_WORKLIST.md`'s **F10.2 "Flagship B: structured temporal/latent model"** lists 6
tasks. `examples/flagship_temporal_sunspots.py` (added by #320, merged 2026-07-11) covered 3:
define observation/sequence semantics, compare against hmmlearn on the same held-out split, and
report held-out likelihood. Verified fresh against the current tip: still missing were **state
stability across seeds, runtime/memory characterization, inspection of learned state
emissions/transitions, and a test of an impossible observation** — exactly the F10.2 task list:

> - report likelihood, predictive metric, **state stability across seeds, runtime, and memory**;
> - **inspect learned state emissions/transitions**;
> - **test impossible**/missing observations;

This PR builds all four for real, each verified against the actual fitted model rather than
asserted.

## What changed — `examples/flagship_temporal_sunspots.py`

- **`seed_stability(seeds=range(10), ..., max_its=200)`**: refits the identical estimator on the
  identical data across N random seeds and reports the real spread of held-out log-likelihood,
  selecting the best fit by TRAINING likelihood (never test — picking by test performance would be
  a subtle leak). `max_its=200` instead of `run()`'s quick-demo default of 10, because direct
  experimentation showed most seeds are still mid-climb (still improving by dozens to hundreds of
  nats) at iteration 10; `max_its=200` is verified converged (bit-identical results through
  `max_its=1000`). A 10-seed run: **mean -1.3946, std 0.2286, range [-2.0764, -1.2462], spread
  0.83**. Most seeds land in one common optimum; a real fraction land in a different (sometimes
  better, sometimes worse) one — genuine EM local-optima behavior on ~37 training sequences,
  reported honestly rather than hidden behind one lucky/unlucky default seed.
- **`run()`** now times and `tracemalloc`-measures the core `optimize()` call in isolation:
  **~0.25s, well under 1 MB** at this flagship's documented scale (2.8k observations). The
  end-to-end script takes tens of seconds, but that's one-time Python import overhead (~25s for
  `mixle`, ~14s for `hmmlearn` — measured by bisecting the script with `time.perf_counter()`
  around each import) plus the network fetch, not the fit itself — reported separately so a reader
  isn't misled about what actually scales with data size.
- **`describe_emissions(model)`**: each hidden state's top emission symbols, Shannon entropy,
  self-transition probability, and implied expected sojourn length (`1/(1-self_transition)`). At a
  properly converged fit the 3 states resolve into interpretable low/mid/high sunspot-activity
  regimes (self-transition 0.95–0.98, ~20–40 month sojourns) — a concrete answer to F10.2's
  acceptance bar ("a clear reason the structured model is useful beyond a flat matrix baseline").
- **`check_impossible_observation(model, valid_seq, n_symbols)`**: splices the sentinel symbol
  `n_symbols` (one past `np.digitize`'s valid `[0, n_symbols)` range, guaranteed unseen) into an
  otherwise-valid sequence and confirms `seq_log_density` scores it exactly `-inf` — not NaN, not a
  crash, not a silently-wrong finite number. This is `CategoricalDistribution`'s own documented
  `default_value=0.0` contract (`log_density` returns `-np.inf` when `p <= 0.0`); the test proves
  it holds end to end through the HMM's vectorized scoring path.

`run()`'s `seed`/`max_its`/`delta` default to exactly the original unseeded/10-iteration values, so
the headline number and the pre-existing hmmlearn-agreement regression gate
(`flagship_temporal_sunspots_smoke_test.py`) are byte-for-byte unchanged — verified: default call
still returns `mixle_test_ll_per_obs = -2.0762`, matching the pre-change baseline.

## Tests — 15 new, all passing

- **12 new fast, network-free unit tests** in new file `flagship_temporal_sunspots_inspection_test.py`
  exercise `describe_emissions`/`check_impossible_observation` against small hand-built HMMs with
  known parameters (entropy checked against hand-computed Shannon entropy, sojourn against
  `1/(1-p)`, tie-breaking, absorbing/zero-self-transition edge cases), including a **negative
  control**: a model with nonzero `default_value` (so the "impossible" symbol is not actually
  impossible for it) must NOT be flagged — proving the check is a real behavioral assertion, not
  vacuously true.
- **3 new tests** extend `flagship_temporal_sunspots_smoke_test.py` for the network-gated pieces —
  seed-stability bounds, runtime/memory bounds, and the impossible-observation check against the
  REAL fitted sunspots model. None of the three need `hmmlearn` (only mixle's own fit), unlike the
  original test. All four test classes in that file are now triaged `("optional", "slow")` in
  `conftest.py`'s registry (matching the sibling Banking77/F10.3 precedent), so the default fast
  gate is unaffected regardless of whether `hmmlearn` happens to be installed.
- The pre-existing `test_mixle_hmm_matches_hmmlearn_on_held_out` passes unchanged.

## Verification

- Targeted run (`flagship_temporal_sunspots_inspection_test.py` +
  `flagship_temporal_sunspots_smoke_test.py` + `example_classification_test.py`, `-m ""`, real
  network + `hmmlearn` installed): **29 passed**, 0 failed.
- `python -m pytest mixle/tests --collect-only -m "not optional and not benchmark"`:
  **6776/7060 collected cleanly** (284 deselected by the marker filter, 5 pre-existing unrelated
  skips for uninstalled optional deps: `mpi4py`, `pyspark`, compiled kernels) — no collection
  errors, confirming the `conftest.py` registry addition and the new/modified test files are
  structurally sound repo-wide.
- Could not complete a full **execution** pass of the entire 6776-test suite: this machine is
  under extreme, unrelated concurrent load for the duration of this session (`uptime` showed load
  averages of ~150–165 from many other simultaneous sessions/builds across other projects; the
  collect-only pass alone took ~16 minutes of wall time under this load). Given zero core library
  files are touched by this PR (only `examples/`, plus test/registry files), the targeted
  verification above directly covers every changed file and its dependents.

## Not merging

Leaving this open for review rather than self-merging, matching the pattern on this repo's recent
audit/worklist-derived PRs (#510, #511).
