### PR TITLE
fix(inference): sort discrete levels by repr in structure.py, not bare comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,11 @@ to post-0.8 or kept under `mixle.experimental` per the feature freeze.
 - Sequential-design acquisition budgets reject invalid values and explicitly count the initial fit;
   root lazy imports preserve nested dependency failures.
 - Ordinary Pytest collection recognizes both supported test filename conventions.
+- `mixle.inference.structure`'s `dependency_gain`, `learn_structure`, and `learn_mixture_structure`
+  (via `_init_matrix`) crashed with `TypeError: '<' not supported between instances of 'NoneType' and
+  'str'` whenever a discrete parent/child column mixed a missing-value sentinel (`None`) with
+  str/int/bool levels -- the same class of bug already fixed in `bayesian_network.py`'s
+  `learn_bayesian_network`; all three sites now sort on `key=repr`.
 
 ### Fixed
 

--- a/mixle/inference/structure.py
+++ b/mixle/inference/structure.py
@@ -72,7 +72,10 @@ def dependency_gain(
     rng = np.random.RandomState(0) if rng is None else rng
     child = list(child)
     n = len(child)
-    levels = sorted(set(parent))
+    # key=repr (not bare comparison): a discrete parent may carry a missing sentinel (``None``) beside
+    # str/int/bool levels, and ``None`` has no ``<`` against those types (TypeError). repr gives a total,
+    # deterministic order regardless of level type mix -- same guard `_GLMFactor.fit` applies in bayesian_network.py.
+    levels = sorted(set(parent), key=repr)
     marginal = fit(child, _clone(child_estimator), max_its=max_its, out=None, rng=rng)
     ll_marginal = float(np.sum(marginal.seq_log_density(marginal.dist_to_encoder().seq_encode(child))))
 
@@ -815,8 +818,9 @@ def learn_structure(
         else:
             p = parents[i]
             keys = keyed[p]
+            # key=repr: see the dependency_gain guard above -- keys may carry a ``None`` sentinel.
             est = ConditionalDistributionEstimator(
-                estimator_map={lv: _clone(templates[i]) for lv in sorted(set(keys))}, given_estimator=None
+                estimator_map={lv: _clone(templates[i]) for lv in sorted(set(keys), key=repr)}, given_estimator=None
             )
             factors[i] = fit(list(zip(keys, cols[i])), est, max_its=max_its, out=None, rng=rng)
             edge_binners[i] = binners[p]
@@ -834,7 +838,9 @@ def _init_matrix(data: list[tuple], *, numeric_only: bool) -> np.ndarray:
     numerics, onehots = [], []
     for c in cols:
         if _is_discrete(c):
-            levels = sorted(set(c))
+            # key=repr: see the dependency_gain guard above -- c may carry a ``None`` sentinel; the one-hot
+            # encoding below only needs a total, deterministic order, not a semantically meaningful one.
+            levels = sorted(set(c), key=repr)
             onehots.append(np.array([[1.0 if v == lv else 0.0 for lv in levels] for v in c]))
         else:
             arr = np.asarray(c, dtype=np.float64)

--- a/mixle/tests/structure_learning_test.py
+++ b/mixle/tests/structure_learning_test.py
@@ -367,5 +367,56 @@ class GLMEdgeTest(unittest.TestCase):
         self.assertEqual(len(seq), 2)
 
 
+def _dependent_with_missing_categorical(seed, n=600):
+    """Same shape as _dependent, but the category carries a missing sentinel (None) alongside its str
+    levels -- the exact real-heterogeneous-data case (e.g. UCI Adult's workclass field) that crashed
+    dependency_gain/learn_structure's bare ``sorted(set(...))`` calls before they compared on ``key=repr``."""
+    r = np.random.RandomState(seed)
+    out = []
+    for _ in range(n):
+        c = None if r.rand() < 0.1 else ("hi" if r.rand() < 0.5 else "lo")
+        base = 5.0 if c == "hi" else (-5.0 if c == "lo" else 0.0)
+        x = base + r.randn()
+        out.append((c, float(x)))
+    return out
+
+
+class MissingCategoricalSentinelTest(unittest.TestCase):
+    """dependency_gain and learn_structure must not crash when a discrete column mixes a ``None``
+    sentinel with str/int/bool levels -- ``sorted(set(...))`` has no ``<`` between ``None`` and those
+    types. Regression coverage for the same bug learn_bayesian_network hit in bayesian_network.py
+    (fixed there via PR #520) at the analogous sites in mixle.inference.structure."""
+
+    def test_dependency_gain_does_not_crash_on_none_sentinel(self):
+        data = _dependent_with_missing_categorical(0)
+        cat = [d[0] for d in data]
+        real = [d[1] for d in data]
+        self.assertTrue(any(c is None for c in cat))  # the planted sentinel is actually present
+        gain = dependency_gain(cat, real, st.GaussianEstimator())
+        self.assertTrue(np.isfinite(gain))
+        self.assertGreater(gain, 50.0)  # the planted hi/lo/None -> real dependence is still found
+
+    def test_learn_structure_does_not_crash_on_none_sentinel(self):
+        data = _dependent_with_missing_categorical(1)
+        model = learn_structure(data)
+        self.assertIsInstance(model, DependencyTreeDistribution)
+        self.assertIn((0, 1), model.edges())  # category(0, incl. None) -> real(1) still discovered
+        missing_rows = [r for r in data if r[0] is None]
+        present_rows = [r for r in data if r[0] is not None]
+        self.assertTrue(missing_rows)  # the planted sentinel survived into the fitted data
+        for row in missing_rows[:10] + present_rows[:10]:
+            self.assertTrue(np.isfinite(model.log_density(row)))  # sensible score, missing or not
+
+    def test_init_matrix_one_hot_does_not_crash_on_none_sentinel(self):
+        # exercises _init_matrix's own sorted(set(...)) site indirectly via learn_mixture_structure,
+        # which calls it during k-means initialization over the discrete (possibly None-containing) fields
+        r = np.random.RandomState(2)
+        data = [
+            (None if i % 7 == 0 else ("hi" if i % 2 == 0 else "lo"), float(i % 2) * 5.0 + r.randn()) for i in range(200)
+        ]
+        model = learn_mixture_structure(data, 2, max_iter=10)
+        self.assertTrue(np.isfinite(model.log_density(data[0])))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

While completing worklist F10.1, a crash was found and fixed in `mixle/inference/bayesian_network.py`'s `learn_bayesian_network` (PR #520): `sorted(set(column))` over a discrete field raises `TypeError: '<' not supported between instances of 'NoneType' and 'str'` whenever that column mixes a missing-value sentinel (`None`) with str/int/bool levels.

The same pattern exists, unfixed, in the older single-parent-forest structure learner `mixle/inference/structure.py`:
- `dependency_gain`'s `levels = sorted(set(parent))`
- `learn_structure`'s per-parent-key conditional estimator map, `sorted(set(keys))`
- `learn_mixture_structure`'s `_init_matrix` one-hot encoding, `sorted(set(c))`

All three crash the same way on real heterogeneous data with a genuinely missing categorical field.

## Fix

Sort on `key=repr` instead of bare comparison at all three sites, matching the guard already applied in `bayesian_network.py`'s `_GLMFactor.fit` and `learn_bayesian_network`.

## Verification

- Reproduced the crash independently at both `dependency_gain` and `learn_structure` before fixing (a minimal repro with a `None`-containing discrete column).
- New regression tests in `structure_learning_test.py` (`MissingCategoricalSentinelTest`, 3 tests) confirmed failing pre-fix and passing post-fix via `git stash`.
- Full `structure_learning_test.py`: 26 passed.
- All other test files exercising `mixle.inference.structure` (`bayesian_network_test.py`, `condition_test.py`, `inverse_test.py`, `task_quantize_test.py`, `structure_embedded_test.py`, `structure_clone_isolation_test.py`): 99 passed, 1 pre-existing unrelated failure (`inverse_test.py::test_sequential_refinement_sharpens_posterior_at_observed_y`, confirmed identical with the fix stashed out).
- `ruff check` / `ruff format --check`: clean.

## Test plan
- [x] Reproduced the crash before fixing
- [x] New regression tests fail pre-fix, pass post-fix
- [x] Full `structure_learning_test.py` passes
- [x] All sibling test files exercising `mixle.inference.structure` pass (1 pre-existing unrelated failure confirmed)
- [x] ruff clean