### PR TITLE
fix(core): register the mine-planning modules in the maturity registry

### DIFF
--- a/docs/maturity.rst
+++ b/docs/maturity.rst
@@ -74,6 +74,11 @@ sync, so this table and the registry cannot drift apart.
      - Active application/research workflows
      - Scientific design, Bayesian optimization, model-improvement loops, and
        anti-regression experiments.
+   * - ``mixle.blending``, ``mixle.mine_planning``, and ``mixle.pipeline_twin``
+     - Active mine-planning workflows (worklist H2, H3, H8)
+     - Blend-to-spec LP/MILP with IIS feasibility diagnostics; ultimate-pit
+       and time-phased extraction scheduling; and digital-twin, period-stepped
+       re-solve simulation of the mine-to-plant-to-customer pipeline.
    * - ``mixle.inference.production``
      - Practical helpers, not a platform
      - Provenance headers, filesystem registries, scoring wrappers, activity

--- a/maturity_manifest.json
+++ b/maturity_manifest.json
@@ -7,7 +7,7 @@
     },
     "mixle.blending": {
       "maturity": "provisional",
-      "status": "Unclassified (provisional by default)"
+      "status": "Active mine-planning workflow (worklist H2: ore blending & grade control)"
     },
     "mixle.capability": {
       "maturity": "provisional",
@@ -75,7 +75,7 @@
     },
     "mixle.mine_planning": {
       "maturity": "provisional",
-      "status": "Unclassified (provisional by default)"
+      "status": "Active mine-planning workflow (worklist H3: production scheduling & block sequencing)"
     },
     "mixle.models": {
       "maturity": "provisional",
@@ -87,7 +87,7 @@
     },
     "mixle.pipeline_twin": {
       "maturity": "provisional",
-      "status": "Unclassified (provisional by default)"
+      "status": "Active mine-planning workflow (worklist H8: digital-twin pipeline simulation)"
     },
     "mixle.pool": {
       "maturity": "provisional",

--- a/mixle/maturity.py
+++ b/mixle/maturity.py
@@ -49,6 +49,24 @@ MATURITY_REGISTRY: dict[str, tuple[Maturity, str]] = {
     "mixle.scientist": (Maturity.PROVISIONAL, "Optional assembled workflow"),
     "mixle.doe": (Maturity.PROVISIONAL, "Active application/research workflows"),
     "mixle.evolve": (Maturity.PROVISIONAL, "Active application/research workflows"),
+    # H-series mine-planning worklist: active, tested acceptance-DoD modules (each has a dedicated
+    # test_h*.py in mixle/tests/) with zero non-test callers elsewhere in the tree today, which made them
+    # look dead in an earlier pass -- they are simply new and not yet wired into a consumer. Real worklist
+    # IDs confirmed against their own module docstrings/tests and this repo's commit history, not guessed:
+    # H2 landed in #448 "Ore blending & grade control", H3 in #452 "Production scheduling & block
+    # sequencing", H8 in #461 "Digital-twin simulation of the pipeline".
+    "mixle.blending": (
+        Maturity.PROVISIONAL,
+        "Active mine-planning workflow (worklist H2: ore blending & grade control)",
+    ),
+    "mixle.mine_planning": (
+        Maturity.PROVISIONAL,
+        "Active mine-planning workflow (worklist H3: production scheduling & block sequencing)",
+    ),
+    "mixle.pipeline_twin": (
+        Maturity.PROVISIONAL,
+        "Active mine-planning workflow (worklist H8: digital-twin pipeline simulation)",
+    ),
     "mixle.experimental": (Maturity.EXPERIMENTAL, "No compatibility guarantee"),
 }
 


### PR DESCRIPTION
## Gap

`mixle/blending.py`, `mixle/mine_planning.py`, and `mixle/pipeline_twin.py` are active, tested
mine-planning features -- each has a dedicated acceptance test (`test_h2_blending.py`,
`test_h3_scheduling.py`, `test_h8_twin.py`) and a real worklist ID -- but none were registered in
`mixle.maturity`'s `MATURITY_REGISTRY`. They have zero non-test callers elsewhere in the tree,
which made them look dead in an earlier audit pass, until closer inspection found each is simply
new and not yet wired into a downstream consumer, not abandoned.

Because `scripts/gen_maturity_manifest.py` enumerates *every* top-level module regardless of
registry membership, all three already appeared as keys in `maturity_manifest.json` -- just under
the generic `"Unclassified (provisional by default)"` fallback, unlike genuinely-classified active
features (`mixle.doe`, `mixle.task`, `mixle.reason`, ...). That's the orphaned-looking state this
fixes: present but unclassified, not literally absent.

(Related, separate gap fixed in a companion PR: 31 domain-vertical test files missing from
`conftest.py`'s test-tier registry.)

## Correction worth flagging

The worklist-ID mapping is: **`blending.py` = H2**, but **`mine_planning.py` = H3** and
**`pipeline_twin.py` = H8** (not H8 for `mine_planning.py` -- confirmed independently against
each module's own test docstring and this repo's commit history, not assumed):

- `8c327836` "H2: Ore blending & grade control" (PR #448) -> `mixle/blending.py`
- `198a8101` "H3: Production scheduling & block sequencing" (PR #452) -> `mixle/mine_planning.py`
- `c62be486` "H8: Digital-twin simulation of the pipeline" (PR #461) -> `mixle/pipeline_twin.py`

`test_h3_scheduling.py` imports `mine_planning` and is titled "(H3)"; `test_h8_twin.py` imports
`pipeline_twin` and is titled "(H8)". Registered accordingly.

## Change

- `mixle/maturity.py`: add all three to `MATURITY_REGISTRY` as `PROVISIONAL` (active, tested,
  evolving -- not API-frozen, but not under `mixle.experimental`'s no-compatibility-guarantee
  umbrella either), each with a status string naming its real worklist ID.
- `maturity_manifest.json`: regenerated via `python scripts/gen_maturity_manifest.py` -- a
  3-line diff, exactly the three status strings changing from the generic fallback to the real
  description.
- `docs/maturity.rst`: added the matching Maturity Map row (the prose mirror of the registry).

## Verification

- `maturity_registry_test.py` (7 tests) and `maturity_manifest_test.py` (3 tests): all pass,
  including the manifest drift/staleness check and the doc-sync test.
- `test_h2_blending.py`, `test_h3_scheduling.py`, `test_h8_twin.py`: all 11 tests still pass
  (this change touches no runtime code, only the maturity registry/manifest/docs).
