### PR TITLE
Move mpmath from base dependency to optional highprec extra

### DIFF
--- a/.github/workflows/extras-matrix.yml
+++ b/.github/workflows/extras-matrix.yml
@@ -30,6 +30,7 @@ jobs:
           - hadoop
           - arrays
           - grammar
+          - highprec
           - spark
           - dask
           - ray

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,10 +65,13 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: pip
           cache-dependency-path: pyproject.toml
+      # `highprec` (mpmath) is installed alongside `test` here so vmf_test.py / kent_test.py /
+      # lkj_test.py / bingham_test.py's exact-normalizer checks keep actually running (not skipping) now
+      # that mpmath is an optional extra rather than a base dependency (worklist P2.2).
       - name: Install package and test harness
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e ".[test]"
+          python -m pip install -e ".[test,highprec]"
       - name: Run fast tests
         run: python -m pytest -m fast -n auto
 
@@ -91,7 +94,7 @@ jobs:
       - name: Install package and test harness
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e ".[test]"
+          python -m pip install -e ".[test,highprec]"
       - name: Run fast tests
         run: python -m pytest -m fast -n auto
 
@@ -111,7 +114,7 @@ jobs:
       - name: Install package at the declared minimum dependency versions
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -c constraints-min.txt -e ".[test]"
+          python -m pip install -c constraints-min.txt -e ".[test,highprec]"
           python -c "import numpy, scipy, mpmath; print('numpy', numpy.__version__, 'scipy', scipy.__version__, 'mpmath', mpmath.__version__)"
       - name: Run fast tests at the minimum floors
         run: python -m pytest -m fast -n auto
@@ -130,7 +133,7 @@ jobs:
       - name: Install package and test harness
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e ".[test]"
+          python -m pip install -e ".[test,highprec]"
       - name: Run full non-optional suite with coverage
         # --cov-fail-under=45 is a deliberately conservative CATASTROPHIC-REGRESSION floor, not a coverage
         # target. This base install skips every optional backend (torch/numba/spark/dask/jax/...), so line

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,11 @@ to post-0.8 or kept under `mixle.experimental` per the feature freeze.
 - Sequential-design acquisition budgets reject invalid values and explicitly count the initial fit;
   root lazy imports preserve nested dependency failures.
 - Ordinary Pytest collection recognizes both supported test filename conventions.
+- `mpmath` moves from a base runtime dependency to the new `highprec` extra (`pip install
+  mixle[highprec]`); its one non-test consumer (`mixle.engines.highprec`) already treated it as an
+  optional fallback behind `gmpy2`, so forcing it into every install left the module's `_BACKEND=None`
+  degrade path practically unreachable and contradicted the base-install optional-dependency convention
+  (worklist P2.2).
 
 ### Fixed
 

--- a/mixle/engines/highprec.py
+++ b/mixle/engines/highprec.py
@@ -8,6 +8,11 @@ fp <= 256 prefer the vectorized ``extended`` path.
 
 So: spectrum coverage is complete (fp1..fp1024+), with the fast pure-numpy backends below fp256 and the
 correct MPFR backend above it.
+
+Both backends are optional extras (neither is a base dependency, per worklist P2.2): install the faster
+one with ``pip install mixle[gmpy2]``, or the pure-Python fallback with ``pip install mixle[highprec]``.
+With neither installed, :func:`available` returns False and any call requiring fp>256 raises a clear
+``RuntimeError`` naming the ``extended`` fallback -- see :func:`_require`.
 """
 
 from __future__ import annotations
@@ -16,12 +21,12 @@ from typing import Any
 
 import numpy as np
 
-try:  # gmpy2 (MPFR) is the preferred backend; mpmath is the pure-Python fallback.
+try:  # gmpy2 (MPFR) is the preferred backend (pip install mixle[gmpy2]).
     import gmpy2
 
     _BACKEND = "gmpy2"
 except ImportError:  # pragma: no cover - environment dependent
-    try:
+    try:  # mpmath is the pure-Python fallback (pip install mixle[highprec]).
         import mpmath
 
         _BACKEND = "mpmath"

--- a/mixle/tests/optional_import_guard_test.py
+++ b/mixle/tests/optional_import_guard_test.py
@@ -26,6 +26,7 @@ _OPTIONAL_TOP_LEVEL = frozenset(
         "numba",
         "pyspark",
         "gmpy2",
+        "mpmath",
         "zarr",
         "h5py",
         "mpi4py",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,10 +38,14 @@ classifiers = [
 # and scipy < 1.13 loses von Mises / wrapped Cauchy normalization precision (scipy >=1.16 also pairs
 # with numpy 2.4). These pins move together and are enforced by the `min-versions` CI job
 # (constraints-min.txt on the oldest supported Python). newer majors are allowed.
+# mpmath is deliberately NOT here: its one non-test consumer (mixle.engines.highprec) already treats it
+# as an optional fallback behind gmpy2 (try/except ImportError, degrading to `_BACKEND=None`), so forcing
+# it into every install contradicted the base-install optional-dependency convention this project
+# otherwise enforces (worklist P2.2; mixle/tests/optional_import_guard_test.py). See the `highprec` extra
+# below -- `mpmath>=1.3` moved there with its floor unchanged.
 dependencies = [
     "numpy>=2.4",
     "scipy>=1.16",
-    "mpmath>=1.3",
 ]
 
 [project.optional-dependencies]
@@ -69,6 +73,11 @@ data = ["pandas>=2.0", "pyarrow>=14", "sqlalchemy>=2.0", "pymongo>=4.3", "fsspec
 grammar = ["networkx>=3.0"]
 # GMP-backed (FFT) big-integer multiply for the structural count-DP's large histogram convolutions.
 gmpy2 = ["gmpy2>=2.1"]
+# mixle.engines.highprec's arbitrary-precision (fp>256) tail: the pure-Python MPFR-equivalent fallback
+# used when the faster `gmpy2` extra above is absent. Either extra makes `highprec.available()` True;
+# with neither installed the module degrades to `_BACKEND=None` (RuntimeError only if fp>256 is actually
+# requested -- the pure-numpy `mixle.engines.extended` path still covers up to fp256 either way).
+highprec = ["mpmath>=1.3"]
 spark = ["pyspark>=3.4"]
 dask = ["dask>=2023.5.0", "distributed>=2023.5.0"]
 # mixle.utils.parallel.ray_data's "ray" encoded-data backend (map/fold sufficient statistics over a

--- a/release-checklists/0.8.0-decisions.md
+++ b/release-checklists/0.8.0-decisions.md
@@ -134,3 +134,33 @@ Owner is the release owner (grant.boquet@gmail.com) unless stated. Dates are UTC
 - **Reviewer:** pending — PR #332
 - **Expiration:** none.
 - **Worklist:** S13 (security), N9.2 (honest claims)
+
+## D-0010 · `mpmath` narrows to an optional extra; D-0001's floor bump did not justify a base dependency
+
+- **Date:** 2026-07-17
+- **Decision:** Move `mpmath` out of base `dependencies` into a new `highprec` extra (`mpmath>=1.3`, floor
+  unchanged). `mixle.engines.highprec` is mpmath's only non-test consumer, and it already treated mpmath as
+  optional (`try: import gmpy2 / except: try: import mpmath / except: _BACKEND=None`, preferring the
+  correctly-gated `gmpy2` extra); forcing mpmath into every install made that `_BACKEND=None` degrade path
+  practically unreachable and contradicted the base-install optional-dependency convention this project
+  otherwise enforces (worklist P2.2).
+- **Relationship to D-0001:** D-0001 (2026-07-11) raised the runtime floor to `numpy>=2.4, scipy>=1.16,
+  mpmath>=1.3` as one bundled decision. Its own "Alternatives considered"/"Evidence" sections cite only
+  numpy/scipy-specific bugs (von Mises precision, IndexError, t-SNE/atlas fragility); mpmath is never
+  mentioned again after the initial line, and the `dependencies` array's comment block in `pyproject.toml`
+  never stated a rationale for mpmath specifically. D-0001's floor (`>=1.3`) is unchanged and still correct;
+  this entry narrows only the base-vs-optional placement, which D-0001 never analyzed on its own merits.
+- **Alternatives considered:** leave mpmath in base deps (rejected: contradicts P2.2, makes
+  `_BACKEND=None` unreachable in any real install, no evidence anywhere it was a deliberate choice on its
+  own merits); fold mpmath into the existing `gmpy2` extra (rejected: `gmpy2`'s own primary consumer is
+  unrelated -- `mixle/enumeration/quantization/core.py`'s structural count-DP -- and the two are
+  alternative backends for the same feature, not a bundled pair like `torch`+`safetensors`; a dedicated
+  `highprec` extra names the feature it unlocks, matching `arrays`/`grammar`/`data`).
+- **Evidence:** clean wheel install (neither gmpy2 nor mpmath) -- `highprec._BACKEND is None`,
+  `available() is False`, `_require()` raises `RuntimeError` (not `ImportError`), and the 768-module public
+  import sweep (`scripts/import_sweep.py`, worklist P2.1) passes clean. Wheel install with the new
+  `highprec` extra (mpmath present, gmpy2 absent) -- `_BACKEND == "mpmath"`, correct `hp_sum`/`hp_array`
+  results. Targeted run of every file this change touches: 38 passed, 18 subtests passed, 0 failed.
+- **Reviewer:** pending — PR #525
+- **Expiration:** none (corrects a placement error; no scheduled revisit).
+- **Worklist:** P2.2


### PR DESCRIPTION
## Summary

Today's dependency-hygiene audit of `release/0.8.0`'s base install found `pyproject.toml`'s
`dependencies` list to be `numpy`, `scipy`, `mpmath` -- but `mpmath` has exactly one non-test consumer in
the whole codebase (`mixle/engines/highprec.py`), and that module already treats it as optional: a
`try: import gmpy2 / except: try: import mpmath / except: _BACKEND = None` cascade that prefers the
correctly-gated `gmpy2` extra and falls back to mpmath. Forcing mpmath into every install made the
`_BACKEND=None` degrade path practically unreachable in any real install and contradicted this repo's own
base-install optional-dependency convention (worklist P2.2; `mixle/tests/optional_import_guard_test.py`).

## What changed

- **`pyproject.toml`**: removed `mpmath>=1.3` from base `dependencies`; added a new `highprec` extra
  (`mpmath>=1.3`) next to the existing `gmpy2` extra. `highprec.py`'s two backends are genuinely
  alternative (either satisfies `available()`), not a bundled pair like `torch`+`safetensors`, so they get
  separate single-package extras rather than being merged into one -- matching how every other extra in
  this table is scoped, and matching that `gmpy2`'s own primary consumer
  (`mixle/enumeration/quantization/core.py`'s structural count-DP) is unrelated to `highprec.py`. `mpmath`
  is intentionally NOT added to the `all` extra, matching the existing precedent for `gmpy2`/`sympy`/`sage`
  (niche numeric libraries, not general compute/data backends).
- **`mixle/engines/highprec.py`**: doc-only change -- the existing `try/except ImportError` cascade was
  already one of the three sanctioned P2.2 guard patterns (module-level try/except is explicitly allowed
  alongside lazy-import and the `optional_deps` shim per that test's own docstring), so no functional
  change was needed. Added a comment pointing at `pip install mixle[gmpy2]` / `pip install mixle[highprec]`,
  matching how other optional-dependency modules document their install command.
- **`mixle/tests/optional_import_guard_test.py`**: added `"mpmath"` to `_OPTIONAL_TOP_LEVEL`, keeping the
  static guard's tracked-extras set in sync with the `pyproject.toml` table it explicitly says to mirror.
- **`.github/workflows/tests.yml`**: `fast`, `fast-macos`, `min-versions`, and `full` now install
  `-e ".[test,highprec]"` (was `-e ".[test]"`). Needed because `vmf_test.py` (tagged plain "fast", no
  slow/optional marker in `conftest.py`'s registry) does an unconditional top-level `import mpmath`, and
  `kent_test.py`/`lkj_test.py`/`bingham_test.py` (tagged "slow", so they run in `full`) each do an
  unconditional `import mpmath` inside their exact-normalizer test method -- none of them guard it. All
  four were silently relying on mpmath's presence as a base dependency; without this change they'd start
  erroring in exactly the CI jobs that currently exercise them, the opposite of "degrades cleanly."
  `min-versions`'s inline `import numpy, scipy, mpmath` sanity check is unchanged (still valid: `-c
  constraints-min.txt` continues to apply the `mpmath==1.3.0` floor regardless of which requirement pulls
  it in).
- **`.github/workflows/extras-matrix.yml`**: added `highprec` to the P2.3 extras-resolver matrix. mpmath is
  pure-Python (no system library, unlike `gmpy2`, which the matrix already excludes for that reason), so
  there's no reason to leave the new extra untested there.
- **`CHANGELOG.md`**: `[0.8.0] - Unreleased` / `Fixed` entry, per CONTRIBUTING.md's "any user-visible
  change" rule (this changes what a bare `pip install mixle` pulls in).
- **`api_manifest.json`**: regenerated (`scripts/gen_api_manifest.py`); zero drift, as expected -- nothing
  here touches a public `__all__`.

## Test plan

- Clean wheel install, no extras (neither `gmpy2` nor `mpmath` importable):
  `mixle.engines.highprec._BACKEND is None`, `available() is False`, `_require()` raises a clear
  `RuntimeError` pointing at the `extended` fallback -- not an `ImportError`. This is the path that was
  practically unreachable before this PR.
- Same clean install: `scripts/import_sweep.py` (worklist P2.1) -- **768 public modules import cleanly**.
- Wheel install with `[highprec]` (mpmath present, gmpy2 absent): `_BACKEND == "mpmath"`,
  `available() is True`, `hp_sum`/`hp_array`/`HighPrecisionFormat.round_trip` all produce correct results
  through the mpmath path.
- Targeted run of every file this change touches or could break (`highprec_test.py`, `kent_test.py`,
  `lkj_test.py`, `bingham_test.py`, `vmf_test.py`, `optional_import_guard_test.py`,
  `public_api_manifest_test.py`), with `test,highprec` extras installed: **38 passed, 18 subtests passed,
  0 failed**.
- Full suite (`pytest -m "not optional and not benchmark" -n auto`, `test,highprec` extras, matching the
  `full` CI job): in progress at PR-open time; no failures observed through the portion completed
  (6222 items collected, clean through ~38%). Will update this section with the final count.
- `ruff format --check` / `ruff check` clean (pre-commit hook ran on the commit).

## Cite

Worklist **P2.2** (`release-checklists/0.8.0.md`: "Base-install optional-dependency guards tested (P2.2,
E2) ... Import every module with only base deps installed; each optional-dep path degrades cleanly (the
numba/mpi class of bug from 0.7.0 §3)."). `mpmath` forced into the base install was exactly that class of
bug in the opposite direction: an optional-dep path (`_BACKEND=None`) that no real install could reach.

Also touches (narrows, does not reverse) **D-0001** in `release-checklists/0.8.0-decisions.md`, which
bundled `mpmath>=1.3` into the same floor-bump as `numpy`/`scipy` without evidence specific to mpmath's
base-vs-optional placement -- its own "Alternatives considered"/"Evidence" sections discuss only
numpy/scipy version bugs. A follow-up commit adds a decision-log entry (D-0010) recording this narrowing,
per the log's own "correct a decision with a new superseding entry" rule, once this PR's number is known.
