### PR TITLE
docs(core): mark which T3.1 test tiers are actually populated

### DIFF
--- a/docs/test-tiers.rst
+++ b/docs/test-tiers.rst
@@ -12,36 +12,66 @@ command line with ``-m``, for example ``pytest -m smoke``.
 
 .. list-table::
    :header-rows: 1
-   :widths: 14 46 40
+   :widths: 12 36 22 30
 
    * - Tier
      - Purpose
      - Budget
+     - Status
    * - ``smoke``
      - Import, public-API, and critical-fit-path checks -- "is the package
        fundamentally working?"
      - <= 30 s local, <= 60 s in CI
+     - Usable now -- 4 tests collected.
    * - ``core``
      - Stable base-install correctness (no optional extras).
      - <= 4 min per Python CI job
+     - Declared, not yet populated -- 0 tests collected.
    * - ``full``
      - All non-optional correctness, including the ``slow`` stochastic,
        integration, and exhaustive tests.
      - <= 20 min
+     - Declared, not yet populated -- 0 tests collected.
    * - ``optional``
      - Tests that require optional extras or external executables; one job per
        installed backend group.
      - per backend group
+     - Usable now -- 277 tests collected.
    * - ``numerical``
      - Repeated-seed and numerical-stress tests.
      - nightly (not a per-commit gate)
+     - Declared, not yet populated -- 0 tests collected.
    * - ``benchmark``
      - Timing-oriented performance tests. Never mixed with correctness
        assertions except explicit parity gates.
      - performance only
+     - Usable now -- 7 tests collected.
    * - ``hardware``
      - Real MPI / GPU / multi-process receipts.
      - scheduled or manually gated
+     - Declared, not yet populated -- 0 tests collected.
+
+Current Status
+---------------
+
+Three tiers are usable today and select real tests: ``smoke`` (4 tests, all in
+``mixle/tests/smoke_test.py``), plus the pre-existing ``optional`` (277 tests) and
+``benchmark`` (7 tests) tiers. Verified directly with ``pytest -m <tier>
+--collect-only``.
+
+The four tiers T3.1 introduced alongside ``smoke`` -- ``core``, ``full``,
+``numerical``, and ``hardware`` -- are declared in ``pyproject.toml`` (so
+``--strict-markers`` makes them usable and typo-proof) and documented above with
+their intended purpose and budget, but **no test in the suite carries any of
+these four markers yet**. Running ``pytest -m core``, ``pytest -m full``,
+``pytest -m numerical``, or ``pytest -m hardware`` each currently reports "no
+tests collected". This is not an abandoned feature: the module docstring of
+``mixle/tests/test_tiers_test.py`` states plainly that T3.1 "does not re-mark the
+whole suite (that migration is incremental); it guarantees the vocabulary and the
+smoke tier are real and stay in sync." Re-marking the ~7,200 existing tests into
+``core``/``full``/``numerical``/``hardware`` is tracked as follow-up work, not a
+quick pass -- treat these four names as reserved and typo-proofed, not as usable
+subsets, until this note is updated.
 
 Guidance
 --------


### PR DESCRIPTION
## Worklist item

**Item:** T3.1 (Redesign test tiers around purpose and time budgets) -- documentation-accuracy correction against T3.1's own deliverable, found during a documentation-accuracy audit.

## Summary

`docs/test-tiers.rst` documents seven pytest tiers (`smoke`, `core`, `full`, `optional`,
`numerical`, `benchmark`, `hardware`) with no indication that four of them are currently empty.
Verified fresh against `origin/release/0.8.0` (c970b47b) with `pytest -m <tier> --collect-only`:

| Tier | Collected | Usable today? |
|---|---|---|
| `smoke` | 4 | yes |
| `core` | 0 | no |
| `full` | 0 | no |
| `optional` | 277 | yes (pre-existing marker) |
| `numerical` | 0 | no |
| `benchmark` | 7 | yes (pre-existing marker) |
| `hardware` | 0 | no |

`core`, `full`, `numerical`, and `hardware` are the four tiers T3.1 actually introduced
alongside `smoke`; they're declared in `pyproject.toml` and asserted as declared+documented by
`mixle/tests/test_tiers_test.py`, but no test in the ~7,200-test suite carries any of the four
markers yet. That test file's own docstring says T3.1 "does not re-mark the whole suite (that
migration is incremental)" -- so this is intentional, tracked scope, not an abandoned feature.
The doc's prose just never said so, which reads as if all seven tiers are usable now.

Fix: add a `Status` column to the tier table and a new "Current Status" section stating the
verified counts and quoting the incremental-migration rationale, so a reader can't come away
thinking `pytest -m core` (etc.) selects anything today.

Considered instead populating the four empty tiers with real marker assignments. Decided against
it for this PR: `core`/`full` need a considered split of the existing ~7,200 tests (today's
`fast`/`slow` split doesn't map cleanly onto the `core` <=4min / `full` <=20min budgets without
actually timing the current `fast` gate, which a past regression already let run to 36 minutes),
and `numerical`/`hardware` need genuinely new test content, not relabeling. That's the tracked
follow-up migration itself, not a small addition -- doing it shallowly just to avoid an honest
doc note would be worse than the note.

## Public API impact

- [x] This PR does **not** change any public `__all__`.

## Claims impact

- [x] A claim is affected and the relevant docs / claim-evidence ledger are updated with evidence at the required grade (see table above; doc now matches verified reality).

## Evidence

```
$ pytest -m smoke --collect-only -q       -> 4/7226 tests collected (7222 deselected)
$ pytest -m core --collect-only -q        -> no tests collected (7226 deselected)
$ pytest -m full --collect-only -q        -> no tests collected (7226 deselected)
$ pytest -m optional --collect-only -q    -> 277/7226 tests collected (6949 deselected)
$ pytest -m numerical --collect-only -q   -> no tests collected (7226 deselected)
$ pytest -m benchmark --collect-only -q   -> 7/7226 tests collected (7219 deselected)
$ pytest -m hardware --collect-only -q    -> no tests collected (7226 deselected)
$ pytest -m smoke -q                      -> 4 passed, 4 skipped (unrelated optional/compiled-kernel skips)
$ pytest mixle/tests/test_tiers_test.py -v -> 4 passed
```

All commands run PYTHONPATH-pinned against a fresh worktree of this branch (verified
`mixle.__file__` resolved inside the worktree, not a stale editable-install target) to keep the
counts honest.

## Checklist

- [x] Tests added/updated and passing; `ruff check` + `ruff format --check` clean (no Python changed).
- [x] Consumer suites for any edited module pass (`mixle/tests/test_tiers_test.py`, the only test that reads this doc, passes).
- [x] I am not merging this PR myself, and I have not enabled auto-merge.
