### PR TITLE
docs(core): refresh the example execution manifest for 0.8.0

### DIFF
--- a/docs/example-execution-manifest.rst
+++ b/docs/example-execution-manifest.rst
@@ -9,7 +9,7 @@ public release.
 Current Inventory
 -----------------
 
-The core package currently ships 55 Python example scripts:
+The core package currently ships 57 Python example scripts:
 
 .. list-table::
    :header-rows: 1
@@ -39,30 +39,72 @@ The core package currently ships 55 Python example scripts:
 Release Execution Status
 ------------------------
 
-The 23 base-install ("Execute.") examples were run against the built
-``mixle-0.7.0`` wheel, installed into a bare venv (``pip install dist/mixle-0.7.0-py3-none-any.whl``,
-no extras, no editable install, no ``PYTHONPATH``), each with a 90s budget:
+The 23 base-install ("Execute.") examples were re-run on 2026-07-17 against the
+built ``mixle-0.8.0.dev0`` wheel, installed into a bare venv (``pip install
+dist/mixle-0.8.0.dev0-py3-none-any.whl``, no extras, no editable install, no
+``PYTHONPATH``, Python 3.12), each with a 90s budget:
 
-* **21 passed**: ``enumeration_example.py``, ``extensibility_seams_example.py``,
+* **19 passed**: ``enumeration_example.py``, ``extensibility_seams_example.py``,
   ``gallery_combinators_example.py``, ``gallery_directional_example.py``,
   ``gallery_graphs_example.py``, ``gallery_multivariate_example.py``,
   ``gallery_processes_example.py``, ``gallery_rankings_example.py``,
   ``gallery_structured_example.py``, ``gallery_univariate_example.py``,
   ``heterogeneous_correctness_example.py``, ``hidden_association_example.py``,
-  ``hierarchical_mixture_example.py``, ``joint_mixture_example.py``,
-  ``latent_variable_models_example.py``, ``lookback_hmm_example.py``,
+  ``joint_mixture_example.py``, ``latent_variable_models_example.py``,
   ``ppl_example.py``, ``semi_supervised_mixture_example.py``,
   ``structure_learning_example.py``, ``structured_hmm_example.py``,
   ``structured_leaves_example.py``.
-* **2 reclassified to blocked** (see the Inventory table below):
-  ``skeptic_challenge_example.py`` (needs ``scikit-learn``, not a mixle
-  dependency) and ``win_demo_example.py`` (needs ``torch``; its distillation
-  path has no classical fallback).
+* **2 reclassified to blocked** (unchanged from the prior pass; see the
+  Inventory table below): ``skeptic_challenge_example.py`` (needs
+  ``scikit-learn``, not a mixle dependency) and ``win_demo_example.py`` (needs
+  ``torch``; its distillation path has no classical fallback).
+* **2 exceeded the 90s budget**: ``hierarchical_mixture_example.py`` and
+  ``lookback_hmm_example.py``. Recorded here as ``timed_out`` per this run's
+  evidence, not asserted as a release-blocking regression -- this execution
+  host was under extreme concurrent load for the whole pass (``uptime`` load
+  averages of ~140-175 against 10 cores, from unrelated concurrent work), which
+  inflates every wall-clock measurement in this run. Re-run individually with a
+  15-minute allowance to tell "slow under load" from "hung":
 
-The remaining examples (task/DOE/reasoning/vision workflows) were not executed
-in this pass -- they need optional extras, external datasets, model weights, or
-services per their Inventory entries below, none of which are provisioned in
-this environment.
+  * ``lookback_hmm_example.py`` completed cleanly in 86s on the re-run --
+    essentially at the 90s line, consistent with host-load variance rather
+    than a regression. It calls ``optimize(..., max_its=1000, delta=None)``;
+    ``delta=None`` disables early-stopping, so it always runs the full 1000 EM
+    iterations regardless of convergence, by design -- a fixed amount of work
+    that was already close to the budget before this pass.
+  * ``hierarchical_mixture_example.py`` did **not** complete even with the
+    15-minute allowance (10x the declared budget), while confirmed still
+    actively computing throughout, not deadlocked (steadily increasing CPU
+    time, never crashed or errored). This is a bigger gap than host load alone
+    plausibly explains. Its fit path
+    (``HierarchicalMixtureEstimatorAccumulator``) was rewritten four days
+    before this pass by the EM-monotonicity fix in #435 (2026-07-13, see
+    ``mixle/stats/latent/hierarchical_mixture.py``), which plausibly changed
+    how many of its ``max_its=10000`` iterations are needed to satisfy the
+    default convergence ``delta``. Treat this one as the more likely of the
+    two to be a real behavior change and re-verify on an unloaded runner
+    before re-budgeting or investigating further.
+
+Separately, the two real-data flagship examples added 2026-07-11 (F10.1/F10.2;
+not part of the base-install set above -- both need network access, and the
+Adult flagship additionally needs the optional ``datasets`` package) were run
+against the same wheel with their dependencies met:
+
+* ``flagship_temporal_sunspots.py`` -- **passed**. Fetches the public monthly
+  sunspot series over the network; no extra package is required for the fit
+  itself (the ``hmmlearn`` comparison degrades to ``None`` if absent, but
+  ``hmmlearn`` was installed for this run). Held-out mean log-likelihood per
+  observation: mixle -2.0762 vs. hmmlearn -2.0776 -- independent-baseline
+  agreement is the receipt.
+* ``flagship_heterogeneous_adult.py`` -- **passed**. Downloads UCI Adult via
+  the optional ``datasets`` package (``pip install datasets``; not a core
+  dependency or always-installed extra). Mean log-density: train -10.719,
+  held-out -10.839 (held-out close to train -- generalized, not memorized).
+
+The remaining examples (task/DOE/reasoning/vision workflows, plus the other
+three flagships) were not executed in this pass -- they need optional extras,
+external datasets, model weights, or services per their Inventory entries
+below, none of which are provisioned in this environment.
 
 Execution status should be recorded as evidence, not inferred from import
 success or from an earlier notebook run. If an example writes an artifact, the
@@ -146,10 +188,18 @@ Inventory
      - Execute or classify as long-running.
    * - ``examples/extensibility_seams_example.py``
      - Execute.
+   * - ``examples/flagship_heterogeneous_adult.py``
+     - Execute with network access and the optional ``datasets`` package
+       (downloads UCI Adult, not a core dependency); intended as an F10.4
+       release gate.
    * - ``examples/flagship_kg_agent.py``
      - Manual unless KG/RAG prerequisites are provisioned.
    * - ``examples/flagship_physics_inverse.py``
      - Execute or mark blocked on PDE/scientific dependencies.
+   * - ``examples/flagship_temporal_sunspots.py``
+     - Execute with network access (fetches the public sunspot series);
+       ``hmmlearn`` comparison is optional and degrades to ``None`` if
+       absent; intended as an F10.4 release gate.
    * - ``examples/flagship_triage_app.py``
      - Manual unless local reasoning prerequisites are provisioned.
    * - ``examples/frontier_family_showcase.py``


### PR DESCRIPTION
## Worklist item

**Item:** F10.5 (Retire misleading showcase examples -- acceptance criterion: "example manifest contains no ambiguous 'looks runnable' entries" / "ensure every README-linked example has a release execution status"). Documentation-accuracy correction found during a documentation-accuracy audit; also refreshes evidence gathered against the retired 0.7.0 wheel.

## Summary

`docs/example-execution-manifest.rst` had two concrete problems, both confirmed by
actually running things against current `release/0.8.0` (not inferred):

1. **Stale wheel evidence.** The "Release Execution Status" section's pass/fail record was
   gathered against the built `mixle-0.7.0` wheel (2026-07-09). Rebuilt the wheel from current
   source (`mixle-0.8.0.dev0`), installed it into a fresh bare venv (no extras, no editable
   install, no `PYTHONPATH`, Python 3.12 -- matching the doc's own stated methodology), and
   re-ran all 23 previously-recorded base-install examples plus the two new real-data flagships.
2. **Missing inventory rows.** `examples/flagship_heterogeneous_adult.py` and
   `examples/flagship_temporal_sunspots.py` (added 2026-07-11, PRs #319/#320, worklist F10.1/F10.2)
   were never added to the Inventory table -- the post-merge drift-fix commit
   (805855da, 2026-07-11) caught their missing `Classification:` tags and two other stale
   manifests (`release-checklists/0.8.0-repro-bundle.json`, `serialization_schema_manifest.json`,
   both regenerated via their own scripts) but missed this one, which has no generator script (it's
   a hand-maintained execution ledger by design -- pass/fail/blocked is evidence from actually
   running things, not something a script can infer).

## Fresh verification (this PR)

* Confirmed the two flagship examples are **not** stale -- both pass against current 0.8.0
  source with real data:
  * `flagship_temporal_sunspots.py`: mixle held-out log-likelihood/obs -2.0762 vs. hmmlearn
    -2.0776 (independent-baseline agreement).
  * `flagship_heterogeneous_adult.py`: mean log-density train -10.719, held-out -10.839
    (generalized, not memorized).
* Re-ran the 23 base-install examples: **19 passed**, the same **2 reclassified-to-blocked**
  (`skeptic_challenge_example.py` needs scikit-learn, `win_demo_example.py` needs torch) as
  before, and **2 exceeded the 90s budget** (`hierarchical_mixture_example.py`,
  `lookback_hmm_example.py`) under this run's extreme host contention (`uptime` load averages
  ~140-175 against 10 cores the entire pass). Re-ran each individually with a 15-minute allowance
  to separate "slow under load" from "hung": `lookback_hmm_example.py` completed cleanly in 86s
  (essentially at the 90s line -- it calls `optimize(..., max_its=1000, delta=None)`, which
  disables early-stopping and always runs the full 1000 iterations by design, so it was already
  close to budget); `hierarchical_mixture_example.py` did **not** complete even with 15 minutes
  (10x budget) while confirmed still actively computing throughout (steadily increasing CPU time,
  never crashed). That one's fit path was rewritten 4 days before this pass by the EM-monotonicity
  fix in #435 (2026-07-13) -- plausibly a real convergence-behavior change, not just host noise.
  Recorded both honestly as `timed_out` per the manifest's own evidence standard, with this
  distinction and a recommendation to re-verify on an unloaded runner, rather than silently
  dropping either from the "passed" list or asserting a regression I can't fully confirm on this
  host. Flagging `hierarchical_mixture_example.py` specifically as a separate follow-up task.
* Total example count corrected 55 -> 57 (both new flagships are top-level, not in a subdirectory).

## Public API impact

- [x] This PR does **not** change any public `__all__`.

## Claims impact

- [x] A claim is affected and the relevant docs / claim-evidence ledger are updated with evidence at the required grade (this *is* the claim-evidence ledger for examples/).

## Evidence

```
$ python -m build --wheel --outdir dist/ .                 -> Successfully built mixle-0.8.0.dev0-py3-none-any.whl
$ python3.12 -m venv bare-venv && pip install <wheel>       -> mixle 0.8.0.dev0, no extras
$ python -c "import mixle; print(mixle.__file__)"          -> resolves inside the bare venv's site-packages (non-editable, confirmed)
$ python examples/<each of 23 base-install examples>.py     -> 19 passed, 2 blocked (sklearn/torch missing, expected), 2 exceeded 90s (see doc note)
$ pip install datasets hmmlearn (into the same bare venv)
$ python examples/flagship_temporal_sunspots.py             -> passed, mixle -2.0762 vs hmmlearn -2.0776
$ python examples/flagship_heterogeneous_adult.py           -> passed, train -10.719 / held-out -10.839
```

## Checklist

- [x] Tests added/updated and passing; `ruff check` + `ruff format --check` clean (no Python changed).
- [x] Consumer suites for any edited module pass (no test reads this doc's content; `mixle/tests/example_classification_test.py` is unaffected -- it checks example docstrings, not this manifest).
- [x] I am not merging this PR myself, and I have not enabled auto-merge.
