### PR TITLE
fix(core): remove dead mixle.utils submodule exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,13 @@ to post-0.8 or kept under `mixle.experimental` per the feature freeze.
 - Sequential-design acquisition budgets reject invalid values and explicitly count the initial fit;
   root lazy imports preserve nested dependency failures.
 - Ordinary Pytest collection recognizes both supported test filename conventions.
+- `mixle.utils` no longer lists `parallel_mpi`, `em`, `enumeration`, `estimation`, `mcmc`, `objectives`,
+  or `priors` as importable submodules. Each was a stale name left over from earlier `pysp.utils`
+  reorganizations (the real code lives at `mixle.utils.parallel.mpi`, `mixle.inference.*`, and
+  `mixle.enumeration.algorithms`), so accessing any of them raised `ModuleNotFoundError`/`AttributeError`
+  despite appearing in `mixle.utils.__all__` and `dir(mixle.utils)`. The public-API drift test now
+  resolves every declared dynamic-package name via `getattr` instead of only diffing `__all__` as
+  strings, so a stale export like this cannot pass silently again.
 
 ### Fixed
 

--- a/api_manifest.json
+++ b/api_manifest.json
@@ -2068,18 +2068,11 @@
   "mixle.utils": [
     "analyze_structure",
     "automatic",
-    "em",
-    "enumeration",
-    "estimation",
     "htsne",
-    "mcmc",
     "metrics",
-    "objectives",
     "optional_deps",
     "optsutil",
     "parallel",
-    "parallel_mpi",
-    "priors",
     "pvalues",
     "special",
     "vector"

--- a/mixle/ppl/README.md
+++ b/mixle/ppl/README.md
@@ -39,7 +39,7 @@ through — nothing else to change:
 
 ```python
 Normal(free, free).fit(data, backend="mp", num_workers=8)     # multiprocess EM
-# backend="mpi" / "dask" also supported (see mixle.utils.estimation.optimize)
+# backend="mpi" / "dask" also supported (see mixle.inference.estimation.optimize)
 ```
 
 ## Regression & GLMs (covariates with `Field`)
@@ -324,7 +324,7 @@ message-passing core.
 | `"map"` | maximize joint (scipy) | priors, point estimate |
 | `"vi"` | ADVI — `family='meanfield'|'fullrank'`, tilted Renyi `alpha=`, `batch_size=` (SGVB) | non-conjugate priors, scalable approximate posterior |
 | `"vmp"` | variational message passing (closed-form, ELBO) | conjugate-exponential models (e.g. Gaussian mean+precision) |
-| `"mcmc"` | adaptive Metropolis (`mixle.utils.mcmc`) | full posterior, fast throughput |
+| `"mcmc"` | adaptive Metropolis (`mixle.inference.mcmc.metropolis_hastings`) | full posterior, fast throughput |
 | `"hmc"` | Hamiltonian MC, preconditioned (fixed step) | full posterior |
 | `"nuts"` | No-U-Turn Sampler (auto-tuned HMC, dual-averaging) | correlated / higher-dim posteriors |
 | `"ensemble"` | affine-invariant ensemble (Goodman & Weare) | low/medium-dim, highest ESS/sec |

--- a/mixle/stats/compute/sequence.py
+++ b/mixle/stats/compute/sequence.py
@@ -138,7 +138,7 @@ def seq_log_density_sum(
 
     """
     if hasattr(enc_data, "pysp_seq_log_density_sum"):
-        # parallel-backend handle (mixle.utils.parallel.multiprocessing / parallel_mpi)
+        # parallel-backend handle (mixle.utils.parallel.multiprocessing / mixle.utils.parallel.mpi)
         return enc_data.pysp_seq_log_density_sum(estimate)
 
     if isinstance(enc_data, RDD_TYPES):
@@ -277,7 +277,7 @@ def seq_estimate(
     validate_estimator_keys(estimator)
 
     if hasattr(enc_data, "pysp_seq_estimate"):
-        # parallel-backend handle (mixle.utils.parallel.multiprocessing / parallel_mpi)
+        # parallel-backend handle (mixle.utils.parallel.multiprocessing / mixle.utils.parallel.mpi)
         return enc_data.pysp_seq_estimate(estimator, prev_estimate)
 
     if isinstance(enc_data, RDD_TYPES):
@@ -379,7 +379,7 @@ def seq_initialize(
     validate_estimator_keys(estimator)
 
     if hasattr(enc_data, "pysp_seq_initialize"):
-        # parallel-backend handle (mixle.utils.parallel.multiprocessing / parallel_mpi)
+        # parallel-backend handle (mixle.utils.parallel.multiprocessing / mixle.utils.parallel.mpi)
         return enc_data.pysp_seq_initialize(estimator, rng, p)
 
     if isinstance(enc_data, RDD_TYPES):

--- a/mixle/tests/public_api_manifest_test.py
+++ b/mixle/tests/public_api_manifest_test.py
@@ -84,6 +84,32 @@ class PublicApiManifestTest(unittest.TestCase):
                 "here -- likely an import-ordering regression, not a genuinely missing optional dep",
             )
 
+    def test_dynamic_package_names_actually_resolve(self):
+        """A name in a lazy ``__getattr__``-built ``__all__`` (``mixle``, ``mixle.stats``,
+        ``mixle.utils``) can sit there forever without ever being verified importable: the manifest
+        generator reads ``__all__`` as a plain list of strings, so a stale entry left behind by a
+        rename (e.g. ``mixle.utils.parallel_mpi`` after ``parallel_mpi.py`` became
+        ``parallel/mpi.py``, with the old flat name never dropped from ``_SUBMODULES``) diffs clean
+        against the committed manifest forever, even though ``getattr(mixle.utils, "parallel_mpi")``
+        has raised ``ModuleNotFoundError`` since the rename. Actually resolve every declared name here,
+        the same way a user importing it would."""
+        import importlib
+
+        for key in ("mixle", "mixle.stats", "mixle.utils"):
+            module = importlib.import_module(key)
+            names = getattr(module, "__all__", [])
+            failures = []
+            for name in names:
+                try:
+                    getattr(module, name)
+                except Exception as exc:  # noqa: BLE001 -- report every broken name, not just the first
+                    failures.append(f"  {name}: {type(exc).__name__}: {exc}")
+            self.assertFalse(
+                failures,
+                f"{key}.__all__ declares names that do not actually resolve via getattr "
+                "(stale export left behind by a rename/removal, or a genuine bug):\n" + "\n".join(failures),
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/mixle/utils/__init__.py
+++ b/mixle/utils/__init__.py
@@ -10,18 +10,11 @@ import importlib
 
 _SUBMODULES = [
     "automatic",
-    "enumeration",
-    "estimation",
-    "em",
     "metrics",
-    "mcmc",
-    "objectives",
     "optional_deps",
     "optsutil",
     "parallel",
-    "parallel_mpi",
     "pvalues",
-    "priors",
     "special",
     "vector",
 ]


### PR DESCRIPTION
## Summary

`mixle.utils`'s lazy `_SUBMODULES` list named seven submodules that no longer exist:

- `parallel_mpi` — superseded when `utils/parallel_mpi.py` became `utils/parallel/mpi.py`; the working replacement (`mixle.utils.parallel.mpi`) was already reachable via the existing `parallel` entry.
- `em`, `enumeration`, `estimation`, `mcmc`, `objectives`, `priors` — left behind when the 2026-06-22 `pysp.utils` → `pysp.inference`/`pysp.enumeration` reorg deleted the old flat shim files and repointed ~135 import sites, but never touched this hand-maintained list.

Each name appeared in `mixle.utils.__all__` and `dir(mixle.utils)`, and the committed `api_manifest.json` recorded all seven as legitimate public exports — yet `getattr(mixle.utils, name)` raised `ModuleNotFoundError`/`AttributeError` for every one of them. The manifest drift test only ever diffed `__all__` as strings and never resolved a single name, so this could (and did) regress silently.

## Changes

- `mixle/utils/__init__.py`: drop all seven names from `_SUBMODULES`. The real functionality lives at `mixle.utils.parallel.mpi`, `mixle.inference.{em,estimation,objectives,priors,mcmc}`, and `mixle.enumeration.algorithms` — none of it belongs back under `mixle.utils`, matching the original reorg's intent ("No more pysp.utils.* shims for relocated machinery").
- `mixle/stats/compute/sequence.py`, `mixle/ppl/README.md`: fix stale comments/docs that still pointed at the dead `mixle.utils.{parallel_mpi,estimation,mcmc}` paths as if current.
- `mixle/tests/public_api_manifest_test.py`: add `test_dynamic_package_names_actually_resolve`, which `getattr()`s every name in `mixle`/`mixle.stats`/`mixle.utils`'s runtime-assembled `__all__` instead of only comparing it against the committed manifest as strings. Verified this catches the exact class of bug fixed here (reintroducing any of the seven names fails the test immediately).
- `api_manifest.json`: regenerated; the only diff is the seven names leaving `mixle.utils`'s entry.
- `CHANGELOG.md`: Unreleased/Fixed entry (fixes a real `ModuleNotFoundError` on public attribute access).

## Test plan

- [x] `public_api_manifest_test.py` (all 4 tests) passes, including the new resolve-check.
- [x] Negative control: reintroducing `parallel_mpi` (and separately confirming the other six all also raise `ModuleNotFoundError`) makes the new test fail as expected; removing it again makes it pass.
- [x] Fast gate (`pytest`, PYTHONPATH-pinned): 5408 passed, 10 skipped (pre-existing optional-dependency/hardware skips), 2 failed. The 2 failures (`reproducibility_hash_test.py`'s subprocess-hash-seed tests) are confirmed unrelated — `subprocess.TimeoutExpired` against a hardcoded 10s budget under this machine's concurrent-agent load (~90-125 load average), not a hash mismatch; manually reproduced the exact subprocess command with correct, stable output in 21s wall-clock. Filed as a separate test-fragility follow-up; this diff touches neither file that test imports.

Left open for review per convention.