### PR TITLE
docs(core): add flagship real-data examples to the examples inventory

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -188,12 +188,20 @@ Complete Inventory
    * - ``extensibility_seams_example.py``
      - Extension
      - Show where new families and backends attach.
+   * - ``flagship_heterogeneous_adult.py``
+     - Real-data evidence
+     - Fit heterogeneous UCI Adult census-income fields in one call and
+       report train/held-out log-density as the generalization receipt.
    * - ``flagship_kg_agent.py``
      - Reasoning ecosystem
      - Ontology-constrained graph facts, KG completion, and cited KG-RAG.
    * - ``flagship_physics_inverse.py``
      - Scientific inference
      - Bayesian inverse problem with coverage-oriented uncertainty checks.
+   * - ``flagship_temporal_sunspots.py``
+     - Real-data evidence
+     - Discrete-emission HMM on real monthly sunspot counts (1749-1983),
+       cross-checked against hmmlearn on the same held-out split.
    * - ``flagship_triage_app.py``
      - Reasoning ecosystem
      - Support triage over substrate, skills, pool-style jobs, monitoring, and


### PR DESCRIPTION
## Summary

- `docs/examples.rst`'s "Complete Inventory" list-table never gained rows for
  `examples/flagship_heterogeneous_adult.py` and `examples/flagship_temporal_sunspots.py`
  (added 2026-07-11, PRs #319/#320, worklist F10.1/F10.2) -- the same process gap PR #527
  just closed for the sibling `example-execution-manifest.rst`. This page's own "Execution
  Standard" section calls for updating release-evidence docs when an example ships; the
  Inventory table was the one spot that drifted.
- Added both rows, classified **Real-data evidence**, matching each script's own
  `Classification: evidence` docstring tag (UCI Adult census income; monthly sunspot
  counts, 1749-1983), inserted in alphabetical order alongside the other `flagship_*` rows.
- Did **not** add rows to "Recommended First Runs" or to README.md's "Examples" section.
  Both are explicitly scoped to base-install, no-download workflows by their own stated
  criteria ("Start with the base-install examples... move to real-data workflows only
  after", and README's "no downloads" line) -- both new flagships need network access, and
  the Adult script also needs the optional `datasets` package, so neither fits.

## Cross-check

`mixle/tests/example_classification_test.py` enforces the `Classification:` docstring tag
on aspirationally-named examples but only reads the scripts themselves -- it asserts
nothing about `docs/examples.rst`, so this doc change has no effect on that test (and vice
versa). Ran it directly: 13 passed, unaffected by this change.

## Public API impact

- [x] This PR does not change any public `__all__` (docs-only change, no code touched).

## Evidence

```
$ python -m pytest mixle/tests/example_classification_test.py -q
13 passed

$ python -m sphinx -b html docs docs/_build -W --keep-going   (clean rebuild, this branch)
build finished with problems, 5 warnings (with warnings treated as errors)

$ python -m sphinx -b html docs docs/_build -W --keep-going   (clean rebuild, unmodified
                                                                 origin/release/0.8.0 in a
                                                                 second worktree)
build finished with problems, 5 warnings (with warnings treated as errors)

$ diff <(grep -io "WARNING:.*" this-branch.log | sort) <(grep -io "WARNING:.*" baseline.log | sort)
(no output -- byte-identical warning text on both sides)
```

All 5 warnings are pre-existing on unmodified `origin/release/0.8.0` (two
`development`/`operations` `.rst`/`.md` docname collisions and one orphan page
under `docs/migrations/`, already being tracked/fixed separately) and are
byte-for-byte identical with and without this change, so this PR's two new
rows introduce zero new Sphinx warnings.

## Checklist

- [x] Docs-only change; no Python touched, so no ruff/test impact beyond the sanity check above.
- [x] I am not merging this PR myself, and I have not enabled auto-merge.
