### PR TITLE
Fix the scalar M-step taking its location from the raw sum (kernel-dependent variance error; the 13%-mark CI failure)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,25 @@ defect, and four documentation-only clarifications) are also tracked in the same
 
 ### Fixed
 
+- The scalar M-step of every family carrying the shift-anchored moment track (Gaussian,
+  log-Gaussian, Logistic, Gumbel, Student-t, Rician, Nakagami) formed its reported location from
+  the raw large-magnitude sum, `sum_x / count`, and the anchored variance then squared the
+  displacement of that location from the anchored sample mean into the variance whenever it
+  cleared a 4-ulp rounding clamp. A SIMD-reduced sum of a few hundred observations at 1e15 carries
+  more than 4 ulp of error, by an amount that depends on the BLAS kernel: on x86 OpenBLAS the
+  residual stayed under the clamp, on the arm64 NEON kernel a two-component mixture at `+1e15`
+  reported component variances of 1.07 and 0.94 for a true 0.25 -- while the anchored payload
+  reaching the M-step carried the exact answer on both. The location now comes from the anchored
+  track (`anchored_location`, the form the multivariate Gaussian and generalized Pareto estimators
+  already used), so the clamp only ever sees the rounding of one addition. This was the
+  intermittent failure at the 13% mark of the hosted ubuntu core lanes since 08-28: the host CPU
+  decided the kernel, and the kernel decided the test. Reproduced and verified in a Linux VM
+  (arm64 native; x86_64 under Rosetta with forced OpenBLAS kernels).
+- `mixle.evolve` verify gate: a challenger whose per-observation score beat the champion's by a
+  fraction of an ulp on every row (an `auto_select` challenger identical to its champion:
+  mean difference 5.5e-17, p = 0.0015) was promoted as verified. The paired t-test measures
+  directional consistency, not magnitude; the gate now reports a tie when the mean difference is
+  below 8 ulp of the scores' own magnitude (`evidence["numerical_resolution"]`).
 - A ninth candidate campaign against `441ec4b3` (D-0209) returned NO-GO on its very first pass, and
   the resulting fix wave then required two further full adversarial review rounds against its own
   diff before one confirmed zero new findings of the dominant recurring defect -- 7, then 12, then

--- a/mixle/evolve/verify.py
+++ b/mixle/evolve/verify.py
@@ -193,6 +193,11 @@ def _calibration_no_regression(
     return status, {"champion_calib": champ_cal, "challenger_calib": chal_cal, "calib_tol": calib_tol, "ok": ok}
 
 
+# A paired mean difference below this many ulp of the scores' own magnitude is floating-point
+# residue, not an effect (see the resolution floor in challenger_beats_champion).
+_RESOLUTION_ULPS = 8.0
+
+
 def _check_policy(*, alpha: float, min_effect: float, calib_tol: float) -> None:
     """Validate the gate's policy knobs before any of them can authorize a promotion.
 
@@ -357,10 +362,26 @@ def challenger_beats_champion(
     favored_paired = paired["favored"] == "B"  # 'B' is the challenger in paired_score_difference
     effect_ok = abs(mean_diff) >= min_effect
 
+    # Floating-point resolution floor. The paired test measures directional CONSISTENCY, not
+    # magnitude: two score vectors computed for the same model through two arithmetic paths carry a
+    # systematic same-direction rounding residual of a fraction of an ulp on every row, and at n in
+    # the hundreds a t-test calls that "significant" (observed: an auto_select challenger identical
+    # to its champion, mean_diff = 5.5e-17 on nll scores of order 1, p = 0.0015, promoted). No
+    # ``min_effect`` a caller could reasonably pick guards this -- the default is 0.0 and the value
+    # is far below anything a user would think to write -- so the gate refuses it on its own: a
+    # mean difference below a few ulp of the scores' own magnitude is not evidence either way.
+    resolution = (
+        _RESOLUTION_ULPS
+        * np.finfo(np.float64).eps
+        * float(max(np.max(np.abs(champ_vec)), np.max(np.abs(chal_vec)), 1.0e-300))
+    )
+    below_resolution = abs(mean_diff) < resolution
+    evidence["numerical_resolution"] = {"floor": resolution, "below_floor": below_resolution}
+
     favored = (
         "challenger"
-        if (significant and favored_paired and effect_ok)
-        else ("champion" if (significant and paired["favored"] == "A") else "tie")
+        if (significant and favored_paired and effect_ok and not below_resolution)
+        else ("champion" if (significant and paired["favored"] == "A" and not below_resolution) else "tie")
     )
 
     # non-nested robustness cross-check for family swaps

--- a/mixle/stats/univariate/continuous/_observation_contracts.py
+++ b/mixle/stats/univariate/continuous/_observation_contracts.py
@@ -130,6 +130,39 @@ def scale_anchored_triple(
     return anchor, a_sum * c, a_sum2 * c
 
 
+def anchored_location(
+    anchor: float, a_sum: float, count: float, pseudo_count: float | None = None, prior_mean: float | None = None
+) -> float:
+    """The reported location of an anchored ``(anchor, a_sum)`` track: ``anchor + offset``.
+
+    ``offset`` is the sample mean in anchor-relative coordinates, ``a_sum / count``, blended with a
+    pseudo-count prior the same way the raw form blends it -- ``(sum_x + pc * prior_mean) / (count +
+    pc)`` -- but written as ``(a_sum + pc * (prior_mean - anchor)) / (count + pc)`` so every term is
+    at spread scale and the only large-magnitude operation is the final addition onto ``anchor``.
+
+    Every scalar family that carries the anchored track must form its location THIS way rather than
+    as ``sum_x / count``, and the reason is not accuracy of the location itself but what
+    :func:`anchored_pooled_variance` does with it. That function splits the scatter about the
+    reported location into the scatter about the sample's own mean (all the data, at spread scale)
+    plus ``count * shift**2``, ``shift`` being the displacement of the reported location from the
+    sample mean, and clamps ``shift`` to zero only when it is within :data:`MEAN_ROUNDING_BOUND`
+    (4 ulp) of the magnitude -- the bound a single correctly-rounded division can produce. A raw
+    ``sum_x`` accumulated over ``count`` observations at magnitude 1e15 does NOT carry a 4-ulp
+    error: a SIMD-reduced dot product's summation error grows with the lane count and the reduction
+    tree, and differs by kernel. On x86 OpenBLAS the residual stayed under the clamp; on the arm64
+    NEON kernel the same 600-observation two-component mixture at ``+1e15`` landed a ``shift`` of
+    ~0.9 (7 ulp), which cleared the clamp and was squared straight into the variance: components
+    of true variance 0.25 reported 1.07 and 0.94, with the anchored payload itself carrying the exact
+    answer the whole time. Forming the location from the anchored track makes ``shift`` exactly the
+    rounding of one addition (at most half an ulp), so the clamp is never platform-dependent again.
+    The multivariate and diagonal Gaussian estimators already do this (``anchored[0] +
+    mean_offset``); this is the scalar families' shared equivalent.
+    """
+    if pseudo_count in (None, 0.0) or prior_mean is None:
+        return anchor + a_sum / count
+    return anchor + (a_sum + pseudo_count * (prior_mean - anchor)) / (count + pseudo_count)
+
+
 # --------------------------------------------------------------------------------------------
 # Shift-anchored moment track: the shared repair for every scalar location-scale family.
 #

--- a/mixle/stats/univariate/continuous/gaussian.py
+++ b/mixle/stats/univariate/continuous/gaussian.py
@@ -32,6 +32,7 @@ from mixle.stats.univariate.continuous._gaussian_contracts import (
     scalar_gaussian_moments,
 )
 from mixle.stats.univariate.continuous._observation_contracts import (
+    anchored_location,
     consistent_anchored_triple,
     scale_anchored_triple,
     scored_observation,
@@ -1367,7 +1368,11 @@ class GaussianEstimator(ParameterEstimator):
         prior_mean, prior_variance = self.suff_stat
         # A mean pseudo-count is only usable when its prior mean was supplied; unpaired counts
         # mean "no pseudo-observations" and fall through to the plain maximum-likelihood mean.
-        if pc1 not in (None, 0.0) and prior_mean is not None:
+        if anchored is not None:
+            # From the anchored track, not the raw sum (see ``anchored_location``): the raw quotient's
+            # kernel-dependent rounding residual would otherwise be squared into the variance.
+            mu = anchored_location(anchored[0], anchored[1], count, pc1, prior_mean)
+        elif pc1 not in (None, 0.0) and prior_mean is not None:
             mu = (sum_x + pc1 * prior_mean) / (count + pc1)
         elif count > 0.0:
             mu = sum_x / count

--- a/mixle/stats/univariate/continuous/gumbel.py
+++ b/mixle/stats/univariate/continuous/gumbel.py
@@ -32,6 +32,7 @@ from mixle.stats.compute.pdist import (
 )
 from mixle.stats.univariate.continuous._observation_contracts import (
     AnchoredMomentTrack,
+    anchored_location,
     anchored_pooled_variance,
     consistent_anchored_triple,
     scored_observation,
@@ -431,7 +432,14 @@ class GumbelEstimator(ParameterEstimator):
         if count <= 0.0:
             return GumbelDistribution(name=self.name, keys=self.keys)
 
-        mean = sum_x / count
+        if anchored is not None:
+            # From the anchored track, not the raw sum (see ``anchored_location``): the raw quotient's
+            # kernel-dependent rounding residual would otherwise be squared into the variance.
+            mean = anchored_location(
+                anchored[0], anchored[1], raw_count, pc if prior_mean is not None else None, prior_mean
+            )
+        else:
+            mean = sum_x / count
         notes: tuple[str, ...] = ()
         if anchored is not None:
             # Only the variance loses to cancellation at large magnitude; the mean is a plain

--- a/mixle/stats/univariate/continuous/log_gaussian.py
+++ b/mixle/stats/univariate/continuous/log_gaussian.py
@@ -32,6 +32,7 @@ from mixle.stats.univariate.continuous._gaussian_contracts import (
 )
 from mixle.stats.univariate.continuous._observation_contracts import (
     AnchoredMomentTrack,
+    anchored_location,
     anchored_pooled_variance,
     consistent_anchored_triple,
     scored_observation,
@@ -865,7 +866,11 @@ class LogGaussianEstimator(ParameterEstimator):
         prior_mean, prior_variance = self.suff_stat
         # A mean pseudo-count is only usable when its prior mean was supplied; unpaired counts
         # mean "no pseudo-observations" and fall through to the plain maximum-likelihood mean.
-        if pc1 not in (None, 0.0) and prior_mean is not None:
+        if anchored is not None:
+            # From the anchored track, not the raw sum (see ``anchored_location``): the raw quotient's
+            # kernel-dependent rounding residual would otherwise be squared into the variance.
+            mu = anchored_location(anchored[0], anchored[1], count, pc1, prior_mean)
+        elif pc1 not in (None, 0.0) and prior_mean is not None:
             mu = (log_x + pc1 * prior_mean) / (count + pc1)
         elif count > 0.0:
             mu = log_x / count

--- a/mixle/stats/univariate/continuous/logistic.py
+++ b/mixle/stats/univariate/continuous/logistic.py
@@ -19,6 +19,7 @@ from mixle.stats.compute.pdist import (
     StatisticAccumulatorFactory,
 )
 from mixle.stats.univariate.continuous._observation_contracts import (
+    anchored_location,
     consistent_anchored_triple,
     scale_anchored_triple,
     scored_observation,
@@ -631,7 +632,12 @@ class LogisticEstimator(ParameterEstimator):
         if blended_count <= 0.0:
             return LogisticDistribution(name=self.name, keys=self.keys)
 
-        loc = blended_sum_x / blended_count
+        if anchored is not None:
+            # From the anchored track, not the raw sum (see ``anchored_location``): the raw quotient's
+            # kernel-dependent rounding residual would otherwise be squared into the variance.
+            loc = anchored_location(anchored[0], anchored[1], count, pc if prior_mean is not None else None, prior_mean)
+        else:
+            loc = blended_sum_x / blended_count
 
         notes: tuple[str, ...] = ()
         if anchored is not None:

--- a/mixle/stats/univariate/continuous/nakagami.py
+++ b/mixle/stats/univariate/continuous/nakagami.py
@@ -31,6 +31,7 @@ from mixle.stats.compute.pdist import (
 )
 from mixle.stats.univariate.continuous._observation_contracts import (
     SquaredPowerSumTrack,
+    anchored_location,
     anchored_pooled_variance,
     consistent_anchored_triple,
     finite_observations,
@@ -329,7 +330,14 @@ class NakagamiEstimator(ParameterEstimator):
             count += pc
         if count <= 0.0:
             return NakagamiDistribution(1.0, 1.0, name=self.name, keys=self.keys)
-        omega = s2 / count
+        if anchored is not None:
+            # From the anchored (x**2) track, not the raw sum (see ``anchored_location``): the raw quotient's
+            # kernel-dependent rounding residual would otherwise be squared into the variance.
+            omega = anchored_location(
+                anchored[0], anchored[1], raw_count, pc if prior_mean is not None else None, prior_mean
+            )
+        else:
+            omega = s2 / count
         if anchored is None:
             # Historical raw path, bit-identical: statistics the conditioning gate never needed to
             # anchor, or ones that arrived already reduced and can no longer be corrected.

--- a/mixle/stats/univariate/continuous/rician.py
+++ b/mixle/stats/univariate/continuous/rician.py
@@ -33,6 +33,7 @@ from mixle.stats.compute.pdist import (
 )
 from mixle.stats.univariate.continuous._observation_contracts import (
     SquaredPowerSumTrack,
+    anchored_location,
     anchored_pooled_variance,
     consistent_anchored_triple,
     finite_observations,
@@ -353,7 +354,14 @@ class RicianEstimator(ParameterEstimator):
             count += pc
         if count <= 0.0:
             return RicianDistribution(0.0, 1.0, name=self.name, keys=self.keys)
-        m2 = s2 / count
+        if anchored is not None:
+            # From the anchored (x**2) track, not the raw sum (see ``anchored_location``): the raw quotient's
+            # kernel-dependent rounding residual would otherwise be squared into the variance.
+            m2 = anchored_location(
+                anchored[0], anchored[1], raw_count, pc if prior_mean is not None else None, prior_mean
+            )
+        else:
+            m2 = s2 / count
         if anchored is None:
             # Historical raw path, bit-identical: statistics the conditioning gate never needed to
             # anchor, or ones that arrived already reduced and can no longer be corrected.

--- a/mixle/stats/univariate/continuous/student_t.py
+++ b/mixle/stats/univariate/continuous/student_t.py
@@ -20,6 +20,7 @@ from mixle.stats.compute.pdist import (
 )
 from mixle.stats.univariate.continuous._observation_contracts import (
     AnchoredMomentTrack,
+    anchored_location,
     anchored_pooled_variance,
     consistent_anchored_triple,
     finite_observations,
@@ -421,7 +422,14 @@ class StudentTEstimator(ParameterEstimator):
         if count <= 0.0:
             return StudentTDistribution(self.df, name=self.name, keys=self.keys)
 
-        loc = sum_x / count
+        if anchored is not None:
+            # From the anchored track, not the raw sum (see ``anchored_location``): the raw quotient's
+            # kernel-dependent rounding residual would otherwise be squared into the variance.
+            loc = anchored_location(
+                anchored[0], anchored[1], raw_count, pc if prior_mean is not None else None, prior_mean
+            )
+        else:
+            loc = sum_x / count
         notes: tuple[str, ...] = ()
         if anchored is not None:
             # Only the variance loses to cancellation at large magnitude; the location is a plain

--- a/mixle/tests/campaign3b_clamp_test.py
+++ b/mixle/tests/campaign3b_clamp_test.py
@@ -108,6 +108,29 @@ class ExtremeMagnitudeSpreadTestCase(unittest.TestCase):
             self.assertLess(component.sigma2, 1.0)  # pre-fix: 1e+22, the scale-relative floor
             self.assertGreater(component.sigma2, 0.1)
 
+    def test_m_step_location_comes_from_the_anchored_track_not_the_raw_sum(self):
+        # The fit above passed on x86 OpenBLAS and failed on the arm64 NEON kernel with sigma2 of
+        # 1.07 and 0.94 for components of true variance 0.25 -- while the anchored payload reaching
+        # the M-step carried the exact answer (a_sum2/count - (a_sum/count)**2 = 0.2600) on BOTH.
+        # The M-step took its mean from the RAW sum, ``sum_x / count``; a SIMD-reduced sum of 300
+        # values at 1e15 carries a kernel-dependent residual of several grid steps, and once that
+        # residual cleared the 4-ulp mean-rounding clamp it was squared into the variance. This is the
+        # platform-independent statement of that defect: a raw sum carrying an 8-grid-step residual
+        # (1.0 at this magnitude) alongside an exact anchored payload. The location must come from
+        # the anchored track, so the variance is the anchored scatter and the residual is inert.
+        from mixle.stats.univariate.continuous.gaussian import GaussianSuffStat
+
+        anchor, count = 1.0e15 + 39.625, 300.0
+        a_sum, a_sum2 = 108.125, 116.984375  # the real payload of the 40-component fit above
+        residual = 8.0 * np.spacing(anchor) * count
+        raw_sum = anchor * count + a_sum + residual
+        stat = GaussianSuffStat(raw_sum, raw_sum * raw_sum / count + a_sum2, count, count)
+        stat.anchored = (anchor, a_sum, a_sum2)
+        model = GaussianEstimator().estimate(count, stat)
+        self.assertEqual(model.mu, anchor + a_sum / count)
+        self.assertAlmostEqual(model.sigma2, a_sum2 / count - (a_sum / count) ** 2, places=12)  # pre-fix: 1.26
+        self.assertEqual(model.numerical_repairs(), ())
+
 
 class ClampInvariantsTestCase(unittest.TestCase):
     """What the clamp exists for must still hold."""

--- a/mixle/tests/campaign3c_logistic_test.py
+++ b/mixle/tests/campaign3c_logistic_test.py
@@ -185,7 +185,12 @@ class ShiftInvariantLogisticVarianceTestCase(unittest.TestCase):
         nobs = float(weights.sum() * c)
         scaled_model = est.estimate(nobs, scaled.value())
         expected_model = est.estimate(nobs, expected.value())
-        self.assertAlmostEqual(scaled_model.loc, expected_model.loc, places=9)
+        # ``places=9`` on a value of 1.7e9 was a ONE-ulp check (the grid step there is 2.4e-7): the two
+        # paths form ``(sum w dx) * c`` and ``sum (w c) dx`` at spread scale and round each onto the
+        # anchor independently, so their locations may legitimately land one grid step apart. It
+        # passed on x86 OpenBLAS and failed by exactly one step on the arm64 kernel. Parity here means
+        # agreement to within a few grid steps of the magnitude, and exactness on the scale.
+        self.assertAlmostEqual(scaled_model.loc, expected_model.loc, delta=4.0 * np.spacing(abs(expected_model.loc)))
         self.assertAlmostEqual(scaled_model.scale, expected_model.scale, places=9)
 
 

--- a/mixle/tests/evolve_verify_test.py
+++ b/mixle/tests/evolve_verify_test.py
@@ -47,6 +47,30 @@ class VerifyGateTest(unittest.TestCase):
         verdict = challenger_beats_champion(champion, challenger, self.data, objective=nll_objective(), min_effect=10.0)
         self.assertFalse(verdict.promote)
 
+    def test_one_ulp_systematic_difference_is_below_resolution_not_a_win(self):
+        # The paired t-test measures directional consistency, not magnitude. A challenger whose
+        # per-observation score is better than the champion's by exactly one ulp on EVERY row --
+        # what two arithmetic paths through the same model produce -- is "significant" at n=600
+        # (observed in the wild: an auto_select challenger identical to its champion, mean_diff
+        # 5.5e-17, p=0.0015, promoted). Below a few ulp of the scores' own magnitude the gate must
+        # report a tie on its own; no caller-chosen min_effect is a plausible guard for this.
+        model = _fit(self.data, 3.0, 2.0)
+
+        def _one_ulp_better_seq(enc, *args, **kwargs):
+            return np.nextafter(model.seq_log_density(enc, *args, **kwargs), np.inf)
+
+        def _one_ulp_better(x, *args, **kwargs):
+            return float(np.nextafter(model.log_density(x, *args, **kwargs), np.inf))
+
+        challenger = _DelegatingWrapper(model, seq_log_density=_one_ulp_better_seq, log_density=_one_ulp_better)
+        verdict = challenger_beats_champion(
+            model, challenger, self.data, objective=nll_objective(), require_calibration=False
+        )
+        self.assertLess(verdict.p_value, 0.05)  # the paired test alone calls this a win
+        self.assertTrue(verdict.evidence["numerical_resolution"]["below_floor"])
+        self.assertEqual(verdict.favored, "tie")
+        self.assertFalse(verdict.promote)
+
     def test_worse_challenger_favors_champion(self):
         champion = _fit(self.data, 3.0, 2.0)
         challenger = GaussianDistribution(0.0, 1.0)  # worse


### PR DESCRIPTION
## What

Every scalar family carrying the shift-anchored moment track (Gaussian, log-Gaussian, Logistic, Gumbel, Student-t, Rician, Nakagami) formed its reported location as `sum_x / count` from the raw large-magnitude sum, then handed it to `anchored_pooled_variance`, which adds `count * shift**2` for the displacement of that location from the anchored sample mean and clamps `shift` only within 4 ulp of the magnitude. A SIMD-reduced sum of 300 observations at 1e15 carries more than that, by an amount that depends on the BLAS kernel. On x86 OpenBLAS the residual stayed under the clamp; on the arm64 NEON kernel the two-component mixture in `campaign3b_clamp_test` landed a shift of ~0.9 (7 grid steps), cleared the clamp, and reported `sigma2` of 1.07 and 0.94 for components of true variance 0.25, while the anchored payload reaching the M-step carried the exact answer (0.2600) on both platforms.

The location now comes from the anchored track through one shared helper, `anchored_location` (the form the multivariate/diagonal Gaussian and generalized Pareto estimators already used), so the clamp only ever sees the rounding of a single addition.

Two more platform-fragility findings from the same reproduction:

- `campaign3c_logistic_test` asserted a 1.7e9 location to 9 decimal places, a one-ulp check. It now allows a few grid steps at that magnitude.
- The evolve verify gate promoted a challenger whose per-row nll beat the champion's by a fraction of an ulp on every row (mean diff 5.5e-17, p = 0.0015). The gate now reports a tie below 8 ulp of the scores' magnitude, recorded in `evidence["numerical_resolution"]`.

## Why this matters for release/0.8.0

This is the failure that has been landing at the 13% mark of the hosted ubuntu core lanes since 08-28, always followed minutes later by the runner being killed. Every killed job had it; sibling lanes without it survived; macOS never saw it. It never printed a name because the kill pre-empted pytest's summary. The host CPU decides the OpenBLAS kernel and the kernel decides the test.

## Verification

- ruff format/check clean; duplicate-body gate and public-claim gates pass.
- Affected test files pass on macOS (238), Linux arm64, and Linux x86_64 under Rosetta with the Nehalem and Haswell OpenBLAS kernels (369 each).
- Full core tier on Linux arm64 (colima VM, 4 CPU / 16 GB, OpenBLAS neoversen1): 11381 passed; the only failures are `benchmark_provenance_test` because the source snapshot has no `.git`. The three original failures are gone.
- Full core tier on macOS: the only failures are environment artifacts of the local venv (wheel-provenance version check with no installed distribution metadata, a timing threshold under CPU contention, the README venv path).
- New platform-independent regression tests: `campaign3b_clamp_test` (a raw sum carrying an 8-grid-step residual beside an exact anchored payload, pre-fix sigma2 1.26), `evolve_verify_test` (one-ulp systematic difference is a tie).
