### PR TITLE
Record why the dependabot target has to be moved on main

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,14 @@
 version: 2
+# Dependabot reads THIS FILE FROM THE DEFAULT BRANCH ONLY. Updating the copy on a release branch has
+# no effect on where the bot opens pull requests, so `target-branch` below has to be moved here, on
+# main, whenever the active release line does. It was missed for 0.8.2: the bot kept opening pull
+# requests against release/0.8.1, where they cannot merge and where their checks fail on unrelated
+# drift, and four of them were open at once.
 updates:
   # Python dependencies declared in pyproject.toml.
   - package-ecosystem: "pip"
     directory: "/"
-    target-branch: "release/0.8.1"
+    target-branch: "release/0.8.2"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
@@ -17,6 +22,6 @@ updates:
   # GitHub Actions used in .github/workflows/*.yml.
   - package-ecosystem: "github-actions"
     directory: "/"
-    target-branch: "release/0.8.1"
+    target-branch: "release/0.8.2"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Retargeted to `release/0.8.2`, where the only real change is the comment: this branch already carries `target-branch: release/0.8.2`.

That is exactly the problem being documented. Dependabot reads `.github/dependabot.yml` from the **default branch only**, which is `main`, and main still says `release/0.8.1`. So the correct value has been sitting on this branch doing nothing, and every bot pull request has gone to `release/0.8.1`, which is closed — four are open there now (#541, #542, #543, #544) and none can merge.

**Merging this does not change where the bot files.** It puts the explanation next to the setting so the next release line does not repeat it, and the value reaches main when 0.8.2 does.

#544's seven failing checks are worth recording, since neither cause is the bumps:

- `build_environment_contract_test.py` asserts the build lock matches `pyproject.toml`. The bump moved `pip` to 26.2.1 in the build-system table without regenerating `0.8.1-build-requirements.txt`, which still pins 26.1.2. That file hashes to shard 2, so one assertion accounts for every `shard 2` and `minimum versions` failure.
- `lint` fails because the pinned ruff release reformats three files.