### PR TITLE
Point dependabot at the active release line

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,14 @@
 version: 2
+# Dependabot reads THIS FILE FROM THE DEFAULT BRANCH ONLY. Updating the copy on a release branch has
+# no effect on where the bot opens pull requests, so `target-branch` below has to be moved here, on
+# main, whenever the active release line does. It was missed for 0.8.2: the bot kept opening pull
+# requests against release/0.8.1, where they cannot merge and where their checks fail on unrelated
+# drift, and four of them were open at once.
 updates:
   # Python dependencies declared in pyproject.toml.
   - package-ecosystem: "pip"
     directory: "/"
-    target-branch: "release/0.8.1"
+    target-branch: "release/0.8.2"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
@@ -17,6 +22,6 @@ updates:
   # GitHub Actions used in .github/workflows/*.yml.
   - package-ecosystem: "github-actions"
     directory: "/"
-    target-branch: "release/0.8.1"
+    target-branch: "release/0.8.2"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
This is the copy that decides anything.

Dependabot reads `.github/dependabot.yml` from the **default branch only**. `release/0.8.2` has carried `target-branch: release/0.8.2` since that line opened, and #545 has now added the explanatory comment there — but neither changes where the bot files, because neither is on main. Every pull request it has raised went to `release/0.8.1`, which is closed: #541, #542, #543 and #544 are open there and none can merge.

Brings main to the same content the release branch carries, comment included, so the next line does not repeat this.

Once this lands, the four open pull requests against `release/0.8.1` can be closed; dependabot will re-raise whatever is still relevant against the active branch.

For the record, #544's seven failing checks are not caused by its bumps:

- `build_environment_contract_test.py` asserts the build lock matches `pyproject.toml`. The bump moved `pip` to 26.2.1 in the build-system table without regenerating `0.8.1-build-requirements.txt`, which still pins 26.1.2. That file hashes to shard 2, so one assertion accounts for every `shard 2` and `minimum versions` failure.
- `lint` fails because the pinned ruff release reformats three files.