### PR TITLE
Move the release line in machine governance, not just in the generated file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ Python 3.11 or 3.12 is required; those are the complete 0.8.1 release matrix.
 This summary is generated from `manifests/development_policy.json`; edit the manifest and rerun
 `python scripts/render_contributing_policy.py` rather than changing this block by hand.
 
-Current work targets `release/0.8.1` and milestone `0.8.1`. Automated
+Current work targets `release/0.8.2` and milestone `0.8.2`. Automated
 dependency updates target the same branch. Retarget both the manifest and Dependabot deliberately
 when the release line changes.
 

--- a/manifests/development_policy.json
+++ b/manifests/development_policy.json
@@ -7,8 +7,8 @@
     "stable_deprecation_min_minor_releases": 2
   },
   "release": {
-    "milestone": "0.8.1",
-    "target_branch": "release/0.8.1"
+    "milestone": "0.8.2",
+    "target_branch": "release/0.8.2"
   },
   "validation": {
     "advisory": [


### PR DESCRIPTION
Follow-up to #546, which broke main. The break is the useful part.

`.github/dependabot.yml` is not the source of the release-target value. `manifests/development_policy.json` is; `CONTRIBUTING.md` is rendered from it; and `governance_contract_test.py` asserts all three agree — it counts the policy's `target_branch` in `dependabot.yml` once per ecosystem and got zero. So #546 edited a generated artifact and left its generator behind, failing `core / *shard 2`, `core / macOS arm64`, `core / minimum versions` and `full / shard 2` on main.

This moves the policy and re-renders the prose from it, which is the order the contract expects. `milestone` moves with `target_branch`: leaving it at 0.8.1 would satisfy the dependabot assertion and still be wrong, and `CONTRIBUTING.md` states both in one sentence.

Verified in a throwaway worktree at main before pushing — all four governance contracts pass, and `governance_contract_test.py` is the only test in the tree that reads either file.