### PR TITLE
Make the secret-scan allowlist the shape the pinned scanner actually reads

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -3,10 +3,31 @@ title = "Mixle release secret policy"
 [extend]
 useDefault = true
 
-[[allowlists]]
-description = "Exact synthetic credentials used by redaction tests"
-regexTarget = "match"
+# This block MUST stay `[allowlist]` (singular table), not `[[allowlists]]` (array of tables).
+# gitleaks 8.24.3 -- the build gitleaks-action pins -- parses the plural form without error and then
+# ignores it entirely when the config also extends the default rules. Measured on this repository's
+# own history with that exact binary: the plural form reports 34 findings whether its regexes match
+# nothing or match every line; the singular form with the identical two regexes reports 6. So the
+# allowlist below had never suppressed anything, and the gate had been failing on its own fixtures.
+#
+# Nobody noticed because gitleaks-action scans only the pushed commits on a `push` event and the
+# whole history otherwise: every push run was green while the weekly scheduled run and every
+# release dispatch failed. A required check that is green on the event you watch and red on the
+# event that gates the release is worse than one that is simply red.
+#
+# Everything listed here is a fixture, verified against the blob it was found in:
+#   * the four credential-shaped constants the redaction tests feed to the scanner, which must stay
+#     literal in the tests -- redaction cannot be tested against a value that is not there;
+#   * `secret_policy=`, which is this library's own keyword argument, matched by the generic-api-key
+#     rule where `mixle/substrate/core.py` documents `secret_policy="reject"` in prose.
+# Values are allowlisted, not paths: a real credential committed into a test file still fails.
+[allowlist]
+description = "Synthetic credentials owned by the redaction tests, and one prose parameter name"
+regexTarget = "line"
 regexes = [
   '''sk-abcdefghij1234567890XYZ''',
   '''AKIA1234567890ABCDEF''',
+  '''api_key=abcdefghijklmnop''',
+  '''ghp_abcdefghijklmnopqrstuvwxyz0123456789''',
+  '''secret_policy=''',
 ]

--- a/mixle/tests/repo_hygiene_scan_test.py
+++ b/mixle/tests/repo_hygiene_scan_test.py
@@ -15,6 +15,7 @@ allowlisted by exact value; anything else matching these shapes is a finding.
 
 import re
 import subprocess
+import tomllib
 import unittest
 from pathlib import Path
 
@@ -57,8 +58,27 @@ _REVIEWED_PATH_OCCURRENCES = {
 }
 _HOME_PATH = re.compile(r"/(?:Users|home)/([A-Za-z0-9_.-]+)")
 
-# Deliberately-fake fixtures the secret-redaction feature is tested against (examples/ + tests/).
-_ALLOWED_SECRETS = {"sk-abcdefghij1234567890XYZ", "AKIA1234567890ABCDEF"}
+
+def _gitleaks_fixture_allowlist() -> tuple[re.Pattern, ...]:
+    """The fixture values the release secret scan allows, read from that scan's own config.
+
+    Two scanners cover the same fixtures: this fast tracked-file check and Gitleaks over full
+    history. Until 2026-09-10 each kept its own copy of the list, and the drift that guarantees is
+    not hypothetical -- this test failed on the very commit that repaired the Gitleaks config,
+    because that repair added two fixture values here and nothing told this list about them. One
+    source, read at run time.
+
+    Entries are Gitleaks allowlist regexes, so they are compared as regexes (``fullmatch``) rather
+    than as strings; every current entry happens to be a literal, and a future one need not be.
+    """
+    config = REPO_ROOT / ".gitleaks.toml"
+    if not config.is_file():  # an sdist tree ships no CI config
+        return ()
+    allowlist = tomllib.loads(config.read_text(encoding="utf-8")).get("allowlist", {})
+    return tuple(re.compile(pattern) for pattern in allowlist.get("regexes", ()))
+
+
+_ALLOWED_SECRETS = _gitleaks_fixture_allowlist()
 # Credential shapes, kept conservative so the gate stays low-noise. ERE for git grep; Python re extracts
 # the full match via group(0), so the capturing groups here do not disturb allowlisting.
 _SECRET_ERE = (
@@ -96,7 +116,7 @@ class RepoHygieneScanTest(unittest.TestCase):
         for path, lineno, text in _git_grep_lines(_SECRET_ERE):
             for m in _SECRET_RE.finditer(text):
                 token = m.group(0)
-                if token not in _ALLOWED_SECRETS:
+                if not any(pattern.fullmatch(token) for pattern in _ALLOWED_SECRETS):
                     findings.append(f"{path}:{lineno}: credential-shaped string not on the allowlist")
         self.assertEqual(
             findings,


### PR DESCRIPTION
main's weekly scheduled Security run has been failing on `gitleaks (full history)` since at least 2026-09-07, with 20 findings, while every push run reported success. That split is the scanner's own behaviour: gitleaks-action scans only the pushed commits on a `push` event and the whole history on `schedule` and `workflow_dispatch`. Green on the event being watched, red on the event that means anything.

All 20 are fixtures, each checked against the blob it was found in — the credential-shaped constants the redaction tests feed to the scanner, plus this library's own `secret_policy=` keyword where `mixle/substrate/core.py` documents it in prose. **No real credential is in the history.**

The allowlist meant to cover them had never been read. It was a top-level `[[allowlists]]` array, and gitleaks 8.24.3 — the build the action pins — parses that without error and then ignores it when the config also extends the default rules. Measured with that exact binary: the plural form reports the same count whether its regexes match nothing or match *every* line; the singular `[allowlist]` with identical regexes drops it. Nothing in the output says the allowlist is unread, so it just looks as though the fixtures are leaks.

Verified over this branch's full history: **8052 commits scanned, no leaks found.** Values are allowlisted rather than paths, so a real credential committed into a test file still fails.

`repo_hygiene_scan_test.py` kept a second copy of the same fixture list, which is how the pair drifted; it now reads the values from the config at run time.

Ported from `release/0.8.2`, where both changes are already in and green.