### PR TITLE
Drop the lightning waiver: the release it was waiting for exists

### DIFF
--- a/.github/pip-audit-waivers.json
+++ b/.github/pip-audit-waivers.json
@@ -1,13 +1,4 @@
 {
   "artifact": "mixle.vulnerability_waivers/v1",
-  "waivers": [
-    {
-      "id": "PYSEC-2026-3624",
-      "owner": "Grant Boquet, release owner",
-      "rationale": "CVE-2026-58659: lightning <= 2.6.5 executes attacker-controlled module names from a malicious checkpoint's _instantiator hyperparameters when LightningModule.load_from_checkpoint is called. mixle's entire lightning surface is mini-batch data iteration (LightningEncodedData via LightningDataModule/DataLoader in mixle/utils/parallel/lightning_data.py) and Fabric process launch (training_launchers.py); no mixle code path calls load_from_checkpoint or loads lightning checkpoint files, so the vulnerable function is unreachable through mixle. No fixed lightning release exists on PyPI (the advisory's fix is commit d710d68, unreleased for the 2.x line; every 2.x version through 2.6.5 is affected), so upgrading cannot resolve it. Time-boxed: re-review for a fixed release at expiry, and drop this waiver the moment one exists.",
-      "profiles": ["all"],
-      "reviewed_on": "2026-08-07",
-      "expires_on": "2026-09-07"
-    }
-  ]
+  "waivers": []
 }

--- a/mixle/tests/vulnerability_waiver_contract_test.py
+++ b/mixle/tests/vulnerability_waiver_contract_test.py
@@ -35,18 +35,23 @@ def _record(**updates):
 def test_current_waiver_inventory_is_valid_and_reviewed() -> None:
     """The live inventory is pinned here BY DESIGN: adding a waiver requires this reviewed edit.
 
-    Current inventory (reviewed 2026-08-07): PYSEC-2026-3624 / CVE-2026-58659, a checkpoint-file
-    remote code execution in lightning <= 2.6.5 via LightningModule.load_from_checkpoint. No
-    fixed lightning release exists, and mixle's whole lightning surface is mini-batch data
-    iteration and Fabric launch -- no mixle code path loads lightning checkpoints -- so the
-    vulnerable function is unreachable through mixle. Time-boxed to 2026-09-07 for re-review.
+    Current inventory: EMPTY, as of 2026-09-11.
+
+    It held one entry, PYSEC-2026-3624 / CVE-2026-58659, a checkpoint-file remote code execution
+    in lightning <= 2.6.5. That waiver rested on "no fixed lightning release exists" and promised
+    to be dropped the moment one did. lightning 2.6.6 was published 2026-09-10 and OSV records it
+    as the fixed version, so the premise is gone and the waiver with it -- the resolver reaches
+    2.6.6 on its own under `lightning>=2.4,<3`, and the audit reports no known vulnerabilities
+    without ignoring anything.
+
+    An empty inventory is the correct steady state, and this assertion is what keeps it that way:
+    adding a waiver back requires editing this test, which is a reviewed act rather than a
+    configuration change.
     """
     record = json.loads((ROOT / ".github" / "pip-audit-waivers.json").read_text(encoding="utf-8"))
-    accepted, errors = _module().validate(record, today=dt.date(2026, 8, 7))
+    accepted, errors = _module().validate(record, today=dt.date.today())
     assert errors == []
-    assert [(w["id"], tuple(w["profiles"]), w["expires_on"]) for w in accepted] == [
-        ("PYSEC-2026-3624", ("all",), "2026-09-07")
-    ]
+    assert accepted == [], f"the waiver inventory should be empty; found {accepted}"
     assert all(w["owner"].strip() and len(w["rationale"]) >= 20 for w in accepted)
 
 


### PR DESCRIPTION
Both pip-audit jobs on main fail at *waiver validation*, not at the audit: `PYSEC-2026-3624 expired on 2026-09-07` and nothing renewed it. `release/0.8.2` renewed it to 2026-10-07 on the same unreachability argument, and porting that here looked like the obvious fix.

It's the wrong fix. The waiver's premise was **"no fixed lightning release exists on PyPI"**, and it committed in writing to being dropped the moment one did. **lightning 2.6.6 was published 2026-09-10T09:41Z** and OSV now records it as the fixed version for this advisory. The premise is gone, so the waiver goes rather than gets renewed.

Nothing else has to change for that to work — the constraint is already `lightning>=2.4,<3`, so the resolver reaches 2.6.6 unaided. The release line's last Security run proves it end to end: it installed `lightning-2.6.6` and reported *"No known vulnerabilities found"* with **no "1 ignored" suffix**, meaning the waiver it still carries matched nothing.

The contract test now pins the inventory as **empty** and validates against today rather than a frozen review date, so it can't silently pass on a stale entry again. Adding a waiver back still requires editing that test, which was always the point of pinning the inventory there.

> This is the second advisory in two days whose fix landed within hours of a "no fix exists" reading — the other was CVE-2026-69112 in `accelerate`, fixed by 1.15.0. Both expressed the fix in a form that leaves pip-audit's *Fix Versions* column empty. Re-query before renewing a waiver, not just before writing one.

Verified at main in a throwaway worktree: the verifier emits no ignore arguments, and all 11 tests that read the waiver record pass.

**Note for `release/0.8.2`:** it still carries this waiver, now covering an already-fixed advisory. That's a real finding against the release candidate, but I've left it for the batched final pass rather than pushing into a branch under adversarial review.